### PR TITLE
[fixed] Update eslint dev dependency and fix new warnings.

### DIFF
--- a/docs/build.js
+++ b/docs/build.js
@@ -5,7 +5,7 @@ import routes from './src/Routes';
 import Root from './src/Root';
 import fsp from 'fs-promise';
 import { copy } from '../tools/fs-utils';
-import { exec, spawn } from 'child-process-promise';
+import { exec } from 'child-process-promise';
 
 const repoRoot = path.resolve(__dirname, '../');
 const docsBuilt = path.join(repoRoot, 'docs-built');

--- a/docs/server.js
+++ b/docs/server.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import express from 'express';
 import path from 'path';
-import url from 'url';
 import webpack from 'webpack';
 import webpackMiddleware from 'webpack-dev-middleware';
 import webpackConfigBuilder from '../webpack/webpack.config';

--- a/docs/src/CodeMirror.client.js
+++ b/docs/src/CodeMirror.client.js
@@ -9,4 +9,4 @@ import from './CodeMirror.css';
 export default {
   IS_NODE: false,
   CodeMirror
-}
+};

--- a/docs/src/CodeMirror.js
+++ b/docs/src/CodeMirror.js
@@ -1,4 +1,4 @@
 export default {
   IS_NODE: true,
   CodeMirror: {}
-}
+};

--- a/docs/src/NavMain.js
+++ b/docs/src/NavMain.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import Router, { Link } from 'react-router';
+import { Link } from 'react-router';
 import Navbar from '../../src/Navbar';
 import Nav from '../../src/Nav';
 

--- a/docs/src/Routes.js
+++ b/docs/src/Routes.js
@@ -17,4 +17,4 @@ export default (
     <Route name='getting-started' path='getting-started.html' handler={GettingStartedPage} />
     <Route name='components' path='components.html' handler={ComponentsPage} />
   </Route>
-)
+);

--- a/ie8/server.js
+++ b/ie8/server.js
@@ -1,4 +1,3 @@
-import React from 'react';
 import express from 'express';
 import path from 'path';
 import webpack from 'webpack';

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "colors": "^1.0.3",
     "css-loader": "^0.9.1",
     "es5-shim": "^4.1.0",
-    "eslint": "^0.18.0",
+    "eslint": "^0.19.0",
     "eslint-plugin-react": "^2.1.0",
     "express": "^4.12.3",
     "extract-text-webpack-plugin": "^0.3.8",

--- a/tools/amd/build.js
+++ b/tools/amd/build.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import path from 'path';
 import fsp from 'fs-promise';
 import { copy } from '../fs-utils';
-import { exec, spawn } from 'child-process-promise';
+import { exec } from 'child-process-promise';
 
 const repoRoot = path.resolve(__dirname, '../../');
 const amd = path.join(repoRoot, 'amd');

--- a/tools/build.js
+++ b/tools/build.js
@@ -7,7 +7,6 @@ import lib from './lib/build';
 import docs from '../docs/build';
 import dist from './dist/build';
 import { copy } from './fs-utils';
-import { exec, spawn } from 'child-process-promise';
 
 import yargs from 'yargs';
 
@@ -48,4 +47,3 @@ export default function Build(noExitOnFailure) {
     return result;
   }
 }
-

--- a/tools/dist/build.js
+++ b/tools/dist/build.js
@@ -1,6 +1,5 @@
 import path from 'path';
-import fsp from 'fs-promise';
-import { exec, spawn } from 'child-process-promise';
+import { exec } from 'child-process-promise';
 
 const repoRoot = path.resolve(__dirname, '../../');
 const dist = path.join(repoRoot, 'dist');

--- a/tools/fs-utils.js
+++ b/tools/fs-utils.js
@@ -36,4 +36,4 @@ function copy(src, dest, options) {
 
 export default {
   copy
-}
+};

--- a/tools/lib/build.js
+++ b/tools/lib/build.js
@@ -1,7 +1,6 @@
 import from 'colors';
 import path from 'path';
-import fsp from 'fs-promise';
-import { exec, spawn } from 'child-process-promise';
+import { exec } from 'child-process-promise';
 
 const repoRoot = path.resolve(__dirname, '../../');
 const lib = path.join(repoRoot, 'lib');

--- a/tools/release-scripts/changelog.js
+++ b/tools/release-scripts/changelog.js
@@ -6,4 +6,4 @@ export default (repoRoot, version) => {
   return exec(`node_modules/.bin/changelog -t v${version}`)
     .then(() => exec(`git add ${path.join(repoRoot, 'CHANGELOG.md')}`))
     .then(() => console.log('Generated Changelog'.cyan));
-}
+};

