### PR TITLE
Get rid of webpack warning with `npm run docs`

### DIFF
--- a/docs/server.js
+++ b/docs/server.js
@@ -19,6 +19,7 @@ if (development) {
 
   webpackConfig.output.path = '/';
   webpackConfig.output.publicPath = undefined;
+  webpackConfig.module.noParse = /babel-core\/browser/;
 
   app = app
     .use(webpackMiddleware(webpack(webpackConfig), {


### PR DESCRIPTION
```sh
$ npm run docs
...
WARNING in ./~/babel-core/browser.js
...
This seems to be a pre-built javascript file. ...
```