### PR TITLE
Hide Modal when background is clicked

### DIFF
--- a/src/Modal.jsx
+++ b/src/Modal.jsx
@@ -47,6 +47,7 @@ var Modal = React.createClass({
         role="dialog"
         style={modalStyle}
         className={classSet(classes)}
+        onClick={this.props.backdrop === true ? this.handleBackdropClick : null}
         ref="modal">
         <div className="modal-dialog">
           <div className="modal-content">

--- a/test/ModalSpec.jsx
+++ b/test/ModalSpec.jsx
@@ -16,10 +16,19 @@ describe('Modal', function () {
 
   it('Should close the modal when the backdrop is clicked', function (done) {
     var instance = ReactTestUtils.renderIntoDocument(Modal({
-      onRequestHide: function() { done(); },
+      onRequestHide: function() { done(); }
     }, <strong>Message</strong>));
 
     var backdrop = instance.getDOMNode().getElementsByClassName('modal-backdrop')[0];
+    ReactTestUtils.Simulate.click(backdrop);
+  });
+
+  it('Should close the modal when the modal background is clicked', function (done) {
+    var instance = ReactTestUtils.renderIntoDocument(Modal({
+      onRequestHide: function() { done(); }
+    }, <strong>Message</strong>));
+
+    var backdrop = instance.getDOMNode().getElementsByClassName('modal')[0];
     ReactTestUtils.Simulate.click(backdrop);
   });
 


### PR DESCRIPTION
The handleBackdropClick handler should also bind to div.modal . Otherwise, clicking the background does nothing. The .modal is fullscreen as in the http://getbootstrap.com/javascript/#modals examples and catches the click before it arrives to the .modal-backdrop.

This restores the functionality broken in https://github.com/stevoland/react-bootstrap/pull/66

I guess the ordering of the .modal-backdrop and .modal can based on the markup so it's best to handle both cases.
