### PR TITLE
Use React.findDOMNode()

### DIFF
--- a/test/AlertSpec.js
+++ b/test/AlertSpec.js
@@ -18,7 +18,7 @@ describe('Alert', function () {
         Message
       </Alert>
     );
-    assert.ok(instance.getDOMNode().className.match(/\balert\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\balert\b/));
   });
 
   it('Should have dismissable style with onDismiss', function () {
@@ -28,7 +28,7 @@ describe('Alert', function () {
         Message
       </Alert>
     );
-    assert.ok(instance.getDOMNode().className.match(/\balert-dismissable\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\balert-dismissable\b/));
   });
 
   it('Should call onDismiss callback on dismiss click', function (done) {
@@ -40,7 +40,7 @@ describe('Alert', function () {
         Message
       </Alert>
     );
-    ReactTestUtils.Simulate.click(instance.getDOMNode().children[0]);
+    ReactTestUtils.Simulate.click(React.findDOMNode(instance).children[0]);
   });
 
   it('Should call onDismiss callback on dismissAfter time', function (done) {
@@ -60,7 +60,7 @@ describe('Alert', function () {
         Message
       </Alert>
     );
-    assert.ok(instance.getDOMNode().className.match(/\balert-\w+\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\balert-\w+\b/));
   });
 
   it('Should have use bsStyle class', function () {
@@ -69,6 +69,6 @@ describe('Alert', function () {
         Message
       </Alert>
     );
-    assert.ok(instance.getDOMNode().className.match(/\balert-danger\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\balert-danger\b/));
   });
 });

--- a/test/BadgeSpec.js
+++ b/test/BadgeSpec.js
@@ -18,7 +18,7 @@ describe('Badge', function () {
         Content
       </Badge>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bbadge\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bbadge\b/));
   });
 
   it('Should have a badge using a number', function () {
@@ -28,7 +28,7 @@ describe('Badge', function () {
         {count}
       </Badge>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bbadge\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bbadge\b/));
   });
 
   it('Should have a badge using a a mix of content', function () {
@@ -38,7 +38,7 @@ describe('Badge', function () {
         £{count}
       </Badge>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bbadge\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bbadge\b/));
   });
 
   it('Should have a badge class pulled right', function () {
@@ -47,13 +47,13 @@ describe('Badge', function () {
         Content
       </Badge>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bpull-right\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bpull-right\b/));
   });
 
   it('Should not have a badge class when empty', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Badge />
     );
-    assert.notOk(instance.getDOMNode().className.match(/\bbadge\b/));
+    assert.notOk(React.findDOMNode(instance).className.match(/\bbadge\b/));
   });
 });

--- a/test/ButtonGroupSpec.js
+++ b/test/ButtonGroupSpec.js
@@ -13,8 +13,8 @@ describe('ButtonGroup', function () {
         </Button>
       </ButtonGroup>
     );
-    assert.equal(instance.getDOMNode().nodeName, 'DIV');
-    assert.ok(instance.getDOMNode().className.match(/\bbtn-group\b/));
+    assert.equal(React.findDOMNode(instance).nodeName, 'DIV');
+    assert.ok(React.findDOMNode(instance).className.match(/\bbtn-group\b/));
   });
 
   it('Should add size', function () {
@@ -25,7 +25,7 @@ describe('ButtonGroup', function () {
         </Button>
       </ButtonGroup>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bbtn-group-lg\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bbtn-group-lg\b/));
   });
 
   it('Should add vertical variation', function () {
@@ -36,7 +36,7 @@ describe('ButtonGroup', function () {
         </Button>
       </ButtonGroup>
     );
-    assert.equal(instance.getDOMNode().className.trim(), 'btn-group-vertical');
+    assert.equal(React.findDOMNode(instance).className.trim(), 'btn-group-vertical');
   });
 
   it('Should add block variation', function () {
@@ -47,7 +47,7 @@ describe('ButtonGroup', function () {
         </Button>
       </ButtonGroup>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bbtn-block\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bbtn-block\b/));
   });
 
   it('Should warn about block without vertical', function () {
@@ -69,6 +69,6 @@ describe('ButtonGroup', function () {
         </Button>
       </ButtonGroup>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bbtn-group-justified\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bbtn-group-justified\b/));
   });
 });

--- a/test/ButtonInputSpec.js
+++ b/test/ButtonInputSpec.js
@@ -9,7 +9,7 @@ describe('ButtonInput', () =>{
       <ButtonInput value="button" bsStyle="danger" wrapperClassName="test" />
     );
 
-    const node = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'input').getDOMNode();
+    const node = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'input'));
     assert.equal(node.getAttribute('type'), 'button');
     assert.equal(node.getAttribute('class'), 'btn btn-danger');
   });
@@ -19,14 +19,14 @@ describe('ButtonInput', () =>{
       <ButtonInput value="button" type="reset" />
     );
 
-    let node = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'input').getDOMNode();
+    let node = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'input'));
     assert.equal(node.getAttribute('type'), 'reset');
 
     instance = ReactTestUtils.renderIntoDocument(
       <ButtonInput value="button" type="submit" />
     );
 
-    node = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'input').getDOMNode();
+    node = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'input'));
     assert.equal(node.getAttribute('type'), 'submit');
   });
 

