### PR TITLE
[IE9] Check for console before using console.warn

### DIFF
--- a/src/utils/deprecationWarning.js
+++ b/src/utils/deprecationWarning.js
@@ -1,10 +1,16 @@
+function warn(message) {
+  if (window.console && (typeof console.warn === 'function')) {
+    console.warn(message);
+  }
+}
+
 export default function deprecationWarning(oldname, newname, link) {
   if (process.env.NODE_ENV !== 'production') {
     let message = `${oldname} is deprecated. Use ${newname} instead.`;
-    console.warn(message);
+    warn(message);
 
     if (link) {
-      console.warn(`You can read more about it here ${link}`);
+      warn(`You can read more about it here ${link}`);
     }
   }
 }


### PR DESCRIPTION
I realize the check for `NODE_ENV === production` fixes the issue for production builds but I regularly test with IE9 locally while developing.