### PR TITLE
Use new path constants

### DIFF
--- a/tools/amd/build.js
+++ b/tools/amd/build.js
@@ -3,14 +3,11 @@ import path from 'path';
 import fsp from 'fs-promise';
 import { copy } from '../fs-utils';
 import { exec } from '../exec';
-
-const repoRoot = path.resolve(__dirname, '../../');
-const amd = path.join(repoRoot, 'amd');
-const src = path.join(repoRoot, 'src');
+import { repoRoot, srcRoot, bowerRoot } from '../constants';
 
 const packagePath = path.join(repoRoot, 'package.json');
 const bowerTemplate = path.join(__dirname, 'bower.json');
-const bowerDestination = path.join(amd, 'bower.json');
+const bowerJson = path.join(bowerRoot, 'bower.json');
 
 const readme = path.join(__dirname, 'README.md');
 const license = path.join(repoRoot, 'LICENSE');
@@ -23,19 +20,19 @@ function bowerConfig() {
       .then(template => _.template(template))
   ])
   .then(([pkg, template]) => template({ pkg }))
-  .then(config => fsp.writeFile(bowerDestination, config));
+  .then(config => fsp.writeFile(bowerJson, config));
 }
 
 export default function BuildBower() {
   console.log('Building: '.cyan + 'bower module'.green);
 
-  return exec(`rimraf ${amd}`)
-    .then(() => fsp.mkdir(amd))
+  return exec(`rimraf ${bowerRoot}`)
+    .then(() => fsp.mkdir(bowerRoot))
     .then(() => Promise.all([
       bowerConfig(),
-      exec(`babel --modules amd --optional es7.objectRestSpread ${src} --out-dir ${path.join(amd, 'lib')}`),
-      copy(readme, amd),
-      copy(license, amd)
+      exec(`babel --modules amd --optional es7.objectRestSpread ${srcRoot} --out-dir ${path.join(bowerRoot, 'lib')}`),
+      copy(readme, bowerRoot),
+      copy(license, bowerRoot)
     ]))
     .then(() => console.log('Built: '.cyan + 'bower module'.green));
 }

--- a/tools/build.js
+++ b/tools/build.js
@@ -1,19 +1,15 @@
 /* eslint no-process-exit: 0 */
 
 import 'colors';
-import path from 'path';
 import bower from './amd/build';
 import lib from './lib/build';
 import docs from '../docs/build';
 import dist from './dist/build';
 import { copy } from './fs-utils';
 import { setExecOptions } from './exec';
+import { distRoot, bowerRoot } from './constants';
 
 import yargs from 'yargs';
