### PR TITLE
Add Introduction page to docs, explaining project

### DIFF
--- a/docs/comparisons/ButtonGroupDropdown.js
+++ b/docs/comparisons/ButtonGroupDropdown.js
@@ -1,0 +1,14 @@
+/** @jsx React.DOM */
+
+var buttonGroupInstance = (
+    <ButtonGroup>
+      <DropdownButton bsStyle="success" title="Dropdown">
+        <MenuItem key="1">Dropdown link</MenuItem>
+        <MenuItem key="2">Dropdown link</MenuItem>
+      </DropdownButton>
+      <Button bsStyle="info">Middle</Button>
+      <Button bsStyle="info">Right</Button>
+    </ButtonGroup>
+  );
+
+React.renderComponent(buttonGroupInstance, mountNode);

--- a/docs/comparisons/TabbedAreaBS.html
+++ b/docs/comparisons/TabbedAreaBS.html
@@ -1,0 +1,14 @@
+<div id="content"
+  <ul id="myTab" class="nav nav-tabs">
+     <li class="active"><a href="#ArbitraryID1" data-toggle="tab">Tab 1</a></li>
+     <li><a href="#ArbitraryID2" data-toggle="tab">Tab 2</a></li>
+  </ul>
+</div>
+<div class="tab-content">
+  <div class="tab-pane active" id="AbitraryID1">
+    TabPane 1 content
+  </div>
+  <div class="tab-pane" id="ArbitraryID2">
+    TabPane 2 content
+  </div>
+</div>

--- a/docs/comparisons/TabbedAreaRBS.jsx
+++ b/docs/comparisons/TabbedAreaRBS.jsx
@@ -1,0 +1,4 @@
+<TabbedArea defaultActiveKey={2}>
+  <TabPane key={1} tab="Tab 1">TabPane 1 content</TabPane>
+  <TabPane key={2} tab="Tab 2">TabPane 2 content</TabPane>
+</TabbedArea>

--- a/docs/comparisons/noJSXButton.js
+++ b/docs/comparisons/noJSXButton.js
@@ -1,0 +1,5 @@
+var button = ReactBootStrap.button({
+  bsStyle: "success",
+  bsSize: "large",
+  children: "Register"
+});

--- a/docs/comparisons/vanillaButton.js
+++ b/docs/comparisons/vanillaButton.js
@@ -1,0 +1,6 @@
+var button = React.DOM.button({
+  className: "btn btn-sm btn-success",
+  children: "Register"
+});
+
+React.renderComponent(button, mountNode);

