### PR TITLE
Support adding button class to DropdownButton

### DIFF
--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -20,7 +20,8 @@ const DropdownButton = React.createClass({
     onClick:   React.PropTypes.func,
     onSelect:  React.PropTypes.func,
     navItem:   React.PropTypes.bool,
-    noCaret:   React.PropTypes.bool
+    noCaret:   React.PropTypes.bool,
+    buttonClassName: React.PropTypes.string
   },
 
   render() {
@@ -34,7 +35,7 @@ const DropdownButton = React.createClass({
       <Button
         {...this.props}
         ref="dropdownButton"
-        className="dropdown-toggle"
+        className={classNames('dropdown-toggle', this.props.buttonClassName)}
         onClick={this.handleDropdownClick}
         key={0}
         navDropdown={this.props.navItem}

--- a/test/DropdownButtonSpec.js
+++ b/test/DropdownButtonSpec.js
@@ -201,4 +201,16 @@ describe('DropdownButton', function () {
     let carets = button.getElementsByClassName('caret');
     assert.equal(carets.length, 0);
   });
+
+  it('should set button class when buttonClassName is given', function() {
+    instance = ReactTestUtils.renderIntoDocument(
+        <DropdownButton buttonClassName="test-class">
+          <MenuItem eventKey="1">MenuItem 1 content</MenuItem>
+          <MenuItem eventKey="2">MenuItem 2 content</MenuItem>
+        </DropdownButton>
+    );
+
+    let button = ReactTestUtils.findRenderedComponentWithType(instance, Button).getDOMNode();
+    assert.ok(button.className.match(/\btest-class\b/));
+  });
 });


### PR DESCRIPTION
As mentioned on #376, making rounded buttons using classes becomes harder unless we can add custom classes to the wrapped Button element. 

Before fixing #376 this worked OK, but the change broke existing code (ie. code that assumed the classes went to the Button element) that cannot be fixed unless this property is introduced.