### PR TITLE
Added check if we don't need to calc calculate the overlay position on mount

### DIFF
--- a/src/OverlayTrigger.jsx
+++ b/src/OverlayTrigger.jsx
@@ -119,7 +119,9 @@ var OverlayTrigger = React.createClass({
   },
 
   componentDidMount: function() {
-    this.updateOverlayPosition();
+    if (this.props.defaultOverlayShown) {
+      this.updateOverlayPosition();
+    }
   },
 
   handleDelayedShow: function () {


### PR DESCRIPTION
I created this pull request because I was seeing a significant amount of layout thrashing when I had several hundred tooltips being rendered at once. It seems the layout was invalidated by the overlay position calculation fired within `componentDidMount`. By checking `this.props.defaultOverlayShown`, we can avoid this layout reflow when mounting an OverlayTrigger which is not shown by default (should be the only time this calc needs to happen in `componentDidMount`??). I am not sure this will fully resolve #353 , but it helped my implementation quite a bit.

Chrome dev tools with several hundred tooltips:
Before: http://i.imgur.com/e4UZ5l6.png , http://i.imgur.com/Tw39F9t.png 
After: http://i.imgur.com/bU0f7VY.png . 