### PR TITLE
Bugfix for lost DOM properties during fadeout

### DIFF
--- a/src/FadeMixin.js
+++ b/src/FadeMixin.js
@@ -45,7 +45,7 @@ export default = {
     if (els.length) {
       this._fadeOutEl = document.createElement('div');
       document.body.appendChild(this._fadeOutEl);
-      this._fadeOutEl.innerHTML = this.getDOMNode().innerHTML;
+      this._fadeOutEl.appendChild(this.getDOMNode().cloneNode(true));
       // Firefox needs delay for transition to be triggered
       setTimeout(this._fadeOut, 20);
     }


### PR DESCRIPTION
Because they are stored as DOM properties, and not HTML attributes, things like checkbox "checked" state, input values, select values, etc., are all lost right before fadeout. This creates a jarring fadeout transition. 

Using cloneNode() to preserve DOM properties as well as HTML attributes.

Side note: Curious about the possibilities of messing up React by copying "data-reactid" properties here. I haven't seen any issues yet, so I'm not filing a bug.
