### PR TITLE
Allow empty bsStyle attribute

### DIFF
--- a/src/Input.jsx
+++ b/src/Input.jsx
@@ -18,7 +18,7 @@ var Input = React.createClass({
         return;
       }
 
-      return React.PropTypes.oneOf(['success', 'warning', 'error']).apply(null, arguments);
+      return React.PropTypes.oneOf(['success', 'warning', 'error', '']).apply(null, arguments);
     },
     hasFeedback: React.PropTypes.bool,
     groupClassName: React.PropTypes.string,


### PR DESCRIPTION
Consider the following example:

``` js
var MyComponent = React.createClass({
  validationState: function(property) {
    if (this.state.validationMessages[property]) return 'error';
    return '';
  },
  render: function() {
    return (
       // A lot of components here
       <Input bsStyle={this.validationState('foo')} hasFeedback help={this.state.validationMessages.foo} type="text" value={this.state.something} />
     );
  }
});
```

this way you decorate your form inputs _only_ for error states. This already works as expected, it just logs a warning to console.
