### PR TITLE
Fix sourcemaps in test error stack traces

### DIFF
--- a/webpack/strategies/test.js
+++ b/webpack/strategies/test.js
@@ -3,7 +3,7 @@ import _ from 'lodash';
 export default (config, options) => {
   if (options.test) {
     config = _.extend({}, config, {
-      devtool: 'inline-source-map',
+      devtool: 'eval',
       entry: undefined,
       output: {
         pathinfo: true


### PR DESCRIPTION
Without this test failure stack traces were getting reported based on the finalized concatenated file by webpack.