### PR TITLE
Add explicitly node-libs-browser dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "less-loader": "^2.1.0",
     "lodash": "^3.5.0",
     "mocha": "^2.2.1",
+    "node-libs-browser": "^0.5.2",
     "nodemon": "^1.3.7",
     "portfinder": "^0.4.0",
     "react": "^0.13.1",


### PR DESCRIPTION
Fixes `peerDependency` warning for webpack.

![screen shot 2015-05-31 at 1 09 11 pm](https://cloud.githubusercontent.com/assets/847572/7901556/f3a395d0-0796-11e5-9565-7c97a2ab31f7.png)