### PR TITLE
ie8: tooltip

### DIFF
--- a/ie8/index.html
+++ b/ie8/index.html
@@ -15,6 +15,7 @@
     </style>
 
     <!--[if IE 8]>
+    <script src="http://code.jquery.com/jquery-1.11.1.min.js"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/es5-shim/3.4.0/es5-shim.js"></script>
     <script src="http://cdnjs.cloudflare.com/ajax/libs/es5-shim/3.4.0/es5-sham.js"></script>
     <![endif]-->

--- a/src/domUtils.js
+++ b/src/domUtils.js
@@ -4,6 +4,10 @@ export default = {
   },
 
   getOffset: function (DOMNode) {
+    if (window.jQuery) {
+      return window.jQuery(DOMNode).offset();
+    }
+
     var docElem = document.documentElement;
     var box = { top: 0, left: 0 };
 
@@ -20,6 +24,10 @@ export default = {
   },
 
   getPosition: function (elem, offsetParent) {
+    if (window.jQuery) {
+      return window.jQuery(elem).position();
+    }
+
     var offset,
         parentOffset = {top: 0, left: 0};
 


### PR DESCRIPTION
domUtil will use jQuery to compute position and offset if jQuery is present.
jQuery can then be a requirement for react-bootstrap + ie8.

I know even mentioning jQuery in the source will be unpopular,
but it seems like the most reasonable solution.
