### PR TITLE
Allow TabbedArea to control its own state.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,17 +44,29 @@ function handleSelect (selectedIndex) {
 
 ### <a name="Tabs"></a>Tabs
 
+#### Controlled
 ```
 var TabbedArea = require('react-bootstrap/lib/TabbedArea');
 var TabPane    = require('react-bootstrap/lib/TabPane');
 
-var key = 0;
+var key = 1;
 
 function handleSelect (selectedKey) {
   key = selectedKey;
 }
 
 <TabbedArea title="Title" activeKey={key} onSelect={handleSelect}>
+  <TabPane tab="Tab 1" key={1}>TabPane 1 content</TabPane>
+  <TabPane tab={<strong>Tab 2</strong>} key={2}>TabPane 2 content</TabPane>
+</TabbedArea>
+```
+
+#### Uncontrolled
+```
+var TabbedArea = require('react-bootstrap/lib/TabbedArea');
+var TabPane    = require('react-bootstrap/lib/TabPane');
+
+<TabbedArea title="Title" initialActiveKey={1}>
   <TabPane tab="Tab 1" key={1}>TabPane 1 content</TabPane>
   <TabPane tab={<strong>Tab 2</strong>} key={2}>TabPane 2 content</TabPane>
 </TabbedArea>

--- a/lib/TabbedArea.js
+++ b/lib/TabbedArea.js
@@ -12,6 +12,20 @@ var TabbedArea = React.createClass({displayName: 'TabbedArea',
     onSelect: React.PropTypes.func
   },
 
+  getInitialState: function () {
+    var initialActiveKey = this.props.initialActiveKey;
+
+    if (initialActiveKey == null) {
+      var children = this.props.children;
+      initialActiveKey =
+        Array.isArray(children) ? children[0].props.key : children.props.key;
+    }
+
+    return {
+      activeKey: initialActiveKey
+    };
+  },
+
   render: function () {
     var children = this.props.children;
 
@@ -36,32 +50,47 @@ var TabbedArea = React.createClass({displayName: 'TabbedArea',
   },
 
   renderPane: function (child) {
+    var activeKey =
+      this.props.activeKey != null ? this.props.activeKey : this.state.activeKey;
     return utils.cloneWithProps(
         child,
         {
-          isActive: (child.props.key === this.props.activeKey)
+          isActive: (child.props.key === activeKey)
         }
       );
   },
 
   renderTab: function (child) {
+    var activeKey =
+      this.props.activeKey != null ? this.props.activeKey : this.state.activeKey;
     var key = child.props.key;
     return (
       Tab(
         {id:child.props.id,
         ref:'tab' + key,
         key:key,
-        isActive:key === this.props.activeKey,
+        isActive:key === activeKey,
         onSelect:this.handleSelect.bind(this, key)}, 
         child.props.tab
       )
     );
   },
 
+  shouldComponentUpdate: function() {
+    // Defer any updates to this component during the `onSelect` handler.
+    return !this._isChanging;
+  },
+
   handleSelect: function (key) {
     if (this.props.onSelect) {
+      this._isChanging = true;
       this.props.onSelect(key);
+      this._isChanging = false;
     }
+
+    this.setState({
+      activeKey: key
+    });
   }
 });
 

--- a/src/TabbedArea.jsx
+++ b/src/TabbedArea.jsx
@@ -12,6 +12,20 @@ var TabbedArea = React.createClass({
     onSelect: React.PropTypes.func
   },
 
+  getInitialState: function () {
+    var initialActiveKey = this.props.initialActiveKey;
+
+    if (initialActiveKey == null) {
+      var children = this.props.children;
+      initialActiveKey =
+        Array.isArray(children) ? children[0].props.key : children.props.key;
+    }
+
+    return {
+      activeKey: initialActiveKey
+    };
+  },
+
   render: function () {
     var children = this.props.children;
 
@@ -36,32 +50,47 @@ var TabbedArea = React.createClass({
   },
 
   renderPane: function (child) {
+    var activeKey =
+      this.props.activeKey != null ? this.props.activeKey : this.state.activeKey;
     return utils.cloneWithProps(
         child,
         {
-          isActive: (child.props.key === this.props.activeKey)
+          isActive: (child.props.key === activeKey)
         }
       );
   },
 
   renderTab: function (child) {
+    var activeKey =
+      this.props.activeKey != null ? this.props.activeKey : this.state.activeKey;
     var key = child.props.key;
     return (
       <Tab
         id={child.props.id}
         ref={'tab' + key}
         key={key}
-        isActive={key === this.props.activeKey}
+        isActive={key === activeKey}
         onSelect={this.handleSelect.bind(this, key)}>
         {child.props.tab}
       </Tab>
     );
   },
 
+  shouldComponentUpdate: function() {
+    // Defer any updates to this component during the `onSelect` handler.
+    return !this._isChanging;
+  },
+
   handleSelect: function (key) {
     if (this.props.onSelect) {
+      this._isChanging = true;
       this.props.onSelect(key);
+      this._isChanging = false;
     }
+
+    this.setState({
+      activeKey: key
+    });
   }
 });
 

--- a/test/TabbedAreaSpec.jsx
+++ b/test/TabbedAreaSpec.jsx
@@ -91,4 +91,56 @@ describe('TabbedArea', function () {
     );
   });
 
+  it('Should show the correct initial tab', function () {
+    var instance = (
+        <TabbedArea initialActiveKey={2}>
+          <TabPane tab="Tab 1" key={1}>Tab 1 content</TabPane>
+          <TabPane tab="Tab 2" key={2}>Tab 2 content</TabPane>
+        </TabbedArea>
+      );
+
+    ReactTestUtils.renderIntoDocument(instance);
+    assert.notOk(instance.refs.panes.getDOMNode().children[0].className.match(/\bopen\b/));
+    assert.ok(instance.refs.panes.getDOMNode().children[1].className.match(/\bopen\b/));
+    assert.notOk(instance.refs.tab1.getDOMNode().className.match(/\active\b/));
+    assert.ok(instance.refs.tab2.getDOMNode().className.match(/\active\b/));
+  });
+
+  it('Should show the correct first tab with no active key value', function () {
+    var instance = (
+        <TabbedArea>
+          <TabPane tab="Tab 1" key={1}>Tab 1 content</TabPane>
+          <TabPane tab="Tab 2" key={2}>Tab 2 content</TabPane>
+        </TabbedArea>
+      );
+
+    ReactTestUtils.renderIntoDocument(instance);
+    assert.ok(instance.refs.panes.getDOMNode().children[0].className.match(/\bopen\b/));
+    assert.notOk(instance.refs.panes.getDOMNode().children[1].className.match(/\bopen\b/));
+    assert.ok(instance.refs.tab1.getDOMNode().className.match(/\active\b/));
+    assert.notOk(instance.refs.tab2.getDOMNode().className.match(/\active\b/));
+  });
+
+  it('Should show the correct tab when selected', function (done) {
+    var instance = (
+        <TabbedArea initialActiveKey={2}>
+          <TabPane tab="Tab 1" key={1}>Tab 1 content</TabPane>
+          <TabPane tab="Tab 2" key={2}>Tab 2 content</TabPane>
+        </TabbedArea>
+      );
+
+    // Override `componentDidUpdate` for now, but this should be replaced
+    // with `ReactTestUtils#nextUpdate()` when it is merged.
+    // @see https://github.com/facebook/react/pull/948
+    instance.componentDidUpdate = function () {
+      assert.ok(instance.refs.panes.getDOMNode().children[0].className.match(/\bopen\b/));
+      assert.notOk(instance.refs.panes.getDOMNode().children[1].className.match(/\bopen\b/));
+      assert.ok(instance.refs.tab1.getDOMNode().className.match(/\active\b/));
+      assert.notOk(instance.refs.tab2.getDOMNode().className.match(/\active\b/));
+      done();
+    };
+
+    ReactTestUtils.renderIntoDocument(instance);
+    ReactTestUtils.Simulate.click(instance.refs.tab1.refs.button.getDOMNode());
+  });
 });


### PR DESCRIPTION
This has the following changes:
1. Added `initialActiveKey` prop for controlled state.
2. Determine initial state from first child if not set.
3. Suppress change events during the `onSelect` callback, then force a render via setState.
