### PR TITLE
NavItem includes anchor attributes on the li tag

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,6 +59,9 @@ module.exports = function (grunt) {
     },
 
     react: {
+      options: {
+        harmony: true
+      },
       src: {
         files: [
           {

--- a/src/NavItem.jsx
+++ b/src/NavItem.jsx
@@ -22,19 +22,26 @@ var NavItem = React.createClass({
   },
 
   render: function () {
-    var classes = {
-      'active': this.props.active,
-      'disabled': this.props.disabled
-    };
+    var { 
+        disabled,
+        active,
+        href,
+        title,
+        children,
+        ...props } = this.props,
+        classes = {
+          'active': active,
+          'disabled': disabled
+        };
 
     return (
-      <li {...this.props} className={joinClasses(this.props.className, classSet(classes))}>
+      <li {...props} className={joinClasses(props.className, classSet(classes))}>
         <a
-          href={this.props.href}
-          title={this.props.title}
+          href={href}
+          title={title}
           onClick={this.handleClick}
           ref="anchor">
-          {this.props.children}
+          { children }
         </a>
       </li>
     );

--- a/test/NavItemSpec.jsx
+++ b/test/NavItemSpec.jsx
@@ -34,6 +34,17 @@ describe('NavItem', function () {
     assert.equal(linkElement.title, 'content');
   });
 
+  it('Should not add anchor properties to li', function () {
+    var instance = ReactTestUtils.renderIntoDocument(
+      <NavItem href='/hi' title='boom!'>
+        Item content
+      </NavItem>
+    );
+
+    assert.ok(!instance.getDOMNode().hasAttribute('href'));
+    assert.ok(!instance.getDOMNode().hasAttribute('title'));
+  });
+
   it('Should call `onSelect` when item is selected', function (done) {
     function handleSelect(key) {
       assert.equal(key, '2');


### PR DESCRIPTION
`{...this.props}` passes DOM attributes to the li tag incorrectly. setting `href` and `title` on the `<li/>` tag

I "fixed" this by turning on the harmony features in grunt-react, and using the spread operator which is the recommended path from React. If the team doesn't want to enable harmony features, then we can just as easily do this manually by either:
- setting the props to null explicitly `<li title={null}`
- including a simple `omit` util like [`_.omit` ](https://lodash.com/docs#omit)

The issue is larger than just passing odd attributes. Unlike `transferToProps()` the spread operator also passes along `props.children`. In _most_ cases I've seen, this doesn't have an adverse affect, but sometimes it causes [weird bugs](http://jsfiddle.net/kb3gN/7772/) where passing it to both the component and as children causes the child to get rendered twice.
