### PR TITLE
Add means to load local dev docs on a different machine

### DIFF
--- a/docs/dev-run
+++ b/docs/dev-run
@@ -3,6 +3,7 @@
 import 'colors';
 import portfinder from 'portfinder';
 import { exec } from 'child-process-promise';
+import ip from 'ip';
 
 portfinder.basePort = 4000;
 
@@ -65,7 +66,7 @@ portfinder.getPorts(2, {}, (portFinderErr, [docsPort, webpackPort]) => {
     process.exit(1);
   }
 
-  runCmd('webpack-dev-server', `nodemon --watch webpack --watch webpack.docs.js --watch node_modules --exec webpack-dev-server -- --config webpack.docs.js --color --port ${webpackPort} --debug --hot`);
+  runCmd('webpack-dev-server', `nodemon --watch webpack --watch webpack.docs.js --watch node_modules --exec webpack-dev-server -- --config webpack.docs.js --color --port ${webpackPort} --debug --hot --host ${ip.address()}`);
 
   runCmd('docs-server', 'nodemon --watch docs --watch src --watch node_modules --exec babel-node docs/server.js', {
     env: {

--- a/docs/server.js
+++ b/docs/server.js
@@ -5,6 +5,7 @@ import path from 'path';
 import Router from 'react-router';
 import routes from './src/Routes';
 import httpProxy from 'http-proxy';
+import ip from 'ip';
 
 const development = process.env.NODE_ENV !== 'production';
 const port = process.env.PORT || 4000;
@@ -14,7 +15,7 @@ let app = express();
 if (development) {
   let proxy = httpProxy.createProxyServer();
   let webpackPort = process.env.WEBPACK_DEV_PORT;
-  let target = `http://localhost:${webpackPort}`;
+  let target = `http://${ip.address()}:${webpackPort}`;
 
   app.get('/assets/*', function (req, res) {
     proxy.web(req, res, { target });
@@ -39,5 +40,7 @@ if (development) {
 }
 
 app.listen(port, function () {
-  console.log(`Server started at http://localhost:${port}`);
+  console.log(`Server started at:`);
+  console.log(`- http://localhost:${port}`);
+  console.log(`- http://${ip.address()}:${port}`);
 });

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "fs-extra": "^0.18.0",
     "fs-promise": "^0.3.1",
     "http-proxy": "^1.11.1",
+    "ip": "^0.3.2",
     "json-loader": "^0.5.1",
     "karma": "~0.12.32",
     "karma-chai": "^0.1.0",

--- a/webpack/docs.config.js
+++ b/webpack/docs.config.js
@@ -2,8 +2,9 @@ import _ from 'lodash';
 import webpack from 'webpack';
 import ExtractTextPlugin from 'extract-text-webpack-plugin';
 import baseConfig, { options, jsLoader } from './base.config';
+import ip from 'ip';
 
-const webpackDevServerAddress = `http://localhost:${options.port}`;
+const webpackDevServerAddress = `http://${ip.address()}:${options.port}`;
 const cssSourceMap = options.debug ? '?sourceMap' : '';
 const reactHot = options.debug ? 'react-hot!' : '';
 


### PR DESCRIPTION
This is useful for cross-browser testing if you have VMs with dedicated versions of browsers.

Since the webpack-dev-server runs on a different port and we need to add http headers to allow cross-origin requests we need this in order to run the docs on one machine and test on another.

The drawback is that in order to reach the webpack-dev-server directly you will have to use the ip address and not `localhost`. Normal usage of the docs can still be reached with `http://localhost:4000` though.