### PR TITLE
Support panel-filling tables and list groups

### DIFF
--- a/docs/examples/PanelListGroupFill.js
+++ b/docs/examples/PanelListGroupFill.js
@@ -1,0 +1,13 @@
+var panelInstance = (
+    <Panel header="Panel heading">
+      Some default panel content here.
+      <ListGroup fill>
+        <ListGroupItem>Item 1</ListGroupItem>
+        <ListGroupItem>Item 2</ListGroupItem>
+        <ListGroupItem>&hellip;</ListGroupItem>
+      </ListGroup>
+      Some more panel content here.
+    </Panel>
+  );
+
+React.render(panelInstance, mountNode);

--- a/docs/examples/PanelListGroupFill.js
+++ b/docs/examples/PanelListGroupFill.js
@@ -1,5 +1,5 @@
 var panelInstance = (
-    <Panel header="Panel heading">
+    <Panel collapsable defaultExpanded header="Panel heading">
       Some default panel content here.
       <ListGroup fill>
         <ListGroupItem>Item 1</ListGroupItem>

--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -188,6 +188,10 @@ var ComponentsPage = React.createClass({
                   <p>Like other components, easily make a panel more meaningful to a particular context by adding a <code>bsStyle</code> prop.</p>
                   <ReactPlayground codeText={fs.readFileSync(__dirname + '/../examples/PanelContextual.js', 'utf8')} />
 
+                  <h3 id="panels-contextual">With tables and list groups</h3>
+                  <p>Add the <code>fill</code> prop to <code>&lt;Table /&gt;</code> or <code>&lt;ListGroup /&gt;</code> elements to make them fill the panel.</p>
+                  <ReactPlayground codeText={fs.readFileSync(__dirname + '/../examples/PanelListGroupFill.js', 'utf8')} />
+
                   <h3 id="panels-controlled">Controlled PanelGroups</h3>
                   <p><code>PanelGroup</code>s can be controlled by a parent component. The <code>activeKey</code> prop dictates which panel is open.</p>
                   <ReactPlayground codeText={fs.readFileSync(__dirname + '/../examples/PanelGroupControlled.js', 'utf8')} />

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -42,7 +42,7 @@ var Panel = React.createClass({
   },
 
   getCollapsableDimensionValue: function () {
-    return this.refs.body.getDOMNode().offsetHeight;
+    return this.refs.panel.getDOMNode().scrollHeight;
   },
 
   getCollapsableDOMNode: function () {
@@ -80,19 +80,7 @@ var Panel = React.createClass({
     var bodyElements = [];
 
     function getProps() {
-      var index = bodyElements.length;
-      var props = {key: index};
-
-      // Arbitrarily assign the body ref to the first element. We can't wrap
-      // all body elements in a single DOM node, because the selector for the
-      // panel-filling behavior in Bootstrap looks like ".panel>.list-group",
-      // which will not work if there are any DOM nodes between the ".panel"
-      // element and the ".list-group" element.
-      if (index == 0) {
-        props.ref = 'body';
-      }
-
-      return props;
+      return {key: bodyElements.length};
     }
 
     function addPanelBody (children) {

--- a/src/Panel.jsx
+++ b/src/Panel.jsx
@@ -84,9 +84,10 @@ var Panel = React.createClass({
       var props = {key: index};
 
       // Arbitrarily assign the body ref to the first element. We can't wrap
-      // all body elements in a single DOM node anyway, because the fill
-      // styling depends on the table or list group element being a direct
-      // descendant of the panel.
+      // all body elements in a single DOM node, because the selector for the
+      // panel-filling behavior in Bootstrap looks like ".panel>.list-group",
+      // which will not work if there are any DOM nodes between the ".panel"
+      // element and the ".list-group" element.
       if (index == 0) {
         props.ref = 'body';
       }

--- a/test/PanelSpec.jsx
+++ b/test/PanelSpec.jsx
@@ -3,6 +3,7 @@
 var React          = require('react');
 var ReactTestUtils = require('react/lib/ReactTestUtils');
 var Panel          = require('../cjs/Panel');
+var Table          = require('../cjs/Table');
 
 describe('Panel', function () {
   it('Should have class and body', function () {
@@ -137,4 +138,19 @@ describe('Panel', function () {
 
     assert.ok(instance.state.expanded);
   });
+
+  it('Should not wrap panel-filling tables in a panel body', function () {
+    var instance = ReactTestUtils.renderIntoDocument(
+      <Panel>
+        Panel content
+        <Table fill />
+        More panel content
+      </Panel>
+    );
+
+    var children = instance.getDOMNode().children;
+    assert.equal(children[0].nodeName, 'DIV');
+    assert.equal(children[1].nodeName, 'TABLE');
+    assert.equal(children[2].nodeName, 'DIV');
+  })
 });

--- a/test/PanelSpec.jsx
+++ b/test/PanelSpec.jsx
@@ -149,8 +149,14 @@ describe('Panel', function () {
     );
 
     var children = instance.getDOMNode().children;
+
     assert.equal(children[0].nodeName, 'DIV');
+    assert.ok(children[0].className.match(/\bpanel-body\b/));
+
     assert.equal(children[1].nodeName, 'TABLE');
+    assert.notOk(children[1].className.match(/\bpanel-body\b/));
+
     assert.equal(children[2].nodeName, 'DIV');
+    assert.ok(children[2].className.match(/\bpanel-body\b/));
   })
 });


### PR DESCRIPTION
For react-bootstrap/react-bootstrap#228

Having multiple body elements in the panel is going to unavoidably screw up the collapse behavior, unfortunately, but it works otherwise.