### PR TITLE
Fix single quote bugs for docs in production

### DIFF
--- a/docs/src/Root.js
+++ b/docs/src/Root.js
@@ -46,16 +46,16 @@ const Root = React.createClass({
 
     let head = {
       __html: `<title>React Bootstrap</title>
-        <meta http-equiv='X-UA-Compatible' content='IE=edge' />
-        <meta name='viewport' content='width=device-width, initial-scale=1.0' />
-        <link href='${this.props.assetBaseUrl}/assets/bundle.css' rel='stylesheet' />
-        <link href='${this.props.assetBaseUrl}/assets/favicon.ico' type='image/x-icon' rel='icon' />
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <link href="${this.props.assetBaseUrl}/assets/bundle.css" rel="stylesheet">
+        <link href="${this.props.assetBaseUrl}/assets/favicon.ico" type="image/x-icon" rel="icon">
         <!--[if lt IE 9]>
-        <script src='https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js'></script>
-        <script src='https://oss.maxcdn.com/respond/1.4.2/respond.min.js'></script>
-        <script src='http://code.jquery.com/jquery-1.11.1.min.js'></script>
-        <script src='http://cdnjs.cloudflare.com/ajax/libs/es5-shim/3.4.0/es5-shim.js'></script>
-        <script src='http://cdnjs.cloudflare.com/ajax/libs/es5-shim/3.4.0/es5-sham.js'></script>
+        <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+        <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+        <script src="http://code.jquery.com/jquery-1.11.1.min.js"></script>
+        <script src="http://cdnjs.cloudflare.com/ajax/libs/es5-shim/3.4.0/es5-shim.js"></script>
+        <script src="http://cdnjs.cloudflare.com/ajax/libs/es5-shim/3.4.0/es5-sham.js"></script>
         <![endif]-->`
     };
 


### PR DESCRIPTION
Fixes most of #677 

The only part it does not fix is on the home page if the url does not include `index.html`. This is because react-router is placing an `active` class name on the brand in the `Navbar`. I don't see a quick easy way to deal with that at the moment.