### PR TITLE
Locking down CI to iojs v2.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "iojs"
+  - "iojs-v2.1.0"
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
This is a temporary measure until nodejs/io.js#1850 is resolved.