### PR TITLE
Remove stale TODO note.

### DIFF
--- a/src/TabbedArea.js
+++ b/src/TabbedArea.js
@@ -40,9 +40,6 @@ const TabbedArea = React.createClass({
     let defaultActiveKey = this.props.defaultActiveKey != null ?
       this.props.defaultActiveKey : getDefaultActiveKeyFromChildren(this.props.children);
 
-    // TODO: In __DEV__ mode warn via `console.warn` if no `defaultActiveKey` has
-    // been set by this point, invalid children or missing key properties are likely the cause.
-
     return {
       activeKey: defaultActiveKey,
       previousActiveKey: null


### PR DESCRIPTION
The check is doing by React now.
```js
propTypes: {
  defaultActiveKey: React.PropTypes.any
```

This comment had served as trigger for the idea at https://github.com/react-bootstrap/react-bootstrap/issues/574 at the first place.