### PR TITLE
Use .ownerDocument instead of root document

### DIFF
--- a/src/AffixMixin.js
+++ b/src/AffixMixin.js
@@ -104,7 +104,7 @@ const AffixMixin = {
     this._onWindowScrollListener =
       EventListener.listen(window, 'scroll', this.checkPosition);
     this._onDocumentClickListener =
-      EventListener.listen(document, 'click', this.checkPositionWithEventLoop);
+      EventListener.listen(React.findDOMNode(this).ownerDocument, 'click', this.checkPositionWithEventLoop);
   },
 
   componentWillUnmount() {

--- a/src/DropdownStateMixin.js
+++ b/src/DropdownStateMixin.js
@@ -56,10 +56,12 @@ const DropdownStateMixin = {
   },
 
   bindRootCloseHandlers() {
+    let doc = React.findDOMNode(this).ownerDocument;
+
     this._onDocumentClickListener =
-      EventListener.listen(document, 'click', this.handleDocumentClick);
+      EventListener.listen(doc, 'click', this.handleDocumentClick);
     this._onDocumentKeyupListener =
-      EventListener.listen(document, 'keyup', this.handleDocumentKeyUp);
+      EventListener.listen(doc, 'keyup', this.handleDocumentKeyUp);
   },
 
   unbindRootCloseHandlers() {

--- a/src/FadeMixin.js
+++ b/src/FadeMixin.js
@@ -57,7 +57,7 @@ export default {
 
   componentWillUnmount: function () {
     let els = getElementsAndSelf(React.findDOMNode(this), ['fade']),
-        container = (this.props.container && React.findDOMNode(this.props.container)) || document.body;
+        container = (this.props.container && React.findDOMNode(this.props.container)) || React.findDOMNode(this).ownerDocument.body;
 
     if (els.length) {
       this._fadeOutEl = document.createElement('div');

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -128,9 +128,9 @@ const Modal = React.createClass({
 
   componentDidMount() {
     this._onDocumentKeyupListener =
-      EventListener.listen(document, 'keyup', this.handleDocumentKeyUp);
+      EventListener.listen(React.findDOMNode(this).ownerDocument, 'keyup', this.handleDocumentKeyUp);
 
-    let container = (this.props.container && React.findDOMNode(this.props.container)) || document.body;
+    let container = (this.props.container && React.findDOMNode(this.props.container)) || React.findDOMNode(this).ownerDocument.body;
     container.className += container.className.length ? ' modal-open' : 'modal-open';
 
     if (this.props.backdrop) {
@@ -146,7 +146,7 @@ const Modal = React.createClass({
 
   componentWillUnmount() {
     this._onDocumentKeyupListener.remove();
-    let container = (this.props.container && React.findDOMNode(this.props.container)) || document.body;
+    let container = (this.props.container && React.findDOMNode(this.props.container)) || React.findDOMNode(this).ownerDocument.body;
     container.className = container.className.replace(/ ?modal-open/, '');
   },
 

--- a/src/OverlayMixin.js
+++ b/src/OverlayMixin.js
@@ -63,6 +63,6 @@ export default {
   },
 
   getContainerDOMNode() {
-    return React.findDOMNode(this.props.container || document.body);
+    return React.findDOMNode(this.props.container || React.findDOMNode(this).ownerDocument.body);
   }
 };

--- a/src/utils/domUtils.js
+++ b/src/utils/domUtils.js
@@ -21,7 +21,7 @@ function getOffset(DOMNode) {
     return window.jQuery(DOMNode).offset();
   }
 
-  let docElem = document.documentElement;
+  let docElem = DOMNode.ownerDocument.documentElement;
   let box = { top: 0, left: 0 };
 
   // If we don't have gBCR, just use 0,0 rather than error
@@ -89,7 +89,7 @@ function getPosition(elem, offsetParent) {
  * @returns {HTMLElement}
  */
 function offsetParentFunc(elem) {
-  let docElem = document.documentElement;
+  let docElem = elem.ownerDocument.documentElement;
   let offsetParent = elem.offsetParent || docElem;
 
   while ( offsetParent && ( offsetParent.nodeName !== 'HTML' &&


### PR DESCRIPTION
With this change, event listeners are attached to the component DOM node's owner document instead of to the window root document. The two are not the same when the component is mounted inside an IFrame, for example using [react-frame-component](https://github.com/ryanseddon/react-frame-component).

In my case, this fixes incorrect positioning of tooltips and broken close handlers of dropdown buttons.

<!---
@huboard:{"order":463.0,"milestone_order":463,"custom_state":""}
-->