-
-const repoRoot = path.resolve(__dirname, '../');
-const distFolder = path.join(repoRoot, 'dist');
-const amdFolder = path.join(repoRoot, 'amd');
 
 const argv = yargs
   .option('docs-only', {
@@ -39,7 +35,7 @@ export default function Build(noExitOnFailure) {
       dist(),
       docs()
     ])
-    .then(() => copy(distFolder, amdFolder));
+    .then(() => copy(distRoot, bowerRoot));
 
     if (!noExitOnFailure) {
       result = result

--- a/tools/constants.js
+++ b/tools/constants.js
@@ -5,6 +5,9 @@ const repoRoot = path.resolve(__dirname, '../');
 const bowerRepo = 'git@github.com:react-bootstrap/react-bootstrap-bower.git';
 const docsRepo = 'git@github.com:react-bootstrap/react-bootstrap.github.io.git';
 
+const srcRoot = path.join(repoRoot, 'src/');
+const distRoot = path.join(repoRoot, 'dist/');
+const libRoot = path.join(repoRoot, 'lib/');
 const bowerRoot = path.join(repoRoot, 'amd/');
 const docsRoot = path.join(repoRoot, 'docs-built/');
 
@@ -13,6 +16,7 @@ const tmpDocsRepo = path.join(repoRoot, 'tmp-docs-repo');
 
 export {
   repoRoot,
+  srcRoot, distRoot, libRoot,
   bowerRepo, bowerRoot, tmpBowerRepo,
   docsRoot, docsRepo, tmpDocsRepo,
 };

--- a/tools/dist/build.js
+++ b/tools/dist/build.js
@@ -1,13 +1,10 @@
-import path from 'path';
 import { exec } from '../exec';
-
-const repoRoot = path.resolve(__dirname, '../../');
-const dist = path.join(repoRoot, 'dist');
+import { distRoot } from '../constants';
 
 export default function BuildDistributable() {
   console.log('Building: '.cyan + 'distributable'.green);
 
-  return exec(`rimraf ${dist}`)
+  return exec(`rimraf ${distRoot}`)
     .then(() => Promise.all([
       exec('webpack --bail'),
       exec('webpack --bail -p')

--- a/tools/lib/build.js
+++ b/tools/lib/build.js
@@ -1,15 +1,11 @@
 import 'colors';
-import path from 'path';
 import { exec } from '../exec';
-
-const repoRoot = path.resolve(__dirname, '../../');
-const lib = path.join(repoRoot, 'lib');
-const src = path.join(repoRoot, 'src');
+import { srcRoot, libRoot } from '../constants';
 
 export default function BuildCommonJs() {
   console.log('Building: '.cyan + 'npm module'.green);
 
-  return exec(`rimraf ${lib}`)
-    .then(() => exec(`babel --optional es7.objectRestSpread ${src} --out-dir ${lib}`))
+  return exec(`rimraf ${libRoot}`)
+    .then(() => exec(`babel --optional es7.objectRestSpread ${srcRoot} --out-dir ${libRoot}`))
     .then(() => console.log('Built: '.cyan + 'npm module'.green));
 }

--- a/tools/release-docs-scripts/release-docs.js
+++ b/tools/release-docs-scripts/release-docs.js
@@ -10,7 +10,7 @@ import repoRelease from '../release-scripts/repo-release';
 import tag from '../release-scripts/tag';
 import { lint } from '../release-scripts/test';
 
-import { repoRoot, docsRoot, docsRepo, tmpDocsRepo } from '../constants';
+import { docsRoot, docsRepo, tmpDocsRepo } from '../constants';
 
 const yargsConf = yargs
   .usage('Usage: $0 [-n|--dry-run] [--verbose]')
@@ -37,7 +37,7 @@ const versionBumpOptions = {
 
 preConditions()
   .then(lint)
-  .then(versionBump(repoRoot, versionBumpOptions))
+  .then(versionBump(versionBumpOptions))
   .then(v => { version = v; })
   .then(() => {
     return exec(`npm run docs-build${ argv.verbose ? ' -- --verbose' : '' }`)

--- a/tools/release-scripts/changelog.js
+++ b/tools/release-scripts/changelog.js
@@ -1,8 +1,9 @@
 import 'colors';
 import path from 'path';
 import { exec, safeExec } from '../exec';
+import { repoRoot } from './constants';
 
-export default (repoRoot, version) => {
+export default (version) => {
   return exec(`node_modules/.bin/changelog -t v${version}`)
     .then(() => safeExec(`git add ${path.join(repoRoot, 'CHANGELOG.md')}`))
     .then(() => console.log('Generated Changelog'.cyan));

--- a/tools/release-scripts/release.js
+++ b/tools/release-scripts/release.js
@@ -10,7 +10,7 @@ import tagAndPublish from './tag-and-publish';
 import test from './test';
 import build from '../build';
 
-import { repoRoot, bowerRepo, bowerRoot, tmpBowerRepo, docsRoot, docsRepo, tmpDocsRepo } from '../constants';
+import { bowerRepo, bowerRoot, tmpBowerRepo, docsRoot, docsRepo, tmpDocsRepo } from '../constants';
 
 const yargsConf = yargs
   .usage('Usage: $0 <version> [--preid <identifier>]')
@@ -57,9 +57,9 @@ if (versionBumpOptions.type === undefined && versionBumpOptions.preid === undefi
 
 preConditions()
   .then(test)
-  .then(versionBump(repoRoot, versionBumpOptions))
+  .then(versionBump(versionBumpOptions))
   .then(v => { version = v; })
-  .then(() => addChangelog(repoRoot, version))
+  .then(() => addChangelog(version))
   .then(() => {
     return build(true)
       .catch(err => {

--- a/tools/release-scripts/version-bump.js
+++ b/tools/release-scripts/version-bump.js
@@ -3,8 +3,9 @@ import path from 'path';
 import fsp from 'fs-promise';
 import semver from 'semver';
 import { safeExec } from '../exec';
+import { repoRoot } from './constants';
 
-export default function(repoRoot, { preid, type }) {
+export default function({ preid, type }) {
   const packagePath = path.join(repoRoot, 'package.json');
 
   return () => fsp.readFile(packagePath, { encoding: 'utf8' })


### PR DESCRIPTION
As you suggested in my other pull request (https://github.com/react-bootstrap/react-bootstrap/pull/536) the ```src/``` root folder was a good candidate to add to constants. I also added constants for other folders which simplified the build files. Since I took it a bit further I thought it better to create a separate PR. 