### PR TITLE
PropTypes clean up

### DIFF
--- a/src/Col.jsx
+++ b/src/Col.jsx
@@ -2,7 +2,7 @@
 
 var React = require('react');
 var classSet = require('./utils/classSet');
-var PropTypes = require('./PropTypes');
+var CustomPropTypes = require('./utils/CustomPropTypes');
 var constants = require('./constants');
 
 
@@ -24,7 +24,7 @@ var Col = React.createClass({
     smPull: React.PropTypes.number,
     mdPull: React.PropTypes.number,
     lgPull: React.PropTypes.number,
-    componentClass: PropTypes.componentClass
+    componentClass: CustomPropTypes.componentClass
   },
 
   getDefaultProps: function () {

--- a/src/Grid.jsx
+++ b/src/Grid.jsx
@@ -1,13 +1,13 @@
 /** @jsx React.DOM */
 
 var React = require('react');
-var PropTypes = require('./PropTypes');
+var CustomPropTypes = require('./utils/CustomPropTypes');
 
 
 var Grid = React.createClass({
   propTypes: {
     fluid: React.PropTypes.bool,
-    componentClass: PropTypes.componentClass
+    componentClass: CustomPropTypes.componentClass
   },
 
   getDefaultProps: function () {

--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -2,7 +2,7 @@
 
 var React = require('react');
 var BootstrapMixin = require('./BootstrapMixin');
-var PropTypes = require('./PropTypes');
+var CustomPropTypes = require('./utils/CustomPropTypes');
 var classSet = require('./utils/classSet');
 var cloneWithProps = require('./utils/cloneWithProps');
 var ValidComponentChildren = require('./utils/ValidComponentChildren');
@@ -20,7 +20,7 @@ var Navbar = React.createClass({
     inverse: React.PropTypes.bool,
     fluid: React.PropTypes.bool,
     role: React.PropTypes.string,
-    componentClass: PropTypes.componentClass,
+    componentClass: CustomPropTypes.componentClass,
     brand: React.PropTypes.renderable,
     toggleButton: React.PropTypes.renderable,
     onToggle: React.PropTypes.func,

--- a/src/OverlayMixin.js
+++ b/src/OverlayMixin.js
@@ -1,8 +1,9 @@
 var React = require('react');
+var CustomPropTypes = require('./utils/CustomPropTypes');
 
 module.exports = {
   propTypes: {
-    container: React.PropTypes.object.isRequired
+    container: CustomPropTypes.mountable
   },
 
   getDefaultProps: function () {

--- a/src/PropTypes.js
+++ b/src/PropTypes.js
@@ -1,7 +1,0 @@
-var React = require('react');
-
-module.exports = {
-  componentClass: function (props, propName, componentName) {
-    return React.isValidClass(props[propName]);
-  }
-};

--- a/src/Row.jsx
+++ b/src/Row.jsx
@@ -1,12 +1,12 @@
 /** @jsx React.DOM */
 
 var React = require('react');
-var PropTypes = require('./PropTypes');
+var CustomPropTypes = require('./utils/CustomPropTypes');
 
 
 var Row = React.createClass({
   propTypes: {
-    componentClass: PropTypes.componentClass
+    componentClass: CustomPropTypes.componentClass
   },
 
   getDefaultProps: function () {

--- a/src/Table.jsx
+++ b/src/Table.jsx
@@ -2,7 +2,6 @@
 
 var React = require('react');
 var classSet = require('./utils/classSet');
-var PropTypes = require('./PropTypes');
 
 var Table = React.createClass({
   propTypes: {

--- a/src/utils/CustomPropTypes.js
+++ b/src/utils/CustomPropTypes.js
@@ -1,0 +1,40 @@
+var React = require('react');
+
+var CustomPropTypes = {
+  /**
+   * Checks whether a prop is a valid React class
+   *
+   * @param props
+   * @param propName
+   * @param componentName
+   * @returns {Error|undefined}
+   */
+  componentClass: function (props, propName, componentName) {
+    if (!React.isValidClass(props[propName])) {
+      return new Error('Invalid `' + propName + '` prop in `' + componentName + '`, expected be ' +
+        'a valid React class');
+    }
+  },
+
+  /**
+   * Checks whether a prop provides a DOM element
+   *
+   * The element can be provided in two forms:
+   * - Directly passed
+   * - Or passed an object which has a `getDOMNode` method which will return the required DOM element
+   *
+   * @param props
+   * @param propName
+   * @param componentName
+   * @returns {Error|undefined}
+   */
+  mountable: function (props, propName, componentName) {
+    if (typeof props[propName] !== 'object' ||
+      typeof props[propName].getDOMNode !== 'function' && props[propName].nodeType !== 1) {
+      return new Error('Invalid `' + propName + '` prop in `' + componentName + '`, expected be ' +
+        'a DOM element or an object that has a `getDOMNode` method');
+    }
+  }
+};
+
+module.exports = CustomPropTypes;

--- a/test/CustomPropTypesSpec.jsx
+++ b/test/CustomPropTypesSpec.jsx
@@ -1,0 +1,42 @@
+/** @jsx React.DOM */
+/*global describe, it, assert, afterEach */
+
+var React           = require('react');
+var ReactTestUtils  = require('react/lib/ReactTestUtils');
+var CustomPropTypes = require('../cjs/utils/CustomPropTypes');
+
+describe('CustomPropTypes', function () {
+  describe('componentClass', function () {
+    function validate(prop) {
+      return CustomPropTypes.componentClass({p: prop}, 'p', 'Component');
+    }
+    var nullClass = React.createClass({
+      render: function() { return <div />; }
+    });
+
+    it('Should return error with non componentClass', function() {
+      assert.instanceOf(validate(), Error);
+      assert.instanceOf(validate({}), Error);
+      assert.instanceOf(validate(nullClass()), Error);
+    });
+    it('Should return undefined with componentClass', function() {
+      assert.isUndefined(validate(React.DOM.div));
+      assert.isUndefined(validate(nullClass));
+    });
+  });
+  describe('mountable', function () {
+    function validate(prop) {
+      return CustomPropTypes.mountable({p: prop}, 'p', 'Component');
+    }
+
+    it('Should return error with non mountable values', function() {
+      assert.instanceOf(validate(), Error);
+      assert.instanceOf(validate({}), Error);
+    });
+    it('Should return undefined with mountable values', function() {
+      assert.isUndefined(validate(document.createElement('div')));
+      assert.isUndefined(validate(document.body));
+      assert.isUndefined(validate(ReactTestUtils.renderIntoDocument(<div />)));
+    });
+  });
+});


### PR DESCRIPTION
Changes:
- Moved propTypes to utils and renamed to CustomPropTypes so its not confused as a proxy of `React.PropTypes`.
- Update componentClass validator to match PropType signature, it now returns an `Error` if invalid instead of a boolean.
- Added mountable validator, as per #161
- TESTS!
