### PR TITLE
remove duplicate BootstrapMixin test

### DIFF
--- a/test/BootstrapMixinSpec.jsx
+++ b/test/BootstrapMixinSpec.jsx
@@ -91,13 +91,6 @@ describe('BootstrapMixin', function () {
       assert.deepEqual(instance.getBsClassSet(), {'btn': true, 'btn-default': true});
     });
 
-    it('should return "btn btn-default"', function () {
-      var instance = ReactTestUtils.renderIntoDocument(
-        Component({bsClass: 'button', bsStyle: 'default'}, 'content')
-      );
-      assert.deepEqual(instance.getBsClassSet(), {'btn': true, 'btn-default': true});
-    });
-
     it('should return "btn btn-primary"', function () {
       var instance = ReactTestUtils.renderIntoDocument(
         Component({bsClass: 'button', bsStyle: 'primary'}, 'content')


### PR DESCRIPTION
Removing duplicate BootstrapMixin unit test.  Some CI / reporting systems choke on duplicate test names.
