### PR TITLE
[fixed] #231. Accessibility of MenuItem

### DIFF
--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -10,13 +10,15 @@ const MenuItem = React.createClass({
     target:    React.PropTypes.string,
     onSelect:  React.PropTypes.func,
     eventKey:  React.PropTypes.any,
-    active:    React.PropTypes.bool
+    active:    React.PropTypes.bool,
+    tabIndex:  React.PropTypes.string
   },
 
   getDefaultProps() {
     return {
       href: '#',
-      active: false
+      active: false,
+      tabIndex: null
     };
   },
 
@@ -29,7 +31,7 @@ const MenuItem = React.createClass({
 
   renderAnchor() {
     return (
-      <a onClick={this.handleClick} href={this.props.href} target={this.props.target} title={this.props.title} tabIndex="-1">
+      <a onClick={this.handleClick} href={this.props.href} target={this.props.target} title={this.props.title} tabIndex={this.props.tabIndex}>
         {this.props.children}
       </a>
     );
@@ -50,7 +52,7 @@ const MenuItem = React.createClass({
     }
 
     return (
-      <li {...this.props} role="presentation" title={null} href={null}
+      <li {...this.props} role="menuitem" title={null} href={null}
         className={classNames(this.props.className, classes)}>
         {children}
       </li>

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -31,7 +31,7 @@ const MenuItem = React.createClass({
 
   renderAnchor() {
     return (
-      <a onClick={this.handleClick} href={this.props.href} target={this.props.target} title={this.props.title} tabIndex={this.props.tabIndex}>
+      <a onClick={this.handleClick} href={this.props.href} target={this.props.target} title={this.props.title} tabIndex={this.props.tabIndex} role="menuitem">
         {this.props.children}
       </a>
     );
@@ -52,7 +52,7 @@ const MenuItem = React.createClass({
     }
 
     return (
-      <li {...this.props} role="menuitem" title={null} href={null}
+      <li {...this.props} role="presentation" title={null} href={null}
         className={classNames(this.props.className, classes)}>
         {children}
       </li>

--- a/test/MenuItemSpec.js
+++ b/test/MenuItemSpec.js
@@ -10,7 +10,7 @@ describe('MenuItem', function () {
       </MenuItem>
     );
     assert.equal(instance.getDOMNode().nodeName, 'LI');
-    assert.equal(instance.getDOMNode().getAttribute('role'), 'presentation');
+    assert.equal(instance.getDOMNode().getAttribute('role'), 'menuitem');
   });
 
   it('should pass through props', function () {
@@ -44,7 +44,18 @@ describe('MenuItem', function () {
     );
 
     let anchor = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a');
-    assert.equal(anchor.getDOMNode().getAttribute('tabIndex'), '-1');
+    assert.equal(anchor.getDOMNode().getAttribute('tabIndex'), null);
+  });
+
+  it('should have have a tabIndex if supplied', function () {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <MenuItem tabIndex='1'>
+        Title
+      </MenuItem>
+    );
+
+    let anchor = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a');
+    assert.equal(anchor.getDOMNode().getAttribute('tabIndex'), '1');
   });
 
   it('should fire callback on click of link', function (done) {

--- a/test/MenuItemSpec.js
+++ b/test/MenuItemSpec.js
@@ -10,7 +10,7 @@ describe('MenuItem', function () {
       </MenuItem>
     );
     assert.equal(instance.getDOMNode().nodeName, 'LI');
-    assert.equal(instance.getDOMNode().getAttribute('role'), 'menuitem');
+    assert.equal(instance.getDOMNode().getAttribute('role'), 'presentation');
   });
 
   it('should pass through props', function () {
@@ -45,6 +45,7 @@ describe('MenuItem', function () {
 
     let anchor = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a');
     assert.equal(anchor.getDOMNode().getAttribute('tabIndex'), null);
+    assert.equal(anchor.getDOMNode().getAttribute('role'), 'menuitem');
   });
 
   it('should have have a tabIndex if supplied', function () {


### PR DESCRIPTION
tabIndex is not provided by default, meaning MenuItems can be tabbed through when they are visible, and are ignored when hidden. A specific tabIndex can be provided via props. Also added aria `role="menuitem"`

