### PR TITLE
Adding a way to override Input Addon wrapper

### DIFF
--- a/docs/examples/InputAddons.js
+++ b/docs/examples/InputAddons.js
@@ -5,6 +5,9 @@ var inputAddonsInstance = (
       <Input type="text" addonBefore="@" />
       <Input type="text" addonAfter=".00" />
       <Input type="text" addonBefore="$" addonAfter=".00" />
+      <Input type="text" addonAfter={<Glyphicon glyph="music" />} />
+      <Input type="text" wrapAddonAfter={false}
+        addonAfter={<div className="input-group-addon customClass"><Glyphicon glyph="chevron-up" /></div>} />
     </form>
   );
 

--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -487,7 +487,10 @@ var ComponentsPage = React.createClass({
                   <p>Supports <code>select</code>, <code>textarea</code>, <code>static</code> as well as standard HTML input types.</p>
                   <ReactPlayground codeText={fs.readFileSync(__dirname + '/../examples/InputTypes.js', 'utf8')} />
                   <h2 id="input-addons">Add-ons</h2>
-                  <p>Use <code>addonBefore</code> and <code>addonAfter</code>. Does not support buttons.</p>
+                  <p>Use <code>addonBefore</code> and <code>addonAfter</code>. Does not support buttons directly, but they support anything that is renderable.
+                  Exotic configurations may require some css on your side.
+                  If you want to override the wrapper, you can do so by setting the <code>wrapAddonBefore</code> or <code>wrapAddonAfter</code>
+                  property to false</p>
                   <ReactPlayground codeText={fs.readFileSync(__dirname + '/../examples/InputAddons.js', 'utf8')} />
                   <h2 id="input-validation">Validation</h2>
                   <p>Set <code>bsStyle</code> to one of <code>success</code>, <code>warning</code> or <code>error</code>.

--- a/src/Input.jsx
+++ b/src/Input.jsx
@@ -9,12 +9,21 @@ var Input = React.createClass({
     label: React.PropTypes.renderable,
     help: React.PropTypes.renderable,
     addonBefore: React.PropTypes.renderable,
+    wrapAddonBefore: React.PropTypes.bool,
     addonAfter: React.PropTypes.renderable,
+    wrapAddonAfter: React.PropTypes.bool,
     bsStyle: React.PropTypes.oneOf(['success', 'warning', 'error']),
     hasFeedback: React.PropTypes.bool,
     groupClassName: React.PropTypes.string,
     wrapperClassName: React.PropTypes.string,
     labelClassName: React.PropTypes.string
+  },
+
+  getDefaultProps: function() {
+    return {
+      wrapAddonAfter: true,
+      wrapAddonBefore: true,
+    };
   },
 
   getInputDOMNode: function () {
@@ -75,17 +84,21 @@ var Input = React.createClass({
   },
 
   renderInputGroup: function (children) {
-    var addonBefore = this.props.addonBefore ? (
-      <span className="input-group-addon" key="addonBefore">
-        {this.props.addonBefore}
-      </span>
-    ) : null;
+    var addonBefore = this.props.addonBefore ?
+      this.props.wrapAddonBefore ? (
+        <span className="input-group-addon" key="addonBefore">
+          {this.props.addonBefore}
+        </span>
+      ) : this.props.addonBefore
+    : null;
 
-    var addonAfter = this.props.addonAfter ? (
-      <span className="input-group-addon" key="addonAfter">
-        {this.props.addonAfter}
-      </span>
-    ) : null;
+    var addonAfter = this.props.addonAfter ?
+      this.props.wrapAddonAfter ? (
+        <span className="input-group-addon" key="addonAfter">
+          {this.props.addonAfter}
+        </span>
+      ) : this.props.addonAfter
+    : null;
 
     return addonBefore || addonAfter ? (
       <div className="input-group" key="input-group">

--- a/test/InputSpec.jsx
+++ b/test/InputSpec.jsx
@@ -90,7 +90,6 @@ describe('Input', function () {
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'wrapper'));
   });
 
-
   it('renders input-group', function () {
     var instance = ReactTestUtils.renderIntoDocument(
       <Input addonBefore="$" />
@@ -99,6 +98,7 @@ describe('Input', function () {
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'input-group'));
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'input-group-addon'));
   });
+
 
   it('renders help', function () {
     var instance = ReactTestUtils.renderIntoDocument(
@@ -152,5 +152,37 @@ describe('Input', function () {
     );
 
     assert.equal(instance.getChecked(), true);
+  });
+
+  it('renders addonBefore with overriden wrapper', function () {
+    var addonBeforeClass = 'overriden-wrapper';
+
+    var addonBefore = (
+      <div className={addonBeforeClass}>$</div>
+    );
+
+    var instance = ReactTestUtils.renderIntoDocument(
+      <Input addonBefore={addonBefore} wrapAddonBefore={false} />
+    );
+
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'input-group'));
+    assert.throws(function () { ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'input-group-addon') });
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, addonBeforeClass));
+  });
+
+  it('renders addonAfter with overriden wrapper', function () {
+    var addonAfterClass = 'overriden-wrapper';
+
+    var addonAfter = (
+      <div className={addonAfterClass}>$</div>
+    );
+
+    var instance = ReactTestUtils.renderIntoDocument(
+      <Input addonBefore={addonAfter} wrapAddonBefore={false} />
+    );
+
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'input-group'));
+    assert.throws(function () { ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'input-group-addon') });
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, addonAfterClass));
   });
 });


### PR DESCRIPTION
I was trying to make a "spinner" (up and down button) addon on an input and was having some issues because of the default wrapper class which is "input-group-addon".

This does not change the default behavior as "wrapAddon(Before|After)" defaults to true, but lets the user to override it if he wants to provide it's own wrapper.

One thing though, I wasn't sure about calling it "wrapAddon..." and add a "getDefaultProps" function OR find a better name that says the inverse so you don't need the getDefaultProps. I ended up doing the former because it looked more intuitive to me.

With this, it enables you to have so slick addons like 

```
function upClick () {}
function downClick () {}
var addon = (
  <div className="input-group-spinner">
    <Button><Glyphicon glyph="chevron-up" onClick={upClick} /></Button>
    <Button><Glyphicon glyph="chevron-down" onClick={downClick} /></Button>
  </div>
);
<Input type="text" addonAfter={addon} wrapAddonAfter={false}  />
```

Let me know what you think about that
