### PR TITLE
Revert "Use Chrome on TravisCI instead of PhantomJS."

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,3 @@ notifications:
     on_success: always
     on_failure: always
     on_start: false
-before_install:
-  - export CHROME_BIN=chromium-browser
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,14 +43,7 @@ module.exports = function (config) {
 
     autoWatch: true,
 
-    browsers: [ isCI ? 'ChromeTravisCI' : 'Chrome' ],
-
-    customLaunchers: {
-      ChromeTravisCI: {
-        base: 'Chrome',
-        flags: ['--no-sandbox']
-      }
-    },
+    browsers: [ isCI ? 'PhantomJS' : 'Chrome' ],
 
     captureTimeout: 60000,
     browserNoActivityTimeout: 45000,

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "karma-firefox-launcher": "~0.1.3",
     "karma-mocha": "~0.1.1",
     "karma-mocha-reporter": "^1.0.2",
+    "karma-phantomjs-launcher": "~0.1.1",
     "karma-sinon": "^1.0.3",
     "karma-sourcemap-loader": "^0.3.4",
     "karma-webpack": "^1.5.0",


### PR DESCRIPTION
Reverts react-bootstrap/react-bootstrap#630

It seems TravisCI didn't like my play with 26 re-runs of tests using Chrome
and they have disabled `chromium-browser`.

Back to `PhantomJS` because of new PR's failing tests.