### PR TITLE
Added navbar-right class prop to Nav component

### DIFF
--- a/src/Nav.jsx
+++ b/src/Nav.jsx
@@ -20,7 +20,8 @@ var Nav = React.createClass({
     onSelect: React.PropTypes.func,
     collapsable: React.PropTypes.bool,
     expanded: React.PropTypes.bool,
-    navbar: React.PropTypes.bool
+    navbar: React.PropTypes.bool,
+    right: React.PropTypes.bool,
   },
 
   getDefaultProps: function () {
@@ -64,6 +65,7 @@ var Nav = React.createClass({
     classes['nav-justified'] = this.props.justified;
     classes['navbar-nav'] = this.props.navbar;
     classes['pull-right'] = this.props.pullRight;
+    classes['navbar-right'] = this.props.right;
 
     return (
       <ul className={classSet(classes)} ref="ul">

--- a/test/NavSpec.jsx
+++ b/test/NavSpec.jsx
@@ -60,6 +60,16 @@ describe('Nav', function () {
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'pull-right'));
   });
 
+  it('Should add navbar-right class', function () {
+    var instance = ReactTestUtils.renderIntoDocument(
+          <Nav bsStyle="tabs" right activeKey={1}>
+            <NavItem key={1} ref="item1">Tab 1 content</NavItem>
+            <NavItem key={2} ref="item2">Tab 2 content</NavItem>
+          </Nav>
+        );
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'navbar-right'));
+  });
+
   it('Should call on select when item is selected', function (done) {
     function handleSelect(key) {
       assert.equal(key, 2);


### PR DESCRIPTION
Nav components need `navbar-right` classes for dropdown menus to appropriately shift. As it stands, using `pull-right` and the corresponding `pullRight` prop, dropdown menus go offscreen. This makes `pullRight` redundant, but I have kept it for compatibility purposes.

The bootstrap CSS that makes this important ([Source](https://github.com/twbs/bootstrap/blob/35f09315ed543a0479719afa2143240952c215db/less/dropdowns.less#L203)):

```
.navbar-right .dropdown-menu {
  right: 0;
  left: auto;
}
```
