### PR TITLE
Update for Bootstrap 3.3: render a .modal-backdrop inside of its .modal.

### DIFF
--- a/src/Modal.jsx
+++ b/src/Modal.jsx
@@ -47,7 +47,7 @@ var Modal = React.createClass({
       'in': !this.props.animation || !document.querySelectorAll
     };
 
-    var modal = (
+    return (
       <div
         {...this.props}
         title={null}
@@ -57,6 +57,7 @@ var Modal = React.createClass({
         className={joinClasses(this.props.className, classSet(classes))}
         onClick={this.props.backdrop === true ? this.handleBackdropClick : null}
         ref="modal">
+        {this.props.backdrop ? this.renderBackdrop() : null}
         <div className={classSet(dialogClasses)}>
           <div className="modal-content">
             {this.props.title ? this.renderHeader() : null}
@@ -65,12 +66,9 @@ var Modal = React.createClass({
         </div>
       </div>
     );
-
-    return this.props.backdrop ?
-      this.renderBackdrop(modal) : modal;
   },
 
-  renderBackdrop: function (modal) {
+  renderBackdrop: function () {
     var classes = {
       'modal-backdrop': true,
       'fade': this.props.animation
@@ -82,10 +80,7 @@ var Modal = React.createClass({
       this.handleBackdropClick : null;
 
     return (
-      <div>
-        <div className={classSet(classes)} ref="backdrop" onClick={onClick} />
-        {modal}
-      </div>
+      <div className={classSet(classes)} ref="backdrop" onClick={onClick} />
     );
   },
 

--- a/test/ModalSpec.jsx
+++ b/test/ModalSpec.jsx
@@ -69,8 +69,8 @@ describe('Modal', function () {
       </Modal>
     );
 
-    var backdrop = instance.getDOMNode().getElementsByClassName('modal')[0];
-    ReactTestUtils.Simulate.click(backdrop);
+    var modal = instance.getDOMNode();
+    ReactTestUtils.Simulate.click(modal);
   });
 
   it('Should pass bsSize to the dialog', function () {


### PR DESCRIPTION
In Bootstrap 3.3.0, the `.modal-backdrop` was moved inside its corresponding `.modal`. See: twbs/bootstrap#14724

With this, the `z-index` was removed from the `.modal-backdrop`, meaning that modal backdrops in React Bootstrap aren't layered properly when used with CSS from Bootstrap >= 3.3.0.

Note: this *breaks* Modals in Bootstrap < 3.3.0, because the backdrop winds up *above* the modal content.

What is React Bootstrap's policy for dealing with backwards-incompatible changes like this in Bootstrap itself? If you have a standard-ish way of handling this, I'm happy to update the PR accordingly!