### PR TITLE
Rename "navOpen" to "navExpanded"

### DIFF
--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -56,12 +56,12 @@ var Navbar = React.createClass({
     }
 
     this.setState({
-      navOpen: !this.state.navOpen
+      navExpanded: !this.state.navExpanded
     });
   },
 
-  isNavOpen: function () {
-    return this.props.navOpen != null ? this.props.navOpen : this.state.navOpen;
+  isNavExpanded: function () {
+    return this.props.navExpanded != null ? this.props.navExpanded : this.state.navExpanded;
   },
 
   render: function () {
@@ -87,7 +87,7 @@ var Navbar = React.createClass({
     return cloneWithProps(child, {
       navbar: true,
       collapsable: this.props.toggleNavKey != null && this.props.toggleNavKey === child.props.key,
-      expanded: this.props.toggleNavKey != null && this.props.toggleNavKey === child.props.key && this.isNavOpen(),
+      expanded: this.props.toggleNavKey != null && this.props.toggleNavKey === child.props.key && this.isNavExpanded(),
       key: child.props.key,
       ref: child.props.ref
     });


### PR DESCRIPTION
There seems to be a non-working mix navOpen and navExpanded which means
getInitialState() sets navExpanded in the state, but isNavOpen refers to
the uninitialised navOpen. I have made it all use navExpanded, which
appears to be the intention, and also added some sensible defaults to
make it easier to get right.

And, erm, this is my first ever pull-request  on Github, so if I've mucked-up, please bear with me...
