### PR TITLE
Only pass through onSelect handler if it has been set on the DropdownButton

### DIFF
--- a/src/DropdownButton.jsx
+++ b/src/DropdownButton.jsx
@@ -1,12 +1,14 @@
 /** @jsx React.DOM */
 
-import React              from './react-es6';
-import classSet           from './react-es6/lib/cx';
-import BootstrapMixin     from './BootstrapMixin';
-import DropdownStateMixin from './DropdownStateMixin';
-import Button             from './Button';
-import ButtonGroup        from './ButtonGroup';
-import DropdownMenu       from './DropdownMenu';
+import React                  from './react-es6';
+import classSet               from './react-es6/lib/cx';
+import BootstrapMixin         from './BootstrapMixin';
+import DropdownStateMixin     from './DropdownStateMixin';
+import Button                 from './Button';
+import ButtonGroup            from './ButtonGroup';
+import DropdownMenu           from './DropdownMenu';
+import utils                  from './utils';
+import ValidComponentChildren from './ValidComponentChildren';
 
 
 var DropdownButton = React.createClass({
@@ -45,10 +47,9 @@ var DropdownButton = React.createClass({
       <DropdownMenu
         ref="menu"
         aria-labelledby={this.props.id}
-        onSelect={this.handleOptionSelect}
         pullRight={this.props.pullRight}
         key={1}>
-        {this.props.children}
+        {ValidComponentChildren.map(this.props.children, this.renderMenuItem)}
       </DropdownMenu>
     ]);
   },
@@ -79,6 +80,26 @@ var DropdownButton = React.createClass({
       <li className={classSet(classes)}>
         {children}
       </li>
+    );
+  },
+
+  renderMenuItem: function (child) {
+    // Only handle the option selection if an onSelect prop has been set on the
+    // component or it's child, this allows a user not to pass an onSelect
+    // handler and have the browser preform the default action.
+    var handleOptionSelect = this.props.onSelect || child.props.onSelect ?
+      this.handleOptionSelect : null;
+
+    return utils.cloneWithProps(
+      child,
+      {
+        // Capture onSelect events
+        onSelect: utils.createChainedFunction(child.props.onSelect, handleOptionSelect),
+
+        // Force special props to be transferred
+        key: child.props.key,
+        ref: child.props.ref
+      }
     );
   },
 

--- a/test/DropdownButtonSpec.jsx
+++ b/test/DropdownButtonSpec.jsx
@@ -92,6 +92,7 @@ describe('DropdownButton', function () {
   it('should call onSelect with key when MenuItem is clicked', function (done) {
     function handleSelect(key) {
       assert.equal(key, 2);
+      assert.equal(instance.state.open, false);
       done();
     }
 
@@ -107,6 +108,39 @@ describe('DropdownButton', function () {
     ReactTestUtils.SimulateNative.click(
       ReactTestUtils.findRenderedDOMComponentWithTag(menuItems[1], 'a')
     );
+  });
+
+  it('should call MenuItem onSelect with key when MenuItem is clicked', function (done) {
+    function handleSelect(key) {
+      assert.equal(key, 2);
+      assert.equal(instance.state.open, false);
+      done();
+    }
+
+    instance = ReactTestUtils.renderIntoDocument(
+      <DropdownButton title="Title">
+        <MenuItem key={1}>MenuItem 1 content</MenuItem>
+        <MenuItem key={2} onSelect={handleSelect}>MenuItem 2 content</MenuItem>
+      </DropdownButton>
+    );
+
+    var menuItems = ReactTestUtils.scryRenderedComponentsWithType(instance, MenuItem);
+    assert.equal(menuItems.length, 2);
+    ReactTestUtils.SimulateNative.click(
+      ReactTestUtils.findRenderedDOMComponentWithTag(menuItems[1], 'a')
+    );
+  });
+
+  it('should not set onSelect to child with no onSelect prop', function () {
+    instance = ReactTestUtils.renderIntoDocument(
+      <DropdownButton title="Title">
+        <MenuItem key={1}>MenuItem 1 content</MenuItem>
+        <MenuItem key={2}>MenuItem 2 content</MenuItem>
+      </DropdownButton>
+    );
+
+    var menuItems = ReactTestUtils.scryRenderedComponentsWithType(instance, MenuItem);
+    assert.notOk(menuItems[0].props.onSelect);
   });
 
   describe('when open', function () {


### PR DESCRIPTION
This change loops over the children and uses `cloneWithProps` to only set the onSelect handler if one has been specified on the component or its child. The `MenuItem` components will call `preventDefault` if a onSelect handler is passed, as it assumes the resulting action will be handled via the user and not the browser, this change therefore is necessary to make sure we don't pass the onSelect handler unless we are sure the user does intend to handle the action.

Fixes #138

@stevoland to CR

@spicyj if you have a second :) it would be good to get your opinion on whether the current approach we are taking with `cloneWithProps` is sane (as in we are using it a lot), is there a significant performance impact of cloning components? With this change the child `MenuItem`'s will each be cloned 2 times before being rendered (once here and once in `DropdownMenu` component). Also is there be any side effects of passing key's and ref's down?
