### PR TITLE
Add react/jsx-uses-vars option for eslint.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,6 +27,7 @@
     "react/react-in-jsx-scope": 1,
     "react/self-closing-comp": 1,
     "react/wrap-multilines": 1,
+    "react/jsx-uses-vars": 1,
     "strict": 0
   }
 }


### PR DESCRIPTION
It removes 17 unnecessary eslint warnings.

Since 0.17.0 the ESLint no-unused-vars rule does not detect variables used in JSX

[react/jsx-uses-vars](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md)

Like in: (Button.js)
```javascript
    let Component = this.props.componentClass || 'a’;
    ...
    return (
      <Component ...
```
eslint warning: `Component is defined but never used.`