### PR TITLE
[fixed] Fix ES6 syntax for 'import'. Dev dependency update.

### DIFF
--- a/docs/client.js
+++ b/docs/client.js
@@ -1,9 +1,9 @@
-import from 'bootstrap/less/bootstrap.less';
-import from './assets/docs.css';
-import from './assets/style.css';
+import 'bootstrap/less/bootstrap.less';
+import './assets/docs.css';
+import './assets/style.css';
 
-import from './assets/carousel.png';
-import from './assets/logo.png';
+import './assets/carousel.png';
+import './assets/logo.png';
 
 import React from 'react';
 import Router from 'react-router';

--- a/docs/src/CodeMirror.client.js
+++ b/docs/src/CodeMirror.client.js
@@ -1,10 +1,9 @@
 import CodeMirror from 'codemirror';
-import from 'codemirror/mode/javascript/javascript';
+import 'codemirror/mode/javascript/javascript';
 
-import from 'codemirror/theme/solarized.css';
-import from 'codemirror/lib/codemirror.css';
-//import from '../vendor/codemirror/syntax.css';
-import from './CodeMirror.css';
+import 'codemirror/theme/solarized.css';
+import 'codemirror/lib/codemirror.css';
+import './CodeMirror.css';
 
 export default {
   IS_NODE: false,

--- a/ie8/src.js
+++ b/ie8/src.js
@@ -16,7 +16,7 @@ import Popover from '../src/Popover';
 import Carousel from '../src/Carousel';
 import CarouselItem from '../src/CarouselItem';
 
-import from './assets/carousel.png';
+import './assets/carousel.png';
 
 const dropdownInstance = (
   <DropdownButton title='Dropdown'>

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "babel": "^4.7.0",
     "babel-core": "^4.7.4",
-    "babel-eslint": "^2.0.2",
+    "babel-eslint": "^3.0.1",
     "babel-loader": "^4.1.0",
     "bootstrap": "^3.3.4",
     "brfs": "^1.4.0",

--- a/test/index.js
+++ b/test/index.js
@@ -1,3 +1,3 @@
-import from 'es5-shim';
+import 'es5-shim';
 const testsContext = require.context('.', true, /Spec$/);
 testsContext.keys().forEach(testsContext);

--- a/tools/build.js
+++ b/tools/build.js
@@ -1,6 +1,6 @@
 /* eslint no-process-exit: 0 */
 
-import from 'colors';
+import 'colors';
 import path from 'path';
 import bower from './amd/build';
 import lib from './lib/build';

--- a/tools/lib/build.js
+++ b/tools/lib/build.js
@@ -1,4 +1,4 @@
-import from 'colors';
+import 'colors';
 import path from 'path';
 import { exec } from 'child-process-promise';
 

--- a/tools/release-scripts/changelog.js
+++ b/tools/release-scripts/changelog.js
@@ -1,4 +1,4 @@
-import from 'colors';
+import 'colors';
 import path from 'path';
 import { exec } from 'child-process-promise';
 

--- a/tools/release-scripts/pre-conditions.js
+++ b/tools/release-scripts/pre-conditions.js
@@ -1,4 +1,4 @@
-import from 'colors';
+import 'colors';
 import { exec } from 'child-process-promise';
 
 function ensureClean() {

--- a/tools/release-scripts/repo-release.js
+++ b/tools/release-scripts/repo-release.js
@@ -1,4 +1,4 @@
-import from 'colors';
+import 'colors';
 import path from 'path';
 import fsp from 'fs-promise';
 import { exec } from 'child-process-promise';

--- a/tools/release-scripts/test.js
+++ b/tools/release-scripts/test.js
@@ -1,4 +1,4 @@
-import from 'colors';
+import 'colors';
 import { exec } from 'child-process-promise';
 
 function test() {

--- a/tools/release-scripts/version-bump.js
+++ b/tools/release-scripts/version-bump.js
@@ -1,4 +1,4 @@
-import from 'colors';
+import 'colors';
 import path from 'path';
 import fsp from 'fs-promise';
 import semver from 'semver';


### PR DESCRIPTION
`import from` => `import`
Babel is more strict now as for `import` syntax.

According to
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import

>Import an entire module for side effects only, without importing any bindings.
>`import "my-module.js";`