### PR TITLE
[added] Optionally allow Modal content styles to be set

### DIFF
--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -217,7 +217,7 @@ const ComponentsPage = React.createClass({
                   <h1 id='modals' className='page-header'>Modals <small>Modal</small></h1>
 
                   <h3 id='modals-static'>A static example</h3>
-                  <p>A rendered modal with header, body, and set of actions in the footer.</p>
+                  <p>A rendered modal with header, body, and set of actions in the footer. An optional <code>contentStyles</code> property can be set to override the styles on <code>.modal-content</code>.</p>
                   <p>The header is added automatically if you pass in a <code>title</code> prop.</p>
                   <ReactPlayground codeText={Samples.ModalStatic} />
 

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -45,6 +45,8 @@ const Modal = React.createClass({
       'in': !this.props.animation || !document.querySelectorAll
     };
 
+    let contentStyle = this.props.contentStyle || {overflow: 'hidden'};
+
     let modal = (
       <div
         {...this.props}
@@ -56,7 +58,7 @@ const Modal = React.createClass({
         onClick={this.props.backdrop === true ? this.handleBackdropClick : null}
         ref="modal">
         <div className={classNames(dialogClasses)}>
-          <div className="modal-content" style={{overflow: 'hidden'}}>
+          <div className="modal-content" style={contentStyle}>
             {this.props.title ? this.renderHeader() : null}
             {this.props.children}
           </div>

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -98,4 +98,28 @@ describe('Modal', function () {
     assert.ok(header.className.match(/\btext-danger\b/));
   });
 
+  it('Should default to overflow hidden on content', function () {
+    let noOp = function () {};
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Modal title="Title" onRequestHide={noOp}>
+        <strong>Message</strong>
+      </Modal>
+    );
+
+    let content = instance.getDOMNode().getElementsByClassName('modal-content')[0];
+    assert.ok(content.style.overflow.match(/hidden/));
+  });
+
+  it('Should allow setting content overflow property', function () {
+    let noOp = function () {};
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Modal title="Title" onRequestHide={noOp} contentStyle={{overflow: 'visible'}}>
+        <strong>Message</strong>
+      </Modal>
+    );
+
+    let content = instance.getDOMNode().getElementsByClassName('modal-content')[0];
+    assert.ok(content.style.overflow.match(/visible/));
+  });
+
 });


### PR DESCRIPTION
I would like to be able to set the .modal-content style in some cases. For example, I am using react-select in a modal and want the autocomplete pane to visibly extend beyond the bottom of the modal.

I updated the documentation but am unsure if I should have for an optional thing like this.