### PR TITLE
[fixed] ProgressBar percentage issue when stacked

### DIFF
--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -27,7 +27,8 @@ const ProgressBar = React.createClass({
   },
 
   getPercentage(now, min, max) {
-    return Math.ceil((now - min) / (max - min) * 100);
+    let roundPrecision = 1000;
+    return Math.round(((now - min) / (max - min) * 100) * roundPrecision) / roundPrecision;
   },
 
   render() {


### PR DESCRIPTION
Using stacked ProgressBar with a maximum superior to 100 could lead to
rounding issues that made the bar incomplete.

See issue #396 for mor details on the error