### PR TITLE
Take extra care when accessing `props.children`

### DIFF
--- a/src/Accordion.jsx
+++ b/src/Accordion.jsx
@@ -1,14 +1,14 @@
 /** @jsx React.DOM */
 
-import React          from './react-es6';
-import PanelGroup     from './PanelGroup';
+import React      from './react-es6';
+import PanelGroup from './PanelGroup';
 
 var Accordion = React.createClass({
 
   render: function () {
     return this.transferPropsTo(
       <PanelGroup isAccordion={true}>
-          {this.props.children}
+        {this.props.children}
       </PanelGroup>
     );
   }

--- a/src/Badge.jsx
+++ b/src/Badge.jsx
@@ -1,12 +1,12 @@
 /** @jsx React.DOM */
 
-import React          from './react-es6';
+import React                  from './react-es6';
+import ValidComponentChildren from './ValidComponentChildren';
 
 var Badge = React.createClass({
-
   render: function () {
     return this.transferPropsTo(
-      <span className={this.props.children ? 'badge': null}>
+      <span className={ValidComponentChildren.hasValidComponent(this.props.children) ? 'badge': null}>
         {this.props.children}
       </span>
     );

--- a/src/DropdownMenu.jsx
+++ b/src/DropdownMenu.jsx
@@ -1,8 +1,9 @@
 /** @jsx React.DOM */
 
-import React          from './react-es6';
-import classSet       from './react-es6/lib/cx';
-import utils          from './utils';
+import React                  from './react-es6';
+import classSet               from './react-es6/lib/cx';
+import utils                  from './utils';
+import ValidComponentChildren from './ValidComponentChildren';
 
 var DropdownMenu = React.createClass({
   propTypes: {
@@ -20,7 +21,7 @@ var DropdownMenu = React.createClass({
         <ul
           className={classSet(classes)}
           role="menu">
-          {utils.modifyChildren(this.props.children, this.renderMenuItem)}
+          {ValidComponentChildren.map(this.props.children, this.renderMenuItem)}
         </ul>
       );
   },

--- a/src/Interpolate.js
+++ b/src/Interpolate.js
@@ -1,9 +1,10 @@
 // https://www.npmjs.org/package/react-interpolate-component
 'use strict';
 
-import React          from './react-es6';
-import invariant      from './react-es6/lib/invariant';
-import utils          from './utils';
+import React                  from './react-es6';
+import invariant              from './react-es6/lib/invariant';
+import utils                  from './utils';
+import ValidComponentChildren from './ValidComponentChildren';
 
 function isString(object) {
   return Object.prototype.toString.call(object) === '[object String]';
@@ -19,7 +20,7 @@ var Interpolate = React.createClass({
   },
 
   render: function() {
-    var format = this.props.children || this.props.format;
+    var format = ValidComponentChildren.hasValidComponent(this.props.children) ? this.props.children : this.props.format;
     var parent = this.props.component;
     var unsafe = this.props.unsafe === true;
     var props  = utils.extend({}, this.props);

--- a/src/Nav.jsx
+++ b/src/Nav.jsx
@@ -1,11 +1,12 @@
 /** @jsx React.DOM */
 
-import React            from './react-es6';
-import classSet         from './react-es6/lib/cx';
-import BootstrapMixin   from './BootstrapMixin';
-import CollapsableMixin from './CollapsableMixin';
-import utils            from './utils';
-import domUtils         from './domUtils';
+import React                  from './react-es6';
+import classSet               from './react-es6/lib/cx';
+import BootstrapMixin         from './BootstrapMixin';
+import CollapsableMixin       from './CollapsableMixin';
+import utils                  from './utils';
+import domUtils               from './domUtils';
+import ValidComponentChildren from './ValidComponentChildren';
 
 
 var Nav = React.createClass({
@@ -64,7 +65,7 @@ var Nav = React.createClass({
 
     return (
       <ul className={classSet(classes)} ref="ul">
-        {utils.modifyChildren(this.props.children, this.renderNavItem)}
+        {ValidComponentChildren.map(this.props.children, this.renderNavItem)}
       </ul>
     );
   },

--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -1,11 +1,12 @@
 /** @jsx React.DOM */
 
-import React          from './react-es6';
-import classSet       from './react-es6/lib/cx';
-import BootstrapMixin from './BootstrapMixin';
-import PropTypes      from './PropTypes';
-import utils          from './utils';
-import Nav            from './Nav';
+import React                  from './react-es6';
+import classSet               from './react-es6/lib/cx';
+import BootstrapMixin         from './BootstrapMixin';
+import PropTypes              from './PropTypes';
+import utils                  from './utils';
+import Nav                    from './Nav';
+import ValidComponentChildren from './ValidComponentChildren';
 
 
 var Navbar = React.createClass({
@@ -73,7 +74,7 @@ var Navbar = React.createClass({
       <componentClass className={classSet(classes)}>
         <div className={this.props.fluid ? 'container-fluid' : 'container'}>
           {(this.props.brand || this.props.toggleButton || this.props.toggleNavKey) ? this.renderHeader() : null}
-          {React.Children.map(this.props.children, this.renderChild)}
+          {ValidComponentChildren.map(this.props.children, this.renderChild)}
         </div>
       </componentClass>
     );

--- a/src/PanelGroup.jsx
+++ b/src/PanelGroup.jsx
@@ -1,9 +1,10 @@
 /** @jsx React.DOM */
 
-import React          from './react-es6';
-import classSet       from './react-es6/lib/cx';
-import BootstrapMixin from './BootstrapMixin';
-import utils          from './utils';
+import React                  from './react-es6';
+import classSet               from './react-es6/lib/cx';
+import BootstrapMixin         from './BootstrapMixin';
+import utils                  from './utils';
+import ValidComponentChildren from './ValidComponentChildren';
 
 var PanelGroup = React.createClass({
   mixins: [BootstrapMixin],
@@ -29,7 +30,7 @@ var PanelGroup = React.createClass({
   render: function () {
     return this.transferPropsTo(
       <div className={classSet(this.getBsClassSet())}>
-          {utils.modifyChildren(this.props.children, this.renderPanel)}
+        {ValidComponentChildren.map(this.props.children, this.renderPanel)}
       </div>
     );
   },

--- a/src/ProgressBar.jsx
+++ b/src/ProgressBar.jsx
@@ -1,10 +1,11 @@
 /** @jsx React.DOM */
 
-import React          from './react-es6';
-import classSet       from './react-es6/lib/cx';
-import Interpolate    from './Interpolate';
-import BootstrapMixin from './BootstrapMixin';
-import utils          from './utils';
+import React                  from './react-es6';
+import classSet               from './react-es6/lib/cx';
+import Interpolate            from './Interpolate';
+import BootstrapMixin         from './BootstrapMixin';
+import utils                  from './utils';
+import ValidComponentChildren from './ValidComponentChildren';
 
 
 var ProgressBar = React.createClass({
@@ -44,7 +45,7 @@ var ProgressBar = React.createClass({
       classes['progress-striped'] = true;
     }
 
-    if (!this.props.children) {
+    if (!ValidComponentChildren.hasValidComponent(this.props.children)) {
       if (!this.props.isChild) {
         return this.transferPropsTo(
           <div className={classSet(classes)}>
@@ -59,7 +60,7 @@ var ProgressBar = React.createClass({
     } else {
       return this.transferPropsTo(
         <div className={classSet(classes)}>
-          {utils.modifyChildren(this.props.children, this.renderChildBar)}
+          {ValidComponentChildren.map(this.props.children, this.renderChildBar)}
         </div>
       );
     }

--- a/src/SubNav.jsx
+++ b/src/SubNav.jsx
@@ -1,9 +1,10 @@
 /** @jsx React.DOM */
 
-import React          from './react-es6';
-import classSet       from './react-es6/lib/cx';
-import BootstrapMixin from './BootstrapMixin';
-import utils          from './utils';
+import React                  from './react-es6';
+import classSet               from './react-es6/lib/cx';
+import BootstrapMixin         from './BootstrapMixin';
+import utils                  from './utils';
+import ValidComponentChildren from './ValidComponentChildren';
 
 
 var SubNav = React.createClass({
@@ -39,8 +40,6 @@ var SubNav = React.createClass({
   },
 
   isChildActive: function (child) {
-    var isActive = false;
-
     if (child.props.active) {
       return true;
     }
@@ -54,7 +53,9 @@ var SubNav = React.createClass({
     }
 
     if (child.props.children) {
-      React.Children.forEach(
+      var isActive = false;
+
+      ValidComponentChildren.forEach(
         child.props.children,
         function (child) {
           if (this.isChildActive(child)) {
@@ -104,7 +105,7 @@ var SubNav = React.createClass({
           {this.props.text}
         </a>
         <ul className="nav">
-          {utils.modifyChildren(this.props.children, this.renderNavItem)}
+          {ValidComponentChildren.map(this.props.children, this.renderNavItem)}
         </ul>
       </li>
     );

--- a/src/ValidComponentChildren.js
+++ b/src/ValidComponentChildren.js
@@ -1,0 +1,91 @@
+import React from './react-es6';
+
+
+/**
+ * Maps children that are typically specified as `props.children`,
+ * but only iterates over children that are "valid components".
+ *
+ * The mapFunction provided index will be normalised to the components mapped,
+ * so an invalid component would not increase the index.
+ *
+ * @param {?*} children Children tree container.
+ * @param {function(*, int)} mapFunction.
+ * @param {*} mapContext Context for mapFunction.
+ * @return {object} Object containing the ordered map of results.
+ */
+function mapValidComponents(children, func, context) {
+  var index = 0;
+
+  return React.Children.map(children, function (child) {
+    if (React.isValidComponent(child)) {
+      var lastIndex = index;
+      index++;
+      return func.call(context, child, lastIndex);
+    }
+
+    return child;
+  });
+}
+
+/**
+ * Iterates through children that are typically specified as `props.children`,
+ * but only iterates over children that are "valid components".
+ *
+ * The provided forEachFunc(child, index) will be called for each
+ * leaf child with the index reflecting the position relative to "valid components".
+ *
+ * @param {?*} children Children tree container.
+ * @param {function(*, int)} forEachFunc.
+ * @param {*} forEachContext Context for forEachContext.
+ */
+function forEachValidComponents(children, func, context) {
+  var index = 0;
+
+  return React.Children.forEach(children, function (child) {
+    if (React.isValidComponent(child)) {
+      func.call(context, child, index);
+      index++;
+    }
+  });
+}
+
+/**
+ * Count the number of "valid components" in the Children container.
+ *
+ * @param {?*} children Children tree container.
+ * @returns {number}
+ */
+function numberOfValidComponents(children) {
+  var count = 0;
+
+  React.Children.forEach(children, function (child) {
+    if (React.isValidComponent(child)) { count++; }
+  });
+
+  return count;
+}
+
+/**
+ * Determine if the Child container has one or more "valid components".
+ *
+ * @param {?*} children Children tree container.
+ * @returns {boolean}
+ */
+function hasValidComponent(children) {
+  var hasValid = false;
+
+  React.Children.forEach(children, function (child) {
+    if (!hasValid && React.isValidComponent(child)) {
+      hasValid = true;
+    }
+  });
+
+  return hasValid;
+}
+
+export default = {
+  map: mapValidComponents,
+  forEach: forEachValidComponents,
+  numberOf: numberOfValidComponents,
+  hasValidComponent: hasValidComponent
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -28,6 +28,10 @@ export default = {
    * Modify each item in a React children array without
    * unnecessarily allocating a new array.
    *
+   * @deprecated
+   * `React.Children.map` should be used instead,
+   * also see `ValidComponentChildren.map`.
+   *
    * @param {array|object} children
    * @param {function} modifier
    * @returns {*}
@@ -43,6 +47,11 @@ export default = {
   /**
    * Filter each item in a React children array without
    * unnecessarily allocating a new array.
+   *
+   * @deprecated
+   * `React.Children.map` should be used instead with a filter
+   * function to null out unwanted children,
+   * also see `ValidComponentChildren.map`.
    *
    * @param {array|object} children
    * @param {function} filter

--- a/test/TabbedAreaSpec.jsx
+++ b/test/TabbedAreaSpec.jsx
@@ -1,11 +1,12 @@
 /** @jsx React.DOM */
 /*global describe, beforeEach, afterEach, it, assert */
 
-var React          = require('react');
-var ReactTestUtils = require('react/lib/ReactTestUtils');
-var TabbedArea     = require('../cjs/TabbedArea');
-var TabPane        = require('../cjs/TabPane');
-var utils          = require('./utils');
+var React           = require('react');
+var ReactTestUtils  = require('react/lib/ReactTestUtils');
+var TabbedArea      = require('../cjs/TabbedArea');
+var TabPane         = require('../cjs/TabPane');
+var utils           = require('./utils');
+var ValidComponentChildren = require('../cjs/ValidComponentChildren');
 
 describe('TabbedArea', function () {
   it('Should show the correct tab', function () {
@@ -31,7 +32,7 @@ describe('TabbedArea', function () {
       </TabbedArea>
     );
 
-    assert.equal(instance.refs.tabs.props.children.length, 2);
+    assert.equal(ValidComponentChildren.numberOf(instance.refs.tabs.props.children), 2);
     assert.equal(instance.refs.tabs.props.activeKey, 3);
   });
 
@@ -106,6 +107,25 @@ describe('TabbedArea', function () {
     assert.equal(instance.refs.pane2.props.active, false);
 
     assert.equal(instance.refs.tabs.props.activeKey, 1);
+  });
+
+  it('Should show the correct first tab with `React.Children.map` children values', function () {
+    var panes = [
+      <div>Tab 1 content</div>,
+      <div>Tab 2 content</div>
+    ];
+    var paneComponents = React.Children.map(panes, function(child, index) {
+      return <TabPane key={index} tab={'Tab #' + index}>{child}</TabPane>;
+    });
+
+    var instance = ReactTestUtils.renderIntoDocument(
+      <TabbedArea>
+        {paneComponents}
+        {null}
+      </TabbedArea>
+    );
+
+    assert.equal(instance.refs.tabs.props.activeKey, 0);
   });
 
   it('Should show the correct tab when selected', function (done) {


### PR DESCRIPTION
Deprecate `utils.modifyChildren` and `utils.filterChildren` in favour of new `ValidComponentChildren` functions, these functions wrap the `React.Children` implementations which is unsurprisingly more robust and covers more edge cases, with added checks to make sure it only operates on "valid components".

In addition to solving #87 this change now allows you to have `null` children for example:

``` javascript
<TabbedArea>
  {aFalsyThing ? <TabPane /> : null}
  <TabPane />
</TabbedArea>
```

This change has touched most of the components but hasn't result in any API changes. We will also need to remember to remove `utils.modifyChildren` and `utils.filterChildren` in a few versions time.
