### PR TITLE
Only transfer props the TabbedArea Nav

### DIFF
--- a/src/TabbedArea.jsx
+++ b/src/TabbedArea.jsx
@@ -57,11 +57,15 @@ var TabbedArea = React.createClass({
     var activeKey =
       this.props.activeKey != null ? this.props.activeKey : this.state.activeKey;
 
-    return this.transferPropsTo(
-      <div>
-        <Nav bsStyle="tabs" activeKey={activeKey} onSelect={this.handleSelect} ref="tabs">
+    var nav = this.transferPropsTo(
+      <Nav bsStyle="tabs" activeKey={activeKey} onSelect={this.handleSelect} ref="tabs">
           {utils.modifyChildren(utils.filterChildren(this.props.children, hasTab), this.renderTab)}
-        </Nav>
+      </Nav>
+    );
+
+    return (
+      <div>
+        {nav}
         <div id={this.props.id} className="tab-content" ref="panes">
           {utils.modifyChildren(this.props.children, this.renderPane)}
         </div>


### PR DESCRIPTION
I ran into an issue : I had a form inside of a TabPane, every time I'd click an input field inside that form, handleSelect would get called, hence the activeKey was set to a synthetic event and my tabs "disappeared".

Transferring props only to the nav fixed that (and I don't see the point in transferring them to all children).
