### PR TITLE
Docs site playground component unmount

### DIFF
--- a/docs/src/ReactPlayground.js
+++ b/docs/src/ReactPlayground.js
@@ -191,6 +191,13 @@ var ReactPlayground = React.createClass({
     }
   },
 
+  componentWillUnmount: function() {
+    var mountNode = this.refs.mount.getDOMNode();
+    try {
+      React.unmountComponentAtNode(mountNode);
+    } catch (e) { }
+  },
+
   executeCode: function() {
     var mountNode = this.refs.mount.getDOMNode();
 


### PR DESCRIPTION
Minor docs bugfix which unmount's examples on react-playground unmount, this is necessary to cleanup `Modal`s and `Overlay`s added to the body when the page changes.
