### PR TITLE
[added] `createSelectedEvent` for consistent onSelect handling

### DIFF
--- a/src/utils/createSelectedEvent.js
+++ b/src/utils/createSelectedEvent.js
@@ -1,0 +1,15 @@
+export default function createSelectedEvent(eventKey) {
+  let selectionPrevented = false;
+
+  return {
+    eventKey,
+
+    preventSelection() {
+      selectionPrevented = true;
+    },
+
+    isSelectionPrevented() {
+      return selectionPrevented;
+    }
+  };
+}


### PR DESCRIPTION
Related to #419 

This is the event that I have started using on the dropdown-revisited branch. Thought I'd pull the event from that branch in hopes that it may help with the events in #786