### PR TITLE
correct _removeEndTransitionListener

### DIFF
--- a/src/CollapsableMixin.js
+++ b/src/CollapsableMixin.js
@@ -47,7 +47,7 @@ var CollapsableMixin = {
     var node = this.getCollapsableDOMNode();
 
     if (node) {
-      TransitionEvents.addEndEventListener(
+      TransitionEvents.removeEndEventListener(
         node,
         this.handleTransitionEnd
       );


### PR DESCRIPTION
_removeEndTransitionListener in CollapsableMixin.js is calling TransitionEvents#addEndEventListener instead of TransitionEvents#removeEndEventListener
