### PR TITLE
Remove Dev dependency "babel-plugin-object-assign".

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,5 @@
 {
   "optional": [
     "es7.objectRestSpread"
-  ],
-  "plugins": [
-    "object-assign"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "babel-core": "^5.1.10",
     "babel-eslint": "^3.0.1",
     "babel-loader": "^5.0.0",
-    "babel-plugin-object-assign": "^1.1.0",
     "bootstrap": "^3.3.4",
     "brfs": "^1.4.0",
     "chai": "^2.2.0",

--- a/src/Interpolate.js
+++ b/src/Interpolate.js
@@ -23,7 +23,7 @@ const Interpolate = React.createClass({
         this.props.children : this.props.format;
     let parent = this.props.component;
     let unsafe = this.props.unsafe === true;
-    let props = Object.assign({}, this.props);
+    let props = {...this.props};
 
     delete props.children;
     delete props.format;

--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -304,10 +304,11 @@ const OverlayTrigger = React.createClass({
     const offset = container.tagName === 'BODY' ?
       domUtils.getOffset(node) : domUtils.getPosition(node, container);
 
-    return Object.assign({}, offset, {
+    return {
+      ...offset, // eslint-disable-line object-shorthand
       height: node.offsetHeight,
       width: node.offsetWidth
-    });
+    };
   }
 });
 


### PR DESCRIPTION
Instead of
`let props = Object.assign({}, this.props);`
use
`let props = {...this.props};`
which is transpiled into
`var props = _extends({}, this.props);`

Instead of
```js
return Object.assign({}, offset, {
  height: node.offsetHeight,
  width: node.offsetWidth
});
```
use
```js
// ES6
return {
  ...offset,
  height: node.offsetHeight,
  width: node.offsetWidth
};
```
which is transpiled into
```js
// ES5
return _extends({}, offset, {
  height: node.offsetHeight,
  width: node.offsetWidth
});
```