### PR TITLE
[added] Row: support a 'fluid' boolean, passing the row-fluid Bootstrap class

### DIFF
--- a/docs/examples/GridBasic.js
+++ b/docs/examples/GridBasic.js
@@ -19,6 +19,10 @@ const navInstance = (
       <Col md={6} mdPush={6}><code>&lt;{'Col md={6} mdPush={6}'} /&gt;</code></Col>
       <Col md={6} mdPull={6}><code>&lt;{'Col md={6} mdPull={6}'} /&gt;</code></Col>
     </Row>
+
+    <Row className='show-grid' fluid>
+      <Col xs={12}><code>&lt;{'Col xs={12} in a *fluid* Row'} /&gt;</code></Col>
+    </Row>
   </Grid>
 );
 

--- a/src/Row.js
+++ b/src/Row.js
@@ -3,7 +3,8 @@ import classNames from 'classnames';
 
 const Row = React.createClass({
   propTypes: {
-    componentClass: React.PropTypes.node.isRequired
+    componentClass: React.PropTypes.node.isRequired,
+    fluid: React.PropTypes.bool
   },
 
   getDefaultProps() {
@@ -14,9 +15,12 @@ const Row = React.createClass({
 
   render() {
     let ComponentClass = this.props.componentClass;
+    let className = this.props.fluid ? 'row-fluid' : 'row';
 
     return (
-      <ComponentClass {...this.props} className={classNames(this.props.className, 'row')}>
+      <ComponentClass
+        {...this.props}
+        className={classNames(this.props.className, className)}>
         {this.props.children}
       </ComponentClass>
     );


### PR DESCRIPTION
Hi, any reason not to support this bootstrap feature that is already supported elsewhere like in `Grid`?

I took inspiration from the `Grid` component; `Grid` and `Row` are now mostly identical. ESLint and tests pass, and I added a simple example.