### PR TITLE
[fixed] failing test of deprecation

### DIFF
--- a/src/CollapsableNav.js
+++ b/src/CollapsableNav.js
@@ -1,7 +1,33 @@
+import React from 'react';
 import CollapsibleNav from './CollapsibleNav';
+import deprecationWarning from './utils/deprecationWarning';
 
-let CollapsableNav = CollapsibleNav;
+const deprecationLink = 'https://github.com/react-bootstrap/react-bootstrap/issues/425#issuecomment-97110963';
 
-CollapsableNav.__deprecated__ = true;
+const CollapsableNav = React.createClass({
+  getCollapsableDOMNode() {
+    return this.refs.collapsible.getCollapsableDOMNode();
+  },
+
+  getCollapsableDimensionValue() {
+    return this.refs.collapsible.getCollapsableDimensionValue();
+  },
+
+  componentDidMount() {
+    deprecationWarning(
+      'CollapsableNav',
+      'CollapsibleNav',
+      deprecationLink
+    );
+  },
+
+  render() {
+    return (<CollapsibleNav {...this.props} ref="collapsible" />);
+  },
+
+  getChildActiveProp(child) {
+    return this.refs.collapsible.getChildActiveProp(child);
+  }
+});
 
 export default CollapsableNav;

--- a/src/CollapsibleNav.js
+++ b/src/CollapsibleNav.js
@@ -3,10 +3,12 @@ import BootstrapMixin from './BootstrapMixin';
 import CollapsibleMixin from './CollapsibleMixin';
 import classNames from 'classnames';
 import domUtils from './utils/domUtils';
-import deprecationWarning from './utils/deprecationWarning';
 
 import ValidComponentChildren from './utils/ValidComponentChildren';
 import createChainedFunction from './utils/createChainedFunction';
