### PR TITLE
Null out onSelect when transferToProps to div

### DIFF
--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -10,9 +10,9 @@ var Panel = React.createClass({
   mixins: [BootstrapMixin, CollapsableMixin],
 
   propTypes: {
+    onSelect: React.PropTypes.func,
     header: React.PropTypes.renderable,
-    footer: React.PropTypes.renderable,
-    onClick: React.PropTypes.func
+    footer: React.PropTypes.renderable
   },
 
   getDefaultProps: function () {
@@ -57,7 +57,7 @@ var Panel = React.createClass({
     classes['panel'] = true;
 
     return this.transferPropsTo(
-      <div className={classSet(classes)} id={this.props.collapsable ? null : this.props.id}>
+      <div className={classSet(classes)} id={this.props.collapsable ? null : this.props.id} onSelect={null}>
         {this.renderHeading()}
         {this.props.collapsable ? this.renderCollapsableBody() : this.renderBody()}
         {this.renderFooter()}

--- a/src/PanelGroup.jsx
+++ b/src/PanelGroup.jsx
@@ -32,7 +32,7 @@ var PanelGroup = React.createClass({
 
   render: function () {
     return this.transferPropsTo(
-      <div className={classSet(this.getBsClassSet())}>
+      <div className={classSet(this.getBsClassSet())} onSelect={null}>
         {ValidComponentChildren.map(this.props.children, this.renderPanel)}
       </div>
     );

--- a/test/PanelGroupSpec.jsx
+++ b/test/PanelGroupSpec.jsx
@@ -1,6 +1,7 @@
 /** @jsx React.DOM */
 /*global describe, it, assert */
 
+var React          = require('react');
 var ReactTestUtils = require('react/lib/ReactTestUtils');
 var PanelGroup     = require('../cjs/PanelGroup');
 var Panel          = require('../cjs/Panel');
@@ -28,5 +29,25 @@ describe('PanelGroup', function () {
     var panel = ReactTestUtils.findRenderedComponentWithType(instance, Panel);
 
     assert.equal(panel.props.bsStyle, 'primary');
+  });
+
+  it('Should not collapse panel by bubbling onSelect callback', function () {
+    var instance = ReactTestUtils.renderIntoDocument(
+      <PanelGroup accordion>
+        <Panel>
+          <input type="text" className="changeme" />
+        </Panel>
+      </PanelGroup>
+    );
+
+    var panel = ReactTestUtils.findRenderedComponentWithType(instance, Panel);
+
+    assert.notOk(panel.state.collapsing);
+
+    ReactTestUtils.Simulate.select(
+      ReactTestUtils.findRenderedDOMComponentWithClass(panel, 'changeme').getDOMNode()
+    );
+
+    assert.notOk(panel.state.collapsing);
   });
 });

--- a/test/PanelSpec.jsx
+++ b/test/PanelSpec.jsx
@@ -14,7 +14,7 @@ describe('Panel', function () {
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-body'));
   });
 
-  it('Should have boostrap style class', function () {
+  it('Should have bootstrap style class', function () {
     var instance = ReactTestUtils.renderIntoDocument(
           <Panel bsStyle="default">Panel content</Panel>
         );


### PR DESCRIPTION
Looking forward to when we implement #188 which should get rid of these weird side effects from transferPropsTo.

Closes #65 #197
