### PR TITLE
Check for the existence of document before accessing it.

### DIFF
--- a/src/OverlayMixin.js
+++ b/src/OverlayMixin.js
@@ -7,7 +7,7 @@ export default = {
 
   getDefaultProps: function () {
     return {
-      container: document.body
+      container: typeof document !== 'undefined' ? document.body : null
     };
   },
 


### PR DESCRIPTION
Since `document` is referenced within `getDefaultProps` which unlike `componentDidMount` is run in both browser and node environments we need to make sure we check it exists before accessing it.
