### PR TITLE
Col Push/Pull/Offset value zero support

### DIFF
--- a/src/Col.jsx
+++ b/src/Col.jsx
@@ -46,19 +46,19 @@ var Col = React.createClass({
 
       prop = size + 'Offset';
       classPart = size + '-offset-';
-      if (this.props[prop]) {
+      if (this.props[prop] >= 0) {
         classes['col-' + classPart + this.props[prop]] = true;
       }
 
       prop = size + 'Push';
       classPart = size + '-push-';
-      if (this.props[prop]) {
+      if (this.props[prop] >= 0) {
         classes['col-' + classPart + this.props[prop]] = true;
       }
 
       prop = size + 'Pull';
       classPart = size + '-pull-';
-      if (this.props[prop]) {
+      if (this.props[prop] >= 0) {
         classes['col-' + classPart + this.props[prop]] = true;
       }
     }, this);

--- a/test/ColSpec.jsx
+++ b/test/ColSpec.jsx
@@ -1,0 +1,43 @@
+/*global describe, it, assert */
+
+var React          = require('react');
+var ReactTestUtils = require('react/lib/ReactTestUtils');
+var Col            = require('../lib/Col');
+
+describe('Col', function () {
+  it('Should set Offset of zero', function () {
+    var instance = ReactTestUtils.renderIntoDocument(
+      <Col xsOffset={0} smOffset={0} mdOffset={0} lgOffset={0} />
+    );
+
+    var instanceClassName = instance.getDOMNode().className;
+    assert.ok(instanceClassName.match(/\bcol-xs-offset-0\b/));
+    assert.ok(instanceClassName.match(/\bcol-sm-offset-0\b/));
+    assert.ok(instanceClassName.match(/\bcol-md-offset-0\b/));
+    assert.ok(instanceClassName.match(/\bcol-lg-offset-0\b/));
+  });
+
+  it('Should set Pull of zero', function () {
+    var instance = ReactTestUtils.renderIntoDocument(
+      <Col xsPull={0} smPull={0} mdPull={0} lgPull={0} />
+    );
+
+    var instanceClassName = instance.getDOMNode().className;
+    assert.ok(instanceClassName.match(/\bcol-xs-pull-0\b/));
+    assert.ok(instanceClassName.match(/\bcol-sm-pull-0\b/));
+    assert.ok(instanceClassName.match(/\bcol-md-pull-0\b/));
+    assert.ok(instanceClassName.match(/\bcol-lg-pull-0\b/));
+  });
+
+  it('Should set Push of zero', function () {
+    var instance = ReactTestUtils.renderIntoDocument(
+      <Col xsPush={0} smPush={0} mdPush={0} lgPush={0} />
+    );
+
+    var instanceClassName = instance.getDOMNode().className;
+    assert.ok(instanceClassName.match(/\bcol-xs-push-0\b/));
+    assert.ok(instanceClassName.match(/\bcol-sm-push-0\b/));
+    assert.ok(instanceClassName.match(/\bcol-md-push-0\b/));
+    assert.ok(instanceClassName.match(/\bcol-lg-push-0\b/));
+  });
+});


### PR DESCRIPTION
According to the Bootstrap documentation (and my own experience), column offsets must be reset to zero for other sizes if not used.

"In addition to column clearing at responsive breakpoints, you may need to reset offsets, pushes, or pulls. See this in action in the grid example."

For example `<Col xsOffset={2} xs={8} sm={4} md={4} lg={4}>...</Col>` when viewed in 'sm/md/lg' does not produce the expected result of having a column width of '4'. It looks only correct when viewed in 'xs'.

The example would have to be rewritten as `<Col xs={8} xsOffset={2} sm={4} smOffset={0} md={4} mdOffset={0} lg={4} lgOffset={0}>...</Col>` to render correctly in all views.

However, Offset/Push/Pull property values were ran through a "truthy" check in Col.jsx. So when the property value was `0` the column would not render. This has been fixed by doing a `>= 0` check instead which ensures that the property value is simply a non-negative number.