### PR TITLE
Only close dropdown if click originated from outside component's root node

### DIFF
--- a/src/DropdownButton.jsx
+++ b/src/DropdownButton.jsx
@@ -34,7 +34,7 @@ var DropdownButton = React.createClass({
         href={this.props.href}
         bsStyle={this.props.bsStyle}
         className={className}
-        onClick={this.handleOpenClick}
+        onClick={this.handleDropdownClick}
         id={this.props.id}
         key={0}
         navDropdown={this.props.navItem}>
@@ -81,10 +81,10 @@ var DropdownButton = React.createClass({
     );
   },
 
-  handleOpenClick: function (e) {
-    this.setDropdownState(true);
-
+  handleDropdownClick: function (e) {
     e.preventDefault();
+
+    this.setDropdownState(!this.state.open);
   },
 
   handleOptionSelect: function (key) {

--- a/src/DropdownStateMixin.js
+++ b/src/DropdownStateMixin.js
@@ -1,5 +1,24 @@
 import React     from './react-es6';
 
+/**
+ * Checks whether a node is within
+ * a root nodes tree
+ *
+ * @param {DOMElement} node
+ * @param {DOMElement} root
+ * @returns {boolean}
+ */
+function isNodeInRoot(node, root) {
+  while (node) {
+    if (node === root) {
+      return true;
+    }
+    node = node.parentNode;
+  }
+
+  return false;
+}
+
 var DropdownStateMixin = {
   getInitialState: function () {
     return {
@@ -25,17 +44,23 @@ var DropdownStateMixin = {
     }
   },
 
-  handleClickOutside: function () {
+  handleDocumentClick: function (e) {
+    // If the click originated from within this component
+    // don't do anything.
+    if (isNodeInRoot(e.target, this.getDOMNode())) {
+      return;
+    }
+
     this.setDropdownState(false);
   },
 
   bindRootCloseHandlers: function () {
-    document.addEventListener('click', this.handleClickOutside);
+    document.addEventListener('click', this.handleDocumentClick);
     document.addEventListener('keyup', this.handleKeyUp);
   },
 
   unbindRootCloseHandlers: function () {
-    document.removeEventListener('click', this.handleClickOutside);
+    document.removeEventListener('click', this.handleDocumentClick);
     document.removeEventListener('keyup', this.handleKeyUp);
   },
 

--- a/src/SplitButton.jsx
+++ b/src/SplitButton.jsx
@@ -41,7 +41,7 @@ var SplitButton = React.createClass({
           ref="button"
           href={this.props.href}
           bsStyle={this.props.bsStyle}
-          onClick={this.props.onClick}>
+          onClick={this.handleButtonClick}>
           {this.props.title}
         </Button>
 
@@ -49,7 +49,7 @@ var SplitButton = React.createClass({
           ref="dropdownButton"
           bsStyle={this.props.bsStyle}
           className="dropdown-toggle"
-          onClick={this.handleOpenClick}>
+          onClick={this.handleDropdownClick}>
           <span className="sr-only">{this.props.dropdownTitle}</span>
           <span className="caret" />
         </Button>
@@ -65,10 +65,20 @@ var SplitButton = React.createClass({
     );
   },
 
-  handleOpenClick: function (e) {
+  handleButtonClick: function (e) {
+    if (this.state.open) {
+      this.setDropdownState(false);
+    }
+
+    if (this.props.onClick) {
+      this.props.onClick(e);
+    }
+  },
+
+  handleDropdownClick: function (e) {
     e.preventDefault();
 
-    this.setDropdownState(true);
+    this.setDropdownState(!this.state.open);
   },
 
   handleOptionSelect: function (key) {


### PR DESCRIPTION
Hey!

I have changed the document click handler for the `DropdownStateMixin` to only close the dropdown if the click happened outside of the component's root, currently any click on the page closes the dropdown, this allows the mixin to cover more complex use cases such as having an `<input />` inside a dropdown like #62.

As a result of this change we need to control the state of the dropdown for clicks within the component and as such i have updated the `SplitButton` and `DropdownButton` to more explicitly set their own state from different internal clicks.