--- a/test/ButtonSpec.js
+++ b/test/ButtonSpec.js
@@ -9,7 +9,7 @@ describe('Button', function () {
         Title
       </Button>
     );
-    assert.equal(instance.getDOMNode().nodeName, 'BUTTON');
+    assert.equal(React.findDOMNode(instance).nodeName, 'BUTTON');
   });
 
   it('Should output a component with button classes', function () {
@@ -18,8 +18,8 @@ describe('Button', function () {
         Title
       </Button>
     );
-    assert.equal(instance.getDOMNode().nodeName, 'INPUT');
-    assert.equal(instance.getDOMNode().getAttribute('class'), 'btn btn-default');
+    assert.equal(React.findDOMNode(instance).nodeName, 'INPUT');
+    assert.equal(React.findDOMNode(instance).getAttribute('class'), 'btn btn-default');
   });
 
   it('Should have type=button by default', function () {
@@ -28,7 +28,7 @@ describe('Button', function () {
         Title
       </Button>
     );
-    assert.equal(instance.getDOMNode().getAttribute('type'), 'button');
+    assert.equal(React.findDOMNode(instance).getAttribute('type'), 'button');
   });
 
   it('Should show the type if passed one', function () {
@@ -37,7 +37,7 @@ describe('Button', function () {
         Title
       </Button>
     );
-    assert.equal(instance.getDOMNode().getAttribute('type'), 'submit');
+    assert.equal(React.findDOMNode(instance).getAttribute('type'), 'submit');
   });
 
   it('Should output an anchor if called with a href', function () {
@@ -47,8 +47,8 @@ describe('Button', function () {
         Title
       </Button>
     );
-    assert.equal(instance.getDOMNode().nodeName, 'A');
-    assert.equal(instance.getDOMNode().getAttribute('href'), href);
+    assert.equal(React.findDOMNode(instance).nodeName, 'A');
+    assert.equal(React.findDOMNode(instance).getAttribute('href'), href);
   });
 
   it('Should output an input if called with a href and an input component', function () {
@@ -58,8 +58,8 @@ describe('Button', function () {
         Title
       </Button>
     );
-    assert.equal(instance.getDOMNode().nodeName, 'INPUT');
-    assert.equal(instance.getDOMNode().getAttribute('href'), href);
+    assert.equal(React.findDOMNode(instance).nodeName, 'INPUT');
+    assert.equal(React.findDOMNode(instance).getAttribute('href'), href);
   });
 
   it('Should output an anchor if called with a target', function () {
@@ -69,8 +69,8 @@ describe('Button', function () {
         Title
       </Button>
     );
-    assert.equal(instance.getDOMNode().nodeName, 'A');
-    assert.equal(instance.getDOMNode().getAttribute('target'), target);
+    assert.equal(React.findDOMNode(instance).nodeName, 'A');
+    assert.equal(React.findDOMNode(instance).getAttribute('target'), target);
   });
 
   it('Should call onClick callback', function (done) {
@@ -82,7 +82,7 @@ describe('Button', function () {
         Title
       </Button>
     );
-    ReactTestUtils.Simulate.click(instance.getDOMNode());
+    ReactTestUtils.Simulate.click(React.findDOMNode(instance));
   });
 
   it('Should be disabled', function () {
@@ -91,7 +91,7 @@ describe('Button', function () {
         Title
       </Button>
     );
-    assert.ok(instance.getDOMNode().disabled);
+    assert.ok(React.findDOMNode(instance).disabled);
   });
 
   it('Should be disabled link', function () {
@@ -100,7 +100,7 @@ describe('Button', function () {
         Title
       </Button>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bdisabled\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bdisabled\b/));
   });
 
   it('Should have block class', function () {
@@ -109,7 +109,7 @@ describe('Button', function () {
         Title
       </Button>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bbtn-block\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bbtn-block\b/));
   });
 
   it('Should apply bsStyle class', function () {
@@ -118,7 +118,7 @@ describe('Button', function () {
         Title
       </Button>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bbtn-danger\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bbtn-danger\b/));
   });
 
   it('Should honour additional classes passed in, adding not overriding', function () {
@@ -127,8 +127,8 @@ describe('Button', function () {
         Title
       </Button>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bbob\b/));
-    assert.ok(instance.getDOMNode().className.match(/\bbtn-danger\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bbob\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bbtn-danger\b/));
   });
 
   it('Should default to bsStyle="default"', function () {
@@ -146,7 +146,7 @@ describe('Button', function () {
         Title
       </Button>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bactive\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bactive\b/));
   });
 
   it('Should render an anchor in a list item when in a nav', function () {
@@ -156,7 +156,7 @@ describe('Button', function () {
       </Button>
     );
 
-    let li = instance.getDOMNode();
+    let li = React.findDOMNode(instance);
     let anchor = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a');
     assert.equal(li.nodeName, 'LI');
     assert.ok(li.className.match(/\bactive\b/));
@@ -170,7 +170,7 @@ describe('Button', function () {
       </Button>
     );
 
-    let anchor = instance.getDOMNode();
+    let anchor = React.findDOMNode(instance);
     assert.equal(anchor.nodeName, 'A');
     assert.ok(anchor.getAttribute('href'), '#');
   });

--- a/test/ButtonToolbarSpec.js
+++ b/test/ButtonToolbarSpec.js
@@ -15,8 +15,9 @@ describe('ButtonToolbar', function () {
         </ButtonGroup>
       </ButtonToolbar>
     );
-    assert.equal(instance.getDOMNode().nodeName, 'DIV');
-    assert.ok(instance.getDOMNode().className.match(/\bbtn-toolbar\b/));
-    assert.equal(instance.getDOMNode().getAttribute('role'), 'toolbar');
+    let node = React.findDOMNode(instance);
+    assert.equal(node.nodeName, 'DIV');
+    assert.ok(node.className.match(/\bbtn-toolbar\b/));
+    assert.equal(node.getAttribute('role'), 'toolbar');
   });
 });

--- a/test/ColSpec.js
+++ b/test/ColSpec.js
@@ -8,7 +8,7 @@ describe('Col', function () {
       <Col xsOffset={0} smOffset={0} mdOffset={0} lgOffset={0} />
     );
 
-    let instanceClassName = instance.getDOMNode().className;
+    let instanceClassName = React.findDOMNode(instance).className;
     assert.ok(instanceClassName.match(/\bcol-xs-offset-0\b/));
     assert.ok(instanceClassName.match(/\bcol-sm-offset-0\b/));
     assert.ok(instanceClassName.match(/\bcol-md-offset-0\b/));
@@ -20,7 +20,7 @@ describe('Col', function () {
       <Col xsPull={0} smPull={0} mdPull={0} lgPull={0} />
     );
 
-    let instanceClassName = instance.getDOMNode().className;
+    let instanceClassName = React.findDOMNode(instance).className;
     assert.ok(instanceClassName.match(/\bcol-xs-pull-0\b/));
     assert.ok(instanceClassName.match(/\bcol-sm-pull-0\b/));
     assert.ok(instanceClassName.match(/\bcol-md-pull-0\b/));
@@ -32,7 +32,7 @@ describe('Col', function () {
       <Col xsPush={0} smPush={0} mdPush={0} lgPush={0} />
     );
 
-    let instanceClassName = instance.getDOMNode().className;
+    let instanceClassName = React.findDOMNode(instance).className;
     assert.ok(instanceClassName.match(/\bcol-xs-push-0\b/));
     assert.ok(instanceClassName.match(/\bcol-sm-push-0\b/));
     assert.ok(instanceClassName.match(/\bcol-md-push-0\b/));

--- a/test/CollapsibleMixinSpec.js
+++ b/test/CollapsibleMixinSpec.js
@@ -12,7 +12,7 @@ describe('CollapsibleMixin', function () {
       mixins: [CollapsibleMixin],
 
       getCollapsibleDOMNode(){
-        return this.refs.panel.getDOMNode();
+        return React.findDOMNode(this.refs.panel);
       },
 
       getCollapsibleDimensionValue(){

--- a/test/DropdownButtonSpec.js
+++ b/test/DropdownButtonSpec.js
@@ -10,7 +10,7 @@ describe('DropdownButton', function () {
 
   afterEach(function() {
     if (instance && ReactTestUtils.isCompositeComponent(instance) && instance.isMounted()) {
-      React.unmountComponentAtNode(instance.getDOMNode());
+      React.unmountComponentAtNode(React.findDOMNode(instance));
     }
   });
 
@@ -22,9 +22,9 @@ describe('DropdownButton', function () {
       </DropdownButton>
     );
 
-    let button = ReactTestUtils.findRenderedComponentWithType(instance, Button).getDOMNode();
-    assert.ok(instance.getDOMNode().className.match(/\bbtn-group\b/));
-    assert.ok(instance.getDOMNode().className.match(/\btest-class\b/));
+    let button = React.findDOMNode(ReactTestUtils.findRenderedComponentWithType(instance, Button));
+    assert.ok(React.findDOMNode(instance).className.match(/\bbtn-group\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\btest-class\b/));
     assert.ok(button.className.match(/\bbtn\b/));
     assert.equal(button.nodeName, 'BUTTON');
     assert.equal(button.type, 'button');
@@ -54,7 +54,7 @@ describe('DropdownButton', function () {
       </DropdownButton>
     );
 
-    let button = ReactTestUtils.findRenderedComponentWithType(instance, Button).getDOMNode();
+    let button = React.findDOMNode(ReactTestUtils.findRenderedComponentWithType(instance, Button));
     assert.ok(button.className.match(/\bbtn-primary\b/));
     assert.equal(button.getAttribute('id'), 'testId');
     assert.ok(button.disabled);
@@ -67,7 +67,7 @@ describe('DropdownButton', function () {
         <MenuItem eventKey="2">MenuItem 2 content</MenuItem>
       </DropdownButton>);
 
-    assert.notOk(instance.getDOMNode().className.match(/\bopen\b/));
+    assert.notOk(React.findDOMNode(instance).className.match(/\bopen\b/));
   });
 
   it('Should open when clicked', function () {
@@ -78,8 +78,8 @@ describe('DropdownButton', function () {
       </DropdownButton>
     );
 
-    ReactTestUtils.SimulateNative.click(instance.refs.dropdownButton.getDOMNode());
-    assert.ok(instance.getDOMNode().className.match(/\bopen\b/));
+    ReactTestUtils.SimulateNative.click(React.findDOMNode(instance.refs.dropdownButton));
+    assert.ok(React.findDOMNode(instance).className.match(/\bopen\b/));
   });
 
   it('should call onSelect with eventKey when MenuItem is clicked', function (done) {
@@ -153,7 +153,7 @@ describe('DropdownButton', function () {
       evt.initEvent('click', true, true);
       document.documentElement.dispatchEvent(evt);
 
-      assert.notOk(instance.getDOMNode().className.match(/\bopen\b/));
+      assert.notOk(React.findDOMNode(instance).className.match(/\bopen\b/));
     });
   });
 
@@ -165,8 +165,8 @@ describe('DropdownButton', function () {
       </DropdownButton>
     );
 
-    let li = instance.getDOMNode();
-    let button = ReactTestUtils.findRenderedComponentWithType(instance, Button).getDOMNode();
+    let li = React.findDOMNode(instance);
+    let button = React.findDOMNode(ReactTestUtils.findRenderedComponentWithType(instance, Button));
     assert.equal(li.nodeName, 'LI');
     assert.ok(li.className.match(/\bdropdown\b/));
     assert.ok(li.className.match(/\btest-class\b/));
@@ -184,7 +184,7 @@ describe('DropdownButton', function () {
         </DropdownButton>
     );
 
-    let button = ReactTestUtils.findRenderedComponentWithType(instance, Button).getDOMNode();
+    let button = React.findDOMNode(ReactTestUtils.findRenderedComponentWithType(instance, Button));
     let carets = button.getElementsByClassName('caret');
     assert.equal(carets.length, 1);
   });
@@ -197,7 +197,7 @@ describe('DropdownButton', function () {
         </DropdownButton>
     );
 
-    let button = ReactTestUtils.findRenderedComponentWithType(instance, Button).getDOMNode();
+    let button = React.findDOMNode(ReactTestUtils.findRenderedComponentWithType(instance, Button));
     let carets = button.getElementsByClassName('caret');
     assert.equal(carets.length, 0);
   });
@@ -210,7 +210,7 @@ describe('DropdownButton', function () {
         </DropdownButton>
     );
 
-    let button = ReactTestUtils.findRenderedComponentWithType(instance, Button).getDOMNode();
+    let button = React.findDOMNode(ReactTestUtils.findRenderedComponentWithType(instance, Button));
     assert.ok(button.className.match(/\btest-class\b/));
   });
 

--- a/test/DropdownMenuSpec.js
+++ b/test/DropdownMenuSpec.js
@@ -18,7 +18,7 @@ describe('DropdownMenu', function () {
 
     let instance = ReactTestUtils.renderIntoDocument(<Parent/>);
 
-    let node = instance.getDOMNode();
+    let node = React.findDOMNode(instance);
 
     assert.ok(node.className.match(/\bdropdown-menu\b/));
     assert.equal(node.nodeName, 'UL');
@@ -37,7 +37,7 @@ describe('DropdownMenu', function () {
       </DropdownMenu>
     );
 
-    let node = instance.getDOMNode();
+    let node = React.findDOMNode(instance);
     assert.ok(node.className.match(/\bnew-fancy-class\b/));
   });
 
@@ -101,7 +101,7 @@ describe('DropdownMenu', function () {
     let menuItems = ReactTestUtils.scryRenderedComponentsWithType(instance, MenuItem);
     let evt = document.createEvent('HTMLEvents');
     evt.initEvent('click', true, true);
-    ReactTestUtils.findRenderedDOMComponentWithTag(menuItems[1], 'a').getDOMNode()
+    React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(menuItems[1], 'a'))
       .dispatchEvent(evt);
   });
 });

--- a/test/FadeMixinSpec.js
+++ b/test/FadeMixinSpec.js
@@ -25,10 +25,10 @@ describe('FadeMixin', function () {
     let child = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'span');
 
     setTimeout(function(){
-      assert.ok(instance.getDOMNode().className.match(/\bin\b/));
-      assert.ok(instance.getDOMNode().className.match(/\bfade\b/));
-      assert.ok(child.getDOMNode().className.match(/\bin\b/));
-      assert.ok(child.getDOMNode().className.match(/\bfade\b/));
+      assert.ok(React.findDOMNode(instance).className.match(/\bin\b/));
+      assert.ok(React.findDOMNode(instance).className.match(/\bfade\b/));
+      assert.ok(React.findDOMNode(child).className.match(/\bin\b/));
+      assert.ok(React.findDOMNode(child).className.match(/\bfade\b/));
       done();
     }, 25);
   });

--- a/test/GlyphiconSpec.js
+++ b/test/GlyphiconSpec.js
@@ -7,7 +7,7 @@ describe('Glyphicon', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Glyphicon glyph='star' />
     );
-    assert.ok(instance.getDOMNode().className.match(/\bglyphicon\b/));
-    assert.ok(instance.getDOMNode().className.match(/\bglyphicon-star\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bglyphicon\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bglyphicon-star\b/));
   });
 });

--- a/test/InputSpec.js
+++ b/test/InputSpec.js
@@ -28,7 +28,7 @@ describe('Input', function () {
 
     let select = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'select');
     assert.ok(select);
-    assert.equal(select.getDOMNode().children.length, 2);
+    assert.equal(React.findDOMNode(select).children.length, 2);
     assert.equal(instance.getValue(), 'v');
   });
 
@@ -78,7 +78,7 @@ describe('Input', function () {
       <Input type="text" defaultValue="v" />
     );
 
-    let node = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'input').getDOMNode();
+    let node = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'input'));
     assert.equal(node.getAttribute('type'), 'text');
     assert.equal(instance.getValue(), 'v');
   });
@@ -99,7 +99,7 @@ describe('Input', function () {
       <Input label="Label" labelClassName="label" id="input" />
     );
 
-    let node = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'label').getDOMNode();
+    let node = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'label'));
     assert.ok(node);
     assert.include(node.className, 'label');
     assert.equal(node.textContent, 'Label');
@@ -300,7 +300,7 @@ describe('Input', function () {
       <Input type="text" disabled={true} />
     );
 
-    let node = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'input').getDOMNode();
+    let node = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'input'));
     assert.isNotNull(node.getAttribute('disabled'));
   });
 });

