### PR TITLE
Fix the subtle bug with deprecation warning.

### DIFF
--- a/src/CollapsableNav.js
+++ b/src/CollapsableNav.js
@@ -1,7 +1,18 @@
-import CollapsibleNav from './CollapsibleNav';
+import React from 'react';
+import deprecationWarning from './utils/deprecationWarning';
+import assign from './utils/Object.assign';
+import {specCollapsibleNav} from './CollapsibleNav';
 
-let CollapsableNav = CollapsibleNav;
+const specCollapsableNav = assign({}, specCollapsibleNav, {
+  componentDidMount() {
+    deprecationWarning(
+      'CollapsableNav',
+      'CollapsibleNav',
+      'https://github.com/react-bootstrap/react-bootstrap/issues/425#issuecomment-97110963'
+    );
+  }
+});
 
-CollapsableNav.__deprecated__ = true;
+const CollapsableNav = React.createClass(specCollapsableNav);
 
 export default CollapsableNav;

--- a/src/CollapsibleNav.js
+++ b/src/CollapsibleNav.js
@@ -3,12 +3,11 @@ import BootstrapMixin from './BootstrapMixin';
 import CollapsibleMixin from './CollapsibleMixin';
 import classNames from 'classnames';
 import domUtils from './utils/domUtils';
-import deprecationWarning from './utils/deprecationWarning';
 
 import ValidComponentChildren from './utils/ValidComponentChildren';
 import createChainedFunction from './utils/createChainedFunction';
 
-const CollapsibleNav = React.createClass({
+const specCollapsibleNav = {
   mixins: [BootstrapMixin, CollapsibleMixin],
 
   propTypes: {
@@ -41,16 +40,6 @@ const CollapsibleNav = React.createClass({
       }
     }
     return height;
-  },
-
-  componentDidMount() {
-    if (this.constructor.__deprecated__) {
-      deprecationWarning(
-        'CollapsableNav',
-        'CollapsibleNav',
-        'https://github.com/react-bootstrap/react-bootstrap/issues/425#issuecomment-97110963'
-      );
-    }
   },
 
   render() {
@@ -127,6 +116,9 @@ const CollapsibleNav = React.createClass({
       }
     );
   }
-});
+};
 
+const CollapsibleNav = React.createClass(specCollapsibleNav);
+
+export {specCollapsibleNav};
 export default CollapsibleNav;


### PR DESCRIPTION
When deprecated `Collaps_a_bleNav` is imported
it also tags `Collaps_i_bleNav` element as deprecated, because
it is done by using pointers which points to the same object.

```js
let CollapsableNav = CollapsibleNav;
CollapsableNav.__deprecated__ = true;
```
https://github.com/react-bootstrap/react-bootstrap/blob/92c57ef7ee/src/CollapsableNav.js#L5

The right and simplest way to make deprecation
in the case of component renaming `CollapsableNav => CollapsibleNav`
by using general for both components part - `classSpecifications`.

Like this:

```js
// NewNameComponent.js
const classSpecificationsFor_NewNameComponent = { /* existing code */ };
const NewNameComponent =
  React.createClass( classSpecificationsFor_NewNameComponent );
export {classSpecificationsFor_NewNameComponent}; // for old component
export default NewNameComponent;

// OldNameComponent.js
import {classSpecificationsFor_NewNameComponent} from 'NewNameComponent';
const classSpecsFor_OldNameComponent =
  assign({}, classSpecificationsFor_NewNameComponent, {
  // here we add deprecation warning
  });
const OldNameComponent =
  React.createClass( classSpecsFor_OldNameComponent );
export default OldNameComponent;
```

Addresses https://github.com/react-bootstrap/react-bootstrap/pull/604
and https://github.com/react-bootstrap/react-bootstrap/pull/607