### PR TITLE
Fixed invalid JSON object under some versions of IE.

### DIFF
--- a/src/SubNav.jsx
+++ b/src/SubNav.jsx
@@ -15,7 +15,7 @@ var SubNav = React.createClass({
     disabled: React.PropTypes.bool,
     href: React.PropTypes.string,
     title: React.PropTypes.string,
-    text: React.PropTypes.renderable,
+    text: React.PropTypes.renderable
   },
 
   getDefaultProps: function () {


### PR DESCRIPTION
Fixed invalid JSON object under some versions of IE. (Trailing comma after last property)

I looked and no other propTypes used the trailing comma.
