### PR TITLE
Add basic Alert component

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - MenuItem
 - [TabbedArea, TabPane, Tab](#Tabs)
 - [CollapsePanel](#CollapsePanel)
+- [Alert](#Alert)
 - SplitButton
 
 ### <a name="Button"></a>Button
@@ -58,6 +59,19 @@ function handleSelect (selectedIndex) {
 </TabbedArea>
 ```
 
+### <a name="Alert"></a>Alert
+
+```
+var Alert = require('react-bootstrap/lib/Alert');
+
+function handleDismiss () {
+}
+
+<Alert bsStyle="danger" onDismiss={handleDismiss} dismissAfter={5000}>
+  <strong>Oh snap!</strong> Change a few things up and try submitting again.
+</Alert>
+```
+
 ### <a name="CollapsePanel"></a>CollapsePanel
 
 `var CollapsePanel = require('react-bootstrap/lib/CollapsePanel')`
@@ -70,5 +84,4 @@ TODO docs
 - Accordion
 - Nav, NavItem
 - Pagination, Pager
-- Alert
 - Modal

--- a/lib/Alert.js
+++ b/lib/Alert.js
@@ -1,0 +1,61 @@
+/** @jsx React.DOM */
+
+var React          = require('react');
+var merge          = require('react/lib/merge');
+var BootstrapMixin = require('./BootstrapMixin');
+
+var Alert = React.createClass({displayName: 'Alert',
+  mixins: [BootstrapMixin],
+
+  propTypes: {
+    onDismiss: React.PropTypes.func,
+    dismissAfter: React.PropTypes.number
+  },
+
+  getDefaultProps: function () {
+    return {
+      bsClass: 'alert',
+      bsStyle: 'info'
+    };
+  },
+
+  renderDismissButton: function () {
+    return (
+      React.DOM.button(
+        {type:"button",
+        className:"close",
+        onClick:this.props.onDismiss,
+        'aria-hidden':"true"}, 
+        " × "
+      )
+    );
+  },
+
+  render: function () {
+    var classes = this.getClassSetFromString(this.extendClassName());
+    var isDismissable = !!this.props.onDismiss;
+
+    classes['alert-dismissable'] = isDismissable;
+
+    var className = React.addons.classSet(classes);
+
+    return this.transferPropsTo(
+      React.DOM.div( {className:className}, 
+        isDismissable ? this.renderDismissButton() : null,
+        this.props.children
+      )
+    );
+  },
+
+  componentDidMount: function() {
+    if (this.props.dismissAfter && this.props.onDismiss) {
+      this.dismissTimer = setTimeout(this.props.onDismiss, this.props.dismissAfter);
+    }
+  },
+
+  componentWillUnmount: function() {
+    clearTimeout(this.dismissTimer);
+  }
+});
+
+module.exports = Alert;

--- a/src/Alert.jsx
+++ b/src/Alert.jsx
@@ -1,0 +1,61 @@
+/** @jsx React.DOM */
+
+var React          = require('react');
+var merge          = require('react/lib/merge');
+var BootstrapMixin = require('./BootstrapMixin');
+
+var Alert = React.createClass({
+  mixins: [BootstrapMixin],
+
+  propTypes: {
+    onDismiss: React.PropTypes.func,
+    dismissAfter: React.PropTypes.number
+  },
+
+  getDefaultProps: function () {
+    return {
+      bsClass: 'alert',
+      bsStyle: 'info'
+    };
+  },
+
+  renderDismissButton: function () {
+    return (
+      <button
+        type="button"
+        className="close"
+        onClick={this.props.onDismiss}
+        aria-hidden="true">
+        &times;
+      </button>
+    );
+  },
+
+  render: function () {
+    var classes = this.getClassSetFromString(this.extendClassName());
+    var isDismissable = !!this.props.onDismiss;
+
+    classes['alert-dismissable'] = isDismissable;
+
+    var className = React.addons.classSet(classes);
+
+    return this.transferPropsTo(
+      <div className={className}>
+        {isDismissable ? this.renderDismissButton() : null}
+        {this.props.children}
+      </div>
+    );
+  },
+
+  componentDidMount: function() {
+    if (this.props.dismissAfter && this.props.onDismiss) {
+      this.dismissTimer = setTimeout(this.props.onDismiss, this.props.dismissAfter);
+    }
+  },
+
+  componentWillUnmount: function() {
+    clearTimeout(this.dismissTimer);
+  }
+});
+
+module.exports = Alert;

--- a/test/AlertSpec.jsx
+++ b/test/AlertSpec.jsx
@@ -1,0 +1,68 @@
+/** @jsx React.DOM */
+/*global describe, beforeEach, afterEach, it, assert */
+
+var React = require('react/addons');
+var Alert = require('../lib/Alert');
+
+var ReactTestUtils;
+
+describe('Alert', function () {
+  beforeEach(function() {
+    ReactTestUtils = React.addons.ReactTestUtils;
+  });
+
+  it('Should output a alert with message', function () {
+    var instance = Alert({}, <strong>Message</strong>);
+    ReactTestUtils.renderIntoDocument(instance);
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'strong'));
+  });
+
+  it('Should have bsType by default', function () {
+    var instance = Alert({}, 'Message');
+    ReactTestUtils.renderIntoDocument(instance);
+    assert.ok(instance.getDOMNode().className.match(/\balert\b/));
+  });
+
+  it('Should have dismissable style with onDismiss', function () {
+    var instance = Alert({
+      onDismiss: function () {}
+    }, 'Message');
+    ReactTestUtils.renderIntoDocument(instance);
+    assert.ok(instance.getDOMNode().className.match(/\balert-dismissable\b/));
+  });
+
+  it('Should call onDismiss callback on dismiss click', function (done) {
+    var instance = Alert({
+      onDismiss: function () {
+        done();
+      }
+    }, 'Message');
+    ReactTestUtils.renderIntoDocument(instance);
+
+    ReactTestUtils.Simulate.click(instance.getDOMNode().children[0]);
+  });
+
+  it('Should call onDismiss callback on dismissAfter time', function (done) {
+    var instance = Alert({
+      onDismiss: function () {
+        done();
+      },
+      dismissAfter: 1
+    }, 'Message');
+    ReactTestUtils.renderIntoDocument(instance);
+  });
+
+  it('Should have a default bsStyle class', function () {
+    var instance = Alert({}, 'Message');
+    ReactTestUtils.renderIntoDocument(instance);
+
+    assert.ok(instance.getDOMNode().className.match(/\balert-\w+\b/));
+  });
+
+  it('Should have use bsStyle class', function () {
+    var instance = Alert({bsStyle: 'danger'}, 'Message');
+    ReactTestUtils.renderIntoDocument(instance);
+
+    assert.ok(instance.getDOMNode().className.match(/\balert-danger\b/));
+  });
+});


### PR DESCRIPTION
Hi!

First want to say awesome project!

I made this component today and thought you might want it. 

As far as i can tell it implements all options of [bs alert](http://getbootstrap.com/components/#alerts).

Have also added the additional functionality of calling the `onDismiss` fn after a timeout via the `dismissAfter={5000}` option. It's not typical bootstrap behaviour but is nice to have for the minimal amount of code it requires, let me know if you want it removed/want to stick more closely to the bootstrap default functionality.
