### PR TITLE
We again "Use Chrome on TravisCI instead of PhantomJS.""

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,7 @@ notifications:
     on_success: always
     on_failure: always
     on_start: false
+before_install:
+  - export CHROME_BIN=chromium-browser
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,7 +43,14 @@ module.exports = function (config) {
 
     autoWatch: true,
 
-    browsers: [ isCI ? 'PhantomJS' : 'Chrome' ],
+    browsers: [ isCI ? 'ChromeTravisCI' : 'Chrome' ],
+
+    customLaunchers: {
+      ChromeTravisCI: {
+        base: 'Chrome',
+        flags: ['--no-sandbox']
+      }
+    },
 
     captureTimeout: 60000,
     browserNoActivityTimeout: 45000,

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "karma-firefox-launcher": "~0.1.3",
     "karma-mocha": "~0.1.1",
     "karma-mocha-reporter": "^1.0.2",
-    "karma-phantomjs-launcher": "~0.1.1",
     "karma-sinon": "^1.0.3",
     "karma-sourcemap-loader": "^0.3.4",
     "karma-webpack": "^1.5.0",


### PR DESCRIPTION
Reverts react-bootstrap/react-bootstrap#635

Today I received notice about `karma-chrome-launcher` update.
The only commit in this version is `put 'which' back` https://github.com/karma-runner/karma-chrome-launcher/commit/d2c7f23cc63c656b024c52e702ba34d142d96436

As it turned out it is a cure for yesterday's problem with `Travis + Chrome`.
(Travis had not been deleting `chromium`. hurray :balloon: )

I've checked it [on my travis acc](https://travis-ci.org/AlexKVal/react-bootstrap/builds/61951566) before doing this revert of `revert`.