--- a/test/JumbotronSpec.js
+++ b/test/JumbotronSpec.js
@@ -18,6 +18,6 @@ describe('Jumbotron', function () {
         Content
       </Jumbotron>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bjumbotron\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bjumbotron\b/));
   });
 });

--- a/test/LabelSpec.js
+++ b/test/LabelSpec.js
@@ -19,7 +19,7 @@ describe('Label', function () {
         Message
       </Label>
     );
-    assert.ok(instance.getDOMNode().className.match(/\blabel\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\blabel\b/));
   });
 
   it('Should have bsStyle by default', function () {
@@ -28,7 +28,7 @@ describe('Label', function () {
         Message
       </Label>
     );
-    assert.ok(instance.getDOMNode().className.match(/\blabel-default\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\blabel-default\b/));
   });
 
 });

--- a/test/ListGroupItemSpec.js
+++ b/test/ListGroupItemSpec.js
@@ -8,7 +8,7 @@ describe('ListGroupItem', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ListGroupItem>Text</ListGroupItem>
     );
-    assert.equal(instance.getDOMNode().nodeName, 'SPAN');
+    assert.equal(React.findDOMNode(instance).nodeName, 'SPAN');
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'list-group-item'));
   });
 
@@ -16,7 +16,7 @@ describe('ListGroupItem', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ListGroupItem href='#test'>Anchor</ListGroupItem>
     );
-    assert.equal(instance.getDOMNode().nodeName, 'A');
+    assert.equal(React.findDOMNode(instance).nodeName, 'A');
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'list-group-item'));
   });
 
@@ -24,7 +24,7 @@ describe('ListGroupItem', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ListGroupItem listItem>Item 1</ListGroupItem>
     );
-    assert.equal(instance.getDOMNode().nodeName, 'LI');
+    assert.equal(React.findDOMNode(instance).nodeName, 'LI');
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'list-group-item'));
   });
 
@@ -53,24 +53,28 @@ describe('ListGroupItem', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ListGroupItem header='Heading'>Item text</ListGroupItem>
     );
