### PR TITLE
Hide Modal when backdrop is clicked

### DIFF
--- a/src/Modal.jsx
+++ b/src/Modal.jsx
@@ -43,7 +43,6 @@ var Modal = React.createClass({
         role="dialog"
         style={modalStyle}
         className={classSet(classes)}
-        onClick={this.props.backdrop === true ? this.handleBackdropClick : null}
         ref="modal">
         <div className="modal-dialog">
           <div className="modal-content">
@@ -66,9 +65,12 @@ var Modal = React.createClass({
 
     classes['in'] = !this.props.animation || !document.querySelectorAll;
 
+    var onClick = this.props.backdrop === true ?
+      this.handleBackdropClick : null;
+
     return (
       <div>
-        <div className={classSet(classes)} ref="backdrop" />
+        <div className={classSet(classes)} ref="backdrop" onClick={onClick} />
         {modal}
       </div>
     );

--- a/test/ModalSpec.jsx
+++ b/test/ModalSpec.jsx
@@ -1,0 +1,24 @@
+/** @jsx React.DOM */
+/*global describe, it, assert */
+
+var React          = require('react');
+var ReactTestUtils = require('react/lib/ReactTestUtils');
+var Modal          = require('../cjs/Modal');
+
+describe('Modal', function () {
+
+  it('Should render the modal content', function() {
+    var instance = ReactTestUtils.renderIntoDocument(Modal({}, <strong>Message</strong>));
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'strong'));
+  });
+
+  it('Should close the modal when the backdrop is clicked', function (done) {
+    var instance = ReactTestUtils.renderIntoDocument(Modal({
+      onRequestHide: function() { done(); },
+    }, <strong>Message</strong>));
+
+    var backdrop = instance.getDOMNode().getElementsByClassName('modal-backdrop')[0];
+    ReactTestUtils.Simulate.click(backdrop);
+  });
+
+});


### PR DESCRIPTION
The `handleBackdropClick` handler should bind to the .modal-backdrop div. Otherwise, clicking the backdrop does nothing - the only way to fire the handler was to click the very edge of the modal window (the .modal div).
