### PR TITLE
Changing NavItem title prop to node

### DIFF
--- a/src/NavItem.jsx
+++ b/src/NavItem.jsx
@@ -11,7 +11,7 @@ var NavItem = React.createClass({
     active: React.PropTypes.bool,
     disabled: React.PropTypes.bool,
     href: React.PropTypes.string,
-    title: React.PropTypes.string,
+    title: React.PropTypes.node,
     eventKey: React.PropTypes.any,
     target: React.PropTypes.string
   },


### PR DESCRIPTION
Current NavItem titles are restricted to strings, which is not how Bootstrap was designed. Changing this to node to allow for more complicated functions.