### PR TITLE
[changed] Fix button dropdown not closing when clicking button on IE8

### DIFF
--- a/src/DropdownStateMixin.js
+++ b/src/DropdownStateMixin.js
@@ -49,7 +49,9 @@ const DropdownStateMixin = {
   handleDocumentClick(e) {
     // If the click originated from within this component
     // don't do anything.
-    if (isNodeInRoot(e.target, React.findDOMNode(this))) {
+    // e.srcElement is required for IE8 as e.target is undefined
+    let target = e.target || e.srcElement;
+    if (isNodeInRoot(target, React.findDOMNode(this))) {
       return;
     }
 

--- a/src/RootCloseWrapper.js
+++ b/src/RootCloseWrapper.js
@@ -42,7 +42,9 @@ export default class RootCloseWrapper extends React.Component {
 
   handleDocumentClick(e) {
     // If the click originated from within this component, don't do anything.
-    if (isNodeInRoot(e.target, React.findDOMNode(this))) {
+    // e.srcElement is required for IE8 as e.target is undefined
+    let target = e.target || e.srcElement;
+    if (isNodeInRoot(target, React.findDOMNode(this))) {
       return;
     }
 


### PR DESCRIPTION
Fixes a bug where attempting to close a button dropdown menu, by clicking the *button* itself did not close the menu.

`e.target` is undefined in IE8 so `isNodeInRoot` returned false, allowing the click event to bubble to the document and re-open the menu.