### PR TITLE
Adds Property to Modal for Large Size

### DIFF
--- a/src/Modal.jsx
+++ b/src/Modal.jsx
@@ -40,6 +40,7 @@ var Modal = React.createClass({
     var dialogClasses = this.getBsClassSet();
     delete dialogClasses.modal;
     dialogClasses['modal-dialog'] = true;
+    dialogClasses['modal-lg'] = this.props.large;
 
     var classes = {
       modal: true,


### PR DESCRIPTION
Pretty simple alteration I found myself needing and couldn't find the best route to insert.

It looks like div.modal-dialog classes are not accessible from the Modal component.

In order to create large modals in Bootstrap, the class .modal-lg needs to be added to the div.modal-dialog element (http://getbootstrap.com/javascript/#modals-sizes).

This adds a property to Modal "large" (Boolean) that will add that class to dialogClasses.

```
<Modal title="Modal Title" large />
```