### PR TITLE
[fixed] Fix scroll top calculation for overlays

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -281,19 +281,21 @@ const OverlayTrigger = React.createClass({
 
   _getContainerDimensions() {
     const containerNode = this.getContainerDOMNode();
-    let width, height;
+    let width, height, scroll;
+
     if (containerNode.tagName === 'BODY') {
       width = window.innerWidth;
       height = window.innerHeight;
+      scroll =
+        domUtils.ownerDocument(containerNode).documentElement.scrollTop ||
+        containerNode.scrollTop;
     } else {
       width = containerNode.offsetWidth;
       height = containerNode.offsetHeight;
+      scroll = containerNode.scrollTop;
     }
 
-    return {
-      width, height,
-      scroll: containerNode.scrollTop
-    };
+    return {width, height, scroll};
   },
 
   getPosition() {


### PR DESCRIPTION
Fixes #724 

Was calculating bod scrollTop in a way that didn't work in Firefox. This bug is not present on IE11.

Checked by hand with Chrome 44, Firefox 40, Safari 8 on OS X 10.10 because I'm still not sure how I'd write proper tests for this.