### PR TITLE
Bugfix for unmounting component with OverlayMixin

### DIFF
--- a/src/OverlayMixin.js
+++ b/src/OverlayMixin.js
@@ -13,9 +13,11 @@ export default = {
 
   componentWillUnmount: function () {
     this._unrenderOverlay();
-    this.getContainerDOMNode()
-      .removeChild(this._overlayTarget);
-    this._overlayTarget = null;
+    if (this._overlayTarget) {
+      this.getContainerDOMNode()
+        .removeChild(this._overlayTarget);
+      this._overlayTarget = null;
+    }
   },
 
   componentDidUpdate: function () {


### PR DESCRIPTION
Should not try to .removeChild when the target div has not been created yet, browser throws NotFoundError.