-    assert.equal(instance.getDOMNode().firstChild.nodeName, 'H4');
-    assert.equal(instance.getDOMNode().firstChild.innerText, 'Heading');
-    assert.ok(instance.getDOMNode().firstChild.className.match(/\blist-group-item-heading\b/));
-    assert.equal(instance.getDOMNode().lastChild.nodeName, 'P');
-    assert.equal(instance.getDOMNode().lastChild.innerText, 'Item text');
-    assert.ok(instance.getDOMNode().lastChild.className.match(/\blist-group-item-text\b/));
+
+    let node = React.findDOMNode(instance);
+    assert.equal(node.firstChild.nodeName, 'H4');
+    assert.equal(node.firstChild.innerText, 'Heading');
+    assert.ok(node.firstChild.className.match(/\blist-group-item-heading\b/));
+    assert.equal(node.lastChild.nodeName, 'P');
+    assert.equal(node.lastChild.innerText, 'Item text');
+    assert.ok(node.lastChild.className.match(/\blist-group-item-text\b/));
   });
 
   it('Should support "header" prop as a ReactComponent', function () {
-    let header = <h2>Heading</h2>,
-        instance = ReactTestUtils.renderIntoDocument(
-          <ListGroupItem header={header}>Item text</ListGroupItem>
-        );
-    assert.equal(instance.getDOMNode().firstChild.nodeName, 'H2');
-    assert.equal(instance.getDOMNode().firstChild.innerText, 'Heading');
-    assert.ok(instance.getDOMNode().firstChild.className.match(/\blist-group-item-heading\b/));
-    assert.equal(instance.getDOMNode().lastChild.nodeName, 'P');
-    assert.equal(instance.getDOMNode().lastChild.innerText, 'Item text');
-    assert.ok(instance.getDOMNode().lastChild.className.match(/\blist-group-item-text\b/));
+    let header = <h2>Heading</h2>;
+    let instance = ReactTestUtils.renderIntoDocument(
+      <ListGroupItem header={header}>Item text</ListGroupItem>
+    );
+
+    let node = React.findDOMNode(instance);
+    assert.equal(node.firstChild.nodeName, 'H2');
+    assert.equal(node.firstChild.innerText, 'Heading');
+    assert.ok(node.firstChild.className.match(/\blist-group-item-heading\b/));
+    assert.equal(node.lastChild.nodeName, 'P');
+    assert.equal(node.lastChild.innerText, 'Item text');
+    assert.ok(node.lastChild.className.match(/\blist-group-item-text\b/));
   });
 });

--- a/test/MenuItemSpec.js
+++ b/test/MenuItemSpec.js
@@ -9,8 +9,8 @@ describe('MenuItem', function () {
         Title
       </MenuItem>
     );
-    assert.equal(instance.getDOMNode().nodeName, 'LI');
-    assert.equal(instance.getDOMNode().getAttribute('role'), 'presentation');
+    assert.equal(React.findDOMNode(instance).nodeName, 'LI');
+    assert.equal(React.findDOMNode(instance).getAttribute('role'), 'presentation');
   });
 
   it('should pass through props', function () {
@@ -24,13 +24,13 @@ describe('MenuItem', function () {
       </MenuItem>
     );
 
-    let node = instance.getDOMNode();
+    let node = React.findDOMNode(instance);
     assert(node.className.match(/\btest-class\b/));
     assert.equal(node.getAttribute('href'), null);
     assert.equal(node.getAttribute('title'), null);
     assert.ok(node.className.match(/\bactive\b/));
 
-    let anchorNode = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a').getDOMNode();
+    let anchorNode = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a'));
     assert.notOk(anchorNode.className.match(/\btest-class\b/));
     assert.equal(anchorNode.getAttribute('href'), '#hi-mom!');
     assert.equal(anchorNode.getAttribute('title'), 'hi mom!');
@@ -44,7 +44,7 @@ describe('MenuItem', function () {
     );
 
     let anchor = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a');
-    assert.equal(anchor.getDOMNode().getAttribute('tabIndex'), '-1');
+    assert.equal(React.findDOMNode(anchor).getAttribute('tabIndex'), '-1');
   });
 
   it('should fire callback on click of link', function (done) {
@@ -68,8 +68,8 @@ describe('MenuItem', function () {
       </MenuItem>
     );
 
-    assert(instance.getDOMNode().className.match(/\bdivider\b/), 'Has no divider class');
-    assert.equal(instance.getDOMNode().innerText, '');
+    assert(React.findDOMNode(instance).className.match(/\bdivider\b/), 'Has no divider class');
+    assert.equal(React.findDOMNode(instance).innerText, '');
   });
 
   it('should be a header with no anchor', function () {
@@ -79,8 +79,8 @@ describe('MenuItem', function () {
       </MenuItem>
     );
 
-    assert(instance.getDOMNode().className.match(/\bdropdown-header\b/), 'Has no header class');
-    assert.equal(instance.getDOMNode().innerHTML, 'Title');
+    assert(React.findDOMNode(instance).className.match(/\bdropdown-header\b/), 'Has no header class');
+    assert.equal(React.findDOMNode(instance).innerHTML, 'Title');
   });
 
   it('Should set target attribute on anchor', function () {
@@ -91,7 +91,7 @@ describe('MenuItem', function () {
     );
 
     let anchor = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a');
-    assert.equal(anchor.getDOMNode().getAttribute('target'), '_blank');
+    assert.equal(React.findDOMNode(anchor).getAttribute('target'), '_blank');
   });
 
   it('Should call `onSelect` with target attribute', function (done) {
@@ -114,6 +114,6 @@ describe('MenuItem', function () {
         Title
       </MenuItem>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bdisabled\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bdisabled\b/));
   });
 });

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -38,12 +38,12 @@ describe('Modal', function () {
     let instance = ReactTestUtils.renderIntoDocument(
         <Container />
     );
-    assert.ok(instance.getDOMNode().className.match(/\modal-open\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\modal-open\b/));
 
-    let backdrop = instance.getDOMNode().getElementsByClassName('modal-backdrop')[0];
+    let backdrop = React.findDOMNode(instance).getElementsByClassName('modal-backdrop')[0];
     ReactTestUtils.Simulate.click(backdrop);
     setTimeout(function(){
-      assert.equal(instance.getDOMNode().className.length, 0);
+      assert.equal(React.findDOMNode(instance).className.length, 0);
       done();
     }, 0);
 
@@ -57,7 +57,7 @@ describe('Modal', function () {
       </Modal>
     );
 
-    let backdrop = instance.getDOMNode().getElementsByClassName('modal-backdrop')[0];
+    let backdrop = React.findDOMNode(instance).getElementsByClassName('modal-backdrop')[0];
     ReactTestUtils.Simulate.click(backdrop);
   });
 
@@ -69,7 +69,7 @@ describe('Modal', function () {
       </Modal>
     );
 
-    let backdrop = instance.getDOMNode().getElementsByClassName('modal')[0];
+    let backdrop = React.findDOMNode(instance).getElementsByClassName('modal')[0];
     ReactTestUtils.Simulate.click(backdrop);
   });
 
@@ -81,7 +81,7 @@ describe('Modal', function () {
       </Modal>
     );
 
-    let dialog = instance.getDOMNode().getElementsByClassName('modal-dialog')[0];
+    let dialog = React.findDOMNode(instance).getElementsByClassName('modal-dialog')[0];
     assert.ok(dialog.className.match(/\bmodal-sm\b/));
   });
 
@@ -147,11 +147,11 @@ describe('Modal', function () {
 
       setTimeout(function () {
         // modal should be focused when opened
-        let modal = instance.getDOMNode().getElementsByClassName('modal')[0];
+        let modal = React.findDOMNode(instance).getElementsByClassName('modal')[0];
         document.activeElement.should.equal(modal);
 
         // close the modal
-        let backdrop = instance.getDOMNode().getElementsByClassName('modal-backdrop')[0];
+        let backdrop = React.findDOMNode(instance).getElementsByClassName('modal-backdrop')[0];
         ReactTestUtils.Simulate.click(backdrop);
       }, 0);
     });

--- a/test/NavItemSpec.js
+++ b/test/NavItemSpec.js
@@ -27,7 +27,7 @@ describe('NavItem', function () {
         Item content
       </NavItem>
     );
-    let linkElement = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a').getDOMNode();
+    let linkElement = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a'));
     assert.ok(linkElement.href.indexOf('/some/unique-thing/') >= 0);
     assert.equal(linkElement.title, 'content');
   });
@@ -39,8 +39,8 @@ describe('NavItem', function () {
       </NavItem>
     );
 
-    assert.ok(!instance.getDOMNode().hasAttribute('href'));
-    assert.ok(!instance.getDOMNode().hasAttribute('title'));
+    assert.ok(!React.findDOMNode(instance).hasAttribute('href'));
+    assert.ok(!React.findDOMNode(instance).hasAttribute('title'));
   });
 
   it('Should call `onSelect` when item is selected', function (done) {
@@ -72,7 +72,7 @@ describe('NavItem', function () {
     let instance = ReactTestUtils.renderIntoDocument(
           <NavItem href="/some/unique-thing/" target="_blank">Item content</NavItem>
         );
-    let linkElement = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a').getDOMNode();
+    let linkElement = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a'));
     assert.equal(linkElement.target, '_blank');
   });
 
@@ -94,7 +94,7 @@ describe('NavItem', function () {
           <NavItem href="#" target="_blank">Item content</NavItem>
         );
 
-    let linkElement = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a').getDOMNode();
+    let linkElement = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a'));
     assert(linkElement.outerHTML.match('role="button"'), true);
   });
 
@@ -103,7 +103,7 @@ describe('NavItem', function () {
           <NavItem href="/path/to/stuff" target="_blank">Item content</NavItem>
         );
 
-    let linkElement = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a').getDOMNode();
+    let linkElement = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a'));
     assert.equal(linkElement.outerHTML.match('role="button"'), null);
   });
 });

