### PR TITLE
Only run CI against latest iojs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "iojs"
 notifications:
   webhooks:


### PR DESCRIPTION
Node 0.12 keeps getting killed for no distinguishable reason, and we
aren’t really doing anything that targets anything in the core of Node.
Our tests are run in a browser which is the really important part, and
the tools we use test the various releases, so we could rely on their
successful runs.

When the merger between Node and iojs completes then we'll change to the
latest release they produce together.