### PR TITLE
Allows for large modals

### DIFF
--- a/docs/examples/ModalLarge.js
+++ b/docs/examples/ModalLarge.js
@@ -1,0 +1,24 @@
+var MyModal = React.createClass({
+  render: function() {
+    return (
+        <Modal {...this.props} title="Large Modal" bsClass="modal-lg" animation={false}>
+          <div className="modal-body">
+            <h4>Text in a modal</h4>
+            <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</p>
+
+          </div>
+          <div className="modal-footer">
+            <Button onClick={this.props.onRequestHide}>Close</Button>
+          </div>
+        </Modal>
+      );
+  }
+});
+
+var overlayTriggerInstance = (
+    <ModalTrigger modal={<MyModal />}>
+      <Button bsStyle="primary" bsSize="large">Launch a large modal</Button>
+    </ModalTrigger>
+  );
+
+React.render(overlayTriggerInstance, mountNode);

--- a/docs/examples/ModalStatic.js
+++ b/docs/examples/ModalStatic.js
@@ -7,6 +7,7 @@ var modalInstance = (
       <Modal title="Modal title"
         backdrop={false}
         animation={false}
+        bsClass="modal-lg"
         container={mountNode}
         onRequestHide={handleHide}>
         <div className="modal-body">

--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -213,6 +213,10 @@ var ComponentsPage = React.createClass({
                   <p>Use <code>&lt;ModalTrigger /&gt;</code> to create a real modal that's added to the document body when opened.</p>
                   <ReactPlayground codeText={fs.readFileSync(__dirname + '/../examples/ModalTrigger.js', 'utf8')} />
 
+                  <h3 id="modals-large">Large Modal</h3>
+                  <p>Passing <code>bsClass="modal-lg"</code> to the modal opens a wide modal</p>
+                  <ReactPlayground codeText={fs.readFileSync(__dirname + '/../examples/ModalLarge.js', 'utf8')} />
+
                   <h3 id="modals-custom">Custom trigger</h3>
                   <p>Use <code>&lt;OverlayMixin /&gt;</code> in a custom component to manage the modal's state yourself.</p>
                   <ReactPlayground codeText={fs.readFileSync(__dirname + '/../examples/ModalOverlayMixin.js', 'utf8')} />

--- a/src/constants.js
+++ b/src/constants.js
@@ -16,6 +16,7 @@ module.exports = {
     'nav': 'nav',
     'navbar': 'navbar',
     'modal': 'modal',
+    'modal-lg':'modal-lg',
     'row': 'row',
     'well': 'well'
   },


### PR DESCRIPTION
A minor adjustment to allow for large modals via 

```
      <Modal title="My Modal"  bsClass="modal-lg">
        <div className="modal-body">
           <p>Modal Body</p>
        </div>
        <div className="modal-footer">
          <Button onClick={@close}>Close</Button>
        </div>
      </Modal> 

```