--- a/test/NavbarSpec.js
+++ b/test/NavbarSpec.js
@@ -9,7 +9,7 @@ describe('Nav', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Navbar />
     );
-    let nav = instance.getDOMNode();
+    let nav = React.findDOMNode(instance);
     assert.equal(nav.nodeName, 'NAV');
     assert.ok(nav.className.match(/\bnavbar\b/));
     assert.ok(nav.getAttribute('role'), 'navigation');
@@ -54,14 +54,14 @@ describe('Nav', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Navbar role="banner"/>
     );
-    assert.ok(instance.getDOMNode().getAttribute('role'), 'banner');
+    assert.ok(React.findDOMNode(instance).getAttribute('role'), 'banner');
   });
 
   it('Should override node class', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Navbar componentClass={'header'}/>
     );
-    assert.ok(instance.getDOMNode().nodeName, 'HEADER');
+    assert.ok(React.findDOMNode(instance).nodeName, 'HEADER');
   });
 
   it('Should add header with brand', function () {
@@ -76,7 +76,7 @@ describe('Nav', function () {
     let brand = ReactTestUtils.findRenderedDOMComponentWithClass(header, 'navbar-brand');
 
     assert.ok(brand);
-    assert.equal(brand.getDOMNode().innerText, 'Brand');
+    assert.equal(React.findDOMNode(brand).innerText, 'Brand');
   });
 
   it('Should add header with brand component', function () {
@@ -91,8 +91,8 @@ describe('Nav', function () {
     let brand = ReactTestUtils.findRenderedDOMComponentWithClass(header, 'navbar-brand');
 
     assert.ok(brand);
-    assert.equal(brand.getDOMNode().nodeName, 'A');
-    assert.equal(brand.getDOMNode().innerText, 'Brand');
+    assert.equal(React.findDOMNode(brand).nodeName, 'A');
+    assert.equal(React.findDOMNode(brand).innerText, 'Brand');
   });
 
   it('Should pass navbar prop to navs', function () {
@@ -112,14 +112,14 @@ describe('Nav', function () {
       <Nav />
     );
 
-    let navNode = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'nav').getDOMNode();
+    let navNode = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'nav'));
     assert.ok(navNode);
     assert.equal(navNode.nodeName, 'UL');
     assert.equal(navNode.parentNode.nodeName, 'NAV');
 
     instance.setProps({navbar: true});
 
-    navNode = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'nav').getDOMNode();
+    navNode = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'nav'));
     assert.ok(navNode);
     assert.equal(navNode.nodeName, 'UL');
     assert.equal(navNode.parentNode.nodeName, 'DIV');

--- a/test/OverlayMixinSpec.js
+++ b/test/OverlayMixinSpec.js
@@ -19,7 +19,7 @@ describe('OverlayMixin', function () {
 
   afterEach(function() {
     if (instance && ReactTestUtils.isCompositeComponent(instance) && instance.isMounted()) {
-      React.unmountComponentAtNode(instance.getDOMNode());
+      React.unmountComponentAtNode(React.findDOMNode(instance));
     }
   });
 
@@ -44,7 +44,7 @@ describe('OverlayMixin', function () {
       <Container />
     );
 
-    assert.equal(instance.getDOMNode().querySelectorAll('#test1').length, 1);
+    assert.equal(React.findDOMNode(instance).querySelectorAll('#test1').length, 1);
   });
 
   it('Should not render a null overlay', function() {

--- a/test/PageHeaderSpec.js
+++ b/test/PageHeaderSpec.js
@@ -18,7 +18,7 @@ describe('PageHeader', function () {
         Content
       </PageHeader>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bpage-header\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bpage-header\b/));
   });
 
 });

--- a/test/PageItemSpec.js
+++ b/test/PageItemSpec.js
@@ -7,9 +7,11 @@ describe('PageItem', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <PageItem href="#">Text</PageItem>
     );
-    assert.equal(instance.getDOMNode().nodeName, 'LI');
-    assert.equal(instance.getDOMNode().children.length, 1);
-    assert.equal(instance.getDOMNode().children[0].nodeName, 'A');
+
+    let node = React.findDOMNode(instance);
+    assert.equal(node.nodeName, 'LI');
+    assert.equal(node.children.length, 1);
+    assert.equal(node.children[0].nodeName, 'A');
   });
 
   it('Should output "disabled" attribute as a class', function () {
@@ -61,7 +63,7 @@ describe('PageItem', function () {
     );
 
     let anchor = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a');
-    assert.equal(anchor.getDOMNode().getAttribute('target'), '_blank');
+    assert.equal(React.findDOMNode(anchor).getAttribute('target'), '_blank');
   });
 
   it('Should call "onSelect" with target attribute', function (done) {

--- a/test/PagerSpec.js
+++ b/test/PagerSpec.js
@@ -8,7 +8,7 @@ describe('Pager', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Pager/>
     );
-    assert.equal(instance.getDOMNode().nodeName, 'UL');
+    assert.equal(React.findDOMNode(instance).nodeName, 'UL');
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'pager'));
   });
 
@@ -18,8 +18,8 @@ describe('Pager', function () {
         <PageItem href="#">Top</PageItem>
       </Pager>
     );
-    assert.equal(instance.getDOMNode().children.length, 1);
-    assert.equal(instance.getDOMNode().children[0].nodeName, 'LI');
+    assert.equal(React.findDOMNode(instance).children.length, 1);
+    assert.equal(React.findDOMNode(instance).children[0].nodeName, 'LI');
   });
 
   it('Should allow multiple "PageItem" as child elements', function () {

--- a/test/PanelGroupSpec.js
+++ b/test/PanelGroupSpec.js
@@ -42,7 +42,7 @@ describe('PanelGroup', function () {
     assert.notOk(panel.state.collapsing);
 
     ReactTestUtils.Simulate.select(
-      ReactTestUtils.findRenderedDOMComponentWithClass(panel, 'changeme').getDOMNode()
+      ReactTestUtils.findRenderedDOMComponentWithClass(panel, 'changeme')
     );
 
     assert.notOk(panel.state.collapsing);

--- a/test/PanelSpec.js
+++ b/test/PanelSpec.js
@@ -8,7 +8,7 @@ describe('Panel', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel>Panel content</Panel>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bpanel\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bpanel\b/));
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-body'));
   });
 
@@ -16,22 +16,22 @@ describe('Panel', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel bsStyle="default">Panel content</Panel>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bpanel-default\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bpanel-default\b/));
   });
 
   it('Should honour additional classes passed in, adding not overriding', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel className="bob"/>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bbob\b/));
