### PR TITLE
Refactor the TabbedArea component

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ function handleSelect (selectedIndex) {
 var TabbedArea = require('react-bootstrap/lib/TabbedArea');
 var TabPane    = require('react-bootstrap/lib/TabPane');
 
-var index = 0;
+var key = 0;
 
-function handleSelect (selectedIndex) {
-    index = selectedIndex;
+function handleSelect (selectedKey) {
+  key = selectedKey;
 }
 
-<TabbedArea title="Title" activeIndex={index} onSelect={handleSelect}>
-  <TabPane title="Tab 1" key="1">TabPane 1 content</TabPane>
-  <TabPane title="Tab 1" key="2">TabPane 2 content</TabPane>
+<TabbedArea title="Title" activeKey={key} onSelect={handleSelect}>
+  <TabPane tab="Tab 1" key={1}>TabPane 1 content</TabPane>
+  <TabPane tab={<strong>Tab 2</strong>} key={2}>TabPane 2 content</TabPane>
 </TabbedArea>
 ```
 

--- a/lib/TabbedArea.js
+++ b/lib/TabbedArea.js
@@ -8,65 +8,60 @@ var Tab                = require('./Tab');
 var TabbedArea = React.createClass({displayName: 'TabbedArea',
   mixins: [BootstrapMixin],
 
-  tabs : [],
-
-  panes: [],
-
-  handleSelect: function (i) {
-    if (typeof this.props.onSelect === 'function') {
-      this.props.onSelect(i);
-    }
-  },
-
-  createChild: function (child, i) {
-    var isActive = (i === this.props.activeIndex);
-
-    this.panes.push(
-      utils.cloneWithProps(
-        child,
-        {
-          isActive: isActive
-        }
-      )
-    );
-
-    if (child.props.tab) {
-      this.panes.push(Tab({
-        id: child.props.id,
-        ref: 'tab' + i,
-        key: 'tab' + i,
-        isActive: isActive,
-        onSelect: this.handleSelect.bind(this, i)
-      }, child.props.tab));
-    }
-  },
-
-  createChildren: function () {
-    var children = this.props.children;
-
-    if (!utils.isArray(children)) {
-      children = [children]
-    }
-
-    this.tabs = [];
-    this.panes = [];
-
-    this.props.children.forEach(this.createChild);
+  propTypes: {
+    onSelect: React.PropTypes.func
   },
 
   render: function () {
-    this.createChildren();
+    var children = this.props.children;
+
+    if (!Array.isArray(children)) {
+      children = [children]
+    }
+
+    function hasTab (child) {
+      return !!child.props.tab;
+    }
 
     return this.transferPropsTo(
       React.DOM.div(null, 
         React.DOM.ul( {className:"nav nav-tabs", ref:"tabs"}, 
-          this.tabs
+          children.filter(hasTab).map(this.renderTab)
         ),
         React.DOM.div( {id:this.props.id, ref:"panes"}, 
-          this.panes
+          children.map(this.renderPane)
         )
       )
     );
+  },
+
+  renderPane: function (child) {
+    return utils.cloneWithProps(
+        child,
+        {
+          isActive: (child.props.key === this.props.activeKey)
+        }
+      );
+  },
+
+  renderTab: function (child) {
+    var key = child.props.key;
+    return (
+      Tab(
+        {id:child.props.id,
+        ref:'tab' + key,
+        key:key,
+        isActive:key === this.props.activeKey,
+        onSelect:this.handleSelect.bind(this, key)}, 
+        child.props.tab
+      )
+    );
+  },
+
+  handleSelect: function (key) {
+    if (this.props.onSelect) {
+      this.props.onSelect(key);
+    }
   }
 });
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,9 +1,6 @@
 var ReactPropTransferer = require('react/lib/ReactPropTransferer');
 
 module.exports = {
-  isArray: function (obj) {
-    return (Object.prototype.toString.call(obj) === '[object Array]');
-  },
 
   /**
    * Sometimes you want to change the props of a child passed to you. Usually
@@ -19,4 +16,4 @@ module.exports = {
       ReactPropTransferer.mergeProps(child.props, props)
     );
   }
-}
+};

--- a/src/TabbedArea.jsx
+++ b/src/TabbedArea.jsx
@@ -8,65 +8,60 @@ var Tab                = require('./Tab');
 var TabbedArea = React.createClass({
   mixins: [BootstrapMixin],
 
-  tabs : [],
-
-  panes: [],
-
-  handleSelect: function (i) {
-    if (typeof this.props.onSelect === 'function') {
-      this.props.onSelect(i);
-    }
-  },
-
-  createChild: function (child, i) {
-    var isActive = (i === this.props.activeIndex);
-
-    this.panes.push(
-      utils.cloneWithProps(
-        child,
-        {
-          isActive: isActive
-        }
-      )
-    );
-
-    if (child.props.tab) {
-      this.panes.push(Tab({
-        id: child.props.id,
-        ref: 'tab' + i,
-        key: 'tab' + i,
-        isActive: isActive,
-        onSelect: this.handleSelect.bind(this, i)
-      }, child.props.tab));
-    }
-  },
-
-  createChildren: function () {
-    var children = this.props.children;
-
-    if (!utils.isArray(children)) {
-      children = [children]
-    }
-
-    this.tabs = [];
-    this.panes = [];
-
-    this.props.children.forEach(this.createChild);
+  propTypes: {
+    onSelect: React.PropTypes.func
   },
 
   render: function () {
-    this.createChildren();
+    var children = this.props.children;
+
+    if (!Array.isArray(children)) {
+      children = [children]
+    }
+
+    function hasTab (child) {
+      return !!child.props.tab;
+    }
 
     return this.transferPropsTo(
       <div>
         <ul className="nav nav-tabs" ref="tabs">
-          {this.tabs}
+          {children.filter(hasTab).map(this.renderTab)}
         </ul>
         <div id={this.props.id} ref="panes">
-          {this.panes}
+          {children.map(this.renderPane)}
         </div>
       </div>
     );
+  },
+
+  renderPane: function (child) {
+    return utils.cloneWithProps(
+        child,
+        {
+          isActive: (child.props.key === this.props.activeKey)
+        }
+      );
+  },
+
+  renderTab: function (child) {
+    var key = child.props.key;
+    return (
+      <Tab
+        id={child.props.id}
+        ref={'tab' + key}
+        key={key}
+        isActive={key === this.props.activeKey}
+        onSelect={this.handleSelect.bind(this, key)}>
+        {child.props.tab}
+      </Tab>
+    );
+  },
+
+  handleSelect: function (key) {
+    if (this.props.onSelect) {
+      this.props.onSelect(key);
+    }
   }
 });
 

--- a/src/utils.jsx
+++ b/src/utils.jsx
@@ -1,9 +1,6 @@
 var ReactPropTransferer = require('react/lib/ReactPropTransferer');
 
 module.exports = {
-  isArray: function (obj) {
-    return (Object.prototype.toString.call(obj) === '[object Array]');
-  },
 
   /**
    * Sometimes you want to change the props of a child passed to you. Usually
@@ -19,4 +16,4 @@ module.exports = {
       ReactPropTransferer.mergeProps(child.props, props)
     );
   }
-}
+};

--- a/test/TabbedAreaSpec.jsx
+++ b/test/TabbedAreaSpec.jsx
@@ -7,50 +7,86 @@ var TabbedArea     = require('../lib/TabbedArea');
 var TabPane        = require('../lib/TabPane');
 
 describe('TabbedArea', function () {
-  it('Should show the correct tab initially', function () {
+  it('Should show the correct tab', function () {
     var instance = (
-        <TabbedArea activeIndex={0}>
-          <TabPane tab="Tab 1" key="1">Tab 1 content</TabPane>
-          <TabPane tab="Tab 2" key="2">Tab 2 content</TabPane>
+        <TabbedArea activeKey={1}>
+          <TabPane tab="Tab 1" key={1}>Tab 1 content</TabPane>
+          <TabPane tab="Tab 2" key={2}>Tab 2 content</TabPane>
         </TabbedArea>
       );
 
     ReactTestUtils.renderIntoDocument(instance);
-    assert(instance.refs.panes.getDOMNode().children[0].className.match(/\bopen\b/));
-    assert(!instance.refs.panes.getDOMNode().children[1].className.match(/\bopen\b/));
-    assert(instance.refs.tab0.getDOMNode().className.match(/\active\b/));
-    assert(!instance.refs.tab1.getDOMNode().className.match(/\active\b/));
+    assert.ok(instance.refs.panes.getDOMNode().children[0].className.match(/\bopen\b/));
+    assert.notOk(instance.refs.panes.getDOMNode().children[1].className.match(/\bopen\b/));
+    assert.ok(instance.refs.tab1.getDOMNode().className.match(/\active\b/));
+    assert.notOk(instance.refs.tab2.getDOMNode().className.match(/\active\b/));
+  });
+
+	it('Should only show the tabs with tab prop', function () {
+    var instance = (
+        <TabbedArea activeKey={3}>
+          <TabPane tab="Tab 1" key={1}>Tab 1 content</TabPane>
+          <TabPane key={2}>Tab 2 content</TabPane>
+          <TabPane tab="Tab 2" key={3}>Tab 3 content</TabPane>
+        </TabbedArea>
+      );
+
+    ReactTestUtils.renderIntoDocument(instance);
+    var panes = instance.refs.panes.getDOMNode();
+    assert.equal(panes.children.length, 3);
+    assert.notOk(panes.children[0].className.match(/\bopen\b/));
+    assert.notOk(panes.children[1].className.match(/\bopen\b/));
+    assert.ok(panes.children[2].className.match(/\bopen\b/));
+    var tabs = instance.refs.tabs.getDOMNode();
+    assert.equal(tabs.children.length, 2);
+    assert.notOk(tabs.children[0].className.match(/\active\b/));
+    assert.ok(tabs.children[1].className.match(/\active\b/));
+  });
+
+	it('Should allow tab to have React components', function () {
+    var tabTitle = (
+      <strong>Tab 2</strong>
+      );
+    var instance = (
+        <TabbedArea activeKey={3}>
+          <TabPane tab="Tab 1" key={1}>Tab 1 content</TabPane>
+          <TabPane tab={tabTitle} key={2}>Tab 2 content</TabPane>
+        </TabbedArea>
+      );
+
+    ReactTestUtils.renderIntoDocument(instance);
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithTag(instance.refs.tab2, 'strong'));
   });
 
   it('Should call onSelect when tab is selected', function (done) {
-    var onSelect = function (index) {
-        assert.equal(index, 1);
+    var onSelect = function (key) {
+        assert.equal(key, 2);
         done();
       },
       instance = (
-        <TabbedArea onSelect={onSelect} activeIndex={0}>
-          <TabPane tab="Tab 1" key="1">Tab 1 content</TabPane>
-          <TabPane tab="Tab 2" key="2">Tab 2 content</TabPane>
+        <TabbedArea onSelect={onSelect} activeKey={1}>
+          <TabPane tab="Tab 1" key={1}>Tab 1 content</TabPane>
+          <TabPane tab="Tab 2" key={2}>Tab 2 content</TabPane>
         </TabbedArea>
       );
 
     ReactTestUtils.renderIntoDocument(instance);
-    ReactTestUtils.Simulate.click(instance.refs.tab1.refs.button.getDOMNode());
+    ReactTestUtils.Simulate.click(instance.refs.tab2.refs.button.getDOMNode());
   });
 
-  it('should have children with the correct props', function () {
+  it('Should have children with the correct props', function () {
     var instance = (
-        <TabbedArea activeIndex={0}>
-          <TabPane tab="Tab 1" className="custom" id="pane0id" key="1">Tab 1 content</TabPane>
-          <TabPane tab="Tab 2"  key="2">Tab 2 content</TabPane>
+        <TabbedArea activeKey={1}>
+          <TabPane tab="Tab 1" className="custom" id="pane0id" key={1}>Tab 1 content</TabPane>
+          <TabPane tab="Tab 2" key={2}>Tab 2 content</TabPane>
         </TabbedArea>
       );
 
     ReactTestUtils.renderIntoDocument(instance);
-    assert(instance.refs.panes.getDOMNode().children[0].className.match(/\bcustom\b/));
+    assert.ok(instance.refs.panes.getDOMNode().children[0].className.match(/\bcustom\b/));
     assert.equal(instance.refs.panes.getDOMNode().children[0].id, 'pane0id');
     assert.equal(
-      instance.refs.tab0.refs.button.getDOMNode().getAttribute('href'),
+      instance.refs.tab1.refs.button.getDOMNode().getAttribute('href'),
       '#pane0id'
     );
   });


### PR DESCRIPTION
Hi Again!

I was having a play with the TabbedArea component and ended up making a few changes:
1. Use `key` instead of array index, this allows Tabs to be reordered without updated without needing to working the new `activeIndex`.
2. Use render functions instead of pushing to arrays stored on the component, this is more consistent with the other components.
3. Removed `utils#isArray()` we should be able to rely on an es5 environment since [React itself requires this](http://facebook.github.io/react/docs/working-with-the-browser.html#browser-support-and-polyfills).

Let me know what you think/ merge.
