### PR TITLE
Additional test for check if a prop provides a DOM element.

### DIFF
--- a/src/utils/CustomPropTypes.js
+++ b/src/utils/CustomPropTypes.js
@@ -70,7 +70,7 @@ function createComponentClassChecker() {
 
 function createMountableChecker() {
   function validate(props, propName, componentName) {
-    if (typeof props[propName] !== 'object' ||
+    if (typeof props[propName] !== 'object' || props[propName] === null ||
       typeof props[propName].getDOMNode !== 'function' && props[propName].nodeType !== 1) {
       return new Error(
         'Invalid prop `' + propName + '` supplied to ' +


### PR DESCRIPTION
If a prop was null before, the check had failed to detect this, as typeof null is also object. Resulted in an error. Explicit null check has been added.
