### PR TITLE
Fix for bug 547 in tools/release.

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -7,7 +7,7 @@ import lib from './lib/build';
 import docs from '../docs/build';
 import dist from './dist/build';
 import { copy } from './fs-utils';
-import { setExecOptions } from './exec';
+import { exec, setExecOptions } from './exec';
 
 import yargs from 'yargs';
 
@@ -37,7 +37,7 @@ export default function Build(noExitOnFailure) {
       lib(),
       bower(),
       dist(),
-      docs()
+      exec(`npm run docs-build`)
     ])
     .then(() => copy(distFolder, amdFolder));
 


### PR DESCRIPTION
Conversation is here #547.
Idea for this patch totally belongs to @mtscout6.
I have just tested it and made PR.

As @dozoisch has mentioned  
> docs-build runs with docs-only and doesn't take the same branch in the file

There is no recursion in scripts and everything works fine as expected.