--- a/tools/release-scripts/changelog.js
+++ b/tools/release-scripts/changelog.js
@@ -1,6 +1,6 @@
 import from 'colors';
 import path from 'path';
-import { exec, spawn } from 'child-process-promise';
+import { exec } from 'child-process-promise';
 
 export default (repoRoot, version) => {
   return exec(`node_modules/.bin/changelog -t v${version}`)

--- a/tools/release-scripts/pre-conditions.js
+++ b/tools/release-scripts/pre-conditions.js
@@ -1,5 +1,5 @@
 import from 'colors';
-import { exec, spawn } from 'child-process-promise';
+import { exec } from 'child-process-promise';
 
 function ensureClean() {
   return exec('git diff-index --name-only HEAD --')

--- a/tools/release-scripts/release.js
+++ b/tools/release-scripts/release.js
@@ -2,7 +2,7 @@
 
 import path from 'path';
 import yargs from 'yargs';
-import { exec, spawn } from 'child-process-promise';
+import { exec } from 'child-process-promise';
 
 import preConditions from './pre-conditions';
 import versionBump from './version-bump';

--- a/tools/release-scripts/repo-release.js
+++ b/tools/release-scripts/repo-release.js
@@ -30,4 +30,4 @@ export default (repo, srcFolder, tmpFolder, version) => {
     .then(() => exec(`cd ${tmpFolder} && git push --tags`))
     .then(() => exec(`rimraf ${tmpFolder}`))
     .then(() => console.log('Released: '.cyan + repo.green));
-}
+};

--- a/tools/release-scripts/repo-release.js
+++ b/tools/release-scripts/repo-release.js
@@ -1,7 +1,7 @@
 import from 'colors';
 import path from 'path';
 import fsp from 'fs-promise';
-import { exec, spawn } from 'child-process-promise';
+import { exec } from 'child-process-promise';
 import { copy } from '../fs-utils';
 
 const repoRoot = path.resolve(__dirname, '../../');

--- a/tools/release-scripts/tag-and-publish.js
+++ b/tools/release-scripts/tag-and-publish.js
@@ -8,4 +8,4 @@ export default (version) => {
     .then(() => exec(`git push --tags`))
     .then(() => exec('npm publish'))
     .then(() => console.log('Released: '.cyan + 'npm module'.green));
-}
+};

--- a/tools/release-scripts/tag-and-publish.js
+++ b/tools/release-scripts/tag-and-publish.js
@@ -1,4 +1,4 @@
-import { exec, spawn } from 'child-process-promise';
+import { exec } from 'child-process-promise';
 
 export default (version) => {
   console.log('Releasing: '.cyan + 'npm module'.green);

--- a/tools/release-scripts/test.js
+++ b/tools/release-scripts/test.js
@@ -1,5 +1,5 @@
 import from 'colors';
-import { exec, spawn } from 'child-process-promise';
+import { exec } from 'child-process-promise';
 
 function test() {
   console.log('Running: '.cyan + 'tests'.green);

--- a/tools/release-scripts/version-bump.js
+++ b/tools/release-scripts/version-bump.js
@@ -2,7 +2,7 @@ import from 'colors';
 import path from 'path';
 import fsp from 'fs-promise';
 import semver from 'semver';
-import { exec, spawn } from 'child-process-promise';
+import { exec } from 'child-process-promise';
 
 export default function(repoRoot, { preid, type }) {
   const packagePath = path.join(repoRoot, 'package.json');

--- a/webpack/strategies/development.js
+++ b/webpack/strategies/development.js
@@ -10,4 +10,4 @@ export default (config, options) => {
   }
 
   return config;
-}
+};

--- a/webpack/strategies/docs.js
+++ b/webpack/strategies/docs.js
@@ -52,4 +52,4 @@ export default (config, options) => {
   }
 
   return config;
-}
+};

--- a/webpack/strategies/ie8.js
+++ b/webpack/strategies/ie8.js
@@ -23,4 +23,4 @@ export default (config, options) => {
   }
 
   return config;
-}
+};

--- a/webpack/strategies/optimize.js
+++ b/webpack/strategies/optimize.js
@@ -12,4 +12,4 @@ export default (config, options) => {
   }
 
   return config;
-}
+};

--- a/webpack/strategies/test.js
+++ b/webpack/strategies/test.js
@@ -15,4 +15,4 @@ export default (config, options) => {
   }
 
   return config;
-}
+};

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -60,4 +60,4 @@ export default (options) => {
   return strategies.reduce((conf, strategy) => {
     return strategy(conf, options);
   }, config);
-}
+};


### PR DESCRIPTION
In eslint 0.19.0 were fixed `semi` and `no-unused-vars` rules for ES6 code.