### PR TITLE
Show test title in afterEach() hook.

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,9 @@ beforeEach(function() {
 
 afterEach(function() {
   if (typeof console.warn.restore === 'function') {
-    assert(!console.warn.called, () => console.warn.getCall(0).args[0]);
+    assert(!console.warn.called, () => {
+      return `${console.warn.getCall(0).args[0]} \nIn '${this.currentTest.fullTitle()}'`;
+    });
     console.warn.restore();
   }
 });


### PR DESCRIPTION
When I add deprecation warning for any element,
afterEach() hook catch it, but it is not clear in which test.
```
  ✖ "after each" hook
  AssertionError: collapsable in CollapsibleNav is deprecated. Use collapsible instead. 
```
with this fix it adds a line with a full "path" of the failed test:
```
...
In 'CollapsibleNav Should create div and add collapse class'
```
