### PR TITLE
Include missing PropType validations for another 4 warnings in src/*

### DIFF
--- a/src/Nav.js
+++ b/src/Nav.js
@@ -22,6 +22,7 @@ const Nav = React.createClass({
     expanded: React.PropTypes.bool,
     navbar: React.PropTypes.bool,
     eventKey: React.PropTypes.any,
+    pullRight: React.PropTypes.bool,
     right: React.PropTypes.bool
   },
 

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -1,3 +1,6 @@
+/* eslint react/prop-types: [1, { ignore: ["children", "className", "bsStyle"] }] */
+/* for `bsStyle` type validation takes place in BootstrapMixin */
+
 import React, { cloneElement } from 'react';
 import classNames from 'classnames';
 
@@ -9,6 +12,7 @@ const PanelGroup = React.createClass({
 
   propTypes: {
     collapsable: React.PropTypes.bool,
+    accordion: React.PropTypes.bool,
     activeKey: React.PropTypes.any,
     defaultActiveKey: React.PropTypes.any,
     onSelect: React.PropTypes.func

--- a/src/SubNav.js
+++ b/src/SubNav.js
@@ -14,6 +14,7 @@ const SubNav = React.createClass({
     activeHref: React.PropTypes.string,
     activeKey: React.PropTypes.any,
     disabled: React.PropTypes.bool,
+    eventKey: React.PropTypes.any,
     href: React.PropTypes.string,
     title: React.PropTypes.string,
     text: React.PropTypes.node,


### PR DESCRIPTION
I wasn't able to find a way to add only { ignore: "bsStyle" } to /* .. */
so that others { ignore: ["children", "className"] } from .eslintrc
are taken into account automatically.

It seems there is no way to merge arrays in comments /* ... */,
because eslint reads rules in /* ... */ as JSON.