### PR TITLE
Fixed pre-release to tag as such with npm publish

### DIFF
--- a/tools/release-scripts/tag-and-publish.js
+++ b/tools/release-scripts/tag-and-publish.js
@@ -1,10 +1,18 @@
+import 'colors';
 import { safeExec } from '../exec';
+import semver from 'semver';
 import tag from './tag';
 
 export default (version) => {
   console.log('Releasing: '.cyan + 'npm module'.green);
+  let parsed = semver.parse(version);
+  let additionalPublishArgs = '';
+
+  if (parsed.prerelease.length > 0) {
+    additionalPublishArgs = `--tag ${parsed.prerelease[0]}`;
+  }
 
   return tag(version)
-    .then(() => safeExec('npm publish'))
+    .then(() => safeExec(`npm publish ${additionalPublishArgs}`))
     .then(() => console.log('Released: '.cyan + 'npm module'.green));
 };


### PR DESCRIPTION
The default is `latest` which would install the pre-release for users
installing via `npm install react-boostrap`, which we don't want.