-    assert.ok(instance.getDOMNode().className.match(/\bpanel\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bbob\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bpanel\b/));
   });
 
   it('Should have unwrapped header', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel header="Heading">Panel content</Panel>
     );
-    let header = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-heading').getDOMNode();
+    let header = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-heading'));
     assert.equal(header.innerHTML, 'Heading');
   });
 
@@ -40,7 +40,7 @@ describe('Panel', function () {
         instance = ReactTestUtils.renderIntoDocument(
           <Panel header={header}>Panel content</Panel>
         );
-    header = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-heading').getDOMNode();
+    header = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-heading'));
     assert.equal(header.firstChild.nodeName, 'H3');
     assert.ok(header.firstChild.className.match(/\bpanel-title\b/));
     assert.equal(header.firstChild.innerHTML, 'Heading');
@@ -51,7 +51,7 @@ describe('Panel', function () {
         instance = ReactTestUtils.renderIntoDocument(
           <Panel header={header} collapsible={true}>Panel content</Panel>
         );
-    header = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-heading').getDOMNode();
+    header = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-heading'));
     assert.equal(header.firstChild.nodeName, 'H3');
     assert.ok(header.firstChild.className.match(/\bpanel-title\b/));
     assert.equal(header.firstChild.firstChild.nodeName, 'A');
@@ -63,7 +63,7 @@ describe('Panel', function () {
         instance = ReactTestUtils.renderIntoDocument(
           <Panel header={header}>Panel content</Panel>
         );
-    header = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-heading').getDOMNode();
+    header = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-heading'));
     assert.equal(header.firstChild.nodeName, 'H3');
     assert.ok(header.firstChild.className.match(/\bpanel-title\b/));
     assert.ok(header.firstChild.className.match(/\bcustom-class\b/));
@@ -74,7 +74,7 @@ describe('Panel', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel footer="Footer">Panel content</Panel>
     );
-    let footer = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-footer').getDOMNode();
+    let footer = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-footer'));
     assert.equal(footer.innerText, 'Footer');
   });
 
@@ -82,23 +82,23 @@ describe('Panel', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel collapsible={true} expanded={true}>Panel content</Panel>
     );
-    assert.ok(instance.getDOMNode().querySelector('.panel-collapse.collapse.in'));
+    assert.ok(React.findDOMNode(instance).querySelector('.panel-collapse.collapse.in'));
   });
 
   it('Should pass through dom properties', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel collapsible={false} id="testid">Panel content</Panel>
     );
-    assert.equal(instance.getDOMNode().id, 'testid');
+    assert.equal(React.findDOMNode(instance).id, 'testid');
   });
 
   it('Should pass id to panel-collapse', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel collapsible={true} id="testid" header="Heading">Panel content</Panel>
     );
-    assert.notOk(instance.getDOMNode().id);
-    let collapse = instance.getDOMNode().querySelector('.panel-collapse');
-    let anchor = instance.getDOMNode().querySelector('.panel-title a');
+    assert.notOk(React.findDOMNode(instance).id);
+    let collapse = React.findDOMNode(instance).querySelector('.panel-collapse');
+    let anchor = React.findDOMNode(instance).querySelector('.panel-title a');
     assert.equal(collapse.id, 'testid');
     assert.equal(anchor.getAttribute('href'), '#testid');
   });
@@ -107,8 +107,8 @@ describe('Panel', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel collapsible={true} expanded={true} header="Heading">Panel content</Panel>
     );
-    let collapse = instance.getDOMNode().querySelector('.panel-collapse');
-    let anchor = instance.getDOMNode().querySelector('.panel-title a');
+    let collapse = React.findDOMNode(instance).querySelector('.panel-collapse');
+    let anchor = React.findDOMNode(instance).querySelector('.panel-title a');
     assert.ok(collapse.className.match(/\bin\b/));
     assert.notOk(anchor.className.match(/\bcollapsed\b/));
   });
@@ -117,8 +117,8 @@ describe('Panel', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel collapsible={true} expanded={false} header="Heading">Panel content</Panel>
     );
-    let collapse = instance.getDOMNode().querySelector('.panel-collapse');
-    let anchor = instance.getDOMNode().querySelector('.panel-title a');
+    let collapse = React.findDOMNode(instance).querySelector('.panel-collapse');
+    let anchor = React.findDOMNode(instance).querySelector('.panel-title a');
     assert.notOk(collapse.className.match(/\bin\b/));
     assert.ok(anchor.className.match(/\bcollapsed\b/));
   });
@@ -127,8 +127,8 @@ describe('Panel', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel collapsible={true} expanded={true} header="Heading">Panel content</Panel>
     );
-    let collapse = instance.getDOMNode().querySelector('.panel-collapse');
-    let anchor = instance.getDOMNode().querySelector('.panel-title a');
+    let collapse = React.findDOMNode(instance).querySelector('.panel-collapse');
+    let anchor = React.findDOMNode(instance).querySelector('.panel-title a');
     assert.equal(collapse.getAttribute('aria-expanded'), 'true');
     assert.equal(anchor.getAttribute('aria-expanded'), 'true');
   });
@@ -137,8 +137,8 @@ describe('Panel', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel collapsible={true} expanded={false} header="Heading">Panel content</Panel>
     );
-    let collapse = instance.getDOMNode().querySelector('.panel-collapse');
-    let anchor = instance.getDOMNode().querySelector('.panel-title a');
+    let collapse = React.findDOMNode(instance).querySelector('.panel-collapse');
+    let anchor = React.findDOMNode(instance).querySelector('.panel-title a');
     assert.equal(collapse.getAttribute('aria-expanded'), 'false');
     assert.equal(anchor.getAttribute('aria-expanded'), 'false');
   });
@@ -152,7 +152,7 @@ describe('Panel', function () {
       <Panel collapsible={true} onSelect={handleSelect} header="Click me" eventKey='1'>Panel content</Panel>
     );
     let title = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-title');
-    ReactTestUtils.Simulate.click(title.getDOMNode().firstChild);
+    ReactTestUtils.Simulate.click(React.findDOMNode(title).firstChild);
   });
 
   it('Should toggle when uncontrolled', function () {
@@ -163,7 +163,7 @@ describe('Panel', function () {
     assert.notOk(instance.state.expanded);
 
     ReactTestUtils.Simulate.click(
-      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-title').getDOMNode().firstChild
+      React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-title')).firstChild
     );
 
     assert.ok(instance.state.expanded);
@@ -178,7 +178,7 @@ describe('Panel', function () {
       </Panel>
     );
 
-    let children = instance.getDOMNode().children;
+    let children = React.findDOMNode(instance).children;
     assert.equal(children.length, 3);
 
     assert.equal(children[0].nodeName, 'DIV');
@@ -198,7 +198,7 @@ describe('Panel', function () {
       </Panel>
     );
 
-    let children = instance.getDOMNode().children;
+    let children = React.findDOMNode(instance).children;
     assert.equal(children.length, 1);
 
     assert.equal(children[0].nodeName, 'TABLE');

--- a/test/PopoverSpec.js
+++ b/test/PopoverSpec.js
@@ -21,6 +21,6 @@ describe('Popover', function () {
         <strong>Popover Content</strong>
       </Popover>
     );
-    assert.equal(instance.getDOMNode().className.match(/\bfade\b/), null, 'The fade class should not be present');
+    assert.equal(React.findDOMNode(instance).className.match(/\bfade\b/), null, 'The fade class should not be present');
   });
 });

--- a/test/ProgressBarSpec.js
+++ b/test/ProgressBarSpec.js
@@ -2,8 +2,8 @@ import React from 'react';
 import ReactTestUtils from 'react/lib/ReactTestUtils';
 import ProgressBar from '../src/ProgressBar';
 
-const getProgressBar = function (wrapper) {
-  return ReactTestUtils.findRenderedDOMComponentWithClass(wrapper, 'progress-bar');
+const getProgressBarNode = function (wrapper) {
+  return React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithClass(wrapper, 'progress-bar'));
 };
 
 describe('ProgressBar', function () {
@@ -11,55 +11,50 @@ describe('ProgressBar', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar min={0} max={10} now={0} />
     );
-    let bar = getProgressBar(instance);
 
-    assert.equal(instance.getDOMNode().nodeName, 'DIV');
-    assert.ok(instance.getDOMNode().className.match(/\bprogress\b/));
-    assert.ok(bar.getDOMNode().className.match(/\bprogress-bar\b/));
-    assert.equal(bar.getDOMNode().getAttribute('role'), 'progressbar');
+    assert.equal(React.findDOMNode(instance).nodeName, 'DIV');
+    assert.ok(React.findDOMNode(instance).className.match(/\bprogress\b/));
+    assert.ok(getProgressBarNode(instance).className.match(/\bprogress-bar\b/));
+    assert.equal(getProgressBarNode(instance).getAttribute('role'), 'progressbar');
   });
 
   it('Should have the default class', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar min={0} max={10} now={0} bsStyle='default' />
     );
-    let bar = getProgressBar(instance);
 
-    assert.ok(bar.getDOMNode().className.match(/\bprogress-bar-default\b/));
+    assert.ok(getProgressBarNode(instance).className.match(/\bprogress-bar-default\b/));
   });
 
   it('Should have the primary class', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar min={0} max={10} now={0} bsStyle='primary' />
     );
-    let bar = getProgressBar(instance);
 
-    assert.ok(bar.getDOMNode().className.match(/\bprogress-bar-primary\b/));
+    assert.ok(getProgressBarNode(instance).className.match(/\bprogress-bar-primary\b/));
   });
 
   it('Should have the success class', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar min={0} max={10} now={0} bsStyle='success' />
     );
