### PR TITLE
[Fix] #396 - use of math.round in ProgressBar

### DIFF
--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -27,7 +27,7 @@ const ProgressBar = React.createClass({
   },
 
   getPercentage(now, min, max) {
-    return Math.round((now - min) / (max - min) * 100);
+    return Math.round(((now - min) / (max - min) * 100)*1000)/1000;
   },
 
   render() {

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -27,7 +27,7 @@ const ProgressBar = React.createClass({
   },
 
   getPercentage(now, min, max) {
-    return Math.ceil((now - min) / (max - min) * 100);
+    return Math.round((now - min) / (max - min) * 100);
   },
 
   render() {


### PR DESCRIPTION
Use math.round in getPercentage of ProgressBar to avoid the bug described in #396 with stacked bars