### PR TITLE
[changed] Updated extract-text-webpack-plugin. Dev dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "eslint": "^0.21.0",
     "eslint-plugin-react": "^2.1.0",
     "express": "^4.12.3",
-    "extract-text-webpack-plugin": "^0.3.8",
+    "extract-text-webpack-plugin": "^0.8.0",
     "file-loader": "^0.8.1",
     "fs-extra": "^0.18.0",
     "fs-promise": "^0.3.1",


### PR DESCRIPTION
https://github.com/webpack/extract-text-webpack-plugin/issues/57 is resolved.
I've checked how it looks `npm run docs` now.
The same as with 0.3.8.

I'm not merging it because I may miss something subtle,
because there are no code tests for this issue, only visual.

At least it needs @mtscout6 visual check and therefore approval.