### PR TITLE
[fixed] Modal div.modal-content should not have hidden class

### DIFF
--- a/docs/examples/ModalContained.js
+++ b/docs/examples/ModalContained.js
@@ -12,7 +12,7 @@
 const ContainedModal = React.createClass({
   render() {
     return (
-      <Modal {...this.props} bsStyle='primary' title='Contained Modal' animation>
+      <Modal {...this.props} title='Contained Modal' animation>
         <div className='modal-body'>
           Elit est explicabo ipsum eaque dolorem blanditiis doloribus sed id ipsam, beatae, rem fuga id earum? Inventore et facilis obcaecati.
         </div>

--- a/docs/examples/ModalOverlayMixin.js
+++ b/docs/examples/ModalOverlayMixin.js
@@ -28,7 +28,7 @@ const CustomModalTrigger = React.createClass({
     }
 
     return (
-      <Modal bsStyle='primary' title='Modal heading' onRequestHide={this.handleToggle}>
+      <Modal title='Modal heading' onRequestHide={this.handleToggle}>
         <div className='modal-body'>
           This modal is controlled by our custom trigger component.
         </div>

--- a/docs/examples/ModalStatic.js
+++ b/docs/examples/ModalStatic.js
@@ -5,7 +5,6 @@ function handleHide() {
 const modalInstance = (
   <div className='static-modal'>
     <Modal title='Modal title'
-      bsStyle='primary'
       backdrop={false}
       animation={false}
       container={mountNode}

--- a/docs/examples/ModalTrigger.js
+++ b/docs/examples/ModalTrigger.js
@@ -1,7 +1,7 @@
 const MyModal = React.createClass({
   render() {
     return (
-      <Modal {...this.props} bsStyle='primary' title='Modal heading' animation={false}>
+      <Modal {...this.props} title='Modal heading' animation={false}>
         <div className='modal-body'>
           <h4>Text in a modal</h4>
           <p>Duis mollis, est non commodo luctus, nisi erat porttitor ligula.</p>

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -95,23 +95,8 @@ const Modal = React.createClass({
         );
     }
 
-    let bsStyle = this.props.bsStyle;
-    let classes = {
-      'modal-header': true
-    };
-    classes['bg-' + bsStyle] = bsStyle;
-    classes['text-' + bsStyle] = bsStyle;
-
-    let className = classNames(classes);
-
-    let style = {};
-    if (this.props.bsStyle) {
-      style.borderTopLeftRadius = 'inherit';
-      style.borderTopRightRadius = 'inherit';
-    }
-
     return (
-      <div className={className} style={style}>
+      <div className="modal-header">
         {closeButton}
         {this.renderTitle()}
       </div>

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -56,7 +56,7 @@ const Modal = React.createClass({
         onClick={this.props.backdrop === true ? this.handleBackdropClick : null}
         ref="modal">
         <div className={classNames(dialogClasses)}>
-          <div className="modal-content" style={{overflow: 'hidden'}}>
+          <div className="modal-content">
             {this.props.title ? this.renderHeader() : null}
             {this.props.children}
           </div>
@@ -95,17 +95,23 @@ const Modal = React.createClass({
         );
     }
 
-    let style = this.props.bsStyle;
+    let bsStyle = this.props.bsStyle;
     let classes = {
       'modal-header': true
     };
-    classes['bg-' + style] = style;
-    classes['text-' + style] = style;
+    classes['bg-' + bsStyle] = bsStyle;
+    classes['text-' + bsStyle] = bsStyle;
 
     let className = classNames(classes);
 
+    let style = {};
+    if (this.props.bsStyle) {
+      style.borderTopLeftRadius = 'inherit';
+      style.borderTopRightRadius = 'inherit';
+    }
+
     return (
-      <div className={className}>
+      <div className={className} style={style}>
         {closeButton}
         {this.renderTitle()}
       </div>

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -85,17 +85,4 @@ describe('Modal', function () {
     assert.ok(dialog.className.match(/\bmodal-sm\b/));
   });
 
-  it('Should pass bsStyle to the header', function () {
-    let noOp = function () {};
-    let instance = ReactTestUtils.renderIntoDocument(
-      <Modal bsStyle='danger' title="Title" onRequestHide={noOp}>
-        <strong>Message</strong>
-      </Modal>
-    );
-
-    let header = instance.getDOMNode().getElementsByClassName('modal-header')[0];
-    assert.ok(header.className.match(/\bbg-danger\b/));
-    assert.ok(header.className.match(/\btext-danger\b/));
-  });
-
 });


### PR DESCRIPTION
Vanilla Bootstrap Modal does not have the CSS class `hidden` by default on the `div.modal-content`. It was added to react-bootstrap in commit https://github.com/react-bootstrap/react-bootstrap/commit/13f395d2304727d65ee22242423150c22b73addb that added support for bsStyle property to Modal for setting the header color. There were a number of changes and why `hidden` was added to `div.modal-content` isn't clear.

My reason for not wanting this is when using say react-select inside a modal, the dropdown should be visible in the event it overflows the modal.