### PR TITLE
Return <DOCTYPE!> back and little refactoring of docs/build.js

### DIFF
--- a/docs/build.js
+++ b/docs/build.js
@@ -25,6 +25,7 @@ export default function BuildDocs() {
         .map(fileName => new Promise((resolve, reject) => {
           Router.run(routes, '/' + fileName, Handler => {
             let RootHTML = React.renderToString(React.createElement(Handler));
+            RootHTML = '<!doctype html>' + RootHTML;
             let write = fsp.writeFile(path.join(docsBuilt, fileName), RootHTML);
             resolve(write);
           });

--- a/docs/server.js
+++ b/docs/server.js
@@ -26,7 +26,7 @@ if (development) {
 
     Router.run(routes, req.url, Handler => {
       let html = React.renderToString(<Handler assetBaseUrl={target} />);
-      res.send(html);
+      res.send('<!doctype html>' + html);
     });
   });
 

--- a/docs/src/Root.js
+++ b/docs/src/Root.js
@@ -75,4 +75,4 @@ const Root = React.createClass({
 });
 
 
-module.exports = Root;
+export default Root;

--- a/docs/src/Root.js
+++ b/docs/src/Root.js
@@ -5,15 +5,6 @@ const Root = React.createClass({
   statics: {
 
     /**
-     * Get the doctype the page expects to be rendered with
-     *
-     * @returns {string}
-     */
-    getDoctype() {
-      return '<!doctype html>';
-    },
-
-    /**
      * Get the list of pages that are renderable
      *
      * @returns {Array}
@@ -25,21 +16,6 @@ const Root = React.createClass({
         'getting-started.html',
         'components.html'
       ];
-    },
-
-    renderToString(props) {
-      return Root.getDoctype() +
-        React.renderToString(<Root {...props} />);
-    },
-
-    /**
-     * Get the Base url this app sits at
-     * This url is appended to all app urls to make absolute url's within the app.
-     *
-     * @returns {string}
-     */
-    getBaseUrl() {
-      return '/';
     }
   },
 
@@ -84,17 +60,17 @@ const Root = React.createClass({
     };
 
     return (
-        <html>
-          <head dangerouslySetInnerHTML={head} />
+      <html>
+        <head dangerouslySetInnerHTML={head} />
 
-          <body>
-            <Router.RouteHandler />
+        <body>
+          <Router.RouteHandler />
 
-            <script dangerouslySetInnerHTML={browserInitScriptObj} />
-            <script src={`${this.props.assetBaseUrl}/assets/bundle.js`} />
-          </body>
-        </html>
-      );
+          <script dangerouslySetInnerHTML={browserInitScriptObj} />
+          <script src={`${this.props.assetBaseUrl}/assets/bundle.js`} />
+        </body>
+      </html>
+    );
   }
 });
 


### PR DESCRIPTION
Return `<DOCTYPE!>` to pages.

First time it was introduced here
https://github.com/react-bootstrap/react-bootstrap/blob/120ba6d38a4/Gruntfile.js#L204

Then it was moved here
https://github.com/react-bootstrap/react-bootstrap/commit/addc3965b0d832a3721983d0a891a03a086c8225#diff-31cfa4797a188b7ab32b049b80c82ea6R63

And finally it was lost `Root` => `React` easy to overlook
from `var RootHTML = Root.renderToString()`
to `var RootHTML = React.renderToString()`
here
https://github.com/react-bootstrap/react-bootstrap/commit/804c24a33f390166a89276f68772fa64b1510ba8#diff-4cd8a3a29faaf037ff2ec547bf1635abL10
and here
https://github.com/react-bootstrap/react-bootstrap/commit/804c24a33f390166a89276f68772fa64b1510ba8#diff-ce9d98be04f7a23d325c274fc1a0a089L21

After that `Root.renderToString()` method (and some others) became unused.


And I've moved out html generating code for all docs - pages into standalone function
for clarity.
Those `spagetty` drives me crazy. 

Less complexity promotes easier entrance for new contributors.