### PR TITLE
Comment out no-unused-vars eslint warnings back.

### DIFF
--- a/src/ButtonInput.js
+++ b/src/ButtonInput.js
@@ -6,7 +6,7 @@ import childrenValueValidation from './utils/childrenValueInputValidation';
 
 class ButtonInput extends InputBase {
   renderFormGroup(children) {
-    let {bsStyle, value, ...other} = this.props; // eslint-disable-line object-shorthand
+    let {bsStyle, value, ...other} = this.props; // eslint-disable-line object-shorthand, no-unused-vars
     return <FormGroup {...other}>{children}</FormGroup>;
   }
 


### PR DESCRIPTION
```
src/ButtonInput.js
  9:9   warning  bsStyle is defined but never used  no-unused-vars
  9:18  warning  value is defined but never used    no-unused-vars
```
https://github.com/babel/babel-eslint/issues/120

Alas, that was a bug, not a feature. :cry: 