### PR TITLE
ClassName helpers refactor

### DIFF
--- a/lib/Alert.js
+++ b/lib/Alert.js
@@ -1,7 +1,7 @@
 /** @jsx React.DOM */
 
 var React          = require('react');
-var merge          = require('react/lib/merge');
+var classSet       = require('react/lib/cx');
 var BootstrapMixin = require('./BootstrapMixin');
 
 var Alert = React.createClass({displayName: 'Alert',
@@ -32,13 +32,13 @@ var Alert = React.createClass({displayName: 'Alert',
   },
 
   render: function () {
+    var classes = this.getBsClassSet();
     var isDismissable = !!this.props.onDismiss;
-    var className = this.extendClassName({
-      'alert-dismissable': isDismissable
-    });
+
+    classes['alert-dismissable'] = isDismissable;
 
     return this.transferPropsTo(
-      React.DOM.div( {className:className}, 
+      React.DOM.div( {className:classSet(classes)}, 
         isDismissable ? this.renderDismissButton() : null,
         this.props.children
       )

--- a/lib/BootstrapMixin.js
+++ b/lib/BootstrapMixin.js
@@ -1,5 +1,4 @@
-var React     = require('react/addons');
-var merge     = require('react/lib/merge');
+var React     = require('react');
 var constants = require('./constants');
 
 var BootstrapMixin = {
@@ -10,45 +9,21 @@ var BootstrapMixin = {
     bsVariation: React.PropTypes.string
   },
 
-  getClassSetFromString: function (className) {
+  getBsClassSet: function () {
     var classes = {};
 
-    className = className || '';
-
-    className.split(' ').map(
-      function (cssClass) {
-        if (cssClass) {
-          classes[cssClass] = true;
-        }
-      }
-    );
-
-    return classes;
-  },
-
-  getClassSetFromClassName: function () {
-    return this.getClassSetFromString(this.props.className);
-  },
-
-  extendClassName: function (extraClasses) {
-    var prefix,
-        className,
-        classes = this.getClassSetFromClassName(),
-        bsClass,
-        bsStyle,
-        bsSize;
-
-    bsClass = this.props.bsClass && constants.CLASSES[this.props.bsClass];
+    var bsClass = this.props.bsClass && constants.CLASSES[this.props.bsClass];
     if (bsClass) {
       classes[bsClass] = true;
 
-      prefix = bsClass + '-';
+      var prefix = bsClass + '-';
 
-      bsSize = this.props.bsSize && constants.SIZES[this.props.bsSize];
+      var bsSize = this.props.bsSize && constants.SIZES[this.props.bsSize];
       if (bsSize) {
         classes[prefix + bsSize] = true;
       }
-      bsStyle = this.props.bsStyle && constants.STYLES[this.props.bsStyle];
+
+      var bsStyle = this.props.bsStyle && constants.STYLES[this.props.bsStyle];
       if (this.props.bsStyle) {
         classes[prefix + bsStyle] = true;
       }
@@ -58,13 +33,7 @@ var BootstrapMixin = {
       }
     }
 
-    if (extraClasses) {
-      classes = merge(classes, extraClasses);
-    }
-
-    className = React.addons.classSet(classes);
-
-    return className.replace(/\s+/, ' ');
+    return classes;
   }
 };
 

--- a/lib/Button.js
+++ b/lib/Button.js
@@ -1,7 +1,7 @@
 /** @jsx React.DOM */
 
 var React          = require('react');
-var merge          = require('react/lib/merge');
+var classSet       = require('react/lib/cx');
 var BootstrapMixin = require('./BootstrapMixin');
 
 var Button = React.createClass({displayName: 'Button',
@@ -21,11 +21,11 @@ var Button = React.createClass({displayName: 'Button',
     };
   },
 
-  renderAnchor: function (children, className, isDisabled) {
-    return (
+  renderAnchor: function (children, classes, isDisabled) {
+    return this.transferPropsTo(
       React.DOM.a(
         {href:this.props.href,
-        className:className,
+        className:classSet(classes),
         onClick:this.props.onClick,
         disabled:isDisabled}, 
         children
@@ -33,11 +33,11 @@ var Button = React.createClass({displayName: 'Button',
     );
   },
 
-  renderButton: function (children, className, isDisabled) {
-    return (
+  renderButton: function (children, classes, isDisabled) {
+    return this.transferPropsTo(
       React.DOM.button(
         {type:this.props.type || "button",
-        className:className,
+        className:classSet(classes),
         onClick:this.props.onClick,
         disabled:isDisabled}, 
         children
@@ -47,10 +47,10 @@ var Button = React.createClass({displayName: 'Button',
 
   render: function () {
     var isDisabled = !!(this.props.isDisabled || this.props.isLoading);
-    var className = this.extendClassName({
-      disabled: isDisabled,
-      active: this.props.isActive
-    });
+
+    var classes = this.getBsClassSet();
+    classes['disabled'] = isDisabled;
+    classes['active'] = this.props.isActive;
 
     var children = this.props.isLoading ?
       this.props.loadingChildren : this.props.children;
@@ -58,7 +58,7 @@ var Button = React.createClass({displayName: 'Button',
     var renderFuncName = (this.props.href) ?
       'renderAnchor' : 'renderButton';
 
-    return this[renderFuncName](children, className, isDisabled);
+    return this[renderFuncName](children, classes, isDisabled);
   }
 });
 

--- a/lib/CollapsePanel.js
+++ b/lib/CollapsePanel.js
@@ -1,8 +1,8 @@
 /** @jsx React.DOM */
 
-var React          = require('react/addons');
+var React          = require('react');
+var classSet       = require('react/lib/cx');
 var BootstrapMixin = require('./BootstrapMixin');
-var classSet       = React.addons.classSet;
 
 var CollapsePanel  = React.createClass({displayName: 'CollapsePanel',
   mixins: [BootstrapMixin],
@@ -41,7 +41,7 @@ var CollapsePanel  = React.createClass({displayName: 'CollapsePanel',
     var isOpen = (this.props.isStateful) ?
       this.state.isOpen : this.props.isOpen;
 
-    var panelClassName = this.extendClassName();
+    var panelClassName = classSet(this.getBsClassSet());
 
     var anchorClassName = classSet({
       "collapsed": !isOpen
@@ -53,7 +53,7 @@ var CollapsePanel  = React.createClass({displayName: 'CollapsePanel',
       "collapse": !isOpen
     });
 
-    return (
+    return this.transferPropsTo(
       React.DOM.div( {className:panelClassName}, 
         React.DOM.div( {className:"panel-heading"}, 
           HeadingClass(

--- a/lib/DropdownButton.js
+++ b/lib/DropdownButton.js
@@ -1,9 +1,10 @@
 /** @jsx React.DOM */
 
-var React              = require('react/addons');
-var Button             = require('./Button');
-var BootstrapMixin     = require('./BootstrapMixin');
-var utils              = require('./utils');
+var React          = require('react');
+var classSet       = require('react/lib/cx');
+var Button         = require('./Button');
+var BootstrapMixin = require('./BootstrapMixin');
+var utils          = require('./utils');
 
 
 var DropdownButton = React.createClass({displayName: 'DropdownButton',
@@ -73,25 +74,22 @@ var DropdownButton = React.createClass({displayName: 'DropdownButton',
   },
 
   render: function () {
-    var groupClassName = React.addons.classSet({
+    var groupClassName = classSet({
       'btn-group': true,
       'open': this.state.open
     });
 
-    var className = this.extendClassName();
+    var className = classSet(this.getBsClassSet());
 
-    var menuItems = [];
-
-    this.props.children.forEach(function (child, i) {
-      menuItems.push(
-        utils.cloneWithProps(
+    var menuItems = this.props.children
+      .map(function (child, i) {
+        return utils.cloneWithProps(
           child,
           {
             onSelect: this.handleOptionSelect.bind(this, i)
           }
-        )
-      );
-    }.bind(this));
+        );
+      }, this);
 
 
     var title = this.props.isTitleHidden ?
@@ -110,8 +108,7 @@ var DropdownButton = React.createClass({displayName: 'DropdownButton',
             {className:"dropdown-menu",
             role:"menu",
             ref:"menu",
-            'aria-labelledby':this.props.id}
-          , 
+            'aria-labelledby':this.props.id}, 
             menuItems
           )
       )

--- a/lib/Input.js
+++ b/lib/Input.js
@@ -1,4 +1,7 @@
-var React = require('react/addons');
+/** @jsx React.DOM */
+
+var React    = require('react');
+var classSet = require('react/lib/cx');
 
 var INPUT_TYPES = [
   'text',
@@ -17,7 +20,7 @@ var INPUT_TYPES = [
   'color'
 ];
 
-var Input = React.createClass({
+var Input = React.createClass({displayName: 'Input',
   propTypes: {
     name: React.PropTypes.string.isRequired,
     type: React.PropTypes.oneOf(INPUT_TYPES).isRequired,
@@ -35,35 +38,37 @@ var Input = React.createClass({
   },
 
   renderInput: function () {
-    var className = 'form-control input-md';
+    var classes = {
+      'form-control': true,
+      'input-md': true
+    };
 
     return (
-      <input
-        id={this.props.id}
-        type={this.props.type}
-        className={className}
-        placeholder={this.props.placeholder}
-        ref="input"
-      />
+      React.DOM.input(
+        {id:this.props.id,
+        type:this.props.type,
+        className:classSet(classes),
+        placeholder:this.props.placeholder,
+        ref:"input"}
+      )
     );
   },
 
   renderLabel: function () {
-    return this.props.label ? <label for={this.props.id}>{this.props.label}</label> : null;
+    return this.props.label ? React.DOM.label( {for:this.props.id}, this.props.label) : null;
   },
 
   render: function () {
-    var className = 'form-group';
-
-    if (this.state.error) {
-      className += ' has-error';
-    }
+    var classes = {
+      'form-group': true,
+      'has-error': !!this.state.error
+    };
 
     return (
-      <div className={className} onBlur={this.handleBlur} onFocus={this.handleFocus}>
-        {this.renderInput()}
-        {this.renderLabel()}
-      </div>
+      React.DOM.div( {className:classSet(classes), onBlur:this.handleBlur, onFocus:this.handleFocus}, 
+        this.renderInput(),
+        this.renderLabel()
+      )
     );
   },
 

--- a/lib/MenuItem.js
+++ b/lib/MenuItem.js
@@ -1,6 +1,6 @@
 /** @jsx React.DOM */
 
-var React          = require('react/addons');
+var React = require('react');
 
 var MenuItem = React.createClass({displayName: 'MenuItem',
   handleClick: function (e) {

--- a/lib/SplitButton.js
+++ b/lib/SplitButton.js
@@ -1,7 +1,7 @@
 /** @jsx React.DOM */
 
 var React          = require('react');
-var merge          = require('react/lib/merge');
+var classSet       = require('react/lib/cx');
 var BootstrapMixin = require('./BootstrapMixin');
 var Button         = require('./Button');
 var DropdownButton = require('./DropdownButton');
@@ -38,8 +38,9 @@ var SplitButton = React.createClass({displayName: 'SplitButton',
   },
 
   render: function () {
-    var classes = this.getClassSetFromClassName();
+    var classes = {};
 
+    classes[this.state.className] = true;
     classes['btn-group'] = !this.props.isInInputGroup;
     classes['input-group-btn'] = this.props.isInInputGroup;
 
@@ -47,10 +48,8 @@ var SplitButton = React.createClass({displayName: 'SplitButton',
       classes[this.props.bsVariation] = true;
     }
 
-    var className = React.addons.classSet(classes);
-
     return (
-      React.DOM.div( {className:className}, 
+      React.DOM.div( {className:classSet(classes)}, 
         this.transferPropsTo(Button( {onClick:this.handleClick}, this.props.title)),
         this.transferPropsTo(
           DropdownButton(

--- a/lib/Tab.js
+++ b/lib/Tab.js
@@ -1,6 +1,7 @@
 /** @jsx React.DOM */
 
-var React = require('react/addons');
+var React    = require('react');
+var classSet = require('react/lib/cx');
 
 var Tab = React.createClass({displayName: 'Tab',
   handleClick: function () {
@@ -10,20 +11,20 @@ var Tab = React.createClass({displayName: 'Tab',
   },
 
   render: function () {
-    var className = React.addons.classSet({
+    var classes = {
       'nav': true,
       'nav-tab': true,
       'active': this.props.isActive
-    });
+    };
 
     return this.transferPropsTo(
-      React.DOM.li( {className:className}, 
+      React.DOM.li( {className:classSet(classes)}, 
         React.DOM.a(
           {ref:"button",
           href:this.props.id ? '#' + this.props.id : null,
           onClick:this.handleClick}, 
-            this.props.children
-          )
+          this.props.children
+        )
       )
     );
   }

--- a/lib/TabPane.js
+++ b/lib/TabPane.js
@@ -1,16 +1,17 @@
 /** @jsx React.DOM */
 
-var React = require('react/addons');
+var React    = require('react');
+var classSet = require('react/lib/cx');
 
 var TabPane = React.createClass({displayName: 'TabPane',
   render: function () {
-    var className = React.addons.classSet({
+    var classes = {
       'tab-pane': true,
       'open': this.props.isActive
-    });
+    };
 
     return this.transferPropsTo(
-      React.DOM.div( {className:className}, 
+      React.DOM.div( {className:classSet(classes)}, 
         this.props.children
       )
     );

--- a/lib/TabbedArea.js
+++ b/lib/TabbedArea.js
@@ -1,6 +1,6 @@
 /** @jsx React.DOM */
 
-var React              = require('react/addons');
+var React              = require('react');
 var BootstrapMixin     = require('./BootstrapMixin');
 var utils              = require('./utils');
 var Tab                = require('./Tab');

--- a/src/Alert.jsx
+++ b/src/Alert.jsx
@@ -1,7 +1,7 @@
 /** @jsx React.DOM */
 
 var React          = require('react');
-var merge          = require('react/lib/merge');
+var classSet       = require('react/lib/cx');
 var BootstrapMixin = require('./BootstrapMixin');
 
 var Alert = React.createClass({
@@ -32,13 +32,13 @@ var Alert = React.createClass({
   },
 
   render: function () {
+    var classes = this.getBsClassSet();
     var isDismissable = !!this.props.onDismiss;
-    var className = this.extendClassName({
-      'alert-dismissable': isDismissable
-    });
+
+    classes['alert-dismissable'] = isDismissable;
 
     return this.transferPropsTo(
-      <div className={className}>
+      <div className={classSet(classes)}>
         {isDismissable ? this.renderDismissButton() : null}
         {this.props.children}
       </div>

--- a/src/BootstrapMixin.jsx
+++ b/src/BootstrapMixin.jsx
@@ -1,5 +1,4 @@
-var React     = require('react/addons');
-var merge     = require('react/lib/merge');
+var React     = require('react');
 var constants = require('./constants');
 
 var BootstrapMixin = {
@@ -10,45 +9,21 @@ var BootstrapMixin = {
     bsVariation: React.PropTypes.string
   },
 
-  getClassSetFromString: function (className) {
+  getBsClassSet: function () {
     var classes = {};
 
-    className = className || '';
-
-    className.split(' ').map(
-      function (cssClass) {
-        if (cssClass) {
-          classes[cssClass] = true;
-        }
-      }
-    );
-
-    return classes;
-  },
-
-  getClassSetFromClassName: function () {
-    return this.getClassSetFromString(this.props.className);
-  },
-
-  extendClassName: function (extraClasses) {
-    var prefix,
-        className,
-        classes = this.getClassSetFromClassName(),
-        bsClass,
-        bsStyle,
-        bsSize;
-
-    bsClass = this.props.bsClass && constants.CLASSES[this.props.bsClass];
+    var bsClass = this.props.bsClass && constants.CLASSES[this.props.bsClass];
     if (bsClass) {
       classes[bsClass] = true;
 
-      prefix = bsClass + '-';
+      var prefix = bsClass + '-';
 
-      bsSize = this.props.bsSize && constants.SIZES[this.props.bsSize];
+      var bsSize = this.props.bsSize && constants.SIZES[this.props.bsSize];
       if (bsSize) {
         classes[prefix + bsSize] = true;
       }
-      bsStyle = this.props.bsStyle && constants.STYLES[this.props.bsStyle];
+
+      var bsStyle = this.props.bsStyle && constants.STYLES[this.props.bsStyle];
       if (this.props.bsStyle) {
         classes[prefix + bsStyle] = true;
       }
@@ -58,13 +33,7 @@ var BootstrapMixin = {
       }
     }
 
-    if (extraClasses) {
-      classes = merge(classes, extraClasses);
-    }
-
-    className = React.addons.classSet(classes);
-
-    return className.replace(/\s+/, ' ');
+    return classes;
   }
 };
 

--- a/src/Button.jsx
+++ b/src/Button.jsx
@@ -1,7 +1,7 @@
 /** @jsx React.DOM */
 
 var React          = require('react');
-var merge          = require('react/lib/merge');
+var classSet       = require('react/lib/cx');
 var BootstrapMixin = require('./BootstrapMixin');
 
 var Button = React.createClass({
@@ -21,11 +21,11 @@ var Button = React.createClass({
     };
   },
 
-  renderAnchor: function (children, className, isDisabled) {
-    return (
+  renderAnchor: function (children, classes, isDisabled) {
+    return this.transferPropsTo(
       <a
         href={this.props.href}
-        className={className}
+        className={classSet(classes)}
         onClick={this.props.onClick}
         disabled={isDisabled}>
         {children}
@@ -33,11 +33,11 @@ var Button = React.createClass({
     );
   },
 
-  renderButton: function (children, className, isDisabled) {
-    return (
+  renderButton: function (children, classes, isDisabled) {
+    return this.transferPropsTo(
       <button
         type={this.props.type || "button"}
-        className={className}
+        className={classSet(classes)}
         onClick={this.props.onClick}
         disabled={isDisabled}>
         {children}
@@ -47,10 +47,10 @@ var Button = React.createClass({
 
   render: function () {
     var isDisabled = !!(this.props.isDisabled || this.props.isLoading);
-    var className = this.extendClassName({
-      disabled: isDisabled,
-      active: this.props.isActive
-    });
+
+    var classes = this.getBsClassSet();
+    classes['disabled'] = isDisabled;
+    classes['active'] = this.props.isActive;
 
     var children = this.props.isLoading ?
       this.props.loadingChildren : this.props.children;
@@ -58,7 +58,7 @@ var Button = React.createClass({
     var renderFuncName = (this.props.href) ?
       'renderAnchor' : 'renderButton';
 
-    return this[renderFuncName](children, className, isDisabled);
+    return this[renderFuncName](children, classes, isDisabled);
   }
 });
 

--- a/src/CollapsePanel.jsx
+++ b/src/CollapsePanel.jsx
@@ -1,8 +1,8 @@
 /** @jsx React.DOM */
 
-var React          = require('react/addons');
+var React          = require('react');
+var classSet       = require('react/lib/cx');
 var BootstrapMixin = require('./BootstrapMixin');
-var classSet       = React.addons.classSet;
 
 var CollapsePanel  = React.createClass({
   mixins: [BootstrapMixin],
@@ -41,7 +41,7 @@ var CollapsePanel  = React.createClass({
     var isOpen = (this.props.isStateful) ?
       this.state.isOpen : this.props.isOpen;
 
-    var panelClassName = this.extendClassName();
+    var panelClassName = classSet(this.getBsClassSet());
 
     var anchorClassName = classSet({
       "collapsed": !isOpen
@@ -53,7 +53,7 @@ var CollapsePanel  = React.createClass({
       "collapse": !isOpen
     });
 
-    return (
+    return this.transferPropsTo(
       <div className={panelClassName}>
         <div className="panel-heading">
           <HeadingClass

--- a/src/DropdownButton.jsx
+++ b/src/DropdownButton.jsx
@@ -1,9 +1,10 @@
 /** @jsx React.DOM */
 
-var React              = require('react/addons');
-var Button             = require('./Button');
-var BootstrapMixin     = require('./BootstrapMixin');
-var utils              = require('./utils');
+var React          = require('react');
+var classSet       = require('react/lib/cx');
+var Button         = require('./Button');
+var BootstrapMixin = require('./BootstrapMixin');
+var utils          = require('./utils');
 
 
 var DropdownButton = React.createClass({
@@ -73,25 +74,22 @@ var DropdownButton = React.createClass({
   },
 
   render: function () {
-    var groupClassName = React.addons.classSet({
+    var groupClassName = classSet({
       'btn-group': true,
       'open': this.state.open
     });
 
-    var className = this.extendClassName();
+    var className = classSet(this.getBsClassSet());
 
-    var menuItems = [];
-
-    this.props.children.forEach(function (child, i) {
-      menuItems.push(
-        utils.cloneWithProps(
+    var menuItems = this.props.children
+      .map(function (child, i) {
+        return utils.cloneWithProps(
           child,
           {
             onSelect: this.handleOptionSelect.bind(this, i)
           }
-        )
-      );
-    }.bind(this));
+        );
+      }, this);
 
 
     var title = this.props.isTitleHidden ?
@@ -110,8 +108,7 @@ var DropdownButton = React.createClass({
             className="dropdown-menu"
             role="menu"
             ref="menu"
-            aria-labelledby={this.props.id}
-          >
+            aria-labelledby={this.props.id}>
             {menuItems}
           </ul>
       </div>

--- a/src/Input.jsx
+++ b/src/Input.jsx
@@ -1,4 +1,7 @@
-var React = require('react/addons');
+/** @jsx React.DOM */
+
+var React    = require('react');
+var classSet = require('react/lib/cx');
 
 var INPUT_TYPES = [
   'text',
@@ -35,13 +38,16 @@ var Input = React.createClass({
   },
 
   renderInput: function () {
-    var className = 'form-control input-md';
+    var classes = {
+      'form-control': true,
+      'input-md': true
+    };
 
     return (
       <input
         id={this.props.id}
         type={this.props.type}
-        className={className}
+        className={classSet(classes)}
         placeholder={this.props.placeholder}
         ref="input"
       />
@@ -53,14 +59,13 @@ var Input = React.createClass({
   },
 
   render: function () {
-    var className = 'form-group';
-
-    if (this.state.error) {
-      className += ' has-error';
-    }
+    var classes = {
+      'form-group': true,
+      'has-error': !!this.state.error
+    };
 
     return (
-      <div className={className} onBlur={this.handleBlur} onFocus={this.handleFocus}>
+      <div className={classSet(classes)} onBlur={this.handleBlur} onFocus={this.handleFocus}>
         {this.renderInput()}
         {this.renderLabel()}
       </div>

--- a/src/MenuItem.jsx
+++ b/src/MenuItem.jsx
@@ -1,6 +1,6 @@
 /** @jsx React.DOM */
 
-var React          = require('react/addons');
+var React = require('react');
 
 var MenuItem = React.createClass({
   handleClick: function (e) {

--- a/src/SplitButton.jsx
+++ b/src/SplitButton.jsx
@@ -1,7 +1,7 @@
 /** @jsx React.DOM */
 
 var React          = require('react');
-var merge          = require('react/lib/merge');
+var classSet       = require('react/lib/cx');
 var BootstrapMixin = require('./BootstrapMixin');
 var Button         = require('./Button');
 var DropdownButton = require('./DropdownButton');
@@ -38,8 +38,9 @@ var SplitButton = React.createClass({
   },
 
   render: function () {
-    var classes = this.getClassSetFromClassName();
+    var classes = {};
 
+    classes[this.state.className] = true;
     classes['btn-group'] = !this.props.isInInputGroup;
     classes['input-group-btn'] = this.props.isInInputGroup;
 
@@ -47,10 +48,8 @@ var SplitButton = React.createClass({
       classes[this.props.bsVariation] = true;
     }
 
-    var className = React.addons.classSet(classes);
-
     return (
-      <div className={className}>
+      <div className={classSet(classes)}>
         {this.transferPropsTo(<Button onClick={this.handleClick}>{this.props.title}</Button>)}
         {this.transferPropsTo(
           <DropdownButton

--- a/src/Tab.jsx
+++ b/src/Tab.jsx
@@ -1,6 +1,7 @@
 /** @jsx React.DOM */
 
-var React = require('react/addons');
+var React    = require('react');
+var classSet = require('react/lib/cx');
 
 var Tab = React.createClass({
   handleClick: function () {
@@ -10,20 +11,20 @@ var Tab = React.createClass({
   },
 
   render: function () {
-    var className = React.addons.classSet({
+    var classes = {
       'nav': true,
       'nav-tab': true,
       'active': this.props.isActive
-    });
+    };
 
     return this.transferPropsTo(
-      <li className={className}>
+      <li className={classSet(classes)}>
         <a
           ref="button"
           href={this.props.id ? '#' + this.props.id : null}
           onClick={this.handleClick}>
-            {this.props.children}
-          </a>
+          {this.props.children}
+        </a>
       </li>
     );
   }

--- a/src/TabPane.jsx
+++ b/src/TabPane.jsx
@@ -1,16 +1,17 @@
 /** @jsx React.DOM */
 
-var React = require('react/addons');
+var React    = require('react');
+var classSet = require('react/lib/cx');
 
 var TabPane = React.createClass({
   render: function () {
-    var className = React.addons.classSet({
+    var classes = {
       'tab-pane': true,
       'open': this.props.isActive
-    });
+    };
 
     return this.transferPropsTo(
-      <div className={className}>
+      <div className={classSet(classes)}>
         {this.props.children}
       </div>
     );

--- a/src/TabbedArea.jsx
+++ b/src/TabbedArea.jsx
@@ -1,6 +1,6 @@
 /** @jsx React.DOM */
 
-var React              = require('react/addons');
+var React              = require('react');
 var BootstrapMixin     = require('./BootstrapMixin');
 var utils              = require('./utils');
 var Tab                = require('./Tab');

--- a/test/AlertSpec.jsx
+++ b/test/AlertSpec.jsx
@@ -1,16 +1,11 @@
 /** @jsx React.DOM */
 /*global describe, beforeEach, afterEach, it, assert */
 
-var React = require('react/addons');
-var Alert = require('../lib/Alert');
-
-var ReactTestUtils;
+var React          = require('react');
+var ReactTestUtils = require('react/lib/ReactTestUtils');
+var Alert          = require('../lib/Alert');
 
 describe('Alert', function () {
-  beforeEach(function() {
-    ReactTestUtils = React.addons.ReactTestUtils;
-  });
-
   it('Should output a alert with message', function () {
     var instance = Alert({}, <strong>Message</strong>);
     ReactTestUtils.renderIntoDocument(instance);

--- a/test/BootstrapMixinSpec.jsx
+++ b/test/BootstrapMixinSpec.jsx
@@ -1,16 +1,14 @@
 /** @jsx React.DOM */
 /*global describe, beforeEach, afterEach, it, assert */
 
-var React = require('react/addons');
+var React          = require('react');
+var ReactTestUtils = require('react/lib/ReactTestUtils');
 var BootstrapMixin = require('../lib/BootstrapMixin');
 
-var ReactTestUtils;
 var Component;
 
-describe('Button', function () {
+describe('BootstrapMixin', function () {
   beforeEach(function() {
-    ReactTestUtils = React.addons.ReactTestUtils;
-
     Component = React.createClass({
       mixins: [BootstrapMixin],
 
@@ -22,124 +20,110 @@ describe('Button', function () {
     });
   });
 
-  describe('#extendClassName', function () {
+  describe('#getBsClassSet', function () {
     it('should return blank', function () {
       var instance = Component({}, 'content');
-      assert.equal(instance.extendClassName(), '');
-    });
-
-    it('should return props.className', function () {
-      var className = 'css-class css-class2';
-      var instance = Component({className: className}, 'content');
-      assert.equal(instance.extendClassName(), className);
+      assert.deepEqual(instance.getBsClassSet(), {});
     });
 
     it('should return "col"', function () {
       var instance = Component({bsClass: 'column'}, 'content');
-      assert.equal(instance.extendClassName(), 'col');
+      assert.deepEqual(instance.getBsClassSet(), {'col': true});
     });
 
     it('should return "btn"', function () {
       var instance = Component({bsClass: 'button'}, 'content');
-      assert.equal(instance.extendClassName(), 'btn');
+      assert.deepEqual(instance.getBsClassSet(), {'btn': true});
     });
 
     it('should return "btn-group"', function () {
       var instance = Component({bsClass: 'button-group'}, 'content');
-      assert.equal(instance.extendClassName(), 'btn-group');
+      assert.deepEqual(instance.getBsClassSet(), {'btn-group': true});
     });
 
     it('should return "label"', function () {
       var instance = Component({bsClass: 'label'}, 'content');
-      assert.equal(instance.extendClassName(), 'label');
+      assert.deepEqual(instance.getBsClassSet(), {'label': true});
     });
 
     it('should return "alert"', function () {
       var instance = Component({bsClass: 'alert'}, 'content');
-      assert.equal(instance.extendClassName(), 'alert');
+      assert.deepEqual(instance.getBsClassSet(), {'alert': true});
     });
 
     it('should return "input-group"', function () {
       var instance = Component({bsClass: 'input-group'}, 'content');
-      assert.equal(instance.extendClassName(), 'input-group');
+      assert.deepEqual(instance.getBsClassSet(), {'input-group': true});
     });
 
     it('should return "form"', function () {
       var instance = Component({bsClass: 'form'}, 'content');
-      assert.equal(instance.extendClassName(), 'form');
+      assert.deepEqual(instance.getBsClassSet(), {'form': true});
     });
 
     it('should return "panel"', function () {
       var instance = Component({bsClass: 'panel'}, 'content');
-      assert.equal(instance.extendClassName(), 'panel');
+      assert.deepEqual(instance.getBsClassSet(), {'panel': true});
     });
 
     it('should return "btn btn-default"', function () {
       var instance = Component({bsClass: 'button', bsStyle: 'default'}, 'content');
-      assert.equal(instance.extendClassName(), 'btn btn-default');
+      assert.deepEqual(instance.getBsClassSet(), {'btn': true, 'btn-default': true});
     });
 
     it('should return "btn btn-default"', function () {
       var instance = Component({bsClass: 'button', bsStyle: 'default'}, 'content');
-      assert.equal(instance.extendClassName(), 'btn btn-default');
+      assert.deepEqual(instance.getBsClassSet(), {'btn': true, 'btn-default': true});
     });
 
     it('should return "btn btn-primary"', function () {
       var instance = Component({bsClass: 'button', bsStyle: 'primary'}, 'content');
-      assert.equal(instance.extendClassName(), 'btn btn-primary');
+      assert.deepEqual(instance.getBsClassSet(), {'btn': true, 'btn-primary': true});
     });
 
     it('should return "btn btn-success"', function () {
       var instance = Component({bsClass: 'button', bsStyle: 'success'}, 'content');
-      assert.equal(instance.extendClassName(), 'btn btn-success');
+      assert.deepEqual(instance.getBsClassSet(), {'btn': true, 'btn-success': true});
     });
 
     it('should return "btn btn-info"', function () {
       var instance = Component({bsClass: 'button', bsStyle: 'info'}, 'content');
-      assert.equal(instance.extendClassName(), 'btn btn-info');
+      assert.deepEqual(instance.getBsClassSet(), {'btn': true, 'btn-info': true});
     });
 
     it('should return "btn btn-link"', function () {
       var instance = Component({bsClass: 'button', bsStyle: 'link'}, 'content');
-      assert.equal(instance.extendClassName(), 'btn btn-link');
+      assert.deepEqual(instance.getBsClassSet(), {'btn': true, 'btn-link': true});
     });
 
     it('should return "btn btn-inline"', function () {
       var instance = Component({bsClass: 'button', bsStyle: 'inline'}, 'content');
-      assert.equal(instance.extendClassName(), 'btn btn-inline');
+      assert.deepEqual(instance.getBsClassSet(), {'btn': true, 'btn-inline': true});
     });
 
     it('should return "btn btn-lg"', function () {
       var instance = Component({bsClass: 'button', bsSize: 'large'}, 'content');
-      assert.equal(instance.extendClassName(), 'btn btn-lg');
+      assert.deepEqual(instance.getBsClassSet(), {'btn': true, 'btn-lg': true});
     });
 
     it('should return "btn btn-md"', function () {
       var instance = Component({bsClass: 'button', bsSize: 'medium'}, 'content');
-      assert.equal(instance.extendClassName(), 'btn btn-md');
+      assert.deepEqual(instance.getBsClassSet(), {'btn': true, 'btn-md': true});
     });
 
     it('should return "btn btn-sm"', function () {
       var instance = Component({bsClass: 'button', bsSize: 'small'}, 'content');
-      assert.equal(instance.extendClassName(), 'btn btn-sm');
+      assert.deepEqual(instance.getBsClassSet(), {'btn': true, 'btn-sm': true});
     });
 
     it('should return "btn btn-xs"', function () {
       var instance = Component({bsClass: 'button', bsSize: 'xsmall'}, 'content');
-      assert.equal(instance.extendClassName(), 'btn btn-xs');
+      assert.deepEqual(instance.getBsClassSet(), {'btn': true, 'btn-xs': true});
     });
 
     it('should return "btn btn-variation"', function () {
       var instance = Component({bsClass: 'button', bsVariation: 'variation'}, 'content');
-      assert.equal(instance.extendClassName(), 'btn btn-variation');
-    });
-
-    it('should accept extra classes which override everything', function () {
-      var instance = Component({bsClass: 'button', bsVariation: 'variation'}, 'content');
-      assert.equal(instance.extendClassName({
-        'btn-variation': false,
-        'extra-class': true
-      }), 'btn extra-class');
+      assert.deepEqual(instance.getBsClassSet(), {'btn': true, 'btn-variation': true});
     });
   });
 });

--- a/test/ButtonSpec.jsx
+++ b/test/ButtonSpec.jsx
@@ -1,16 +1,12 @@
 /** @jsx React.DOM */
 /*global describe, beforeEach, afterEach, it, assert */
 
-var React = require('react/addons');
-var Button = require('../lib/Button');
+var React          = require('react');
+var ReactTestUtils = require('react/lib/ReactTestUtils');
+var Button         = require('../lib/Button');
 
-var ReactTestUtils;
 
 describe('Button', function () {
-  beforeEach(function() {
-    ReactTestUtils = React.addons.ReactTestUtils;
-  });
-
   it('Should output a button', function () {
     var instance = Button({}, 'Title');
     ReactTestUtils.renderIntoDocument(instance);

--- a/test/DropdownButtonSpec.jsx
+++ b/test/DropdownButtonSpec.jsx
@@ -1,17 +1,12 @@
 /** @jsx React.DOM */
 /*global describe, beforeEach, afterEach, it, assert */
 
-var React          = require('react/addons');
+var React          = require('react');
+var ReactTestUtils = require('react/lib/ReactTestUtils');
 var DropdownButton = require('../lib/DropdownButton');
 var MenuItem       = require('../lib/MenuItem');
 
-var ReactTestUtils;
-
 describe('DropdownButton', function () {
-  beforeEach(function() {
-    ReactTestUtils = React.addons.ReactTestUtils;
-  });
-
   it('Should render correctly', function () {
     var instance = (
         <DropdownButton title="Title">

--- a/test/MixinsSpec.jsx
+++ b/test/MixinsSpec.jsx
@@ -1,9 +1,10 @@
 /** @jsx React.DOM */
 /*global describe, beforeEach, afterEach, it, assert */
 
-var React = require('react/addons');
-
-var BootstrapMixin = require('../lib/BootstrapMixin');
+var React            = require('react');
+var ReactTestUtils   = require('react/lib/ReactTestUtils');
+var createObjectFrom = require('react/lib/createObjectFrom');
+var BootstrapMixin   = require('../lib/BootstrapMixin');
 
 var LargeMixin   = require('../lib/LargeMixin');
 var MediumMixin  = require('../lib/MediumMixin');
@@ -19,25 +20,20 @@ var DangerMixin  = require('../lib/DangerMixin');
 var LinkMixin    = require('../lib/LinkMixin');
 var InlineMixin  = require('../lib/InlineMixin');
 
-var ReactTestUtils;
-
-describe('Button', function () {
-  beforeEach(function() {
-    ReactTestUtils = React.addons.ReactTestUtils;
-  });
-
+describe('Mixins', function () {
   var testMixins = function (TestMixins, expectedClassName) {
-      var Component = React.createClass({
-        mixins: [BootstrapMixin].concat(TestMixins),
+    var expectedClasses = createObjectFrom(expectedClassName.split(' '));
+    var Component = React.createClass({
+      mixins: [BootstrapMixin].concat(TestMixins),
 
-        render: function () {
-          return React.DOM.button();
-        }
-      });
-      var instance = Component({bsClass: 'button'}, 'content');
-      ReactTestUtils.renderIntoDocument(instance);
+      render: function () {
+        return React.DOM.button();
+      }
+    });
+    var instance = Component({bsClass: 'button'}, 'content');
+    ReactTestUtils.renderIntoDocument(instance);
 
-      assert.equal(instance.extendClassName(), expectedClassName);
+    assert.deepEqual(instance.getBsClassSet(), expectedClasses);
   };
 
   describe('LargeMixin#extendClassName', function () {

--- a/test/SplitButtonSpec.jsx
+++ b/test/SplitButtonSpec.jsx
@@ -1,16 +1,11 @@
 /** @jsx React.DOM */
 /*global describe, beforeEach, afterEach, it, assert */
 
-var React = require('react/addons');
-var SplitButton = require('../lib/SplitButton');
-
-var ReactTestUtils;
+var React          = require('react');
+var ReactTestUtils = require('react/lib/ReactTestUtils');
+var SplitButton    = require('../lib/SplitButton');
 
 describe('SplitButton', function () {
-  beforeEach(function() {
-    ReactTestUtils = React.addons.ReactTestUtils;
-  });
-
   it('Should throw if missing title', function (done) {
     try {
       var instance = SplitButton({});

--- a/test/TabbedAreaSpec.jsx
+++ b/test/TabbedAreaSpec.jsx
@@ -1,17 +1,12 @@
 /** @jsx React.DOM */
 /*global describe, beforeEach, afterEach, it, assert */
 
-var React      = require('react/addons');
-var TabbedArea = require('../lib/TabbedArea');
-var TabPane    = require('../lib/TabPane');
-
-var ReactTestUtils;
+var React          = require('react');
+var ReactTestUtils = require('react/lib/ReactTestUtils');
+var TabbedArea     = require('../lib/TabbedArea');
+var TabPane        = require('../lib/TabPane');
 
 describe('TabbedArea', function () {
-  beforeEach(function() {
-    ReactTestUtils = React.addons.ReactTestUtils;
-  });
-
   it('Should show the correct tab initially', function () {
     var instance = (
         <TabbedArea activeIndex={0}>


### PR DESCRIPTION
Hi!

I have put together a RFC for a refactor of the way classNames are used as discussed in #3. I think this way provides more flexibility for components with a minimal need for additional boilerplate code.

This are changes include:
1. Use `react/lib/cx` and `react/lib/ReactTestUtils` in favour of `react/addons`, provides more efficient builds.
2. Remove `BootstrapMixin#getClassSetFromClassName()` in favour of using `React#transferPropsTo()` to mixin `state.className`.
3. Create `BootstrapMixin#getBsClassSet()` based on `BootstrapMixin#extendClassName()` but returns a `classSet` instead of a `className` and doesn't mixin `state.className`.
4. Refactor components to use `classSet` to define component className's.
5. Minor whitespace cleanup.
