### PR TITLE
Add a customBefore and customAfter to Input

### DIFF
--- a/docs/examples/InputAddons.js
+++ b/docs/examples/InputAddons.js
@@ -6,6 +6,18 @@ const innerDropdown = (
   </DropdownButton>
 );
 
+const customBefore = (
+  <span className="input-group-addon hidden-xs">
+    Hide this on narrow view
+  </span>
+);
+
+const customAfter = (
+  <span className="input-group-addon hidden-xs">
+    <Button>Search</Button>
+  </span>
+);
+
 const inputAddonsInstance = (
   <form>
     <Input type='text' addonBefore='@' />
@@ -14,6 +26,8 @@ const inputAddonsInstance = (
     <Input type='text' addonAfter={innerGlyphicon} />
     <Input type='text' buttonBefore={innerButton} />
     <Input type='text' buttonAfter={innerDropdown} />
+    <Input type='text' customBefore={customBefore} />
+    <Input type='text' customBefore={customAfter} />
   </form>
 );
 

--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -558,7 +558,7 @@ const ComponentsPage = React.createClass({
                   <p>Supports <code>select</code>, <code>textarea</code>, <code>static</code> as well as standard HTML input types. <code>getValue()</code> returns an array for multiple select.</p>
                   <ReactPlayground codeText={Samples.InputTypes} />
                   <h2 id='input-addons'>Add-ons</h2>
-                  <p>Use <code>addonBefore</code> and <code>addonAfter</code> for normal addons, <code>buttonBefore</code> and <code>buttonAfter</code> for button addons.
+                  <p>Use <code>addonBefore</code> and <code>addonAfter</code> for normal addons, <code>buttonBefore</code> and <code>buttonAfter</code> for button addons, and <code>customBefore</code> and <code>customAfter</code> for custom (unwrapped) addons.
                   Exotic configurations may require some css on your side.</p>
                   <ReactPlayground codeText={Samples.InputAddons} />
                   <h2 id='input-validation'>Validation</h2>

--- a/src/Input.js
+++ b/src/Input.js
@@ -74,19 +74,24 @@ class Input extends React.Component {
       </span>
     ) : null;
 
+    let customBefore = this.props.customBefore;
+    let customAfter = this.props.customAfter;
+
     let inputGroupClassName;
     switch (this.props.bsSize) {
       case 'small': inputGroupClassName = 'input-group-sm'; break;
       case 'large': inputGroupClassName = 'input-group-lg'; break;
     }
 
-    return addonBefore || addonAfter || buttonBefore || buttonAfter ? (
+    return addonBefore || addonAfter || buttonBefore || buttonAfter || customBefore || customAfter ? (
       <div className={classNames(inputGroupClassName, 'input-group')} key="input-group">
         {addonBefore}
         {buttonBefore}
+        {customBefore}
         {children}
         {addonAfter}
         {buttonAfter}
+        {customAfter}
       </div>
     ) : children;
   }

--- a/test/InputSpec.js
+++ b/test/InputSpec.js
@@ -165,6 +165,28 @@ describe('Input', function () {
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'dropdown-menu'));
   });
 
+  it('renders custom before', function() {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Input customBefore={<span className="custom"></span>} />
+    );
+
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'input-group'));
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'custom'));
+    assert.equal(ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'input-group-addon').length, 0);
+    assert.equal(ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'input-group-btn').length, 0);
+  });
+
+  it('renders custom after', function() {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Input customAfter={<span className="custom"></span>} />
+    );
+
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'input-group'));
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'custom'));
+    assert.equal(ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'input-group-addon').length, 0);
+    assert.equal(ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'input-group-btn').length, 0);
+  });
+
   it('renders help', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Input help="Help" />


### PR DESCRIPTION
How about adding a `customBefore` and `customAfter` to `Input` to allow complete customization? When either is used, the passed in JSX gets rendered as is -- no wrapper at all.  That way, I can control the wrapper completely. The downside is I have to make sure my wrapper markup stays in sync but I see that as a small price to pay for that amount of flexibility.

After mulling it over, I prefer to interact with react-bootstrap in this way. This would also be a solution for an issue I opened around not being able to add `hidden-xs` to the `addonBefore` wrapping markup (https://github.com/react-bootstrap/react-bootstrap/issues/617#issuecomment-99214646)