### PR TITLE
Input bsSize now propgates correctly for css form-group-\*

### DIFF
--- a/docs/examples/InputSizes.js
+++ b/docs/examples/InputSizes.js
@@ -1,0 +1,9 @@
+const inputSizeInstance = (
+  <form>
+    <Input type='text' bsSize="large" placeholder='Large text' />
+    <Input type='text' bsSize="medium" placeholder='Normal text' />
+    <Input type='text' bsSize="small" placeholder='Small text' />
+  </form>
+);
+
+React.render(inputSizeInstance, mountNode);

--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -561,6 +561,9 @@ const ComponentsPage = React.createClass({
                   <p>Use <code>addonBefore</code> and <code>addonAfter</code> for normal addons, <code>buttonBefore</code> and <code>buttonAfter</code> for button addons.
                   Exotic configurations may require some css on your side.</p>
                   <ReactPlayground codeText={Samples.InputAddons} />
+                  <h2 id='input-sizes'>Sizes</h2>
+                  <p>Use <code>bsSize</code> to change the size of inputs. It also works with addons and most other options.</p>
+                  <ReactPlayground codeText={Samples.InputSizes} />
                   <h2 id='input-validation'>Validation</h2>
                   <p>Set <code>bsStyle</code> to one of <code>success</code>, <code>warning</code> or <code>error</code>.
                   Add <code>hasFeedback</code> to show glyphicon. Glyphicon may need additional styling if there is an add-on or no label.</p>

--- a/docs/src/Samples.js
+++ b/docs/src/Samples.js
@@ -84,6 +84,7 @@ export default {
   Input:                         require('fs').readFileSync(__dirname + '/../examples/Input.js', 'utf8'),
   InputTypes:                    require('fs').readFileSync(__dirname + '/../examples/InputTypes.js', 'utf8'),
   InputAddons:                   require('fs').readFileSync(__dirname + '/../examples/InputAddons.js', 'utf8'),
+  InputSizes:                    require('fs').readFileSync(__dirname + '/../examples/InputSizes.js', 'utf8'),
   InputValidation:               require('fs').readFileSync(__dirname + '/../examples/InputValidation.js', 'utf8'),
   InputHorizontal:               require('fs').readFileSync(__dirname + '/../examples/InputHorizontal.js', 'utf8'),
   InputWrapper:                  require('fs').readFileSync(__dirname + '/../examples/InputWrapper.js', 'utf8')

--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -28,7 +28,13 @@ FormGroup.defaultProps = {
 FormGroup.propTypes = {
   standalone: React.PropTypes.bool,
   hasFeedback: React.PropTypes.bool,
-  bsSize: React.PropTypes.oneOf(['small', 'medium', 'large']),
+  bsSize (props) {
+    if (props.standalone) {
+      return new Error('bsSize will not be used when `standalone` is set.');
+    }
+
+    return React.PropTypes.oneOf(['small', 'medium', 'large']).apply(null, arguments);
+  },
   bsStyle: React.PropTypes.oneOf(['success', 'warning', 'error']),
   groupClassName: React.PropTypes.string
 };

--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -5,6 +5,8 @@ class FormGroup extends React.Component {
   render() {
     let classes = {
       'form-group': !this.props.standalone,
+      'form-group-lg': !this.props.standalone && this.props.bsSize === 'large',
+      'form-group-sm': !this.props.standalone && this.props.bsSize === 'small',
       'has-feedback': this.props.hasFeedback,
       'has-success': this.props.bsStyle === 'success',
       'has-warning': this.props.bsStyle === 'warning',
@@ -26,6 +28,7 @@ FormGroup.defaultProps = {
 FormGroup.propTypes = {
   standalone: React.PropTypes.bool,
   hasFeedback: React.PropTypes.bool,
+  bsSize: React.PropTypes.oneOf(['small', 'medium', 'large']),
   bsStyle: React.PropTypes.oneOf(['success', 'warning', 'error']),
   groupClassName: React.PropTypes.string
 };

--- a/test/FormGroupSpec.js
+++ b/test/FormGroupSpec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactTestUtils from 'react/lib/ReactTestUtils';
 import FormGroup from '../src/FormGroup';
+import {shouldWarn} from './helpers';
 
 describe('FormGroup', function() {
   it('renders children', function() {
@@ -45,6 +46,14 @@ describe('FormGroup', function() {
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'form-group-lg'));
   });
 
+  it('throws warning about bsSize when standalone', function () {
+    ReactTestUtils.renderIntoDocument(
+      <FormGroup standalone bsSize="large" />
+    );
+
+    shouldWarn('Failed propType: bsSize');
+  });
+
   it('renders no form-group class when standalone', function() {
     let instance = ReactTestUtils.renderIntoDocument(
       <FormGroup standalone>
@@ -53,6 +62,15 @@ describe('FormGroup', function() {
     );
 
     assert.equal(ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'form-group').length, 0);
+  });
+
+  it('renders no form-group-* class when standalone', function () {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <FormGroup standalone bsSize="large" />
+    );
+
+    assert.equal(ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'form-group').length, 0);
+    assert.equal(ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'form-group-lg').length, 0);
   });
 
   [{

--- a/test/FormGroupSpec.js
+++ b/test/FormGroupSpec.js
@@ -25,6 +25,26 @@ describe('FormGroup', function() {
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'form-group'));
   });
 
+  it('renders form-group with sm or lg class when bsSize is small or large', function () {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <FormGroup bsSize="small">
+        <span />
+      </FormGroup>
+    );
+
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'form-group'));
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'form-group-sm'));
+
+    instance = ReactTestUtils.renderIntoDocument(
+      <FormGroup bsSize="large">
+        <span />
+      </FormGroup>
+    );
+
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'form-group'));
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'form-group-lg'));
+  });
+
   it('renders no form-group class when standalone', function() {
     let instance = ReactTestUtils.renderIntoDocument(
       <FormGroup standalone>

--- a/test/InputSpec.js
+++ b/test/InputSpec.js
@@ -127,6 +127,22 @@ describe('Input', function () {
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'input-group-addon'));
   });
 
+  it('renders form-group with sm or lg class when bsSize is small or large', function () {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Input bsSize="small" />
+    );
+
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'form-group'));
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'form-group-sm'));
+
+    instance = ReactTestUtils.renderIntoDocument(
+      <Input bsSize="large" />
+    );
+
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'form-group'));
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'form-group-lg'));
+  });
+
   it('renders input-group with sm or lg class name when bsSize is small or large', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Input addonBefore="$" bsSize="small" />


### PR DESCRIPTION
`FormGroup` now honors the `bsSize` property by applying form-group-lg and form-group-sm, for bsSize="large" and bsSize="small", respectively. 

This allows us to do something as simple as `<Input bsSize="large" />` which was not possible before. 