### PR TITLE
Collapsable Mixin fix for broken Panel Groups

### DIFF
--- a/src/CollapsableMixin.js
+++ b/src/CollapsableMixin.js
@@ -68,15 +68,10 @@ var CollapsableMixin = {
     var node = this.getCollapsableDOMNode();
 
     this._removeEndTransitionListener();
-    if (node && nextProps.expanded !== this.props.expanded && this.props.expanded) {
-      node.style[dimension] = this.getCollapsableDimensionValue() + 'px';
-    }
   },
 
   componentDidUpdate: function (prevProps, prevState) {
-    if (this.state.collapsing !== prevState.collapsing) {
-      this._afterRender();
-    }
+    this._afterRender();
   },
 
   _afterRender: function () {
@@ -89,17 +84,12 @@ var CollapsableMixin = {
   },
 
   _updateDimensionAfterRender: function () {
-    var dimension = (typeof this.getCollapsableDimension === 'function') ?
-      this.getCollapsableDimension() : 'height';
     var node = this.getCollapsableDOMNode();
-
     if (node) {
-        if(this.isExpanded() && !this.state.collapsing) {
-            node.style[dimension] = 'auto';
-        } else {
-            node.style[dimension] = this.isExpanded() ?
-              this.getCollapsableDimensionValue() + 'px' : '0px';
-        }
+        var dimension = (typeof this.getCollapsableDimension === 'function') ?
+            this.getCollapsableDimension() : 'height';
+        node.style[dimension] = this.isExpanded() ?
+            this.getCollapsableDimensionValue() + 'px' : '0px';
     }
   },
 


### PR DESCRIPTION
Fixes 2 issues with collapsable panels in current master:
- https://github.com/react-bootstrap/react-bootstrap/issues/265
  - Panel with defaultExpanded={false} doesn't render correctly when opened
  - BROKEN = http://screencast.com/t/EAizMEI8JSh
  - FIXED = http://screencast.com/t/mSDw54i6
- https://github.com/react-bootstrap/react-bootstrap/issues/266
  - Panel Group animation has become irregular / unpredictable
  - BROKEN = http://screencast.com/t/QnFadPU2hU8o
  - FIXED = http://screencast.com/t/NhNwQsu8ePrm
- also still works with content that changes size (the original problem that the master changes was originally fixing)
  - http://screencast.com/t/wBQAJZXF
- also now allows for rapid clicking of panel headers to interrupt / redirect the animated transition in flight
  - http://screencast.com/t/F0YQDxW8G

@stevoland 
@pieterv 