--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -54,8 +54,22 @@ var ComponentsPage = React.createClass({
             subTitle="" />
 
           <div className="container bs-docs-container">
+
             <div className="row">
               <div className="col-md-9" role="main">
+              <div className="lead">
+                This page lists the React-Bootstrap components. For each component, we provide:
+                <ul>
+                    <li>Usage instructions;</li>
+                    <li>An example code snippet;</li>
+                    <li>The rendered result of the example snippet.</li>
+                </ul>
+
+                <p>Click "show code" below the rendered component to reveal the snippet.</p>
+                <p>All snippets are editable, and changes will be reflected in the rendered component.
+                </p>
+
+              </div>
 
                 {/* Buttons */}
                 <div className="bs-docs-section">

--- a/docs/src/GettingStartedPage.js
+++ b/docs/src/GettingStartedPage.js
@@ -22,29 +22,14 @@ var Page = React.createClass({
 
           <PageHeader
             title="Getting started"
-            subTitle="React-Bootstrap overview, installation and usage."/>
+            subTitle="React-Bootstrap installation and usage."/>
 
           <div className="container bs-docs-container">
             <div className="row">
               <div className="col-md-9" role="main">
                 <div className="bs-docs-section">
-                  <h2 id="overview" className="page-header">What and Why</h2>
-                  <p className="lead">
-                    React-Bootstrap is a library of front-end components drawn from Twitter Bootstrap, for use in React.js applications.  You get the responsive layout and consistency of a Bootstrap page, but with code that is much easier to read, maintain and extend.
-                  </p>
-                  <p>Here is how you create a simple tabbed-navigation area with React-Bootstrap, with the Bootstrap-only code given for comparison:</p>
-                  <TabbedArea defaultActiveKey={2}>
-                   <TabPane key={1} tab="With Bootstrap">               
-                       <pre style={preStyles}>
-                         {fs.readFileSync(__dirname + '/../comparisons/TabbedAreaBS.html', 'utf8')} 
-                       </pre>
-                   </TabPane>
-                   <TabPane key={2} tab="With React-Bootstrap">
-                      <pre style={preStyles}>{fs.readFileSync(__dirname + '/../examples/TabbedAreaUncontrolled.js', 'utf8')}</pre>
-                   </TabPane>
-                  </TabbedArea>
                   <h2 id="setup" className="page-header">Setup</h2>
-                  <p className="lead">You can import the lib with as AMD modules, CommonJS modules as a global JS script.</p>
+                  <p>You can import the lib with as AMD modules, CommonJS modules as a global JS script.</p>
 
                   <p>First add the bootstrap CSS to your project then:</p>
 

--- a/docs/src/GettingStartedPage.js
+++ b/docs/src/GettingStartedPage.js
@@ -10,20 +10,39 @@ var PageHeader = require('./PageHeader');
 var PageFooter = require('./PageFooter');
 var ReactPlayground = require('./ReactPlayground');
 
+var TabbedArea = require('../../cjs/TabbedArea');
+var TabPane = require('../../cjs/TabPane');
+
 var Page = React.createClass({
   render: function () {
+    var preStyles = {"overflow": true};
     return (
         <div>
           <NavMain activePage="getting-started" />
 
           <PageHeader
             title="Getting started"
-            subTitle="An overview of React-Bootstrap and how to install and use." />
+            subTitle="React-Bootstrap overview, installation and usage."/>
 
           <div className="container bs-docs-container">
             <div className="row">
               <div className="col-md-9" role="main">
                 <div className="bs-docs-section">
+                  <h2 id="overview" className="page-header">What and Why</h2>
+                  <p className="lead">
+                    React-Bootstrap is a library of front-end components drawn from Twitter Bootstrap, for use in React.js applications.  You get the responsive layout and consistency of a Bootstrap page, but with code that is much easier to read, maintain and extend.
+                  </p>
+                  <p>Here is how you create a simple tabbed-navigation area with React-Bootstrap, with the Bootstrap-only code given for comparison:</p>
+                  <TabbedArea defaultActiveKey={2}>
+                   <TabPane key={1} tab="With Bootstrap">               
+                       <pre style={preStyles}>
+                         {fs.readFileSync(__dirname + '/../comparisons/TabbedAreaBS.html', 'utf8')} 
+                       </pre>
+                   </TabPane>
+                   <TabPane key={2} tab="With React-Bootstrap">
+                      <pre style={preStyles}>{fs.readFileSync(__dirname + '/../examples/TabbedAreaUncontrolled.js', 'utf8')}</pre>
+                   </TabPane>
+                  </TabbedArea>
                   <h2 id="setup" className="page-header">Setup</h2>
                   <p className="lead">You can import the lib with as AMD modules, CommonJS modules as a global JS script.</p>
 

--- a/docs/src/HomePage.js
+++ b/docs/src/HomePage.js
@@ -8,6 +8,9 @@ var NavMain = require('./NavMain');
 var PageHeader = require('./PageHeader');
 var PageFooter = require('./PageFooter');
 
+var Button = require('../../cjs/Button');
+var ButtonToolbar = require('../../cjs/ButtonToolbar');
+
 var HomePage = React.createClass({
   render: function () {
     return (
@@ -18,6 +21,11 @@ var HomePage = React.createClass({
             <div className="container">
               <span className="bs-docs-booticon bs-docs-booticon-lg bs-docs-booticon-outline"></span>
               <p className="lead">The most popular front-end framework, rebuilt for React.</p>
+              <ButtonToolbar bsSize="medium">
+                <Button bsStyle="primary" href="/getting-started.html">Get Started</Button>
+                <Button bsStyle="primary" href="http://github.com/react-bootstrap/">Github</Button>
+                <Button bsStyle="primary" href="/introduction.html">What is this?</Button>
+              </ButtonToolbar>
             </div>
           </main>
 

--- a/docs/src/HomePage.js
+++ b/docs/src/HomePage.js
@@ -22,9 +22,9 @@ var HomePage = React.createClass({
               <span className="bs-docs-booticon bs-docs-booticon-lg bs-docs-booticon-outline"></span>
               <p className="lead">The most popular front-end framework, rebuilt for React.</p>
               <ButtonToolbar bsSize="medium">
-                <Button bsStyle="primary" href="/getting-started.html">Get Started</Button>
-                <Button bsStyle="primary" href="http://github.com/react-bootstrap/">Github</Button>
                 <Button bsStyle="primary" href="/introduction.html">What is this?</Button>
+                <Button bsStyle="primary" href="/getting-started.html">Get Started</Button>
+                <Button bsStyle="primary" href="http://github.com/react-bootstrap/react-bootstrap">Github</Button>
               </ButtonToolbar>
             </div>
           </main>

--- a/docs/src/IntroductionPage.js
+++ b/docs/src/IntroductionPage.js
@@ -30,29 +30,48 @@ var Page = React.createClass({
             <div className="row">
               <div className="col-md-9" role="main">
                 <div className="bs-docs-section">
+                  <p className="lead">React-Bootstrap is a library of reuseable front-end components.  You'll get the look-and-feel of Twitter Bootstrap, but with much cleaner code, via Facebook's React.js framework.
+                  </p>
+                  <p>
+                    Let's say you want a small button that says "Something", to trigger the function someCallback. If were writing a native application, you might write something like:
+                  </p>
+                   {StaticExample({codeText: 'button(size=SMALL, color=GREEN, text="Something", onClick=someCallback)'})}
+                  <p>
+                    With the most popular web front-end framework, Twitter Bootstrap, you'd write this in your HTML:
+                  </p>
+                  {StaticExample({codeText: '<button id="something-btn" type="button" class="btn btn-success btn-sm">\n\tSomething\n</button>'})}
+                  <p>
+                    And something like <code>$('#something-btn').click(someCallback);</code> in your Javascript.
+                    By web standards this is quite nice, but it's still quite nasty.  React-Bootstrap lets you write this:
+                  </p>
+                    {StaticExample({codeText: '<Button bsStyle="success" bsSize="small" onClick={someCallback}>\n\tSomething\n</Button>'})}
 
                   <p>
-                    Let's say you want a small button that says "Something". Bootstrap lets you write this:
+                  The HTML/CSS implementation details are abstracted away, leaving you with an interface that more closely resembles what you would expect to write in other programming languages.
                   </p>
-                  {StaticExample({codeText: '<button id="something-btn" type="button" class="btn btn-success btn-sm">\n\tSome Text\n</button>'})}
-                  <p className="lead">
-                    Compared to other HTML/CSS solutions, this is quite nice; but compared to what's possible in any other language, it's quite nasty. With React-Bootstrap, you can write:
-                  </p>
-                    {StaticExample({codeText: '<Button bsStyle="success" bsSize="small" onClick={someHandler}>\n\tSomething\n</Button>'})}
                   <p>
-                    This is rendered by React into an element with the same markup as the Bootstrap example, and the click event is handled with React's virtual event system.
+                    Here's a more complicated example: a tabbed navigation area, showing the implementation with Bootstrap, and React-Bootstrap:
                   </p>
+
+                  <TabbedArea defaultActiveKey={2}>
+                    <TabPane key={1} tab="With Bootstrap">               
+                      <pre>{fs.readFileSync(__dirname + '/../comparisons/TabbedAreaBS.html', 'utf8')}</pre>
+                   </TabPane>
+                   <TabPane key={2} tab="With React-Bootstrap">
+                      <pre>{fs.readFileSync(__dirname + '/../comparisons/TabbedAreaRBS.jsx', 'utf8')}</pre>
+                   </TabPane>
+                  </TabbedArea>
 
                   <h2>A better Bootstrap API using React.js</h2>
                   <p>
-                    The Bootstrap code is so repetetive because HTML and CSS do not support the abstractions you need to write a nice library of components. That's why we have to write <small>btn</small> three times, within an element called <small>button</small>. 
+                    The Bootstrap code is so repetitive because HTML and CSS do not support the abstractions necessary for a nice library of components. That's why we have to write <small>btn</small> three times, within an element called <small>button</small>. 
                   </p>
           
                   <p><strong>The React.js solution is to write directly in Javascript.</strong>   React takes over the page-rendering entirely; you just give it a tree of Javascript objects, and tell it how state is transmitted between them.</p> 
 
                   <p>For instance, we might tell React to render a page displaying a single button, styled using the handy Bootstrap CSS:
                   </p>
-                  <ReactPlayground show={true} codeText={fs.readFileSync(__dirname + '/../comparisons/vanillaButton.js', 'utf8')} />
+                  <StaticExample codeText={fs.readFileSync(__dirname + '/../comparisons/vanillaButton.js', 'utf8')} />
                   <p>
                     But now that we're in Javascript, we can wrap the HTML/CSS, and provide a much better API:
                   </p>
@@ -63,20 +82,23 @@ var Page = React.createClass({
                   <p>
                     While each React component is really just a Javascript object, writing tree-structures that way gets tedious. React encourages the use of a syntactic-sugar called JSX, which lets you write the tree in an HTML-like syntax:
                   </p>
-                  <ReactPlayground show={true} codeText={fs.readFileSync(__dirname + '/../examples/ButtonGroupJustified.js', 'utf8')} />
-                  <h3>No More DOM Selectors</h3>
+                  <ReactPlayground show={true} codeText={fs.readFileSync(__dirname + '/../comparisons/ButtonToolbarDropdown.js', 'utf8')} />
+
                   <p>
-                    React-Bootstrap really shines on components that require some Javascript functionality.  In Bootstrap, this is achieved either through data attributes, or in Javascript, defined separately from the HTML code it references via arbitrary ID strings.
-                      For instance, here is a simple tabbed navigation area, displaying the difference in implementation:
+                   Some people's first impression of React.js is that it seems messy to mix Javascript and HTML in this way. 
+                     However, compare the code required to add
+
+                      a dropdown button in the example above to the <a href="http://getbootstrap.com/javascript/#dropdowns">
+                        Bootstrap Javascript</a> and <a href="http://getbootstrap.com/components/#btn-dropdowns">Components</a> documentation for creating a dropdown button. 
+                          The documentation is split in two because you have to implement the component in two places in your code: first you must add the HTML/CSS elements, and then you must call some Javascript setup code to wire the component together.
                   </p>
-                  <TabbedArea defaultActiveKey={2}>
-                    <TabPane key={1} tab="With Bootstrap">               
-                      <pre>{fs.readFileSync(__dirname + '/../comparisons/TabbedAreaBS.html', 'utf8')}</pre>
-                   </TabPane>
-                   <TabPane key={2} tab="With React-Bootstrap">
-                      <StaticExample codeText={fs.readFileSync(__dirname + '/../examples/TabbedAreaUncontrolled.js', 'utf8')} />
-                   </TabPane>
-                  </TabbedArea>
+                  <p>
+                  The React-Bootstrap component library tries to follow the React.js philosophy that a single piece of functionality should be defined in a single place.
+                  View the current React-Bootstrap library on the <a href="/components.html">components page</a>.
+                  </p>
+                  <p>
+                  The project is under active development --- APIs will change, and the documentation is far from complete. Contributions are encouraged!
+                  </p>
                 </div>
               </div>
             </div>

--- a/docs/src/IntroductionPage.js
+++ b/docs/src/IntroductionPage.js
@@ -82,7 +82,7 @@ var Page = React.createClass({
                   <p>
                     While each React component is really just a Javascript object, writing tree-structures that way gets tedious. React encourages the use of a syntactic-sugar called JSX, which lets you write the tree in an HTML-like syntax:
                   </p>
-                  <ReactPlayground show={true} codeText={fs.readFileSync(__dirname + '/../comparisons/ButtonToolbarDropdown.js', 'utf8')} />
+                  <ReactPlayground show={true} codeText={fs.readFileSync(__dirname + '/../comparisons/ButtonGroupDropdown.js', 'utf8')} />
 
                   <p>
                    Some people's first impression of React.js is that it seems messy to mix Javascript and HTML in this way. 

--- a/docs/src/IntroductionPage.js
+++ b/docs/src/IntroductionPage.js
@@ -31,22 +31,26 @@ var Page = React.createClass({
               <div className="col-md-9" role="main">
                 <div className="bs-docs-section">
 
-                  <h3>HTML/CSS Limit the Bootstrap API</h3>
                   <p>
-                    Let's say you want a small button that says "Register". With the Bootstrap framework, you would write this:
+                    Let's say you want a small button that says "Something". Bootstrap lets you write this:
                   </p>
-                  {StaticExample({codeText: '<button class="btn btn-success btn-sm">Some Text</button>'})}
+                  {StaticExample({codeText: '<button id="something-btn" type="button" class="btn btn-success btn-sm">\n\tSome Text\n</button>'})}
+                  <p className="lead">
+                    Compared to other HTML/CSS solutions, this is quite nice; but compared to what's possible in any other language, it's quite nasty. With React-Bootstrap, you can write:
+                  </p>
+                    {StaticExample({codeText: '<Button bsStyle="success" bsSize="small" onClick={someHandler}>\n\tSomething\n</Button>'})}
                   <p>
-                    Compared to raw HTML, this is quite nice; but compared to a normal GUI library, it's quite nasty. In Python, we might write <small>Button(size="large", style="success")</small>. With HTML/CSS, we write <small>btn</small> three times, within an element of type <small>button</small>! 
+                    This is rendered by React into an element with the same markup as the Bootstrap example, and the click event is handled with React's virtual event system.
                   </p>
 
-                  <h3>A better Bootstrap API using React.js</h3>
+                  <h2>A better Bootstrap API using React.js</h2>
                   <p>
-                    The problem is that HTML and CSS are under-powered for providing a library of reuseable components, as they are for many other tasks we want to accomplish on the web today.
+                    The Bootstrap code is so repetetive because HTML and CSS do not support the abstractions you need to write a nice library of components. That's why we have to write <small>btn</small> three times, within an element called <small>button</small>. 
                   </p>
-                  <p><strong>The React.js solution is to write directly in Javascript.</strong>   React.js takes over the page-rendering entirely; you just give it a tree of Javascript objects, and tell it how state is transmitted between them.</p> 
+          
+                  <p><strong>The React.js solution is to write directly in Javascript.</strong>   React takes over the page-rendering entirely; you just give it a tree of Javascript objects, and tell it how state is transmitted between them.</p> 
 
-                  <p>For instance, we might tell React.js to render a page displaying a single button, styled using the handy Bootstrap CSS:
+                  <p>For instance, we might tell React to render a page displaying a single button, styled using the handy Bootstrap CSS:
                   </p>
                   <ReactPlayground show={true} codeText={fs.readFileSync(__dirname + '/../comparisons/vanillaButton.js', 'utf8')} />
                   <p>
@@ -57,7 +61,7 @@ var Page = React.createClass({
                   React-Bootstrap is a library of such components, which you can also easily extend and enhance with your own functionality. 
                   <h3>JSX Syntax</h3>
                   <p>
-                    While each React component is really just a Javascript object, writing tree-structures that way gets tedious. React.js encourages the use of a syntactic-sugar called JSX, which lets you write the tree in an HTML-like syntax:
+                    While each React component is really just a Javascript object, writing tree-structures that way gets tedious. React encourages the use of a syntactic-sugar called JSX, which lets you write the tree in an HTML-like syntax:
                   </p>
                   <ReactPlayground show={true} codeText={fs.readFileSync(__dirname + '/../examples/ButtonGroupJustified.js', 'utf8')} />
                   <h3>No More DOM Selectors</h3>

--- a/docs/src/IntroductionPage.js
+++ b/docs/src/IntroductionPage.js
@@ -33,7 +33,7 @@ var Page = React.createClass({
                   <p className="lead">React-Bootstrap is a library of reuseable front-end components.  You'll get the look-and-feel of Twitter Bootstrap, but with much cleaner code, via Facebook's React.js framework.
                   </p>
                   <p>
-                    Let's say you want a small button that says "Something", to trigger the function someCallback. If were writing a native application, you might write something like:
+                    Let's say you want a small button that says "Something", to trigger the function someCallback. If you were writing a native application, you might write something like:
                   </p>
                    {StaticExample({codeText: 'button(size=SMALL, color=GREEN, text="Something", onClick=someCallback)'})}
                   <p>

--- a/docs/src/IntroductionPage.js
+++ b/docs/src/IntroductionPage.js
@@ -1,0 +1,90 @@
+/** @jsx React.DOM */
+
+'use strict';
+
+var React = require('react');
+var fs = require('fs');
+
+var NavMain = require('./NavMain');
+var PageHeader = require('./PageHeader');
+var PageFooter = require('./PageFooter');
+var StaticExample = require('./StaticExample');
+var ReactPlayground = require('./ReactPlayground')
+
+
+var TabbedArea = require('../../cjs/TabbedArea');
+var TabPane = require('../../cjs/TabPane');
+var preStyles = {"overflow": true};
+
+var Page = React.createClass({
+  render: function () {
+    return (
+        <div>
+          <NavMain activePage="introduction" />
+
+          <PageHeader
+            title="Introduction"
+            subTitle="The most popular front-end framework, rebuilt for React."/>
+
+          <div className="container bs-docs-container">
+            <div className="row">
+              <div className="col-md-9" role="main">
+                <div className="bs-docs-section">
+
+                  <h3>HTML/CSS Limit the Bootstrap API</h3>
+                  <p>
+                    Let's say you want a small button that says "Register". With the Bootstrap framework, you would write this:
+                  </p>
+                  {StaticExample({codeText: '<button class="btn btn-success btn-sm">Some Text</button>'})}
+                  <p>
+                    Compared to raw HTML, this is quite nice; but compared to a normal GUI library, it's quite nasty. In Python, we might write <small>Button(size="large", style="success")</small>. With HTML/CSS, we write <small>btn</small> three times, within an element of type <small>button</small>! 
+                  </p>
+
+                  <h3>A better Bootstrap API using React.js</h3>
+                  <p>
+                    The problem is that HTML and CSS are under-powered for providing a library of reuseable components, as they are for many other tasks we want to accomplish on the web today.
+                  </p>
+                  <p><strong>The React.js solution is to write directly in Javascript.</strong>   React.js takes over the page-rendering entirely; you just give it a tree of Javascript objects, and tell it how state is transmitted between them.</p> 
+
+                  <p>For instance, we might tell React.js to render a page displaying a single button, styled using the handy Bootstrap CSS:
+                  </p>
+                  <ReactPlayground show={true} codeText={fs.readFileSync(__dirname + '/../comparisons/vanillaButton.js', 'utf8')} />
+                  <p>
+                    But now that we're in Javascript, we can wrap the HTML/CSS, and provide a much better API:
+                  </p>
+                    <StaticExample codeText={fs.readFileSync(__dirname + '/../comparisons/noJSXButton.js', 'utf8')} />
+
+                  React-Bootstrap is a library of such components, which you can also easily extend and enhance with your own functionality. 
+                  <h3>JSX Syntax</h3>
+                  <p>
+                    While each React component is really just a Javascript object, writing tree-structures that way gets tedious. React.js encourages the use of a syntactic-sugar called JSX, which lets you write the tree in an HTML-like syntax:
+                  </p>
+                  <ReactPlayground show={true} codeText={fs.readFileSync(__dirname + '/../examples/ButtonGroupJustified.js', 'utf8')} />
+                  <h3>No More DOM Selectors</h3>
+                  <p>
+                    React-Bootstrap really shines on components that require some Javascript functionality.  In Bootstrap, this is achieved either through data attributes, or in Javascript, defined separately from the HTML code it references via arbitrary ID strings.
+                      For instance, here is a simple tabbed navigation area, displaying the difference in implementation:
+                  </p>
+                  <TabbedArea defaultActiveKey={2}>
+                    <TabPane key={1} tab="With Bootstrap">               
+                      <pre>{fs.readFileSync(__dirname + '/../comparisons/TabbedAreaBS.html', 'utf8')}</pre>
+                   </TabPane>
+                   <TabPane key={2} tab="With React-Bootstrap">
+                      <StaticExample codeText={fs.readFileSync(__dirname + '/../examples/TabbedAreaUncontrolled.js', 'utf8')} />
+                   </TabPane>
+                  </TabbedArea>
+                </div>
+              </div>
+            </div>
+          </div>
+          <PageFooter />
+        </div>
+      );
+  },
+
+  shouldComponentUpdate: function() {
+    return false;
+  }
+});
+
+module.exports = Page;

--- a/docs/src/NavMain.js
+++ b/docs/src/NavMain.js
@@ -10,6 +10,10 @@ var Nav = require('../../cjs/Nav');
 var InternalLink = Router.Link;
 
 var NAV_LINKS = {
+  'introduction': {
+    link: '/introduction.html',
+    title: 'Introduction'
+  },
   'getting-started': {
     link: '/getting-started.html',
     title: 'Getting started'

--- a/docs/src/ReactPlayground.js
+++ b/docs/src/ReactPlayground.js
@@ -119,6 +119,7 @@ var ReactPlayground = React.createClass({
 
   propTypes: {
     codeText: React.PropTypes.string.isRequired,
+    show: React.PropTypes.bool,
     transformer: React.PropTypes.func,
     renderCode: React.PropTypes.bool
   },
@@ -133,7 +134,7 @@ var ReactPlayground = React.createClass({
 
   getInitialState: function() {
     return {
-      mode: this.MODES.NONE,
+      mode: this.props.show ? this.MODES.JSX : this.MODES.NONE,
       code: this.props.codeText
     };
   },

--- a/docs/src/Root.js
+++ b/docs/src/Root.js
@@ -53,7 +53,8 @@ var Root = React.createClass({
         'getting-started.html',
         'css.html',
         'components.html',
-        'javascript.html'
+        'javascript.html',
+        'introduction.html'
       ];
     },
 

--- a/docs/src/Root.js
+++ b/docs/src/Root.js
@@ -7,6 +7,7 @@ var Router = require('react-router-component');
 
 var HomePage = require('./HomePage');
 var GettingStartedPage = require('./GettingStartedPage');
+var IntroductionPage = require('./IntroductionPage');
 var ComponentsPage = require('./ComponentsPage');
 var NotFoundPage = require('./NotFoundPage');
 
@@ -20,6 +21,7 @@ var PagesHolder = React.createClass({
         <Locations contextual>
           <Location path="/" handler={HomePage} />
           <Location path="/index.html" handler={HomePage} />
+          <Location path="/introduction.html" handler={IntroductionPage} />
           <Location path="/getting-started.html" handler={GettingStartedPage} />
           <Location path="/components.html" handler={ComponentsPage} />
           <NotFound handler={NotFoundPage} />

--- a/docs/src/StaticExample.js
+++ b/docs/src/StaticExample.js
@@ -1,0 +1,62 @@
+/** @jsx React.DOM */
+
+'use strict';
+
+var React = require('react');
+var CodeMirror = global.CodeMirror;
+
+var IS_MOBILE = typeof navigator !== 'undefined' && (
+  navigator.userAgent.match(/Android/i)
+    || navigator.userAgent.match(/webOS/i)
+    || navigator.userAgent.match(/iPhone/i)
+    || navigator.userAgent.match(/iPad/i)
+    || navigator.userAgent.match(/iPod/i)
+    || navigator.userAgent.match(/BlackBerry/i)
+    || navigator.userAgent.match(/Windows Phone/i)
+  );
+
+
+var StaticExample = React.createClass({
+  componentDidMount: function() {
+    if (IS_MOBILE) return;
+
+    this.editor = CodeMirror.fromTextArea(this.refs.editor.getDOMNode(), {
+      mode: 'javascript',
+      lineNumbers: false,
+      lineWrapping: true,
+      matchBrackets: true,
+      tabSize: 2,
+      theme: 'solarized-light',
+      readOnly: 'nocursor'
+    });
+  },
+
+  componentDidUpdate: function() {
+    if (this.props.readOnly) {
+      this.editor.setValue(this.props.codeText);
+    }
+  },
+
+  render: function() {
+    // wrap in a div to fully contain CodeMirror
+    var editor;
+
+    if (IS_MOBILE) {
+      var preStyles = {overflow: 'scroll'};
+      editor = <pre style={preStyles}>{this.props.codeText}</pre>;
+    } else {
+      editor = <textarea ref="editor" defaultValue={this.props.codeText} />;
+    }
+
+    return (
+      <div style={this.props.style} className={this.props.className}>
+        {editor}
+        <br/>
+      </div>
+      );
+  }
+});
+
+
+module.exports = StaticExample;    
+


### PR DESCRIPTION
Edit: I've revised the text at introduction.html, scrapped the changes I was proposing to Getting Started, and now suggest a button group of links on the homepage.

I've pushed a demo to my gh-pages, but the gh-pages version is a bit broken (the production version looks okay --- this gh-pages version is just so you can view the pages easily.)

https://syllog1sm.github.io/react-bootstrap/introduction.html
https://syllog1sm.github.com/react-bootstrap/
