### PR TITLE
44 less superfluous eslint warnings in docs and tests.

### DIFF
--- a/docs/.eslintrc
+++ b/docs/.eslintrc
@@ -1,7 +1,6 @@
 {
   "rules": {
     "comma-spacing": 0,
-    "react/no-did-mount-set-state": 0,
     "react/no-multi-comp": 0,
     "react/prop-types": 0
   }

--- a/docs/.eslintrc
+++ b/docs/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "rules": {
+    "comma-spacing": 0,
+    "react/no-did-mount-set-state": 0,
+    "react/no-multi-comp": 0,
+    "react/prop-types": 0
+  }
+}

--- a/ie8/.eslintrc
+++ b/ie8/.eslintrc
@@ -1,0 +1,5 @@
+{
+  rules: {
+    "react/no-multi-comp": 0
+  }
+}

--- a/src/TabbedArea.js
+++ b/src/TabbedArea.js
@@ -31,7 +31,7 @@ const TabbedArea = React.createClass({
 
   getDefaultProps() {
     return {
-      bsStyle: "tabs",
+      bsStyle: 'tabs',
       animation: true
     };
   },

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -9,6 +9,7 @@
   "rules": {
     "no-script-url": 1,
     "no-unused-expressions": 0,
-    "react/no-multi-comp": 0
+    "react/no-multi-comp": 0,
+    "react/prop-types": 0
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -7,7 +7,7 @@
     "sinon": true
   },
   "rules": {
-    "no-script-url": 1,
+    "no-script-url": 0,
     "no-unused-expressions": 0,
     "react/no-multi-comp": 0,
     "react/prop-types": 0

--- a/test/BadgeSpec.js
+++ b/test/BadgeSpec.js
@@ -42,7 +42,7 @@ describe('Badge', function () {
 
   it('Should not have a badge class when empty', function () {
     let instance = ReactTestUtils.renderIntoDocument(
-      <Badge></Badge>
+      <Badge />
     );
     assert.notOk(instance.getDOMNode().className.match(/\bbadge\b/));
   });


### PR DESCRIPTION
After that there is only 25 warnings left.
And all of them are for src/*

