### PR TITLE
Add .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+amd/**
+dist/**
+docs-built/**
+lib/**
+node_modules/**


### PR DESCRIPTION
For those who use realtime linting by editors and trying to open generated files.