### PR TITLE
exposed utils namespace

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ import Table from './Table';
 import TabPane from './TabPane';
 import Thumbnail from './Thumbnail';
 import Tooltip from './Tooltip';
+import utils from './utils';
 import Well from './Well';
 import styleMaps from './styleMaps';
 
@@ -104,6 +105,7 @@ export default {
   TabPane,
   Thumbnail,
   Tooltip,
+  utils,
   Well,
   styleMaps
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,10 +2,8 @@ import childrenValueInputValidation from './childrenValueInputValidation';
 import createChainedFunction from './createChainedFunction';
 import createContextWrapper from './createContextWrapper';
 import CustomPropTypes from './CustomPropTypes';
-import deprecationWarning from './deprecationWarning';
 import domUtils from './domUtils';
 import EventListener from './EventListener';
-import assign from './Object.assign';
 import ValidComponentChildren from './ValidComponentChildren';
 
 export default {
@@ -13,9 +11,7 @@ export default {
   createChainedFunction,
   createContextWrapper,
   CustomPropTypes,
-  deprecationWarning,
   domUtils,
   EventListener,
-  assign,
   ValidComponentChildren
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -3,7 +3,6 @@ import createChainedFunction from './createChainedFunction';
 import createContextWrapper from './createContextWrapper';
 import CustomPropTypes from './CustomPropTypes';
 import domUtils from './domUtils';
-import EventListener from './EventListener';
 import ValidComponentChildren from './ValidComponentChildren';
 
 export default {
@@ -12,6 +11,5 @@ export default {
   createContextWrapper,
   CustomPropTypes,
   domUtils,
-  EventListener,
   ValidComponentChildren
 };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,6 +1,5 @@
 import childrenValueInputValidation from './childrenValueInputValidation';
 import createChainedFunction from './createChainedFunction';
-import createContextWrapper from './createContextWrapper';
 import CustomPropTypes from './CustomPropTypes';
 import domUtils from './domUtils';
 import ValidComponentChildren from './ValidComponentChildren';
@@ -8,7 +7,6 @@ import ValidComponentChildren from './ValidComponentChildren';
 export default {
   childrenValueInputValidation,
   createChainedFunction,
-  createContextWrapper,
   CustomPropTypes,
   domUtils,
   ValidComponentChildren

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,0 +1,21 @@
+import childrenValueInputValidation from './childrenValueInputValidation';
+import createChainedFunction from './createChainedFunction';
+import createContextWrapper from './createContextWrapper';
+import CustomPropTypes from './CustomPropTypes';
+import deprecationWarning from './deprecationWarning';
+import domUtils from './domUtils';
+import EventListener from './EventListener';
+import assign from './Object.assign';
+import ValidComponentChildren from './ValidComponentChildren';
+
+export default {
+  childrenValueInputValidation,
+  createChainedFunction,
+  createContextWrapper,
+  CustomPropTypes,
+  deprecationWarning,
+  domUtils,
+  EventListener,
+  assign,
+  ValidComponentChildren
+};


### PR DESCRIPTION
Exposed all utils into utils namespace.

fixes https://github.com/react-bootstrap/react-bootstrap/issues/743

Kept the reference to `EventListener` until a third party option is used instead.

Mapped Object.assign.js to just `assign`