### PR TITLE
Use ES6 import with lodash methods to improve readability.

### DIFF
--- a/tools/amd/build.js
+++ b/tools/amd/build.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { template } from 'lodash';
 import path from 'path';
 import fsp from 'fs-promise';
 import { copy } from '../fs-utils';
@@ -22,9 +22,9 @@ function bowerConfig() {
     fsp.readFile(packagePath)
       .then(json => JSON.parse(json)),
     fsp.readFile(bowerTemplate)
-      .then(template => _.template(template))
+      .then(templateString => template(templateString))
   ])
-  .then(([pkg, template]) => template({ pkg }))
+  .then(([pkg, compiledTemplateFunc]) => compiledTemplateFunc({ pkg }))
   .then(config => fsp.writeFile(bowerJson, config));
 }
 

--- a/tools/exec.js
+++ b/tools/exec.js
@@ -1,5 +1,5 @@
 import 'colors';
-import _ from 'lodash';
+import { extend } from 'lodash';
 import { exec } from 'child-process-promise';
 
 let executionOptions = {
@@ -52,7 +52,7 @@ function safeExec(command, options = {}) {
 }
 
 function setExecOptions(options) {
-  executionOptions = _.extend({}, executionOptions, options);
+  executionOptions = extend({}, executionOptions, options);
 }
 
 export default {

--- a/tools/generateFactories.js
+++ b/tools/generateFactories.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { template } from 'lodash';
 import path from 'path';
 import fsp from 'fs-promise';
 import { exec } from './exec';
@@ -18,13 +18,13 @@ export default function generateFactories(destination, babelOptions='') {
 
   return Promise.all([
     fsp.readFile(factoryTemplatePath)
-      .then(template => {
+      .then(templateString => {
         Promise.all(components.map(name => {
-          generateCompiledFile(name, _.template(template)({name}));
+          generateCompiledFile(name, template(templateString)({name}));
         }));
       }),
     fsp.readFile(indexTemplatePath)
-      .then(template => _.template(template)({components}))
+      .then(templateString => template(templateString)({components}))
       .then(content => generateCompiledFile('index', content))
   ]);
 

--- a/webpack/strategies/development.js
+++ b/webpack/strategies/development.js
@@ -1,12 +1,10 @@
-import _ from 'lodash';
+import { extend } from 'lodash';
 
 export default (config, options) => {
   if (options.development && !options.docs) {
-    config = _.extend({}, config, {
+    config = extend({}, config, {
       devtool: 'sourcemap'
     });
-
-    return config;
   }
 
   return config;

--- a/webpack/strategies/docs-development.js
+++ b/webpack/strategies/docs-development.js
@@ -1,24 +1,24 @@
-import _ from 'lodash';
+import { extend, mapValues } from 'lodash';
 import webpack from 'webpack';
 
 function addWebpackDevServerScripts(entries, webpackDevServerAddress) {
   let clientScript = `webpack-dev-server/client?${webpackDevServerAddress}`;
   let webpackScripts = ['webpack/hot/dev-server', clientScript];
-  return _.mapValues(entries, entry => webpackScripts.concat(entry));
+  return mapValues(entries, entry => webpackScripts.concat(entry));
 }
 
 export default (config, options) => {
   if (options.development && options.docs) {
     let webpackDevServerAddress = `http://localhost:${options.port}`;
-    config = _.extend({}, config, {
+    config = extend({}, config, {
       entry: addWebpackDevServerScripts(config.entry, webpackDevServerAddress),
-      output: _.extend({}, config.output, {
+      output: extend({}, config.output, {
         publicPath: `${webpackDevServerAddress}/assets/`
       }),
-      module: _.extend({}, config.module, {
+      module: extend({}, config.module, {
         loaders: config.module.loaders.map(value => {
           if (/js/.test(value.test.toString())) {
-            return _.extend({}, value, {
+            return extend({}, value, {
               loader: 'react-hot!' + value.loader
             });
           }
@@ -32,8 +32,6 @@ export default (config, options) => {
         new webpack.NoErrorsPlugin()
       ])
     });
-
-    return config;
   }
 
   return config;

--- a/webpack/strategies/docs.js
+++ b/webpack/strategies/docs.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { extend } from 'lodash';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 
 export default (config, options) => {
@@ -6,7 +6,7 @@ export default (config, options) => {
     let jsLoader = '';
     let cssSourceMap = options.development ? '?sourceMap' : '';
 
-    config = _.extend({}, config, {
+    config = extend({}, config, {
       entry: {
         bundle: './docs/client.js'
       },
@@ -23,10 +23,10 @@ export default (config, options) => {
         noParse: /babel-core\/browser/,
         loaders: config.module.loaders
           .map(value => {
-            if (/\.js\/$/.test(value.test.toString())) {
+            if (/js/.test(value.test.toString())) {
               jsLoader = value.loader;
 
-              return _.extend({}, value, {
+              return extend({}, value, {
                 exclude: /node_modules|Samples\.js/
               });
             }
@@ -47,8 +47,6 @@ export default (config, options) => {
         new ExtractTextPlugin('[name].css')
       ])
     });
-
-    return config;
   }
 
   return config;

--- a/webpack/strategies/ie8.js
+++ b/webpack/strategies/ie8.js
@@ -1,8 +1,8 @@
-import _ from 'lodash';
+import { extend } from 'lodash';
 
 export default (config, options) => {
   if (options.ie8) {
-    config = _.extend({}, config, {
+    config = extend({}, config, {
       entry: {
         bundle: './ie8/src.js'
       },
@@ -18,8 +18,6 @@ export default (config, options) => {
         ])
       }
     });
-
-    return config;
   }
 
   return config;

--- a/webpack/strategies/optimize.js
+++ b/webpack/strategies/optimize.js
@@ -1,14 +1,12 @@
-import _ from 'lodash';
+import { extend } from 'lodash';
 
 export default (config, options) => {
   if (options.optimize) {
-    config = _.extend({}, config, {
-      output: _.extend({}, config.output, {
+    config = extend({}, config, {
+      output: extend({}, config.output, {
         filename: '[name].min.js'
       })
     });
-
-    return config;
   }
 
   return config;

--- a/webpack/strategies/test.js
+++ b/webpack/strategies/test.js
@@ -1,8 +1,8 @@
-import _ from 'lodash';
+import { extend } from 'lodash';
 
 export default (config, options) => {
   if (options.test) {
-    config = _.extend({}, config, {
+    config = extend({}, config, {
       devtool: 'inline-source-map',
       entry: undefined,
       output: {
@@ -10,8 +10,6 @@ export default (config, options) => {
       },
       externals: undefined
     });
-
-    return config;
   }
 
   return config;

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { extend } from 'lodash';
 import webpack from 'webpack';
 import strategies from './strategies';
 import yargs from 'yargs';
@@ -16,7 +16,7 @@ const defaultOptions = {
 };
 
 export default (options) => {
-  options = _.merge({}, defaultOptions, options);
+  options = extend({}, defaultOptions, options);
   const environment = options.test || options.development ?
     'development' : 'production';
 


### PR DESCRIPTION
Also:
Remove unnecessary returns.
Use everywhere `extend`.

Instead of `stumbling`
```js
config = _.extend({}, config, {
```
clean method usage
```js
config = extend({}, config, {
```

Disclaimer: 
I know this is just stylistic commit and I know there is `a bigger fish to fry`.
I'm learning tools usage in this project and `on the way` I am noticing such small details.
I believe that big things begin from small steps.
And slightly improved readability by such kind of stylistic commits,
one by one eventually accumulates into more clean code integrally.
:cherries: 