+
+import deprecationWarning from './utils/deprecationWarning';
+const deprecationLink = 'https://github.com/react-bootstrap/react-bootstrap/issues/425#issuecomment-97110963';
 
 const CollapsibleNav = React.createClass({
   mixins: [BootstrapMixin, CollapsibleMixin],
@@ -43,14 +45,22 @@ const CollapsibleNav = React.createClass({
     return height;
   },
 
-  componentDidMount() {
-    if (this.constructor.__deprecated__) {
+  getCollapsableDOMNode() {
+    deprecationWarning(
+      'getCollapsableDOMNode',
+      'getCollapsibleDOMNode',
+      deprecationLink
+    );
+    return this.getCollapsibleDOMNode();
+  },
+
+  getCollapsableDimensionValue() {
       deprecationWarning(
-        'CollapsableNav',
-        'CollapsibleNav',
-        'https://github.com/react-bootstrap/react-bootstrap/issues/425#issuecomment-97110963'
-      );
-    }
+      'getCollapsableDimensionValue',
+      'getCollapsibleDimensionValue',
+      deprecationLink
+    );
+      return this.getCollapsibleDimensionValue();
   },
 
   render() {

--- a/test/CollapsableNavSpec.js
+++ b/test/CollapsableNavSpec.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import ReactTestUtils from 'react/lib/ReactTestUtils';
+import Navbar from '../src/Navbar';
+import CollapsableNav from '../src/CollapsableNav';
+import Nav from '../src/Nav';
+import NavItem from '../src/NavItem';
+import {shouldWarn} from './helpers';
+
+describe('CollapsableNav', function () {
+  it('Should create div and add collapse class and warn', function () {
+    let Parent = React.createClass({
+      render: function() {
+        return (
+          <Navbar toggleNavKey={1}>
+            <CollapsableNav eventKey={1}>
+              <Nav>
+                <NavItem eventKey={1} ref='item1'>Item 1 content</NavItem>
+                <NavItem eventKey={2} ref='item2'>Item 2 content</NavItem>
+              </Nav>
+            </CollapsableNav>
+            </Navbar>
+        );
+      }
+    });
+    let instance = ReactTestUtils.renderIntoDocument(<Parent />);
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'navbar-collapse'));
+    shouldWarn('deprecated');
+  });
+
+  it('Should warn about getCollapsableDOMNode', function () {
+    let Parent = React.createClass({
+      render: function() {
+        return (
+          <Navbar toggleNavKey={1}>
+            <CollapsableNav ref='collapsable_object' eventKey={1}>
+              <Nav>
+                <NavItem eventKey={1} ref='item1'>Item 1 content</NavItem>
+                <NavItem eventKey={2} ref='item2'>Item 2 content</NavItem>
+              </Nav>
+            </CollapsableNav>
+            </Navbar>
+        );
+      }
+    });
+    let instance = ReactTestUtils.renderIntoDocument(<Parent />);
+    instance.refs.collapsable_object.getCollapsableDOMNode();
+    shouldWarn('deprecated');
+  });
+  it('Should warn about getCollapsableDimensionValue', function () {
+    let Parent = React.createClass({
+      render: function() {
+        return (
+          <Navbar toggleNavKey={1}>
+            <CollapsableNav ref='collapsable_object' eventKey={1}>
+              <Nav>
+                <NavItem eventKey={1} ref='item1'>Item 1 content</NavItem>
+                <NavItem eventKey={2} ref='item2'>Item 2 content</NavItem>
+              </Nav>
+            </CollapsableNav>
+            </Navbar>
+        );
+      }
+    });
+    let instance = ReactTestUtils.renderIntoDocument(<Parent />);
+    instance.refs.collapsable_object.getCollapsableDimensionValue();
+    shouldWarn('deprecated');
+  });
+});

--- a/test/CollapsibleNavSpec.js
+++ b/test/CollapsibleNavSpec.js
@@ -4,6 +4,7 @@ import Navbar from '../src/Navbar';
 import CollapsibleNav from '../src/CollapsibleNav';
 import Nav from '../src/Nav';
 import NavItem from '../src/NavItem';
+import {shouldWarn} from './helpers';
 
 describe('CollapsibleNav', function () {
   it('Should create div and add collapse class', function () {
@@ -110,5 +111,44 @@ describe('CollapsibleNav', function () {
         , classArray = classDOM.split(' ')
         , idx = classArray.indexOf('navbar-collapse');
     assert.equal(classArray.indexOf('navbar-collapse', idx+1), -1);
+  });
+
+  it('Should warn about getCollapsableDOMNode', function () {
+    let Parent = React.createClass({
+      render: function() {
+        return (
+          <Navbar toggleNavKey={1}>
+            <CollapsibleNav ref='collapsible_object' eventKey={1}>
+              <Nav>
+                <NavItem eventKey={1} ref='item1'>Item 1 content</NavItem>
+                <NavItem eventKey={2} ref='item2'>Item 2 content</NavItem>
+              </Nav>
+            </CollapsibleNav>
+            </Navbar>
+        );
+      }
+    });
+    let instance = ReactTestUtils.renderIntoDocument(<Parent />);
+    instance.refs.collapsible_object.getCollapsableDOMNode();
+    shouldWarn('deprecated');
+  });
+  it('Should warn about getCollapsableDimensionValue', function () {
+    let Parent = React.createClass({
+      render: function() {
+        return (
+          <Navbar toggleNavKey={1}>
+            <CollapsibleNav ref='collapsible_object' eventKey={1}>
+              <Nav>
+                <NavItem eventKey={1} ref='item1'>Item 1 content</NavItem>
+                <NavItem eventKey={2} ref='item2'>Item 2 content</NavItem>
+              </Nav>
+            </CollapsibleNav>
+            </Navbar>
+        );
+      }
+    });
+    let instance = ReactTestUtils.renderIntoDocument(<Parent />);
+    instance.refs.collapsible_object.getCollapsableDimensionValue();
+    shouldWarn('deprecated');
   });
 });


### PR DESCRIPTION
I think the __deprecated__ applied to the Collapsible also once Collapsable was being imported. So instead of setting a prop I made wrapper component that exposes the two functions that can be called. I also re-added these two functions with warning to the Collapsible component.