### PR TITLE
Use .babelrc for babel configuration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+  "optional": [
+    "es7.objectRestSpread"
+  ]
+}

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,5 +1,5 @@
 /* eslint no-var: 0 */
-require('./register-babel');
+require('babel/register');
 
 var webpackConfig = require('./webpack/test.config.js');
 var isCI = process.env.CONTINUOUS_INTEGRATION === 'true';

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -46,7 +46,7 @@ module.exports = function (config) {
     browsers: [ isCI ? 'PhantomJS' : 'Chrome' ],
 
     captureTimeout: 60000,
-    browserNoActivityTimeout: 30000,
+    browserNoActivityTimeout: 45000,
 
     singleRun: isCI
   });

--- a/package.json
+++ b/package.json
@@ -8,14 +8,14 @@
   },
   "homepage": "http://react-bootstrap.github.io/",
   "scripts": {
-    "build": "node run-babel tools/build.js",
+    "build": "babel-node tools/build-cli.js",
     "test-watch": "karma start",
     "test": "npm run lint && npm run build && karma start --single-run",
     "lint": "eslint src test docs ie8 tools webpack karma.conf.js webpack.config.js webpack.docs.js",
-    "docs-build": "node run-babel tools/build.js --docs-only",
-    "docs": "node run-babel docs/server.js",
-    "docs-prod": "webpack --config webpack.docs.js -p --progress && NODE_ENV=production node run-babel docs/server.js",
-    "ie8": "node run-babel ie8/server.js"
+    "docs-build": "babel-node tools/build-cli.js --docs-only",
+    "docs": "babel-node docs/server.js",
+    "docs-prod": "webpack --config webpack.docs.js -p --progress && NODE_ENV=production babel-node docs/server.js",
+    "ie8": "babel-node ie8/server.js"
   },
   "main": "lib/index.js",
   "directories": {

--- a/register-babel.js
+++ b/register-babel.js
@@ -1,4 +1,0 @@
-require('babel-core/register')({
-  ignore: /node_modules/,
-  optional: ['es7.objectRestSpread']
-});

--- a/run-babel
+++ b/run-babel
@@ -1,9 +1,0 @@
-#!/usr/bin/env node
-/* eslint no-var: 0 */
-var path = require('path');
-require('./register-babel');
-var mod = require(path.join(__dirname, process.argv[2]));
-
-if (typeof mod === 'function') {
-  mod();
-}

--- a/tools/amd/build.js
+++ b/tools/amd/build.js
@@ -13,7 +13,7 @@ const bowerJson = path.join(bowerRoot, 'bower.json');
 const readme = path.join(__dirname, 'README.md');
 const license = path.join(repoRoot, 'LICENSE');
 
-const babelOptions = '--modules amd --optional es7.objectRestSpread';
+const babelOptions = '--modules amd';
 
 const factoriesDestination = path.join(bowerRoot, 'factories');
 
@@ -35,7 +35,7 @@ export default function BuildBower() {
     .then(() => fsp.mkdirs(factoriesDestination))
     .then(() => Promise.all([
       bowerConfig(),
-      generateFactories(babelOptions, factoriesDestination),
+      generateFactories(factoriesDestination, babelOptions),
       exec(`babel ${babelOptions} ${srcRoot} --out-dir ${bowerRoot}`),
       copy(readme, bowerRoot),
       copy(license, bowerRoot)

--- a/tools/build-cli.js
+++ b/tools/build-cli.js
@@ -1,0 +1,33 @@
+/* eslint no-process-exit: 0 */
+
+import 'colors';
+import build from './build';
+import docs from '../docs/build';
+import { setExecOptions } from './exec';
+
+import yargs from 'yargs';
+
+const argv = yargs
+  .option('docs-only', {
+    demand: false,
+    default: false
+  })
+  .option('verbose', {
+    demand: false,
+    default: false,
+    describe: 'Increased debug output'
+  })
+  .argv;
+
+setExecOptions(argv);
+
+let buildProcess = argv.docsOnly ? docs() : build();
+
+buildProcess
+  .catch(err => {
+    console.error(err.toString().red);
+    if (err.stack) {
+      console.error(err.stack.red);
+    }
+    process.exit(1);
+  });

--- a/tools/build.js
+++ b/tools/build.js
@@ -1,62 +1,26 @@
-/* eslint no-process-exit: 0 */
-
 import 'colors';
 import bower from './amd/build';
 import lib from './lib/build';
-import docs from '../docs/build';
 import dist from './dist/build';
 import { copy } from './fs-utils';
 import { distRoot, bowerRoot } from './constants';
-import { exec, setExecOptions } from './exec';
+import { exec } from './exec';
 
-import yargs from 'yargs';
-
-const argv = yargs
-  .option('docs-only', {
-    demand: false,
-    default: false
-  })
-  .option('verbose', {
-    demand: false,
-    default: false,
-    describe: 'Increased debug output'
-  })
-  .argv;
-
-setExecOptions(argv);
-
-function forkAndBuildDocs(fork) {
+function forkAndBuildDocs(verbose) {
   console.log('Building: '.cyan + 'docs'.green);
 
-  let options = argv.verbose ? ' -- --verbose' : '';
+  let options = verbose ? ' -- --verbose' : '';
 
   return exec(`npm run docs-build${options}`)
     .then(() => console.log('Built: '.cyan + 'docs'.green));
 }
 
-export default function Build(noExitOnFailure) {
-  if (argv.docsOnly) {
-    return docs();
-  } else {
-    let result = Promise.all([
+export default function Build(verbose) {
+  return Promise.all([
       lib(),
       bower(),
       dist(),
-      forkAndBuildDocs()
+      forkAndBuildDocs(verbose)
     ])
     .then(() => copy(distRoot, bowerRoot));
-
-    if (!noExitOnFailure) {
-      result = result
-        .catch(err => {
-          console.error(err.toString().red);
-          if (err.stack) {
-            console.error(err.stack.red);
-          }
-          process.exit(1);
-        });
-    }
-
-    return result;
-  }
 }

--- a/tools/generateFactories.js
+++ b/tools/generateFactories.js
@@ -9,7 +9,7 @@ const templatePath = path.join(srcRoot, 'templates');
 const factoryTemplatePath = path.join(templatePath, 'factory.js.template');
 const indexTemplatePath = path.join(templatePath, 'factory.index.js.template');
 
-export default function generateFactories(babelOptions, destination) {
+export default function generateFactories(destination, babelOptions='') {
 
   let generateCompiledFile = function (file, content) {
     let outpath = path.join(destination, `${file}.js`);

--- a/tools/lib/build.js
+++ b/tools/lib/build.js
@@ -6,7 +6,6 @@ import { srcRoot, libRoot } from '../constants';
 import generateFactories from '../generateFactories';
 
 const factoryDestination = path.join(libRoot, 'factories');
-const babelOptions = '--optional es7.objectRestSpread';
 
 export default function BuildCommonJs() {
   console.log('Building: '.cyan + 'npm module'.green);
@@ -14,8 +13,8 @@ export default function BuildCommonJs() {
   return exec(`rimraf ${libRoot}`)
     .then(() => fsp.mkdirs(factoryDestination))
     .then(() => Promise.all([
-      generateFactories(babelOptions, factoryDestination),
-      exec(`babel ${babelOptions} ${srcRoot} --out-dir ${libRoot}`)
+      generateFactories(factoryDestination),
+      exec(`babel ${srcRoot} --out-dir ${libRoot}`)
     ]))
     .then(() => console.log('Built: '.cyan + 'npm module'.green));
 }

--- a/tools/release
+++ b/tools/release
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /* eslint no-var: 0 */
-require('../register-babel');
+require('babel/register');
 var path = require('path');
 var nodeModulesBin = path.resolve(__dirname, '../node_modules/.bin');
 process.env.PATH = nodeModulesBin + ':' + process.env.PATH;

--- a/tools/release-docs
+++ b/tools/release-docs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /* eslint no-var: 0 */
-require('../register-babel');
+require('babel/register');
 var path = require('path');
 var nodeModulesBin = path.resolve(__dirname, '../node_modules/.bin');
 process.env.PATH = nodeModulesBin + ':' + process.env.PATH;

--- a/tools/release-scripts/release.js
+++ b/tools/release-scripts/release.js
@@ -61,7 +61,7 @@ preConditions()
   .then(v => { version = v; })
   .then(() => addChangelog(version))
   .then(() => {
-    return build(true)
+    return build(argv.verbose)
       .catch(err => {
         console.log('Build failed, reverting version bump'.red);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 /* eslint no-var: 0 */
-require('./register-babel');
+require('babel/register');
 var config = require('./webpack/webpack.config');
 var result = config();
 module.exports = result;

--- a/webpack.docs.js
+++ b/webpack.docs.js
@@ -1,4 +1,4 @@
 /* eslint no-var: 0 */
-require('./register-babel');
+require('babel/register');
 var config = require('./webpack/docs.config');
 module.exports = config;

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -45,7 +45,7 @@ export default (options) => {
 
     module: {
       loaders: [
-        { test: /\.js/, loader: 'babel?optional=es7.objectRestSpread', exclude: /node_modules/ }
+        { test: /\.js/, loader: 'babel', exclude: /node_modules/ }
       ]
     },
 


### PR DESCRIPTION
This will allow us to configure babel in one central location from now
on. Prior to this any time we ran a babel compile, babel-loader, or
babel-node we had to configure them individually which can be error
prone in the long run.