### PR TITLE
Add npm run script for docs prod unoptimized preview

### DIFF
--- a/docs/build.js
+++ b/docs/build.js
@@ -32,8 +32,8 @@ function generateHTML(fileName) {
   });
 }
 
-export default function BuildDocs() {
-  console.log('Building: '.cyan + 'docs'.green);
+export default function BuildDocs({ dev }) {
+  console.log('Building: '.cyan + 'docs'.green + (dev ? ' [DEV]'.grey : ''));
 
   return exec(`rimraf ${docsBuilt}`)
     .then(() => fsp.mkdir(docsBuilt))
@@ -41,10 +41,10 @@ export default function BuildDocs() {
       let pagesGenerators = Root.getPages().map(generateHTML);
 
       return Promise.all(pagesGenerators.concat([
-        exec(`webpack --config webpack.docs.js -p --bail`),
+        exec(`webpack --config webpack.docs.js ${dev ? '' : '-p '}--bail`),
         copy(license, docsBuilt),
         copy(readmeSrc, readmeDest)
       ]));
     })
-    .then(() => console.log('Built: '.cyan + 'docs'.green));
+    .then(() => console.log('Built: '.cyan + 'docs'.green + (dev ? ' [DEV]'.grey : '')));
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "eslint ./",
     "docs-build": "babel-node tools/build-cli.js --docs-only",
     "docs": "docs/dev-run",
-    "docs-prod": "webpack --config webpack.docs.js -p --progress && NODE_ENV=production babel-node docs/server.js",
+    "docs-prod": "npm run docs-build && NODE_ENV=production babel-node docs/server.js",
+    "docs-prod-unoptimized": "npm run docs-build -- --dev && NODE_ENV=production babel-node docs/server.js",
     "ie8": "babel-node ie8/server.js"
   },
   "main": "lib/index.js",

--- a/tools/build-cli.js
+++ b/tools/build-cli.js
@@ -17,11 +17,16 @@ const argv = yargs
     default: false,
     describe: 'Increased debug output'
   })
+  .option('dev', {
+    demand: false,
+    default: false,
+    describe: 'Only used when supplied with the --docs-only flag'
+  })
   .argv;
 
 setExecOptions(argv);
 
-let buildProcess = argv.docsOnly ? docs() : build();
+let buildProcess = argv.docsOnly ? docs(argv) : build();
 
 buildProcess
   .catch(err => {

--- a/webpack/webpack.config.js
+++ b/webpack/webpack.config.js
@@ -17,8 +17,7 @@ const defaultOptions = {
 
 export default (options) => {
   options = _.merge({}, defaultOptions, options);
-  const environment = options.test || options.development ?
-    'development' : 'production';
+  const environment = options.optimize ? 'production' : 'development';
 
   const config = {
     entry: {


### PR DESCRIPTION
Useful for debugging production issues that do not manifest in the dev
isomorphic and hot reloading scenario.

Inspired by #677 (Helps us solve that bug :smile:)