### PR TITLE
Add a few additional checks to checkPosition in Affix

### DIFF
--- a/src/AffixMixin.js
+++ b/src/AffixMixin.js
@@ -26,7 +26,6 @@ var AffixMixin = {
     DOMNode.className += DOMNode.className.length ? ' affix' : 'affix';
 
     this.pinnedOffset = domUtils.getOffset(DOMNode).top - window.pageYOffset;
-
     return this.pinnedOffset;
   },
 
@@ -54,6 +53,19 @@ var AffixMixin = {
       this.props.offsetTop : this.props.offset;
     offsetBottom = this.props.offsetBottom != null ?
       this.props.offsetBottom : this.props.offset;
+
+    if (this.affixed === 'top' && scrollTop < offsetTop) {
+      return;
+    }
+
+    if (this.affixed === 'bottom') {
+      if (scrollTop + this.unpin > position.top) {
+        return;
+      }
+      if (scrollTop + DOMNode.offsetHeight > scrollHeight - offsetBottom) {
+        return;
+      }
+    }
 
     if (offsetTop == null && offsetBottom == null) {
       return;


### PR DESCRIPTION
I was using the affix component and I found that my component was uncontrollably flickering once I had scrolled past the affix's `offsetBottom` value. 

I looked at Bootstrap's JS for the affix plugin and found that there were a few additional checks that weren't present in this Affix component. Including them in `checkPosition` fixed the flickering problem for me.