### PR TITLE
Fix for manual mode of OverlayTrigger.

### DIFF
--- a/src/OverlayTrigger.jsx
+++ b/src/OverlayTrigger.jsx
@@ -89,6 +89,10 @@ var OverlayTrigger = React.createClass({
   },
 
   render: function () {
+    if (this.props.trigger === 'manual') {
+      return React.Children.only(this.props.children);
+    }
+
     var props = {};
 
     if (isOneOf('click', this.props.trigger)) {


### PR DESCRIPTION
Before this fix it was not possible to refer to the component wrapped by the OverlayTrigger using the ref property, because it was not cloned using cloneWithProps.

Now, in manuel mode,  we just return the unmodified child which will still have the ref and all children.
