### PR TITLE
In docs footer don't show docs version.

### DIFF
--- a/docs/src/PageFooter.js
+++ b/docs/src/PageFooter.js
@@ -1,5 +1,13 @@
 import React from 'react';
+import semver from 'semver';
 import packageJSON from '../../package.json';
+
+let parsed = semver.parse(packageJSON.version);
+let version = packageJSON.version;
+
+if (parsed.prerelease.length > 0 && parsed.prerelease[0] === 'docs') {
+  version = `${parsed.major}.${parsed.minor}.${parsed.patch}`;
+}
 
 const PageHeader = React.createClass({
   render() {
@@ -36,7 +44,7 @@ const PageHeader = React.createClass({
             </div>
             <p>Code licensed under <a href='https://github.com/react-bootstrap/react-bootstrap/blob/master/LICENSE' target='_blank'>MIT</a>.</p>
             <ul className='bs-docs-footer-links muted'>
-              <li>Currently v{packageJSON.version}</li>
+              <li>Currently v{version}</li>
               <li>·</li>
               <li><a href='https://github.com/react-bootstrap/react-bootstrap/'>GitHub</a></li>
               <li>·</li>


### PR DESCRIPTION
Without this you would see v0.23.1-docs.0 in the footer of the docs.

![screen shot 2015-06-02 at 12 20 32 pm](https://cloud.githubusercontent.com/assets/736870/7943442/d383d5b2-0921-11e5-97b9-b8e8f98ea479.png)
