### PR TITLE
Upgrade affix component event binding to use React EventListener

### DIFF
--- a/src/AffixMixin.js
+++ b/src/AffixMixin.js
@@ -1,7 +1,8 @@
 /* global window, document */
 
-import React     from './react-es6';
-import domUtils  from './domUtils';
+import React         from './react-es6';
+import domUtils      from './domUtils';
+import EventListener from './react-es6/lib/EventListener';
 
 var AffixMixin = {
   propTypes: {
@@ -104,13 +105,20 @@ var AffixMixin = {
   },
 
   componentDidMount: function () {
-    window.addEventListener('scroll', this.checkPosition);
-    document.addEventListener('click', this.checkPositionWithEventLoop);
+    this._onWindowScrollListener =
+      EventListener.listen(window, 'scroll', this.checkPosition);
+    this._onDocumentClickListener =
+      EventListener.listen(document, 'click', this.checkPositionWithEventLoop);
   },
 
   componentWillUnmount: function () {
-    window.removeEventListener('scroll', this.checkPosition);
-    document.addEventListener('click', this.checkPositionWithEventLoop);
+    if (this._onWindowScrollListener) {
+      this._onWindowScrollListener.remove();
+    }
+
+    if (this._onDocumentClickListener) {
+      this._onDocumentClickListener.remove();
+    }
   },
 
   componentDidUpdate: function (prevProps, prevState) {


### PR DESCRIPTION
This is a first pass at IE8 support for the Affix component, this will get the event listeners working at least. I haven't tested any further than that, but it looks like this component could use some work.
