### PR TITLE
DropdownStateMixin: return early if the target has been detached

### DIFF
--- a/src/DropdownStateMixin.js
+++ b/src/DropdownStateMixin.js
@@ -48,7 +48,7 @@ var DropdownStateMixin = {
   handleDocumentClick: function (e) {
     // If the click originated from within this component
     // don't do anything.
-    if (isNodeInRoot(e.target, this.getDOMNode())) {
+    if (isNodeInRoot(e.target, this.getDOMNode()) || !isNodeInRoot(e.target, document)) {
       return;
     }
 


### PR DESCRIPTION
This happens if there is a dropdown inside a dropdown and the inner
dropdown closes (removing the inner dropdown DOM).