### PR TITLE
[added] inputGroupClassName prop to Input

### DIFF
--- a/src/Input.jsx
+++ b/src/Input.jsx
@@ -4,6 +4,7 @@ var classSet = require('./utils/classSet');
 var Button = require('./Button');
 
 var Input = React.createClass({
+
   propTypes: {
     type: React.PropTypes.string,
     label: React.PropTypes.node,
@@ -12,6 +13,7 @@ var Input = React.createClass({
     addonAfter: React.PropTypes.node,
     buttonBefore: React.PropTypes.node,
     buttonAfter: React.PropTypes.node,
+    bsSize: React.PropTypes.oneOf(['small', 'medium', 'large']),
     bsStyle: function(props) {
       if (props.type === 'submit') {
         // Return early if `type=submit` as the `Button` component
@@ -140,8 +142,14 @@ var Input = React.createClass({
       </span>
     ) : null;
 
+    var inputGroupClassName;
+    switch (this.props.bsSize) {
+      case 'small': inputGroupClassName = 'input-group-sm'; break;
+      case 'large': inputGroupClassName = 'input-group-lg'; break;
+    }
+
     return addonBefore || addonAfter || buttonBefore || buttonAfter ? (
-      <div className="input-group" key="input-group">
+      <div className={joinClasses(inputGroupClassName, 'input-group')} key="input-group">
         {addonBefore}
         {buttonBefore}
         {children}

--- a/test/InputSpec.jsx
+++ b/test/InputSpec.jsx
@@ -123,6 +123,22 @@ describe('Input', function () {
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'input-group-addon'));
   });
 
+  it('renders input-group with sm or lg class name when bsSize is small or large', function () {
+    var instance = ReactTestUtils.renderIntoDocument(
+      <Input addonBefore="$" bsSize="small" />
+    );
+
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'input-group'));
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'input-group-sm'));
+
+    instance = ReactTestUtils.renderIntoDocument(
+      <Input addonBefore="$" bsSize="large" />
+    );
+
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'input-group'));
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'input-group-lg'));
+  });
+
   it('renders btn-group', function() {
     var instance = ReactTestUtils.renderIntoDocument(
       <Input buttonAfter={<Button>!</Button>} />


### PR DESCRIPTION
This allows for specifying a size, such as input-group-sm and input-group-lg, as in:

    <Input
      type="text"
      placeholder="Search"
      inputGroupClassName="input-group-sm"
      buttonAfter={<Button><Glyphicon glyph="search" /></Button>}
      />

Before:

![before](https://cloud.githubusercontent.com/assets/15943/6387010/3669d872-bd49-11e4-9427-b1be09ad5041.png)

After:

![after](https://cloud.githubusercontent.com/assets/15943/6387016/47bfde96-bd49-11e4-9c3b-039011ac267c.png)
