### PR TITLE
Update css-loader 0.14.1 Dev dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "child-process-promise": "^1.0.1",
     "codemirror": "^5.0.0",
     "colors": "^1.0.3",
-    "css-loader": "^0.13.1",
+    "css-loader": "^0.14.1",
     "es5-shim": "^4.1.0",
     "eslint": "0.21.2",
     "eslint-plugin-mocha": "^0.2.2",


### PR DESCRIPTION
`npm run docs-prod` Visually docs seem are the same.

There is only one change in code [module mode](https://github.com/webpack/css-loader/commit/42db9bc4b29c7709eaa0fc022a796a3383bd4f09) actually.
And for us it is not breaking.

--
module mode [breaking change]
new extends syntax
added :global and :local
added module mode
removed old deprecated syntax

breaking change if you are using local scope (it was experimental)