### PR TITLE
Do not release docs when publishing pre-release

### DIFF
--- a/tools/release-scripts/release.js
+++ b/tools/release-scripts/release.js
@@ -80,11 +80,18 @@ preConditions()
       });
   })
   .then(() => safeExec(`git commit -m "Release v${version}"`))
-  .then(() => Promise.all([
-    tagAndPublish(version),
-    repoRelease(bowerRepo, bowerRoot, tmpBowerRepo, version),
-    repoRelease(docsRepo, docsRoot, tmpDocsRepo, version)
-  ]))
+  .then(() => {
+    let releases = [
+      tagAndPublish(version),
+      repoRelease(bowerRepo, bowerRoot, tmpBowerRepo, version)
+    ];
+
+    if (!argv.preid) {
+      releases.push(repoRelease(docsRepo, docsRoot, tmpDocsRepo, version));
+    }
+
+    return Promise.all(releases);
+  })
   .then(() => console.log('Version '.cyan + `v${version}`.green + ' released!'.cyan))
   .catch(err => {
     if (!err.__handled) {


### PR DESCRIPTION
When I published v0.24.0-alpha.0 today the docs were published with it which is less than desirable. This should prevent that from happening again.