### PR TITLE
OverlayTrigger: updateOverlayPosition() on componentDidMount

### DIFF
--- a/src/OverlayTrigger.jsx
+++ b/src/OverlayTrigger.jsx
@@ -118,6 +118,10 @@ var OverlayTrigger = React.createClass({
     clearTimeout(this._hoverDelay);
   },
 
+  componentDidMount: function() {
+    this.updateOverlayPosition();
+  },
+
   handleDelayedShow: function () {
     if (this._hoverDelay != null) {
       clearTimeout(this._hoverDelay);


### PR DESCRIPTION
fixes the `defaultOverlayShown` prop that currently does nothing because
overlay doesn't have a position after mounting
