### PR TITLE
Only transfer props to the Panel heading

### DIFF
--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -128,7 +128,7 @@ var Panel = React.createClass({
     var classes = this.getBsClassSet();
     classes['panel'] = true;
 
-    return this.transferPropsTo(
+    return (
       <div className={classSet(classes)} id={this.props.isCollapsable ? null : this.props.id}>
         {this.renderHeading()}
         {this.props.isCollapsable ? this.renderCollapsableBody() : this.renderBody()}


### PR DESCRIPTION
I stumbled onto another problem related to forms inside a React Bootstrap component : 

When I had a form inside a collapsible Panel (inside and Accordion), clicking on an input of the form would close the Panel (as onClick or onSelect was transferred I guess).
