### PR TITLE
Use grunt-karma for npm run test

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -163,6 +163,16 @@ module.exports = function (grunt) {
         dest: 'amd/<%= pkg.name %>.min.js'
       }
     },
+
+    karma: {
+      unit: {
+        configFile: 'karma.ci.js'
+      },
+      dev: {
+        configFile: 'karma.dev.js'
+      }
+    },
+
   });
 
   grunt.loadNpmTasks('grunt-contrib-uglify');
@@ -173,6 +183,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-browserify');
   grunt.loadNpmTasks('grunt-contrib-requirejs');
+  grunt.loadNpmTasks('grunt-karma');
 
   grunt.registerTask('build', [
     'clean:amd',
@@ -186,6 +197,16 @@ module.exports = function (grunt) {
     'requirejs:dev',
     'uglify:build',
     'clean:transpiled'
+  ]);
+
+  grunt.registerTask('test', [
+    'build',
+    'karma:unit'
+  ]);
+
+  grunt.registerTask('test-watch', [
+    'build',
+    'karma:dev'
   ]);
 
   require('./tools/release/tasks')(grunt);

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "homepage": "http://react-bootstrap.github.io/",
   "scripts": {
     "build": "./node_modules/.bin/grunt build",
-    "test-watch": "./node_modules/.bin/grunt watch 2>&1 >/dev/null & ./node_modules/karma/bin/karma start karma.dev.js",
-    "test": "./node_modules/.bin/grunt build && ./node_modules/karma/bin/karma start karma.ci.js"
+    "test-watch": "./node_modules/.bin/grunt test-watch",
+    "test": "./node_modules/.bin/grunt test"
   },
   "main": "lib/main.js",
   "directories": {
@@ -39,6 +39,7 @@
     "grunt-contrib-requirejs": "~0.4.1",
     "grunt-contrib-uglify": "~0.3.2",
     "grunt-contrib-watch": "~0.5.3",
+    "grunt-karma": "^0.10.1",
     "grunt-react": "~0.10.0",
     "grunt-shell": "~0.6.4",
     "karma": "~0.12.8",


### PR DESCRIPTION
Use grunt-karma to run the "npm run" karma tasks instead of shell
commands, for windows users.