### PR TITLE
Fix errant location arg

### DIFF
--- a/src/utils/CustomPropTypes.js
+++ b/src/utils/CustomPropTypes.js
@@ -45,7 +45,7 @@ function createChainableTypeChecker(validate) {
         );
       }
     } else {
-      return validate(props, propName, componentName, location);
+      return validate(props, propName, componentName);
     }
   }
 


### PR DESCRIPTION
Building current master and running docs displays this error:

ReferenceError: location is not defined
    at checkType (/Volumes/CASE/code/react-bootstrap/cjs/utils/CustomPropTypes.js:48:55)
...

I see no reference to 'location' so removed it.
