### PR TITLE
added autoClose to Navbar props

### DIFF
--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -26,7 +26,7 @@ var Navbar = React.createClass({
     onToggle: React.PropTypes.func,
     navExpanded: React.PropTypes.bool,
     defaultNavExpanded: React.PropTypes.bool,
-    autoClose: React.PropTypes.func
+    autoClose: React.PropTypes.bool
   },
 
   getDefaultProps: function () {
@@ -92,7 +92,7 @@ var Navbar = React.createClass({
       expanded: this.props.toggleNavKey != null && this.props.toggleNavKey === child.props.key && this.isNavOpen(),
       key: child.props.key,
       ref: child.props.ref,
-      onSelect: this.props.autoClose && createChainedFunction(child.props.onSelect, this.handleToggle)
+      onSelect: this.props.autoClose === true ? createChainedFunction(child.props.onSelect, this.handleToggle) : child.props.onSelect
     });
   },
 


### PR DESCRIPTION
## Problem:

Bootstrap allows for a class ( **in** ) to be added to **Nav**, causing **Nav** to collapse. Can be used with props.onToggle(). react-bootstrap introduces a new state ( **navOpen** ) that is hidden from props.onToggle() and prevents the optional bootstrap functionality.
## Current functionality:

With **Nav** open,
click on **NavItem**,
must click on **toggleButton** to close.
## Change:

With **Nav** open,
click on **NavItem**,
Nav closes automatically.
### default:

autoClose: true
#### Notes:

In Bootstrap, adding class ( **in** ) to Nav causes an abrupt closure which must be dealt with in further code. This solution elegantly causes Nav to close with the same animation that it opened with.
