### PR TITLE
Fix eslint `space-infix-ops` rule warnings.

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -253,7 +253,7 @@ const Carousel = React.createClass({
           animateOut: isPreviousActive,
           animateIn: isActive && this.state.previousActiveIndex != null && this.props.slide,
           direction: this.state.direction,
-          onAnimateOutEnd: isPreviousActive ? this.handleItemAnimateOutEnd: null
+          onAnimateOutEnd: isPreviousActive ? this.handleItemAnimateOutEnd : null
         }
       );
   },

--- a/src/TabbedArea.js
+++ b/src/TabbedArea.js
@@ -99,7 +99,7 @@ const TabbedArea = React.createClass({
           key: child.key ? child.key : index,
           animation: this.props.animation,
           onAnimateOutEnd: (this.state.previousActiveKey != null &&
-            child.props.eventKey === this.state.previousActiveKey) ? this.handlePaneAnimateOutEnd: null
+            child.props.eventKey === this.state.previousActiveKey) ? this.handlePaneAnimateOutEnd : null
         }
       );
   },

--- a/test/CollapsibleNavSpec.js
+++ b/test/CollapsibleNavSpec.js
@@ -109,6 +109,6 @@ describe('CollapsibleNav', function () {
     let classDOM = ReactTestUtils.findRenderedDOMComponentWithTag(instance.refs.collapsible_object, 'DIV').props.className
         , classArray = classDOM.split(' ')
         , idx = classArray.indexOf('navbar-collapse');
-    assert.equal(classArray.indexOf('navbar-collapse', idx+1), -1);
+    assert.equal(classArray.indexOf('navbar-collapse', idx + 1), -1);
   });
 });


### PR DESCRIPTION
Detection of them has become possible as a result of https://github.com/babel/babel-eslint/pull/97

ref: [space-infix-ops](http://eslint.org/docs/rules/space-infix-ops)