### PR TITLE
Fix babel@5.4.7 version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
     "react": ">=0.13"
   },
   "devDependencies": {
-    "babel": "^5.1.10",
-    "babel-core": "^5.1.10",
+    "babel": "5.4.7",
+    "babel-core": "5.4.7",
     "babel-eslint": "^3.0.1",
     "babel-loader": "^5.0.0",
     "bootstrap": "^3.3.4",


### PR DESCRIPTION
Because a bug with `babel-core@5.5.x`:
```sh
$ babel-node tools/build-cli.js

/Users/alexkval/src/js/react-bootstrap/node_modules/babel-core/browser.js:1
SX", "Immutable"], "JSXElement":["JSX", "Immutable", "Expression"], "JSXEmptyE
                                                                    ^^^^^^^^^^
SyntaxError: Duplicate data property in object literal not allowed in strict mode
    at exports.runInThisContext (vm.js:73:16)
    at Module._compile (module.js:443:25)
    at normalLoader (/Users/alexkval/src/js/react-bootstrap/node_modules/babel-core/lib/babel/api/register/node.js:160:5)
    at Object.require.extensions.(anonymous function) [as .js] (/Users/alexkval/src/js/react-bootstrap/node_modules/babel-core/lib/babel/api/register/node.js:173:7)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/alexkval/src/js/react-bootstrap/docs/src/ReactPlayground.js:46:20)
    at Module._compile (module.js:460:26)
```

I didn't dig deeper.