### PR TITLE
[fixed] #597 able to set ID on ListGroup

### DIFF
--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -46,7 +46,9 @@ class ListGroup extends React.Component {
     );
 
     return (
-      <ul className={classNames(this.props.className, 'list-group')}>
+      <ul
+        {...this.props}
+        className={classNames(this.props.className, 'list-group')}>
         {listItems}
       </ul>
     );
@@ -54,7 +56,9 @@ class ListGroup extends React.Component {
 
   renderDiv(items) {
     return (
-      <div className={classNames(this.props.className, 'list-group')}>
+      <div
+        {...this.props}
+        className={classNames(this.props.className, 'list-group')}>
         {items}
       </div>
     );
@@ -62,7 +66,8 @@ class ListGroup extends React.Component {
 }
 
 ListGroup.propTypes = {
-  className: React.PropTypes.string
+  className: React.PropTypes.string,
+  id: React.PropTypes.string
 };
 
 export default ListGroup;

--- a/test/ListGroupSpec.js
+++ b/test/ListGroupSpec.js
@@ -136,4 +136,15 @@ describe('ListGroup', function () {
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'list-group'));
   });
 
+  it('Should support an element id through "id" prop', function () {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <ListGroup id="testItem">
+        <ListGroupItem>Child</ListGroupItem>
+      </ListGroup>
+    );
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'list-group'));
+    assert.equal(React.findDOMNode(instance).nodeName, 'UL');
+    assert.equal(React.findDOMNode(instance).id, 'testItem');
+  });
+
 });


### PR DESCRIPTION
Fixed `ListGroup` render to allow setting id on element through spread `{...this.props}` on element.