### PR TITLE
Don't warn about bsSize when it's not specified

### DIFF
--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -29,11 +29,12 @@ FormGroup.propTypes = {
   standalone: React.PropTypes.bool,
   hasFeedback: React.PropTypes.bool,
   bsSize (props) {
-    if (props.standalone) {
+    if (props.standalone && props.bsSize !== undefined) {
       return new Error('bsSize will not be used when `standalone` is set.');
     }
 
-    return React.PropTypes.oneOf(['small', 'medium', 'large']).apply(null, arguments);
+    return React.PropTypes.oneOf(['small', 'medium', 'large'])
+      .apply(null, arguments);
   },
   bsStyle: React.PropTypes.oneOf(['success', 'warning', 'error']),
   groupClassName: React.PropTypes.string

--- a/test/FormGroupSpec.js
+++ b/test/FormGroupSpec.js
@@ -46,6 +46,15 @@ describe('FormGroup', function() {
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'form-group-lg'));
   });
 
+  // This test case must come first, since the error only gets logged once.
+  it('throws no warning without bsSize when standalone', function () {
+    ReactTestUtils.renderIntoDocument(
+      <FormGroup standalone />
+    );
+
+    // Warning thrown above would lead to failure from index.
+  });
+
   it('throws warning about bsSize when standalone', function () {
     ReactTestUtils.renderIntoDocument(
       <FormGroup standalone bsSize="large" />

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,9 +1,5 @@
-function shouldWarn(about) {
+export function shouldWarn(about) {
   console.warn.called.should.be.true;
   console.warn.calledWithMatch(about).should.be.true;
   console.warn.reset();
 }
-
-export default {
-  shouldWarn
-};


### PR DESCRIPTION
Fixes a bug with #624