### PR TITLE
getDOMNode() has been deprecated. Use React.findDOMNode() instead.

### DIFF
--- a/docs/examples/CollapsibleParagraph.js
+++ b/docs/examples/CollapsibleParagraph.js
@@ -2,11 +2,11 @@ const CollapsibleParagraph = React.createClass({
   mixins: [CollapsibleMixin],
 
   getCollapsibleDOMNode(){
-    return this.refs.panel.getDOMNode();
+    return React.findDOMNode(this.refs.panel);
   },
 
   getCollapsibleDimensionValue(){
-    return this.refs.panel.getDOMNode().scrollHeight;
+    return React.findDOMNode(this.refs.panel).scrollHeight;
   },
 
   onHandleToggle(e){

--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -30,15 +30,15 @@ const ComponentsPage = React.createClass({
   },
 
   componentDidMount() {
-    let elem = this.refs.sideNav.getDOMNode(),
+    let elem = React.findDOMNode(this.refs.sideNav),
         domUtils = Affix.domUtils,
         sideNavOffsetTop = domUtils.getOffset(elem).top,
         sideNavMarginTop = parseInt(domUtils.getComputedStyles(elem.firstChild).marginTop, 10),
-        topNavHeight = this.refs.topNav.getDOMNode().offsetHeight;
+        topNavHeight = React.findDOMNode(this.refs.topNav).offsetHeight;
 
     this.setState({
       navOffsetTop: sideNavOffsetTop - topNavHeight - sideNavMarginTop,
-      navOffsetBottom: this.refs.footer.getDOMNode().offsetHeight
+      navOffsetBottom: React.findDOMNode(this.refs.footer).offsetHeight
     });
   },
 

--- a/docs/src/ReactPlayground.js
+++ b/docs/src/ReactPlayground.js
@@ -112,7 +112,7 @@ class CodeMirrorEditor extends React.Component {
       return;
     }
 
-    this.editor = CodeMirror.fromTextArea(this.refs.editor.getDOMNode(), {
+    this.editor = CodeMirror.fromTextArea(React.findDOMNode(this.refs.editor), {
       mode: 'javascript',
       lineNumbers: false,
       lineWrapping: false,
@@ -273,7 +273,7 @@ const ReactPlayground = React.createClass({
   },
 
   componentWillUnmount() {
-    let mountNode = this.refs.mount.getDOMNode();
+    let mountNode = React.findDOMNode(this.refs.mount);
     try {
       React.unmountComponentAtNode(mountNode);
     } catch (e) {
@@ -282,7 +282,7 @@ const ReactPlayground = React.createClass({
   },
 
   executeCode() {
-    let mountNode = this.refs.mount.getDOMNode();
+    let mountNode = React.findDOMNode(this.refs.mount);
 
     try {
       React.unmountComponentAtNode(mountNode);

--- a/src/CollapsibleNav.js
+++ b/src/CollapsibleNav.js
@@ -22,7 +22,7 @@ const specCollapsibleNav = {
   },
 
   getCollapsibleDOMNode() {
-    return this.getDOMNode();
+    return React.findDOMNode(this);
   },
 
   getCollapsibleDimensionValue() {
@@ -31,7 +31,7 @@ const specCollapsibleNav = {
     for (let key in nodes) {
       if (nodes.hasOwnProperty(key)) {
 
-        let n = nodes[key].getDOMNode()
+        let n = React.findDOMNode(nodes[key])
           , h = n.offsetHeight
           , computedStyles = domUtils.getComputedStyles(n);
 


### PR DESCRIPTION
https://facebook.github.io/react/blog/2015/03/10/react-v0.13.html
https://facebook.github.io/react/docs/component-api.html#getdomnode