### PR TITLE
adds ability to require components already wrapped in factories

### DIFF
--- a/src/factories.js
+++ b/src/factories.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import components from './index';
+
+let factoriedComponents = {};
+
+Object.keys(components).forEach(function (componentName) {
+  if (componentName !== 'constants') {
+    factoriedComponents[componentName] = React.createFactory(components[componentName]);
+  } else {
+    factoriedComponents[componentName] = components[componentName];
+  }
+});
+
+export default factoriedComponents;


### PR DESCRIPTION
Allows import of components pre-wrapped in factories with 'react-bootstrap/lib/factories'.

I had same problem as this guy: https://github.com/react-bootstrap/react-bootstrap/issues/423.