### PR TITLE
Add new ealint `object-shorthand` rule.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
     "no-underscore-dangle": 0,
     "no-unused-vars": [1, { "vars": "all", "args": "none" }],
     "no-var": 2,
+    "object-shorthand": 1,
     "quotes": [1, "single", "avoid-escape"],
     "react/display-name": 0,
     "react/jsx-no-undef": 1,

--- a/docs/examples/CollapsibleParagraph.js
+++ b/docs/examples/CollapsibleParagraph.js
@@ -1,20 +1,20 @@
 const CollapsibleParagraph = React.createClass({
   mixins: [CollapsibleMixin],
 
-  getCollapsibleDOMNode: function(){
+  getCollapsibleDOMNode(){
     return this.refs.panel.getDOMNode();
   },
 
-  getCollapsibleDimensionValue: function(){
+  getCollapsibleDimensionValue(){
     return this.refs.panel.getDOMNode().scrollHeight;
   },
 
-  onHandleToggle: function(e){
+  onHandleToggle(e){
     e.preventDefault();
     this.setState({expanded:!this.state.expanded});
   },
 
-  render: function(){
+  render(){
     let styles = this.getCollapsibleClassSet();
     let text = this.isExpanded() ? 'Hide' : 'Show';
     return (

--- a/docs/src/IntroductionPage.js
+++ b/docs/src/IntroductionPage.js
@@ -5,7 +5,7 @@ import PageHeader from './PageHeader';
 import PageFooter from './PageFooter';
 
 const IntroductionPage = React.createClass({
-  render: function () {
+  render() {
     return (
       <div>
         <NavMain activePage="introduction" />

--- a/docs/src/ReactPlayground.js
+++ b/docs/src/ReactPlayground.js
@@ -192,7 +192,7 @@ const ReactPlayground = React.createClass({
   },
 
   handleCodeModeSwitch(mode) {
-    this.setState({mode: mode});
+    this.setState({mode});
   },
 
   handleCodeModeToggle(e) {
@@ -209,7 +209,7 @@ const ReactPlayground = React.createClass({
         mode = this.MODES.NONE;
     }
 
-    this.setState({mode: mode});
+    this.setState({mode});
   },
 
   compileCode() {

--- a/ie8/server.js
+++ b/ie8/server.js
@@ -9,7 +9,7 @@ let app = express();
 
 if (development) {
   let webpackConfig = webpackConfigBuilder({
-    development: development,
+    development,
     ie8: true
   });
   let publicPath = webpackConfig.output.publicPath;
@@ -23,7 +23,7 @@ if (development) {
   app = app
     .use(webpackMiddleware(webpack(webpackConfig), {
       noInfo: false,
-      publicPath: publicPath,
+      publicPath,
       stats: {
           colors: true
       }

--- a/src/Affix.js
+++ b/src/Affix.js
@@ -5,7 +5,7 @@ import domUtils from './utils/domUtils';
 
 const Affix = React.createClass({
   statics: {
-    domUtils: domUtils
+    domUtils
   },
 
   mixins: [AffixMixin],

--- a/src/AffixMixin.js
+++ b/src/AffixMixin.js
@@ -92,7 +92,7 @@ const AffixMixin = {
 
     this.setState({
       affixClass: affixType,
-      affixPositionTop: affixPositionTop
+      affixPositionTop
     });
   },
 

--- a/src/Button.js
+++ b/src/Button.js
@@ -31,7 +31,7 @@ const Button = React.createClass({
     classes = {
       active: this.props.active,
       'btn-block': this.props.block,
-      ...classes
+      ...classes // eslint-disable-line object-shorthand
     };
 
     if (this.props.navItem) {

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -249,7 +249,7 @@ const Carousel = React.createClass({
           active: isActive,
           ref: child.ref,
           key: child.key ? child.key : index,
-          index: index,
+          index,
           animateOut: isPreviousActive,
           animateIn: isActive && this.state.previousActiveIndex != null && this.props.slide,
           direction: this.state.direction,
@@ -278,8 +278,8 @@ const Carousel = React.createClass({
 
       this.setState({
         activeIndex: index,
-        previousActiveIndex: previousActiveIndex,
-        direction: direction
+        previousActiveIndex,
+        direction
       });
     }
   }

--- a/src/CollapsibleNav.js
+++ b/src/CollapsibleNav.js
@@ -98,7 +98,7 @@ const specCollapsibleNav = {
         activeKey: this.props.activeKey,
         activeHref: this.props.activeHref,
         ref: 'nocollapse_' + key,
-        key: key,
+        key,
         navItem: true
       }
     );
@@ -114,7 +114,7 @@ const specCollapsibleNav = {
         activeHref: this.props.activeHref,
         onSelect: createChainedFunction(child.props.onSelect, this.props.onSelect),
         ref: 'collapsible_' + key,
-        key: key,
+        key,
         navItem: true
       }
     );

--- a/src/FadeMixin.js
+++ b/src/FadeMixin.js
@@ -56,7 +56,7 @@ export default {
     }
   },
 
-  componentWillUnmount: function () {
+  componentWillUnmount() {
     let els = getElementsAndSelf(React.findDOMNode(this), ['fade']),
         container = (this.props.container && React.findDOMNode(this.props.container)) ||
           domUtils.ownerDocument(this).body;

--- a/src/Input.js
+++ b/src/Input.js
@@ -178,7 +178,7 @@ class Input extends React.Component {
 
   renderFormGroup(children) {
     if (this.props.type === 'submit') {
-      let {bsStyle, ...other} = this.props; /* eslint no-unused-vars: 0 */
+      let {bsStyle, ...other} = this.props; /* eslint no-unused-vars: 0 object-shorthand: 0 */
       return <FormGroup {...other}>{children}</FormGroup>;
     }
 

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -37,7 +37,7 @@ const Nav = React.createClass({
     return React.findDOMNode(this);
   },
 
-  getCollapsibleDimensionValue: function () {
+  getCollapsibleDimensionValue() {
     let node = React.findDOMNode(this.refs.ul),
         height = node.offsetHeight,
         computedStyles = domUtils.getComputedStyles(node);

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -29,10 +29,10 @@ const NavItem = React.createClass({
         title,
         target,
         children,
-        ...props } = this.props;
+        ...props } = this.props; // eslint-disable-line object-shorthand
     let classes = {
-          'active': active,
-          'disabled': disabled
+          active,
+          disabled
         };
     let linkProps = {
           href,

--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -216,7 +216,7 @@ const OverlayTrigger = React.createClass({
     }
   },
 
-  getPosition: function () {
+  getPosition() {
     let node = React.findDOMNode(this);
     let container = this.getContainerDOMNode();
 

--- a/src/styleMaps.js
+++ b/src/styleMaps.js
@@ -31,7 +31,7 @@ const styleMaps = {
     'tabs': 'tabs',
     'pills': 'pills'
   },
-  addStyle: function(name) {
+  addStyle(name) {
     styleMaps.STYLES[name] = name;
   },
   SIZES: {

--- a/src/utils/EventListener.js
+++ b/src/utils/EventListener.js
@@ -32,18 +32,18 @@ const EventListener = {
    * @param {function} callback Callback function.
    * @return {object} Object with a `remove` method.
    */
-  listen: function(target, eventType, callback) {
+  listen(target, eventType, callback) {
     if (target.addEventListener) {
       target.addEventListener(eventType, callback, false);
       return {
-        remove: function() {
+        remove() {
           target.removeEventListener(eventType, callback, false);
         }
       };
     } else if (target.attachEvent) {
       target.attachEvent('on' + eventType, callback);
       return {
-        remove: function() {
+        remove() {
           target.detachEvent('on' + eventType, callback);
         }
       };

--- a/src/utils/TransitionEvents.js
+++ b/src/utils/TransitionEvents.js
@@ -88,7 +88,7 @@ function removeEventListener(node, eventName, eventListener) {
 }
 
 const ReactTransitionEvents = {
-  addEndEventListener: function(node, eventListener) {
+  addEndEventListener(node, eventListener) {
     if (endEvents.length === 0) {
       // If CSS transitions are not supported, trigger an "end animation"
       // event immediately.
@@ -100,7 +100,7 @@ const ReactTransitionEvents = {
     });
   },
 
-  removeEndEventListener: function(node, eventListener) {
+  removeEndEventListener(node, eventListener) {
     if (endEvents.length === 0) {
       return;
     }

--- a/src/utils/ValidComponentChildren.js
+++ b/src/utils/ValidComponentChildren.js
@@ -86,5 +86,5 @@ export default {
   map: mapValidComponents,
   forEach: forEachValidComponents,
   numberOf: numberOfValidComponents,
-  hasValidComponent: hasValidComponent
+  hasValidComponent
 };

--- a/src/utils/domUtils.js
+++ b/src/utils/domUtils.js
@@ -114,9 +114,9 @@ function offsetParentFunc(elem) {
 }
 
 export default {
-  ownerDocument: ownerDocument,
-  getComputedStyles: getComputedStyles,
-  getOffset: getOffset,
-  getPosition: getPosition,
+  ownerDocument,
+  getComputedStyles,
+  getOffset,
+  getPosition,
   offsetParent: offsetParentFunc
 };

--- a/test/BootstrapMixinSpec.js
+++ b/test/BootstrapMixinSpec.js
@@ -10,7 +10,7 @@ describe('BootstrapMixin', function () {
     Component = React.createClass({
       mixins: [BootstrapMixin],
 
-      render: function () {
+      render() {
         return React.DOM.button(this.props);
       }
     });

--- a/test/CollapsableMixinSpec.js
+++ b/test/CollapsableMixinSpec.js
@@ -12,15 +12,15 @@ describe('CollapsableMixin', function () {
     Component = React.createClass({
       mixins: [CollapsableMixin],
 
-      getCollapsableDOMNode: function(){
+      getCollapsableDOMNode(){
         return this.refs.panel.getDOMNode();
       },
 
-      getCollapsableDimensionValue: function(){
+      getCollapsableDimensionValue(){
         return 15;
       },
 
-      render: function(){
+      render(){
         let styles = this.getCollapsableClassSet();
         return (
           <div>

--- a/test/CollapsableNavSpec.js
+++ b/test/CollapsableNavSpec.js
@@ -8,7 +8,7 @@ import {shouldWarn} from './helpers';
 describe('Deprecations for collapsable property in CollapsibleNav', function () {
   it('Should not warn about deprecation when collaps_i_ble property is used', function () {
     let Component = React.createClass({
-      render: function() {
+      render() {
         return (
           <CollapsibleNav collapsible />
         );
@@ -21,7 +21,7 @@ describe('Deprecations for collapsable property in CollapsibleNav', function () 
 
   it('Should warn about deprecation when collaps_a_ble property is used', function () {
     let Component = React.createClass({
-      render: function() {
+      render() {
         return (
           <CollapsibleNav collapsable />
         );
@@ -36,7 +36,7 @@ describe('Deprecations for collapsable property in CollapsibleNav', function () 
 describe('Deprecations for collapsable property in Panel', function () {
   it('Should not warn about deprecation when collaps_i_ble property is used', function () {
     let Component = React.createClass({
-      render: function() {
+      render() {
         return (
           <Panel collapsible />
         );
@@ -49,7 +49,7 @@ describe('Deprecations for collapsable property in Panel', function () {
 
   it('Should warn about deprecation when collaps_a_ble property is used', function () {
     let Component = React.createClass({
-      render: function() {
+      render() {
         return (
           <Panel collapsable />
         );
@@ -64,7 +64,7 @@ describe('Deprecations for collapsable property in Panel', function () {
 describe('Deprecations for collapsable property in Nav', function () {
   it('Should not warn about deprecation when collaps_i_ble property is used', function () {
     let Component = React.createClass({
-      render: function() {
+      render() {
         return (
           <Nav collapsible />
         );
@@ -77,7 +77,7 @@ describe('Deprecations for collapsable property in Nav', function () {
 
   it('Should warn about deprecation when collaps_a_ble property is used', function () {
     let Component = React.createClass({
-      render: function() {
+      render() {
         return (
           <Nav collapsable />
         );

--- a/test/CollapsibleMixinSpec.js
+++ b/test/CollapsibleMixinSpec.js
@@ -12,15 +12,15 @@ describe('CollapsibleMixin', function () {
     Component = React.createClass({
       mixins: [CollapsibleMixin],
 
-      getCollapsibleDOMNode: function(){
+      getCollapsibleDOMNode(){
         return this.refs.panel.getDOMNode();
       },
 
-      getCollapsibleDimensionValue: function(){
+      getCollapsibleDimensionValue(){
         return 15;
       },
 
-      render: function(){
+      render(){
         let styles = this.getCollapsibleClassSet();
         return (
           <div>
@@ -222,9 +222,9 @@ describe('CollapsibleMixin', function () {
       Component = React.createClass({
         mixins: [CollapsibleMixin],
 
-        getCollapsableDimension: function(){},
+        getCollapsableDimension(){},
 
-        render: function(){
+        render(){
           return ( <div /> );
         }
       });
@@ -241,9 +241,9 @@ describe('CollapsibleMixin', function () {
       Component = React.createClass({
         mixins: [CollapsibleMixin],
 
-        getCollapsibleDimension: function(){},
+        getCollapsibleDimension(){},
 
-        render: function(){
+        render(){
           return ( <div /> );
         }
       });

--- a/test/CollapsibleNavSpec.js
+++ b/test/CollapsibleNavSpec.js
@@ -8,7 +8,7 @@ import NavItem from '../src/NavItem';
 describe('CollapsibleNav', function () {
   it('Should create div and add collapse class', function () {
     let Parent = React.createClass({
-      render: function() {
+      render() {
         return (
           <Navbar toggleNavKey={1}>
             <CollapsibleNav eventKey={1}>
@@ -27,7 +27,7 @@ describe('CollapsibleNav', function () {
 
   it('Should handle multiple Nav elements', function () {
     let Parent = React.createClass({
-      render: function() {
+      render() {
         return (
           <Navbar toggleNavKey={1}>
             <CollapsibleNav eventKey={1} ref='collapsible_object'>
@@ -51,7 +51,7 @@ describe('CollapsibleNav', function () {
 
   it('Should just render children and move along if not in <Navbar>', function () {
     let Parent = React.createClass({
-      render: function() {
+      render() {
         return (
           <CollapsibleNav eventKey={1}>
             <Nav>
@@ -71,7 +71,7 @@ describe('CollapsibleNav', function () {
 
   it('Should retain childrens classes set by className', function () {
     let Parent = React.createClass({
-      render: function() {
+      render() {
         return (
           <Navbar toggleNavKey={1}>
             <CollapsibleNav eventKey={1} ref='collapsible_object'>
@@ -92,7 +92,7 @@ describe('CollapsibleNav', function () {
 
   it('Should should not duplicate classes', function () {
     let Parent = React.createClass({
-      render: function() {
+      render() {
         return (
           <Navbar toggleNavKey={1}>
             <CollapsibleNav eventKey={1} ref='collapsible_object' className='foo navbar-collapse'>

--- a/test/DropdownMenuSpec.js
+++ b/test/DropdownMenuSpec.js
@@ -6,7 +6,7 @@ import MenuItem from '../src/MenuItem';
 describe('DropdownMenu', function () {
   it('Should render menu correctly', function () {
     let Parent = React.createClass({
-      render: function(){
+      render(){
         return (
           <DropdownMenu>
             <MenuItem eventKey="1" ref="item1">MenuItem 1 content</MenuItem>

--- a/test/FactoriesSpec.js
+++ b/test/FactoriesSpec.js
@@ -3,7 +3,7 @@ import components from '../tools/public-components';
 
 let props = {
   Glyphicon: {glyph: 'star'},
-  Modal: {onRequestHide: function() {}},
+  Modal: {onRequestHide() {}},
   ModalTrigger: {modal: React.DOM.div(null)},
   OverlayTrigger: {overlay: React.DOM.div(null)}
 };

--- a/test/FadeMixinSpec.js
+++ b/test/FadeMixinSpec.js
@@ -9,7 +9,7 @@ describe('FadeMixin', function () {
     Component = React.createClass({
       mixins: [ FadeMixin ],
 
-      render: function () {
+      render() {
         return (
           <div {...this.props} className='fade'>
             <span className='fade'/>

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -17,13 +17,13 @@ describe('Modal', function () {
   it('Should add modal-open class to the modal container while open', function(done) {
 
     let Container = React.createClass({
-      getInitialState: function() {
+      getInitialState() {
         return {modalOpen: true};
       },
-      handleCloseModal: function() {
+      handleCloseModal() {
         this.setState({modalOpen: false});
       },
-      render: function() {
+      render() {
         if (this.state.modalOpen) {
           return (
             <Modal onRequestHide={this.handleCloseModal} container={this}>

--- a/test/OverlayMixinSpec.js
+++ b/test/OverlayMixinSpec.js
@@ -8,11 +8,11 @@ describe('OverlayMixin', function () {
   let Overlay = React.createClass({
     mixins: [OverlayMixin],
 
-    render: function() {
+    render() {
       return <div />;
     },
 
-    renderOverlay: function() {
+    renderOverlay() {
       return this.props.overlay;
     }
   });
@@ -35,7 +35,7 @@ describe('OverlayMixin', function () {
 
   it('Should render overlay into container (ReactComponent)', function() {
     let Container = React.createClass({
-      render: function() {
+      render() {
         return <Overlay container={this} overlay={<div id="test1" />} />;
       }
     });
@@ -49,7 +49,7 @@ describe('OverlayMixin', function () {
 
   it('Should not render a null overlay', function() {
     let Container = React.createClass({
-      render: function() {
+      render() {
         return <Overlay ref='overlay' container={this} overlay={null} />;
       }
     });
@@ -65,11 +65,11 @@ describe('OverlayMixin', function () {
     let OnlyOverlay = React.createClass({
       mixins: [OverlayMixin],
 
-      render: function() {
+      render() {
         return null;
       },
 
-      renderOverlay: function() {
+      renderOverlay() {
         return this.props.overlay;
       }
     });

--- a/test/SplitButtonSpec.js
+++ b/test/SplitButtonSpec.js
@@ -53,7 +53,7 @@ describe('SplitButton', function () {
   });
 
   it('Should pass dropdownTitle to dropdown button', function () {
-    let CustomTitle = React.createClass({ render: function() { return <span />; } });
+    let CustomTitle = React.createClass({ render() { return <span />; } });
     instance = ReactTestUtils.renderIntoDocument(
       <SplitButton title={<CustomTitle />} dropdownTitle={<CustomTitle />}>
         <MenuItem eventKey="1">MenuItem 1 content</MenuItem>

--- a/tools/generateFactories.js
+++ b/tools/generateFactories.js
@@ -20,11 +20,11 @@ export default function generateFactories(destination, babelOptions='') {
     fsp.readFile(factoryTemplatePath)
       .then(template => {
         Promise.all(components.map(name => {
-          generateCompiledFile(name, _.template(template)({name: name}));
+          generateCompiledFile(name, _.template(template)({name}));
         }));
       }),
     fsp.readFile(indexTemplatePath)
-      .then(template => _.template(template)({components: components}))
+      .then(template => _.template(template)({components}))
       .then(content => generateCompiledFile('index', content))
   ]);
 


### PR DESCRIPTION
Because of `es7.objectRestSpread` is experimental feature yet,
I've marked three lines of code
[src/NavItem.js#L32](https://github.com/react-bootstrap/react-bootstrap/blob/6dfcf3688eea38/src/NavItem.js#L32)
[src/Input.js#L181](https://github.com/react-bootstrap/react-bootstrap/blob/e694e00ccec612/src/Input.js#L181)
[src/Button.js#L34](https://github.com/react-bootstrap/react-bootstrap/blob/6dfcf3688eea38/src/Button.js#L34)
with this comment `// eslint-disable-line object-shorthand`

When `eslint/eslint#2486` is resolved, the disabling comment will be removed
and #584 issue will be fulfilled.