### PR TITLE
Update OverlayMixin to allow for a null overlay

### DIFF
--- a/src/OverlayMixin.js
+++ b/src/OverlayMixin.js
@@ -54,6 +54,9 @@ module.exports = {
     // Save reference to help testing
     if (overlay !== null) {
       this._overlayInstance = React.render(overlay, this._overlayTarget);
+    } else {
+      // Unrender if the component is null for transitions to null
+      this._unrenderOverlay();
     }
   },
 

--- a/src/OverlayMixin.js
+++ b/src/OverlayMixin.js
@@ -49,8 +49,12 @@ module.exports = {
       this._mountOverlayTarget();
     }
 
+    var overlay = this.renderOverlay();
+
     // Save reference to help testing
-    this._overlayInstance = React.render(this.renderOverlay(), this._overlayTarget);
+    if (overlay !== null) {
+      this._overlayInstance = React.render(this.renderOverlay(), this._overlayTarget);
+    }
   },
 
   _unrenderOverlay: function () {
@@ -63,7 +67,11 @@ module.exports = {
       throw new Error('getOverlayDOMNode(): A component must be mounted to have a DOM node.');
     }
 
-    return this._overlayInstance.getDOMNode();
+    if (this._overlayInstance) {
+      return this._overlayInstance.getDOMNode();
+    }
+
+    return null;
   },
 
   getContainerDOMNode: function () {

--- a/src/OverlayMixin.js
+++ b/src/OverlayMixin.js
@@ -53,7 +53,7 @@ module.exports = {
 
     // Save reference to help testing
     if (overlay !== null) {
-      this._overlayInstance = React.render(this.renderOverlay(), this._overlayTarget);
+      this._overlayInstance = React.render(overlay, this._overlayTarget);
     }
   },
 

--- a/test/OverlayMixinSpec.jsx
+++ b/test/OverlayMixinSpec.jsx
@@ -48,4 +48,18 @@ describe('OverlayMixin', function () {
 
     assert.equal(instance.getDOMNode().querySelectorAll('#test1').length, 1);
   });
+
+  it('Should not render a null overlay', function() {
+    var Container = React.createClass({
+      render: function() {
+        return <Overlay ref='overlay' container={this} overlay={null} />;
+      }
+    });
+
+    instance = ReactTestUtils.renderIntoDocument(
+      <Container />
+    );
+
+    assert.equal(instance.refs.overlay.getOverlayDOMNode(), null);
+  });
 });


### PR DESCRIPTION
Use case:

Large table in which there is an item using OverlayMixin on every row.
If a `<span />` is returned by renderOverlay(), using React Dev Tools can be frustrating as the tree is littered with `<span />`s