### PR TITLE
fade does include the root element

### DIFF
--- a/src/FadeMixin.js
+++ b/src/FadeMixin.js
@@ -1,14 +1,28 @@
-var React = require('react');
-
+/*global document */
 // TODO: listen for onTransitionEnd to remove el
+function getElementsAndSelf (root, classes){
+  var els = root.querySelectorAll('.' + classes.join('.'));
+
+  els = [].map.call(els, function(e){ return e; });
+
+  for(var i = 0; i < classes.length; i++){
+    if( !root.className.match(new RegExp('\\b' +  classes[i] + '\\b'))){
+      return els;
+    }
+  }
+  els.unshift(root);
+  return els;
+}
+
 module.exports = {
   _fadeIn: function () {
     var els;
 
     if (this.isMounted()) {
-      els = this.getDOMNode().querySelectorAll('.fade');
+      els = getElementsAndSelf(this.getDOMNode(), ['fade']);
+
       if (els.length) {
-        Array.prototype.forEach.call(els, function (el) {
+        els.forEach(function (el) {
           el.className += ' in';
         });
       }
@@ -16,10 +30,10 @@ module.exports = {
   },
 
   _fadeOut: function () {
-    var els = this._fadeOutEl.querySelectorAll('.fade.in');
+    var els = getElementsAndSelf(this._fadeOutEl, ['fade', 'in']);
 
     if (els.length) {
-      Array.prototype.forEach.call(els, function (el) {
+      els.forEach(function (el) {
         el.className = el.className.replace(/\bin\b/, '');
       });
     }
@@ -41,8 +55,9 @@ module.exports = {
   },
 
   componentWillUnmount: function () {
-    var els = this.getDOMNode().querySelectorAll('.fade'),
+    var els = getElementsAndSelf(this.getDOMNode(), ['fade']),
         container = (this.props.container && this.props.container.getDOMNode()) || document.body;
+
     if (els.length) {
       this._fadeOutEl = document.createElement('div');
       container.appendChild(this._fadeOutEl);

--- a/test/FadeMixinSpec.jsx
+++ b/test/FadeMixinSpec.jsx
@@ -1,0 +1,63 @@
+/** @jsx React.DOM */
+/*global describe, beforeEach, afterEach, it, assert */
+
+var React          = require('react');
+var ReactTestUtils = require('react/lib/ReactTestUtils');
+var FadeMixin = require('../cjs/FadeMixin');
+
+var Component;
+
+describe('FadeMixin', function () {
+  beforeEach(function() {
+    Component = React.createClass({
+      mixins: [ FadeMixin ],
+
+      render: function () {
+        return this.transferPropsTo(
+          React.DOM.div({ className: 'fade' },
+            React.DOM.span({ className: 'fade' })
+          )
+        );
+      }
+    });
+  });
+
+  it('Should add the in class to all elements', function (done) {
+    var instance = ReactTestUtils.renderIntoDocument(
+          Component()
+        );
+
+    var child = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'span')
+
+    setTimeout(function(){
+      assert.ok(instance.getDOMNode().className.match(/\bin\b/));
+      assert.ok(instance.getDOMNode().className.match(/\bfade\b/));
+      assert.ok(child.getDOMNode().className.match(/\bin\b/));
+      assert.ok(child.getDOMNode().className.match(/\bfade\b/));
+      done()
+    }, 25)
+  });
+
+  it('Should remove the in class for all elements', function (done) {
+    var instance = ReactTestUtils.renderIntoDocument(
+          Component()
+        );
+
+    setTimeout(function(){
+      instance.componentWillUnmount()
+      var element = instance._fadeOutEl.children[0]
+      var child   = element.children[0]
+
+      assert.ok(element.className.match(/\bin\b/));
+      assert.ok(child.className.match(/\bin\b/));
+
+      setTimeout(function(){
+        assert.ok(!element.className.match(/\bin\b/));
+        assert.ok(element.className.match(/\bfade\b/));
+        assert.ok(!child.className.match(/\bin\b/));
+        assert.ok(child.className.match(/\bfade\b/));
+        done()
+      }, 25)
+    }, 25)
+  });
+});


### PR DESCRIPTION
The FadeMixin does not do anything when `this.getDOMNode()` element has a
fade. This causes a bug at least in the Modal when the `backdrop=false` and `animation=true`. see [here](http://jsfiddle.net/Hhc8z/11/)
and the Modal component is the root, causing it to never fade in.

the PR includes the root element in the list of elements searched, similar to `jQuery.addBack()`. Also added tests (albeit ugly ones)!

Other thought is that the correct way to fix this is just to make the modal **not** the root element. but this seems like a cleaner solution. However it affects more than just the modal
