### PR TITLE
Carousel refactor

### DIFF
--- a/src/CarouselItem.jsx
+++ b/src/CarouselItem.jsx
@@ -25,7 +25,7 @@ var CarouselItem = React.createClass({
   },
 
   handleAnimateOutEnd: function () {
-    if (typeof this.props.onAnimateOutEnd === 'function') {
+    if (this.props.onAnimateOutEnd && this.isMounted()) {
       this.props.onAnimateOutEnd(this.props.index);
     }
   },
@@ -52,6 +52,10 @@ var CarouselItem = React.createClass({
   },
 
   startAnimation: function () {
+    if (!this.isMounted()) {
+      return;
+    }
+
     this.setState({
       direction: this.props.direction === 'prev' ?
         'right' : 'left'

--- a/test/CarouselSpec.jsx
+++ b/test/CarouselSpec.jsx
@@ -1,0 +1,76 @@
+/** @jsx React.DOM */
+/*global describe, beforeEach, afterEach, it, assert */
+
+var React           = require('react');
+var ReactTestUtils  = require('react/lib/ReactTestUtils');
+var Carousel        = require('../cjs/Carousel');
+var CarouselItem    = require('../cjs/CarouselItem');
+
+describe('Carousel', function () {
+  it('Should show the correct item', function () {
+    var instance = ReactTestUtils.renderIntoDocument(
+      <Carousel activeIndex={1}>
+        <CarouselItem ref="item1">Item 1 content</CarouselItem>
+        <CarouselItem ref="item2">Item 2 content</CarouselItem>
+      </Carousel>
+    );
+
+    assert.equal(instance.refs.item1.props.active, false);
+    assert.equal(instance.refs.item2.props.active, true);
+
+    instance = ReactTestUtils.renderIntoDocument(
+      <Carousel defaultActiveIndex={1}>
+        <CarouselItem ref="item1">Item 1 content</CarouselItem>
+        <CarouselItem ref="item2">Item 2 content</CarouselItem>
+      </Carousel>
+    );
+
+    assert.equal(instance.refs.item1.props.active, false);
+    assert.equal(instance.refs.item2.props.active, true);
+    assert.equal(
+      ReactTestUtils.scryRenderedDOMComponentsWithTag(
+        ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'carousel-indicators'), 'li'
+      ).length, 2
+    );
+  });
+
+  it('Should handle null children', function () {
+    var instance = ReactTestUtils.renderIntoDocument(
+      <Carousel activeIndex={1}>
+        <CarouselItem ref="item1">Item 1 content</CarouselItem>
+        {null}
+        {false}
+        <CarouselItem ref="item2">Item 2 content</CarouselItem>
+      </Carousel>
+    );
+
+    assert.equal(instance.refs.item1.props.active, false);
+    assert.equal(instance.refs.item2.props.active, true);
+    assert.equal(
+      ReactTestUtils.scryRenderedDOMComponentsWithTag(
+        ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'carousel-indicators'), 'li'
+      ).length, 2
+    );
+  });
+
+  it('Should call onSelect when indicator selected', function (done) {
+    function onSelect(index, direction) {
+      assert.equal(index, 0);
+      assert.equal(direction, 'prev');
+      done();
+    }
+
+    var instance = ReactTestUtils.renderIntoDocument(
+      <Carousel activeIndex={1} onSelect={onSelect}>
+        <CarouselItem ref="item1">Item 1 content</CarouselItem>
+        <CarouselItem ref="item2">Item 2 content</CarouselItem>
+      </Carousel>
+    );
+
+    ReactTestUtils.Simulate.click(
+      ReactTestUtils.scryRenderedDOMComponentsWithTag(
+        ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'carousel-indicators'), 'li'
+      )[0]
+    );
+  });
+});


### PR DESCRIPTION
This change included general logic cleanup as well as the following changes:

Fixed issues
- Clear any timers on `componentWillUnmount` or null any async actions via `this.isMounted` which would cause set states after the component has been unmounted, resolves #112.
- Prevent default on `next` and `prev` callbacks which stops hashes being set to the url.
- Clear auto slide interval timer on manual change to stop multiple timers being set.

Added functionality
- Added `onSlideEnd` prop - useful for queuing state changes.
- Added basic unit tests.

@stevoland would be good to get a good review of this as i ended up changing a few things around :)
