### PR TITLE
Modals are focused on opening, for improved acessibility

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -126,6 +126,8 @@ const Modal = React.createClass({
           domUtils.ownerDocument(this).body;
     container.className += container.className.length ? ' modal-open' : 'modal-open';
 
+    this.focusModalContent();
+
     if (this.props.backdrop) {
       this.iosClickHack();
     }
@@ -142,6 +144,8 @@ const Modal = React.createClass({
     let container = (this.props.container && React.findDOMNode(this.props.container)) ||
           domUtils.ownerDocument(this).body;
     container.className = container.className.replace(/ ?modal-open/, '');
+
+    this.restoreLastFocus();
   },
 
   handleBackdropClick(e) {
@@ -155,6 +159,19 @@ const Modal = React.createClass({
   handleDocumentKeyUp(e) {
     if (this.props.keyboard && e.keyCode === 27) {
       this.props.onRequestHide();
+    }
+  },
+
+  focusModalContent () {
+    this.lastFocus = document.activeElement;
+    let modalContent = React.findDOMNode(this.refs.modal);
+    modalContent.focus();
+  },
+
+  restoreLastFocus () {
+    if (this.lastFocus) {
+      this.lastFocus.focus();
+      this.lastFocus = null;
     }
   }
 });

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -97,4 +97,65 @@ describe('Modal', function () {
     assert.match(dialog.props.className, /\btestCss\b/);
   });
 
+  describe('Focused state', function () {
+    let focusableContainer = null;
+    beforeEach(function () {
+      focusableContainer = document.createElement('div');
+      focusableContainer.tabIndex = 0;
+      document.body.appendChild(focusableContainer);
+      focusableContainer.focus();
+    });
+
+    afterEach(function () {
+      React.unmountComponentAtNode(focusableContainer);
+      document.body.removeChild(focusableContainer);
+    });
+
+    it('Should focus on the Modal when it is opened', function (done) {
+      document.activeElement.should.equal(focusableContainer);
+
+      let doneOp = function () {
+        // focus should be back on the previous element when modal closed
+        setTimeout(function () {
+          document.activeElement.should.equal(focusableContainer);
+          done();
+        }, 0);
+      };
+
+      let Container = React.createClass({
+        getInitialState() {
+          return {modalOpen: true};
+        },
+        handleCloseModal() {
+          this.setState({modalOpen: false});
+          doneOp();
+        },
+        render() {
+          if (this.state.modalOpen) {
+            return (
+              <Modal onRequestHide={this.handleCloseModal} container={this}>
+                <strong>Message</strong>
+              </Modal>
+            );
+          } else {
+            return <span/>;
+          }
+        }
+      });
+
+      let instance = React.render(<Container />, focusableContainer);
+
+      setTimeout(function () {
+        // modal should be focused when opened
+        let modal = instance.getDOMNode().getElementsByClassName('modal')[0];
+        document.activeElement.should.equal(modal);
+
+        // close the modal
+        let backdrop = instance.getDOMNode().getElementsByClassName('modal-backdrop')[0];
+        ReactTestUtils.Simulate.click(backdrop);
+      }, 0);
+    });
+
+  });
+
 });


### PR DESCRIPTION
Modals are now focused when opening them, as requested by #612 . I've also stored the element that was previously focused, so its focused can be restored when the Modal is closed (it is the same behaviour Bootstrap does).

I was unable to do tests for this, as it has a dependency on document.activeElement (and the tests I've looked into only used TestUtilities.renderIntoDocument, which renders to a detached DOM node, so I'm guessing we can't test this without attaching it to the DOM).
