### PR TITLE
Define types for properties to satisfy eslint warnings for src/*. (6 less)

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -9,6 +9,7 @@ const Carousel = React.createClass({
   propTypes: {
     slide: React.PropTypes.bool,
     indicators: React.PropTypes.bool,
+    interval: React.PropTypes.number,
     controls: React.PropTypes.bool,
     pauseOnHover: React.PropTypes.bool,
     wrap: React.PropTypes.bool,

--- a/src/CollapsableNav.js
+++ b/src/CollapsableNav.js
@@ -14,6 +14,7 @@ const CollapsableNav = React.createClass({
     onSelect: React.PropTypes.func,
     activeHref: React.PropTypes.string,
     activeKey: React.PropTypes.any,
+    collapsable: React.PropTypes.bool,
     expanded: React.PropTypes.bool,
     eventKey: React.PropTypes.any
   },

--- a/src/PageItem.js
+++ b/src/PageItem.js
@@ -6,6 +6,7 @@ const PageItem = React.createClass({
   propTypes: {
     href: React.PropTypes.string,
     target: React.PropTypes.string,
+    title: React.PropTypes.string,
     disabled: React.PropTypes.bool,
     previous: React.PropTypes.bool,
     next: React.PropTypes.bool,


### PR DESCRIPTION
Accorging to http://www.w3.org/TR/WCAG20-TECHS/H33.html
The `title` attribute is used to provide additional information to help clarify
or further describe the purpose of a link.

Еherefore I set type for `title` to `string`.