### PR TITLE
Toggle button in collapsed Navbar works again.

### DIFF
--- a/src/Nav.jsx
+++ b/src/Nav.jsx
@@ -17,8 +17,8 @@ var Nav = React.createClass({
     stacked: React.PropTypes.bool,
     justified: React.PropTypes.bool,
     onSelect: React.PropTypes.func,
-    isCollapsable: React.PropTypes.bool,
-    isOpen: React.PropTypes.bool,
+    collapsable: React.PropTypes.bool,
+    expanded: React.PropTypes.bool,
     navbar: React.PropTypes.bool
   },
 
@@ -41,11 +41,11 @@ var Nav = React.createClass({
   },
 
   render: function () {
-    var classes = this.props.isCollapsable ? this.getCollapsableClassSet() : {};
+    var classes = this.props.collapsable ? this.getCollapsableClassSet() : {};
 
-    classes['navbar-collapse'] = this.props.isCollapsable;
+    classes['navbar-collapse'] = this.props.collapsable;
 
-    if (this.props.navbar && !this.props.isCollapsable) {
+    if (this.props.navbar && !this.props.collapsable) {
       return this.transferPropsTo(this.renderUl());
     }
 

--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -85,8 +85,8 @@ var Navbar = React.createClass({
   renderChild: function (child) {
     return utils.cloneWithProps(child, {
       navbar: true,
-      isCollapsable: this.props.toggleNavKey != null && this.props.toggleNavKey === child.props.key,
-      isOpen: this.props.toggleNavKey != null && this.props.toggleNavKey === child.props.key && this.isNavOpen(),
+      collapsable: this.props.toggleNavKey != null && this.props.toggleNavKey === child.props.key,
+      expanded: this.props.toggleNavKey != null && this.props.toggleNavKey === child.props.key && this.isNavOpen(),
       key: child.props.key,
       ref: child.props.ref
     });


### PR DESCRIPTION
As `isOpen` and `isCollapsable` was changed (to `expanded` and `collapsable`) in `CollapsableMixin` the new props needs to be used to get the collapsed `Navbar` working again.

I get some graphical glitches on **Chrome37/Win7** though, that I'm not smart enough to fix;
- Expanded state shows a scroll bar with `1px` scroll space.
- Clicking fast on the toggle button locks it in place, any additional clicks won't expand/collapse the `Navbar`.

No errors on **IE11/Win7**

Best way to test is to go to the [docs page](http://react-bootstrap.github.io/) and contract the window till the `Navbar` collapses.
