### PR TITLE
Fix regexp to test regexps in tools.

### DIFF
--- a/webpack/strategies/docs-development.js
+++ b/webpack/strategies/docs-development.js
@@ -17,7 +17,7 @@ export default (config, options) => {
       }),
       module: _.extend({}, config.module, {
         loaders: config.module.loaders.map(value => {
-          if (/js/.test(value.test.toString())) {
+          if (/\.js\/$/.test(value.test.toString())) {
             return _.extend({}, value, {
               loader: 'react-hot!' + value.loader
             });


### PR DESCRIPTION
Without this commit we've got
`{ test: /\.json$/, loader: 'react-hot!json' }`
and it should be just as
`{ test: /\.json$/, loader: 'json' }`