### PR TITLE
Remove - now extraneous - eslint warning disabling.

### DIFF
--- a/src/ButtonInput.js
+++ b/src/ButtonInput.js
@@ -6,7 +6,7 @@ import childrenValueValidation from './utils/childrenValueInputValidation';
 
 class ButtonInput extends InputBase {
   renderFormGroup(children) {
-    let {bsStyle, value, ...other} = this.props; // eslint-disable-line object-shorthand, no-unused-vars
+    let {bsStyle, value, ...other} = this.props; // eslint-disable-line object-shorthand
     return <FormGroup {...other}>{children}</FormGroup>;
   }
 


### PR DESCRIPTION
Yay.. Now we do not need to `escape` excludable properties
```js
let {bsStyle, value, ...other} = this.props;
```
by eslint-disable. :tada: 

Thanks to `babel-eslint@3.1.10` update.