### PR TITLE
Added getOverlayDOMNode option to OverlayTrigger

### DIFF
--- a/src/OverlayTrigger.jsx
+++ b/src/OverlayTrigger.jsx
@@ -35,7 +35,7 @@ var OverlayTrigger = React.createClass({
     delayHide: React.PropTypes.number,
     defaultOverlayShown: React.PropTypes.bool,
     getOverlayDOMNode: React.PropTypes.func,
-    overlay: React.PropTypes.renderable.isRequired
+    overlay: React.PropTypes.renderable
   },
 
   getDefaultProps: function () {

--- a/src/OverlayTrigger.jsx
+++ b/src/OverlayTrigger.jsx
@@ -34,6 +34,7 @@ var OverlayTrigger = React.createClass({
     delayShow: React.PropTypes.number,
     delayHide: React.PropTypes.number,
     defaultOverlayShown: React.PropTypes.bool,
+    getOverlayDOMNode: React.PropTypes.func,
     overlay: React.PropTypes.renderable.isRequired
   },
 
@@ -178,6 +179,11 @@ var OverlayTrigger = React.createClass({
     var childOffset = this.getPosition();
 
     var overlayNode = this.getOverlayDOMNode();
+
+    if (this.props.getOverlayDOMNode) {
+      overlayNode = this.props.getOverlayDOMNode(overlayNode);
+    }
+
     var overlayHeight = overlayNode.offsetHeight;
     var overlayWidth = overlayNode.offsetWidth;
 


### PR DESCRIPTION
`getOverlayDOMNode` is an override prop for `OverlayTrigger` that allows one to optionally choose what DOM element to use when making positioning calculations.