-    let bar = getProgressBar(instance);
 
-    assert.ok(bar.getDOMNode().className.match(/\bprogress-bar-success\b/));
+    assert.ok(getProgressBarNode(instance).className.match(/\bprogress-bar-success\b/));
   });
 
   it('Should have the warning class', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar min={0} max={10} now={0} bsStyle='warning' />
     );
-    let bar = getProgressBar(instance);
 
-    assert.ok(bar.getDOMNode().className.match(/\bprogress-bar-warning\b/));
+    assert.ok(getProgressBarNode(instance).className.match(/\bprogress-bar-warning\b/));
   });
 
   it('Should default to min:0, max:100', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar now={5} />
     );
-    let bar = getProgressBar(instance).getDOMNode();
+    let bar = getProgressBarNode(instance);
 
     assert.equal(bar.getAttribute('aria-valuemin'), '0');
     assert.equal(bar.getAttribute('aria-valuemax'), '100');
@@ -69,36 +64,32 @@ describe('ProgressBar', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar min={0} max={10} now={0} />
     );
-    let bar = getProgressBar(instance);
 
-    assert.equal(bar.getDOMNode().style.width, '0%');
+    assert.equal(getProgressBarNode(instance).style.width, '0%');
   });
 
   it('Should have 10% computed width', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar min={0} max={10} now={1} />
     );
-    let bar = getProgressBar(instance);
 
-    assert.equal(bar.getDOMNode().style.width, '10%');
+    assert.equal(getProgressBarNode(instance).style.width, '10%');
   });
 
   it('Should have 100% computed width', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar min={0} max={10} now={10} />
     );
-    let bar = getProgressBar(instance);
 
-    assert.equal(bar.getDOMNode().style.width, '100%');
+    assert.equal(getProgressBarNode(instance).style.width, '100%');
   });
 
   it('Should have 50% computed width with non-zero min', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar min={1} max={11} now={6} />
     );
-    let bar = getProgressBar(instance);
 
