### PR TITLE
Add capability to run Phantom locally

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -3,6 +3,7 @@ require('babel/register');
 
 var webpackConfig = require('./webpack/test.config.js');
 var isCI = process.env.CONTINUOUS_INTEGRATION === 'true';
+var devBrowser = process.env.PHANTOM ? 'PhantomJS' : 'Chrome';
 
 module.exports = function (config) {
   config.set({
@@ -43,7 +44,7 @@ module.exports = function (config) {
 
     autoWatch: true,
 
-    browsers: [ isCI ? 'ChromeTravisCI' : 'Chrome' ],
+    browsers: [ isCI ? 'ChromeTravisCI' : devBrowser ],
 
     customLaunchers: {
       ChromeTravisCI: {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "karma-firefox-launcher": "~0.1.3",
     "karma-mocha": "~0.1.1",
     "karma-mocha-reporter": "^1.0.2",
+    "karma-phantomjs-launcher": "^0.1.4",
     "karma-sinon": "^1.0.3",
     "karma-sourcemap-loader": "^0.3.4",
     "karma-webpack": "^1.5.0",


### PR DESCRIPTION
There is a bug with Chrome right now that makes testing rather painfully
slow if no part of the Chrome windows is visible. This has made it
really difficult to do much very fast since I'm constantly waiting for
Chrome to complete running tests. The bug is defined in
https://github.com/karma-runner/karma-chrome-launcher/issues/44.

The difference in test execution time is currently 30 seconds if not
visible, or 1.5 seconds when it is. Since I get the same results via
Phantom I'd like have the option to quickly do so when needed.