### PR TITLE
Fixed behaviour of carousel controls if wrap=true

### DIFF
--- a/src/Carousel.jsx
+++ b/src/Carousel.jsx
@@ -173,7 +173,7 @@ var Carousel = React.createClass({
   },
 
   renderControls: function () {
-    if (this.props.wrap) {
+    if (!this.props.wrap) {
       var activeIndex = this.getActiveIndex();
       var count = ValidComponentChildren.numberOf(this.props.children);
 

--- a/test/CarouselSpec.jsx
+++ b/test/CarouselSpec.jsx
@@ -73,4 +73,45 @@ describe('Carousel', function () {
       )[0]
     );
   });
+
+  it('Should show all controls on the first/last image if wrap is true', function () {
+    var instance = ReactTestUtils.renderIntoDocument(
+      <Carousel activeIndex={0} controls={true} wrap={true}>
+        <CarouselItem ref="item1">Item 1 content</CarouselItem>
+        <CarouselItem ref="item2">Item 2 content</CarouselItem>
+      </Carousel>
+    );
+
+    var backButton = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'left');
+
+    assert.ok(backButton);
+    assert.equal(backButton.props.href, '#prev');
+
+    instance = ReactTestUtils.renderIntoDocument(
+      <Carousel activeIndex={1} controls={true} wrap={true}>
+        <CarouselItem ref="item1">Item 1 content</CarouselItem>
+        <CarouselItem ref="item2">Item 2 content</CarouselItem>
+      </Carousel>
+    );
+
+    var nextButton = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'right');
+
+    assert.ok(nextButton);
+    assert.equal(nextButton.props.href, '#next');
+  });
+
+  it('Should not show the prev button on the first image if wrap is false', function () {
+    var instance = ReactTestUtils.renderIntoDocument(
+      <Carousel activeIndex={0} controls={true} wrap={false}>
+        <CarouselItem ref="item1">Item 1 content</CarouselItem>
+        <CarouselItem ref="item2">Item 2 content</CarouselItem>
+      </Carousel>
+    );
+
+    var backButtons = ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'left');
+    var nextButtons = ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'right');
+
+    assert.equal(backButtons.length, 0);
+    assert.equal(nextButtons.length, 1);
+  });
 });


### PR DESCRIPTION
This PR is based on #405. I’ve changed the commit message and added a test.

Closes #405.