### PR TITLE
[added] property animation on Popover (true by default)

### DIFF
--- a/src/Popover.js
+++ b/src/Popover.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import classNames from 'classnames';
 import BootstrapMixin from './BootstrapMixin';
+import FadeMixin from './FadeMixin';
 
 const Popover = React.createClass({
-  mixins: [BootstrapMixin],
+  mixins: [BootstrapMixin, FadeMixin],
 
   propTypes: {
     placement: React.PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
@@ -15,20 +16,24 @@ const Popover = React.createClass({
     arrowOffsetTop: React.PropTypes.oneOfType([
       React.PropTypes.number, React.PropTypes.string
     ]),
-    title: React.PropTypes.node
+    title: React.PropTypes.node,
+    animation: React.PropTypes.bool
   },
 
   getDefaultProps() {
     return {
+      animation: true,
       placement: 'right'
     };
   },
 
   render() {
     const classes = {
+      'fade': this.props.animation,
       'popover': true,
       [this.props.placement]: true,
-      'in': this.props.positionLeft != null || this.props.positionTop != null
+      'in': !this.props.animation &&
+            (this.props.positionLeft != null || this.props.positionTop != null)
     };
 
     const style = {


### PR DESCRIPTION
Adds the FadeInMixin by default, as [original bootstrap(http://getbootstrap.com/javascript/#popovers-examples)] does. Solves #653 

As the original bootstrap, the animation can be disabled by doing animation={false} on the Popover component. I was going to add this to the documentation, but not found any table with the properties on Popover (maybe we should open a new issue for improving the documentation?)