### PR TITLE
Fixes prop type validator for Navbar 'fluid' prop

### DIFF
--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -17,12 +17,12 @@ var Navbar = React.createClass({
     fixedBottom: React.PropTypes.bool,
     staticTop: React.PropTypes.bool,
     inverse: React.PropTypes.bool,
+    fluid: React.PropTypes.bool,
     role: React.PropTypes.string,
     componentClass: PropTypes.componentClass,
     brand: React.PropTypes.renderable,
     toggleButton: React.PropTypes.renderable,
-    onToggle: React.PropTypes.func,
-    fluid: React.PropTypes.func
+    onToggle: React.PropTypes.func
   },
 
   getDefaultProps: function () {

--- a/test/NavbarSpec.jsx
+++ b/test/NavbarSpec.jsx
@@ -46,6 +46,13 @@ describe('Nav', function () {
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'navbar-inverse'));
   });
 
+  it('Should add fluid variation class', function () {
+    var instance = ReactTestUtils.renderIntoDocument(
+          <Navbar fluid />
+        );
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'container-fluid'));
+  });
+
   it('Should override role attribute', function () {
     var instance = ReactTestUtils.renderIntoDocument(
           <Navbar role="banner"/>


### PR DESCRIPTION
The "fluid" property of Navbar should be a boolean, but is currently validated against `React.PropTypes.func`. This commit also adds a test case for the fluid variation.
