### PR TITLE
Cleanup Lint command

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,3 +3,5 @@ dist/**
 docs-built/**
 lib/**
 node_modules/**
+tmp-bower-repo/**
+tmp-docs-repo/**

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "babel-node tools/build-cli.js",
     "test-watch": "karma start",
     "test": "npm run lint && npm run build && karma start --single-run",
-    "lint": "eslint src test docs ie8 tools webpack karma.conf.js webpack.config.js webpack.docs.js",
+    "lint": "eslint ./",
     "docs-build": "babel-node tools/build-cli.js --docs-only",
     "docs": "docs/dev-run",
     "docs-prod": "webpack --config webpack.docs.js -p --progress && NODE_ENV=production babel-node docs/server.js",


### PR DESCRIPTION
There's no need to explicitly white list AND black list what we are linting. So, let's just use the black list from the .eslintignore file.