### PR TITLE
Downgrade eslint to get linting to pass

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "colors": "^1.0.3",
     "css-loader": "^0.12.0",
     "es5-shim": "^4.1.0",
-    "eslint": "^0.21.0",
+    "eslint": "0.21.0",
     "eslint-plugin-react": "^2.1.0",
     "express": "^4.12.3",
     "extract-text-webpack-plugin": "^0.8.0",


### PR DESCRIPTION
Upgrade to ^0.21.2 after release fixes eslint/eslint#2545

Per https://gitter.im/eslint/eslint?at=555637f5811d64626eebc65f, it will be at least a day or two until a new bugfix release comes out, so we might as well downgrade to get CI to pass.