### PR TITLE
[fixed] Fix for bug #507

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -111,6 +111,7 @@ const Input = React.createClass({
         input = (
           <Button {...this.props} componentClass='input' ref='input' key='input' />
         );
+        delete this.props.bsStyle;
         break;
       default:
         let className = this.isCheckboxOrRadio() || this.isFile() ? '' : 'form-control';

--- a/test/InputSpec.js
+++ b/test/InputSpec.js
@@ -51,6 +51,25 @@ describe('Input', function () {
     assert.equal(instance.getValue(), 'v');
   });
 
+  // for fixing bug #507
+  it('does not throw warning bsStyle=danger when type=submit', function () {
+    ReactTestUtils.renderIntoDocument(
+      <Input type="submit" bsStyle="danger" />
+    );
+
+    console.warn.called.should.be.false;
+  });
+
+  it('throws warning about wrong type for bsStyle=error when type=submit', function () {
+    ReactTestUtils.renderIntoDocument(
+      <Input type="submit" bsStyle="error" />
+    );
+
+    console.warn.called.should.be.true;
+    console.warn.calledWithMatch('propType: Invalid').should.be.true;
+    console.warn.reset(); // reset spy state for afterEach()
+  });
+
   it('renders a submit button element when type=submit', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Input type="submit" bsStyle="danger" wrapperClassName='test' />

--- a/webpack/test.config.js
+++ b/webpack/test.config.js
@@ -1,3 +1,3 @@
 import config from './webpack.config';
 
-export default config({test: true});
+export default config({test: true, development: true});


### PR DESCRIPTION
This bug has not been detected by tests because there was another bug in tests.

When mode is `production` webpack strips out code designed for development mode.
React `console warnings` also are removed in `production`.

In that case tests don't `see` any console warnings from React.
Consequently code like this (in tests):
  console.warn.called.should.be.false;
is useless.

That was a bug in tests.


The cause of bug #507 is following.

In the case when `<Input />` type is `submit`
`bsStyle` is set for `<Button />`.

Consequently default bootstrap styles for `<Button />`
are not OK for `<FormGroup />` that is always
the root element for `<Input />` component.

Therefore we just need to prevent `bsStyle` passing on
to <FormGroup /> where they are not OK.
