### PR TITLE
[fixed] Forward classes to panel title

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -156,17 +156,19 @@ const Panel = React.createClass({
     if (!React.isValidElement(header) || Array.isArray(header)) {
       header = collapsible ?
         this.renderCollapsableTitle(header) : header;
-    } else if (collapsible) {
-
-      header = cloneElement(header, {
-        className: classNames(this.prefixClass('title')),
-        children: this.renderAnchor(header.props.children)
-      });
     } else {
+      const className = classNames(
+        this.prefixClass('title'), header.props.className
+      );
 
-      header = cloneElement(header, {
-        className: classNames(this.prefixClass('title'))
-      });
+      if (collapsible) {
+        header = cloneElement(header, {
+          className,
+          children: this.renderAnchor(header.props.children)
+        });
+      } else {
+        header = cloneElement(header, {className});
+      }
     }
 
     return (

--- a/test/PanelSpec.js
+++ b/test/PanelSpec.js
@@ -58,6 +58,18 @@ describe('Panel', function () {
     assert.equal(header.firstChild.firstChild.innerHTML, 'Heading');
   });
 
+  it('Should have custom component header with custom class', function () {
+    let header = <h3 className="custom-class">Heading</h3>,
+        instance = ReactTestUtils.renderIntoDocument(
+          <Panel header={header}>Panel content</Panel>
+        );
+    header = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-heading').getDOMNode();
+    assert.equal(header.firstChild.nodeName, 'H3');
+    assert.ok(header.firstChild.className.match(/\bpanel-title\b/));
+    assert.ok(header.firstChild.className.match(/\bcustom-class\b/));
+    assert.equal(header.firstChild.innerHTML, 'Heading');
+  });
+
   it('Should have footer', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel footer="Footer">Panel content</Panel>


### PR DESCRIPTION
Currently we're clobbering the classes on the passed-in element.