-    assert.equal(bar.getDOMNode().style.width, '50%');
+    assert.equal(getProgressBarNode(instance).style.width, '50%');
   });
 
   it('Should not have label', function () {
@@ -106,7 +97,7 @@ describe('ProgressBar', function () {
       <ProgressBar min={0} max={10} now={5} bsStyle='primary' />
     );
 
-    assert.equal(instance.getDOMNode().innerText, '');
+    assert.equal(React.findDOMNode(instance).innerText, '');
   });
 
   it('Should have label', function () {
@@ -115,7 +106,7 @@ describe('ProgressBar', function () {
         label='min:%(min)s, max:%(max)s, now:%(now)s, percent:%(percent)s, bsStyle:%(bsStyle)s' />
     );
 
-    assert.equal(instance.getDOMNode().innerText, 'min:0, max:10, now:5, percent:50, bsStyle:primary');
+    assert.equal(React.findDOMNode(instance).innerText, 'min:0, max:10, now:5, percent:50, bsStyle:primary');
   });
 
   it('Should have screen reader only label', function () {
@@ -125,7 +116,7 @@ describe('ProgressBar', function () {
     );
     let srLabel = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'sr-only');
 
-    assert.equal(srLabel.getDOMNode().innerText, 'min:0, max:10, now:5, percent:50, bsStyle:primary');
+    assert.equal(React.findDOMNode(srLabel).innerText, 'min:0, max:10, now:5, percent:50, bsStyle:primary');
   });
 
   it('Should have a label that is a React component', function () {
@@ -160,7 +151,7 @@ describe('ProgressBar', function () {
       <ProgressBar min={1} max={11} now={6} striped />
     );
 
-    assert.ok(instance.getDOMNode().className.match(/\bprogress-striped\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bprogress-striped\b/));
   });
 
   it('Should show animated striped bar', function () {
@@ -168,8 +159,8 @@ describe('ProgressBar', function () {
       <ProgressBar min={1} max={11} now={6} active />
     );
 
-    assert.ok(instance.getDOMNode().className.match(/\bprogress-striped\b/));
-    assert.ok(instance.getDOMNode().className.match(/\bactive\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bprogress-striped\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bactive\b/));
   });
 
   it('Should show stacked bars', function () {
@@ -179,7 +170,7 @@ describe('ProgressBar', function () {
         <ProgressBar key={2} now={30} />
       </ProgressBar>
     );
-    let wrapper = instance.getDOMNode();
+    let wrapper = React.findDOMNode(instance);
     let bar1 = wrapper.firstChild;
     let bar2 = wrapper.lastChild;
 

--- a/test/SplitButtonSpec.js
+++ b/test/SplitButtonSpec.js
@@ -8,7 +8,7 @@ describe('SplitButton', function () {
   let instance;
   afterEach(function() {
     if (instance && ReactTestUtils.isCompositeComponent(instance) && instance.isMounted()) {
-      React.unmountComponentAtNode(instance.getDOMNode());
+      React.unmountComponentAtNode(React.findDOMNode(instance));
     }
   });
 
@@ -20,9 +20,9 @@ describe('SplitButton', function () {
       </SplitButton>
     );
 
-    let button = instance.refs.button.getDOMNode();
-    let dropdownButton = instance.refs.dropdownButton.getDOMNode();
-    assert.ok(instance.getDOMNode().className.match(/\bbtn-group\b/));
+    let button = React.findDOMNode(instance.refs.button);
+    let dropdownButton = React.findDOMNode(instance.refs.dropdownButton);
+    assert.ok(React.findDOMNode(instance).className.match(/\bbtn-group\b/));
     assert.ok(button.className.match(/\bbtn\b/));
     assert.equal(button.nodeName, 'BUTTON');
     assert.equal(button.type, 'button');
@@ -43,7 +43,7 @@ describe('SplitButton', function () {
       </SplitButton>
     );
 
-    let menu = instance.refs.menu.getDOMNode();
+    let menu = React.findDOMNode(instance.refs.menu);
     assert.ok(menu.className.match(/\bdropdown-menu\b/));
     assert.equal(menu.getAttribute('role'), 'menu');
     assert.equal(menu.firstChild.nodeName, 'LI');
@@ -73,7 +73,7 @@ describe('SplitButton', function () {
       </SplitButton>
     );
 
-    let button = instance.refs.button.getDOMNode();
+    let button = React.findDOMNode(instance.refs.button);
     assert.ok(button.className.match(/\bbtn-primary\b/));
   });
 
@@ -85,9 +85,9 @@ describe('SplitButton', function () {
       </SplitButton>
     );
 
-    let button = instance.refs.button.getDOMNode();
+    let button = React.findDOMNode(instance.refs.button);
     assert.ok(button.disabled);
-    let dropdownButton = instance.refs.dropdownButton.getDOMNode();
+    let dropdownButton = React.findDOMNode(instance.refs.dropdownButton);
     assert.ok(dropdownButton.disabled);
   });
 
@@ -99,7 +99,7 @@ describe('SplitButton', function () {
       </SplitButton>
     );
 
-    assert.equal(instance.getDOMNode().getAttribute('id'), 'testId');
+    assert.equal(React.findDOMNode(instance).getAttribute('id'), 'testId');
   });
 
   it('Should be closed by default', function () {
@@ -110,7 +110,7 @@ describe('SplitButton', function () {
       </SplitButton>
     );
 
-    assert.notOk(instance.getDOMNode().className.match(/\bopen\b/));
+    assert.notOk(React.findDOMNode(instance).className.match(/\bopen\b/));
   });
 
   it('Should open when clicked', function () {
@@ -121,9 +121,9 @@ describe('SplitButton', function () {
       </SplitButton>
     );
 
-    ReactTestUtils.SimulateNative.click(instance.refs.dropdownButton.getDOMNode());
+    ReactTestUtils.SimulateNative.click(React.findDOMNode(instance.refs.dropdownButton));
 
-    assert.ok(instance.getDOMNode().className.match(/\bopen\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bopen\b/));
   });
 
   it('should call onSelect with eventKey when MenuItem is clicked', function (done) {
@@ -154,7 +154,7 @@ describe('SplitButton', function () {
       </SplitButton>
     );
 
-    assert.ok(instance.getDOMNode().className.match(/\bdropup\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bdropup\b/));
   });
 
   it('Should pass pullRight prop to menu', function () {
@@ -177,7 +177,7 @@ describe('SplitButton', function () {
 
     let anchors = ReactTestUtils.scryRenderedDOMComponentsWithTag(instance, 'a');
     assert.equal(anchors.length, 2);
-    let linkElement = anchors[0].getDOMNode();
+    let linkElement = React.findDOMNode(anchors[0]);
     assert.equal(linkElement.target, '_blank');
   });
 
@@ -213,7 +213,7 @@ describe('SplitButton', function () {
       evt.initEvent('click', true, true);
       document.documentElement.dispatchEvent(evt);
 
-      assert.notOk(instance.getDOMNode().className.match(/\bopen\b/));
+      assert.notOk(React.findDOMNode(instance).className.match(/\bopen\b/));
     });
   });
 });

--- a/test/TabbedAreaSpec.js
+++ b/test/TabbedAreaSpec.js
@@ -82,8 +82,8 @@ describe('TabbedArea', function () {
 
     let panes = ReactTestUtils.scryRenderedComponentsWithType(instance, TabPane);
 
-    assert.ok(panes[0].getDOMNode().className.match(/\bcustom\b/));
-    assert.equal(panes[0].getDOMNode().id, 'pane0id');
+    assert.ok(React.findDOMNode(panes[0]).className.match(/\bcustom\b/));
+    assert.equal(React.findDOMNode(panes[0]).id, 'pane0id');
   });
 
   it('Should show the correct initial pane', function () {
@@ -194,7 +194,7 @@ describe('TabbedArea', function () {
     let tabPane = ReactTestUtils.scryRenderedComponentsWithType(instance, TabPane);
 
     assert.equal(tabPane.length, 2);
-    assert.equal(tabPane[1].getDOMNode().getAttribute('class').match(/pull-right/)[0], 'pull-right');
+    assert.equal(React.findDOMNode(tabPane[1]).getAttribute('class').match(/pull-right/)[0], 'pull-right');
   });
 
   it('Should pass disabled to NavItem', function () {

--- a/test/TableSpec.js
+++ b/test/TableSpec.js
@@ -7,43 +7,43 @@ describe('Table', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Table />
     );
-    assert.equal(instance.getDOMNode().nodeName, 'TABLE');
-    assert.ok(instance.getDOMNode().className.match(/\btable\b/));
+    assert.equal(React.findDOMNode(instance).nodeName, 'TABLE');
+    assert.ok(React.findDOMNode(instance).className.match(/\btable\b/));
   });
 
   it('Should have correct class when striped', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Table striped />
     );
-    assert.ok(instance.getDOMNode().className.match(/\btable-striped\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\btable-striped\b/));
   });
 
   it('Should have correct class when hover', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Table hover />
     );
-    assert.ok(instance.getDOMNode().className.match(/\btable-hover\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\btable-hover\b/));
   });
 
   it('Should have correct class when bordered', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Table bordered />
     );
-    assert.ok(instance.getDOMNode().className.match(/\btable-bordered\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\btable-bordered\b/));
   });
 
   it('Should have correct class when condensed', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Table condensed />
     );
-    assert.ok(instance.getDOMNode().className.match(/\btable-condensed\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\btable-condensed\b/));
   });
 
   it('Should have responsive wrapper', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Table responsive />
     );
-    assert.ok(instance.getDOMNode().className.match(/\btable-responsive\b/));
-    assert.ok(instance.getDOMNode().firstChild.className.match(/\btable\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\btable-responsive\b/));
+    assert.ok(React.findDOMNode(instance).firstChild.className.match(/\btable\b/));
   });
 });

--- a/test/ThumbnailSpec.js
+++ b/test/ThumbnailSpec.js
@@ -7,7 +7,7 @@ describe('Thumbnail', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Thumbnail href="#" src="#" alt="test" />
     );
-    assert.ok(instance.getDOMNode().className.match(/\bthumbnail\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bthumbnail\b/));
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a'));
   });
 
@@ -22,8 +22,8 @@ describe('Thumbnail', function () {
     let instance = ReactTestUtils.renderIntoDocument(
       <Thumbnail src="#" alt="test" />
     );
-    assert.ok(instance.getDOMNode().className.match(/\bthumbnail\b/));
-    assert.equal(instance.getDOMNode().nodeName, 'DIV');
+    assert.ok(React.findDOMNode(instance).className.match(/\bthumbnail\b/));
+    assert.equal(React.findDOMNode(instance).nodeName, 'DIV');
   });
 
     it('Should have an image', function () {
@@ -42,6 +42,6 @@ describe('Thumbnail', function () {
         </div>
       </Thumbnail>
     );
-    assert.ok(instance.getDOMNode().lastChild.className.match(/\bcaption\b/));
+    assert.ok(React.findDOMNode(instance).lastChild.className.match(/\bcaption\b/));
   });
 });

--- a/test/TooltipSpec.js
+++ b/test/TooltipSpec.js
@@ -19,6 +19,6 @@ describe('Tooltip', function () {
         <strong>Tooltip Content</strong>
       </Tooltip>
     );
-    assert.equal(instance.getDOMNode().className.match(/\bfade\b/), null, 'The fade class should not be present');
+    assert.equal(React.findDOMNode(instance).className.match(/\bfade\b/), null, 'The fade class should not be present');
   });
 });

--- a/test/WellSpec.js
+++ b/test/WellSpec.js
@@ -18,7 +18,7 @@ describe('Well', function () {
         Content
       </Well>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bwell\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bwell\b/));
   });
 
   it('Should accept bsSize arguments', function () {
@@ -27,6 +27,6 @@ describe('Well', function () {
         Content
       </Well>
     );
-    assert.ok(instance.getDOMNode().className.match(/\bwell-sm\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\bwell-sm\b/));
   });
 });


### PR DESCRIPTION
to prevent copy pasting tests in future PRs
like these
https://github.com/react-bootstrap/react-bootstrap/pull/786#discussion_r31755554
[pull/606/files#diff](https://github.com/react-bootstrap/react-bootstrap/pull/606/files#diff-98f7be7274b89654152873944d5e8212R117)

Warning: There is the long diff ahead. :cherries: 

There are not only `getDOMNode` => `React.findDOMNode`
but also some simple DRY re-writings.

No code-logic changes.