### PR TITLE
[fixed] Keyboard traversing on DropdownMenu

### DIFF
--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -4,10 +4,64 @@ import classNames from 'classnames';
 import createChainedFunction from './utils/createChainedFunction';
 import ValidComponentChildren from './utils/ValidComponentChildren';
 
+const traverseKeys = [38, 40];
+
 const DropdownMenu = React.createClass({
   propTypes: {
     pullRight: React.PropTypes.bool,
-    onSelect: React.PropTypes.func
+    onSelect: React.PropTypes.func,
+    style: React.PropTypes.object
+  },
+
+  handleMenuKeyDown(event) {
+
+    if (event.keyCode === 13) {
+      return;
+    }
+
+    event.preventDefault();
+
+    // Go to previous item if possible
+    if (event.keyCode === traverseKeys[0]) {
+      this.focusPrevious();
+    }
+
+    // Go to next item if possible
+    if (event.keyCode === traverseKeys[1]) {
+      this.focusNext();
+    }
+  },
+
+  getFocusableMenuItems() {
+
+    // Grab hyperlinks and convert to array
+    return [].slice.call(this.getDOMNode().querySelectorAll('a'), 0);
+  },
+
+  focusNext() {
+
+    let activeElement = document.activeElement;
+    let items = this.getFocusableMenuItems();
+    let activeItemIndex = items.indexOf(activeElement);
+
+    if (activeItemIndex !== items.length - 1) {
+      items[activeItemIndex + 1].focus();
+    }
+
+  },
+
+  focusPrevious() {
+
+    let activeElement = document.activeElement;
+    let items = this.getFocusableMenuItems();
+    let activeItemIndex = items.indexOf(activeElement);
+
+    if (activeItemIndex === -1) {
+      items[items.length - 1].focus();
+    } else if (activeItemIndex !== 0) {
+      items[activeItemIndex - 1].focus();
+    }
+
   },
 
   render() {
@@ -16,11 +70,19 @@ const DropdownMenu = React.createClass({
         'dropdown-menu-right': this.props.pullRight
       };
 
+    // Remove outline on focus by default
+    let style = this.props.style || {};
+    style.outline = style.outline || 'none';
+
+    // Adding tabIndex -1 to allow for focus, but not tabable
     return (
         <ul
+          tabIndex="-1"
+          onKeyDown={this.handleMenuKeyDown}
           {...this.props}
           className={classNames(this.props.className, classes)}
-          role="menu">
+          role="menu"
+          style={style}>
           {ValidComponentChildren.map(this.props.children, this.renderMenuItem)}
         </ul>
       );
@@ -30,11 +92,13 @@ const DropdownMenu = React.createClass({
     return cloneElement(
       child,
       {
+
         // Capture onSelect events
         onSelect: createChainedFunction(child.props.onSelect, this.props.onSelect),
 
         // Force special props to be transferred
         key: child.key ? child.key : index
+
       }
     );
   }

--- a/src/DropdownStateMixin.js
+++ b/src/DropdownStateMixin.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import domUtils from './utils/domUtils';
 import EventListener from './utils/EventListener';
+import createChainedFunction from './utils/createChainedFunction';
 
 /**
  * Checks whether a node is within
@@ -37,7 +38,11 @@ const DropdownStateMixin = {
 
     this.setState({
       open: newState
-    }, onStateChangeComplete);
+    }, newState && !this.state.open ? createChainedFunction(this.focusMenu, onStateChangeComplete) : onStateChangeComplete);
+  },
+
+  focusMenu() {
+    this.refs.menu.getDOMNode().focus();
   },
 
   handleDocumentKeyUp(e) {

--- a/test/DropdownButtonSpec.js
+++ b/test/DropdownButtonSpec.js
@@ -201,4 +201,37 @@ describe('DropdownButton', function () {
     let carets = button.getElementsByClassName('caret');
     assert.equal(carets.length, 0);
   });
+
+  it('should focus dropdown items when pressing cursor up and down keys', function () {
+
+    // Have to run this in actual DOM to verify focus
+    let testContainer = document.createElement('div');
+    document.body.appendChild(testContainer);
+
+    // Create instance as normal, only in DOM
+    instance = React.render(
+        <DropdownButton title="Title">
+          <MenuItem eventKey="1">MenuItem 1 content</MenuItem>
+          <MenuItem eventKey="2">MenuItem 2 content</MenuItem>
+        </DropdownButton>
+    , testContainer);
+
+    let items = ReactTestUtils.scryRenderedDOMComponentsWithTag(instance, 'a');
+    ReactTestUtils.Simulate.click(instance.refs.dropdownButton);
+
+    let menu = React.findDOMNode(instance.refs.menu);
+
+    ReactTestUtils.Simulate.keyDown(menu, {keyCode: 40});
+    assert.equal(document.activeElement, items[0].getDOMNode());
+    ReactTestUtils.Simulate.keyDown(menu, {keyCode: 40});
+    assert.equal(document.activeElement, items[1].getDOMNode());
+    ReactTestUtils.Simulate.keyDown(menu, {keyCode: 38});
+    assert.equal(document.activeElement, items[0].getDOMNode());
+
+    // Clean up
+    React.unmountComponentAtNode(testContainer);
+    document.body.removeChild(testContainer);
+
+  });
+
 });


### PR DESCRIPTION
The original bootstrap allows for keyboard traversing on dropdowns. This is an important feature as many solutions allow for keyboard traversing in the interface.

React is not able to use state to handle what element to focus, so this has to be handled "outside of React". This is the strategy:

1. Make the dropdown menu focusable, but not tabable, by using `tabIndex="-1"`. This will enable the ability to listen for keydown events

2. When a dropdown menu is opened focus the menu, waiting for keydown events

3. When a 38/40 key event is registered jump to previous or next possible focusable element, which is hyperlinks (a tag). This has to be checked on each keydown as there can be dividers in between the focusables and the list itself might change

Created a test which has to be written a bit differently due to testing focus. But it should all work :-)