### PR TITLE
Add modal-open class to body when modals are opened

### DIFF
--- a/src/Modal.jsx
+++ b/src/Modal.jsx
@@ -126,6 +126,10 @@ var Modal = React.createClass({
 
     if (this.props.backdrop) {
       this.iosClickHack();
+      if (document && document.body) {
+        var orig = document.body.className;
+        document.body.className = orig + (orig ? ' ' : '') + 'modal-open';
+      }
     }
   },
 
@@ -137,6 +141,9 @@ var Modal = React.createClass({
 
   componentWillUnmount: function () {
     this._onDocumentKeyupListener.remove();
+    if (document && document.body) {
+      document.body.className = document.body.className.replace(/ ?modal-open/, '');
+    }
   },
 
   handleBackdropClick: function (e) {


### PR DESCRIPTION
Given that this is how normal bootstrap works, it makes sense to break React's encapsulation convention.

Not sure what the right way to write a test for this is, but I confirmed that the modal demos on the docs site work the same way as on the bootstrap site.
