### PR TITLE
Enable hiding of drop down menu when a MenuItem with a href is clicked

### DIFF
--- a/src/DropdownButton.jsx
+++ b/src/DropdownButton.jsx
@@ -91,7 +91,7 @@ var DropdownButton = React.createClass({
     // Only handle the option selection if an onSelect prop has been set on the
     // component or it's child, this allows a user not to pass an onSelect
     // handler and have the browser preform the default action.
-    var handleOptionSelect = this.props.onSelect || child.props.onSelect ?
+    var handleOptionSelect = this.props.onSelect || child.props.onSelect || child.props.href ?
       this.handleOptionSelect : null;
 
     return cloneWithProps(

--- a/src/MenuItem.jsx
+++ b/src/MenuItem.jsx
@@ -21,7 +21,9 @@ var MenuItem = React.createClass({
 
   handleClick: function (e) {
     if (this.props.onSelect) {
-      e.preventDefault();
+      if (!this.props.href) {
+        e.preventDefault();
+      }
       this.props.onSelect(this.props.eventKey, this.props.href, this.props.target);
     }
   },


### PR DESCRIPTION
This patch hides the drop down menu by adding an onSelect if a href prop is present and ignoring the e.preventDefault().

This may not be the optimal approach, but it satisfies my requirements.

Ref: Issue #368