### PR TITLE
Make it possible to disable the SplitButton

### DIFF
--- a/src/SplitButton.jsx
+++ b/src/SplitButton.jsx
@@ -17,7 +17,8 @@ var SplitButton = React.createClass({
     href:          React.PropTypes.string,
     dropdownTitle: React.PropTypes.renderable,
     onClick:       React.PropTypes.func,
-    onSelect:      React.PropTypes.func
+    onSelect:      React.PropTypes.func,
+    disabled:      React.PropTypes.bool
   },
 
   getDefaultProps: function () {
@@ -32,28 +33,35 @@ var SplitButton = React.createClass({
         'dropup': this.props.dropup
       };
 
+    var button = this.transferPropsTo(
+      <Button
+        ref="button"
+        onClick={this.handleButtonClick}
+        title={null}
+        id={null}>
+        {this.props.title}
+      </Button>
+    );
+
+    var dropdownButton = this.transferPropsTo(
+      <Button
+        ref="dropdownButton"
+        className="dropdown-toggle"
+        onClick={this.handleDropdownClick}
+        title={null}
+        id={null}>
+        <span className="sr-only">{this.props.dropdownTitle}</span>
+        <span className="caret" />
+      </Button>
+    );
+
     return (
       <ButtonGroup
         bsSize={this.props.bsSize}
         className={classSet(groupClasses)}
         id={this.props.id}>
-        <Button
-          ref="button"
-          href={this.props.href}
-          bsStyle={this.props.bsStyle}
-          onClick={this.handleButtonClick}>
-          {this.props.title}
-        </Button>
-
-        <Button
-          ref="dropdownButton"
-          bsStyle={this.props.bsStyle}
-          className="dropdown-toggle"
-          onClick={this.handleDropdownClick}>
-          <span className="sr-only">{this.props.dropdownTitle}</span>
-          <span className="caret" />
-        </Button>
-
+        {button}
+        {dropdownButton}
         <DropdownMenu
           ref="menu"
           onSelect={this.handleOptionSelect}

--- a/test/SplitButtonSpec.jsx
+++ b/test/SplitButtonSpec.jsx
@@ -77,6 +77,20 @@ describe('SplitButton', function () {
     assert.ok(button.className.match(/\bbtn-primary\b/));
   });
 
+  it('Should pass disabled to both buttons', function() {
+    instance = ReactTestUtils.renderIntoDocument(
+      <SplitButton title="Test" disabled={true}>
+        <MenuItem key="1">MenuItem 1 content</MenuItem>
+        <MenuItem key="2">MenuItem 2 content</MenuItem>
+      </SplitButton>
+    );
+
+    var button = instance.refs.button.getDOMNode();
+    assert.ok(button.disabled);
+    var dropdownButton = instance.refs.dropdownButton.getDOMNode();
+    assert.ok(button.disabled);
+  });
+
   it('Should pass id to button group', function () {
     instance = ReactTestUtils.renderIntoDocument(
         <SplitButton title="Title" bsStyle="primary" id="testId">


### PR DESCRIPTION
This change makes it possible to set a SplitButton disabled by simply passing the disabled prop down to both buttons.
