### PR TITLE
OverlayMixin container cleanup

### DIFF
--- a/src/OverlayMixin.js
+++ b/src/OverlayMixin.js
@@ -7,7 +7,12 @@ module.exports = {
 
   getDefaultProps: function () {
     return {
-      container: typeof document !== 'undefined' ? document.body : null
+      container: typeof document !== 'undefined' ? document.body : {
+        // If we are in an environment that doesnt have `document` defined it should be
+        // safe to assume that `componentDidMount` will not run and this will be needed,
+        // just provide enough fake API to pass the propType validation.
+        getDOMNode: function noop() {}
+      }
     };
   },
 
@@ -48,7 +53,7 @@ module.exports = {
     this._overlayInstance = null;
   },
 
-  getOverlayDOMNode: function() {
+  getOverlayDOMNode: function () {
     if (!this.isMounted()) {
       throw new Error('getOverlayDOMNode(): A component must be mounted to have a DOM node.');
     }
@@ -56,8 +61,8 @@ module.exports = {
     return this._overlayInstance.getDOMNode();
   },
 
-  getContainerDOMNode: function() {
-    return React.isValidComponent(this.props.container) ?
+  getContainerDOMNode: function () {
+    return this.props.container.getDOMNode ?
       this.props.container.getDOMNode() : this.props.container;
   }
 };

--- a/test/OverlayMixinSpec.jsx
+++ b/test/OverlayMixinSpec.jsx
@@ -1,0 +1,52 @@
+/** @jsx React.DOM */
+/*global describe, it, assert, afterEach */
+
+var React          = require('react');
+var ReactTestUtils = require('react/lib/ReactTestUtils');
+var OverlayMixin   = require('../cjs/OverlayMixin');
+
+describe('OverlayMixin', function () {
+  var instance;
+
+  var Overlay = React.createClass({
+    mixins: [OverlayMixin],
+
+    render: function() {
+      return <div />;
+    },
+
+    renderOverlay: function() {
+      return this.props.overlay;
+    }
+  });
+
+  afterEach(function() {
+    if (instance && ReactTestUtils.isCompositeComponent(instance) && instance.isMounted()) {
+      React.unmountComponentAtNode(instance.getDOMNode().parent);
+    }
+  });
+
+  it('Should render overlay into container (DOMNode)', function() {
+    var container = document.createElement('div');
+
+    instance = ReactTestUtils.renderIntoDocument(
+      <Overlay container={container} overlay={<div id="test1" />} />
+    );
+
+    assert.equal(container.querySelectorAll('#test1').length, 1);
+  });
+
+  it('Should render overlay into container (ReactComponent)', function() {
+    var Container = React.createClass({
+      render: function() {
+        return <Overlay container={this} overlay={<div id="test1" />} />;
+      }
+    });
+
+    instance = ReactTestUtils.renderIntoDocument(
+      <Container />
+    );
+
+    assert.equal(instance.getDOMNode().querySelectorAll('#test1').length, 1);
+  });
+});


### PR DESCRIPTION
Changes:
- Loosen check on `container` prop so that if an object has a `getDOMNode` method we use it, as per #160.
- ~~Provide a stricter propType check for `container`.~~ (See #163)
- Provide a default prop for `container` that passes the propType check in all cases.
- TESTS!
