### PR TITLE
Fix deprecationWarning for node

### DIFF
--- a/src/utils/deprecationWarning.js
+++ b/src/utils/deprecationWarning.js
@@ -1,6 +1,6 @@
 export default function deprecationWarning(oldname, newname, link) {
   if (process.env.NODE_ENV !== 'production') {
-    if (!window.console && (typeof console.warn !== 'function')) {
+    if ((typeof console === 'undefined') || (typeof console.warn !== 'function')) {
       return;
     }
 


### PR DESCRIPTION
Checking for window object gives reference error in node.js (isomorphic apps) so do typeof check instead.