### PR TITLE
affix bottom bounds fix

### DIFF
--- a/src/AffixMixin.js
+++ b/src/AffixMixin.js
@@ -90,7 +90,7 @@ var AffixMixin = {
       this.getPinnedOffset(DOMNode) : null;
 
     if (affix === 'bottom') {
-      DOMNode.className = DOMNode.className.replace(/affix-top|affix-bottom|affix/, 'affix-top');
+      DOMNode.className = DOMNode.className.replace(/affix-top|affix-bottom|affix/, 'affix-bottom');
       affixPositionTop = scrollHeight - offsetBottom - DOMNode.offsetHeight - domUtils.getOffset(DOMNode).top;
     }
 


### PR DESCRIPTION
The side menu on the docs/components page flickers like crazy when you scroll down to the bottom.  Turns out that the affix class was stuttering between 'affix' and 'affix-bottom' because of an erroneous assignment of 'affix-top'.
