### PR TITLE
[fixed] ListGroup work with single child contained in array

### DIFF
--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -13,7 +13,7 @@ class ListGroup extends React.Component {
 
     if (!this.props.children) {
       return this.renderDiv(items);
-    } else if (React.Children.count(this.props.children) === 1) {
+    } else if (React.Children.count(this.props.children) === 1 && !Array.isArray(this.props.children)) {
       let child = this.props.children;
 
       childrenAnchors = child.props.href ? true : false;
@@ -21,7 +21,9 @@ class ListGroup extends React.Component {
     } else {
 
       childrenAnchors = Array.prototype.some.call(this.props.children, (child) => {
-        return child.props.href;
+        return !Array.isArray(child) ? child.props.href : Array.prototype.some.call(child, (subChild) => {
+            return subChild.props.href;
+        });
       });
 
     }

--- a/test/ListGroupSpec.js
+++ b/test/ListGroupSpec.js
@@ -25,6 +25,19 @@ describe('ListGroup', function () {
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(items[0], 'list-group-item'));
   });
 
+  it('Should support a single "ListGroupItem" child contained in an array', function () {
+    let child = [<ListGroupItem key={42}>Only Child in array</ListGroupItem>];
+    let instance = ReactTestUtils.renderIntoDocument(
+      <ListGroup>
+        {child}
+      </ListGroup>
+    );
+
+    let items = ReactTestUtils.scryRenderedComponentsWithType(instance, ListGroupItem);
+
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(items[0], 'list-group-item'));
+  });
+
   it('Should output a "ul" when single "ListGroupItem" child is a list item', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ListGroup>
@@ -52,6 +65,26 @@ describe('ListGroup', function () {
       <ListGroup>
         <ListGroupItem>1st Child</ListGroupItem>
         <ListGroupItem>2nd Child</ListGroupItem>
+      </ListGroup>
+    );
+
+    let items = ReactTestUtils.scryRenderedComponentsWithType(instance, ListGroupItem);
+
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(items[0], 'list-group-item'));
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(items[1], 'list-group-item'));
+  });
+
+  it('Should support multiple "ListGroupItem" children including a subset contained in an array', function () {
+    let itemArray = [
+      <ListGroupItem key={0}>2nd Child nested</ListGroupItem>,
+      <ListGroupItem key={1}>3rd Child nested</ListGroupItem>
+    ];
+
+    let instance = ReactTestUtils.renderIntoDocument(
+      <ListGroup>
+        <ListGroupItem>1st Child</ListGroupItem>
+        {itemArray}
+        <ListGroupItem>4th Child</ListGroupItem>
       </ListGroup>
     );
 


### PR DESCRIPTION
Check if child is array before accessing props

fixes #548