### PR TITLE
ProgressBar. Assert that chilren can be ProgressBar only.

### DIFF
--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -1,3 +1,6 @@
+/* eslint react/prop-types: [1, {ignore: ["className", "bsStyle"]}]*/
+/* BootstrapMixin contains `bsStyle` type validation */
+
 import React, { cloneElement, PropTypes } from 'react';
 import Interpolate from './Interpolate';
 import BootstrapMixin from './BootstrapMixin';
@@ -14,7 +17,9 @@ const ProgressBar = React.createClass({
     srOnly: PropTypes.bool,
     striped: PropTypes.bool,
     active: PropTypes.bool,
-    children: onlyProgressBar
+    children: onlyProgressBar,
+    interpolateClass: PropTypes.node,
+    isChild: PropTypes.bool
   },
 
   mixins: [BootstrapMixin],

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -1,4 +1,4 @@
-import React, { cloneElement } from 'react';
+import React, { cloneElement, PropTypes } from 'react';
 import Interpolate from './Interpolate';
 import BootstrapMixin from './BootstrapMixin';
 import classNames from 'classnames';
@@ -7,13 +7,14 @@ import ValidComponentChildren from './utils/ValidComponentChildren';
 
 const ProgressBar = React.createClass({
   propTypes: {
-    min: React.PropTypes.number,
-    now: React.PropTypes.number,
-    max: React.PropTypes.number,
-    label: React.PropTypes.node,
-    srOnly: React.PropTypes.bool,
-    striped: React.PropTypes.bool,
-    active: React.PropTypes.bool
+    min: PropTypes.number,
+    now: PropTypes.number,
+    max: PropTypes.number,
+    label: PropTypes.node,
+    srOnly: PropTypes.bool,
+    striped: PropTypes.bool,
+    active: PropTypes.bool,
+    children: onlyProgressBar
   },
 
   mixins: [BootstrapMixin],
@@ -126,5 +127,23 @@ const ProgressBar = React.createClass({
     );
   }
 });
+
+/**
+ * Custom propTypes checker
+ */
+function onlyProgressBar(props, propName, componentName) {
+  if (props[propName]) {
+    let error, childIdentifier;
+
+    React.Children.forEach(props[propName], (child) => {
+      if (child.type !== ProgressBar) {
+        childIdentifier = (child.type.displayName ? child.type.displayName : child.type);
+        error = new Error(`Children of ${componentName} can contain only ProgressBar components. Found ${childIdentifier}`);
+      }
+    });
+
+    return error;
+  }
+}
 
 export default ProgressBar;

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -28,41 +28,34 @@ const ProgressBar = React.createClass({
   },
 
   getPercentage(now, min, max) {
-    let roundPrecision = 1000;
+    const roundPrecision = 1000;
     return Math.round(((now - min) / (max - min) * 100) * roundPrecision) / roundPrecision;
   },
 
   render() {
-    let classes = {
-        progress: true
-      };
-
-    if (this.props.active) {
-      classes['progress-striped'] = true;
-      classes.active = true;
-    } else if (this.props.striped) {
-      classes['progress-striped'] = true;
+    if (this.props.isChild) {
+      return this.renderProgressBar();
     }
 
-    if (!ValidComponentChildren.hasValidComponent(this.props.children)) {
-      if (!this.props.isChild) {
-        return (
-          <div {...this.props} className={classNames(this.props.className, classes)}>
-            {this.renderProgressBar()}
-          </div>
-        );
-      } else {
-        return (
-          this.renderProgressBar()
-        );
-      }
+    const classes = {
+      active: this.props.active,
+      progress: true,
+      'progress-striped': this.props.active || this.props.striped
+    };
+
+    let content;
+
+    if (this.props.children) {
+      content = ValidComponentChildren.map(this.props.children, this.renderChildBar);
     } else {
-      return (
-        <div {...this.props} className={classNames(this.props.className, classes)}>
-          {ValidComponentChildren.map(this.props.children, this.renderChildBar)}
-        </div>
-      );
+      content = this.renderProgressBar();
     }
+
+    return (
+      <div {...this.props} className={classNames(this.props.className, classes)}>
+        {content}
+      </div>
+    );
   },
 
   renderChildBar(child, index) {
@@ -73,28 +66,33 @@ const ProgressBar = React.createClass({
   },
 
   renderProgressBar() {
-    let percentage = this.getPercentage(
-        this.props.now,
-        this.props.min,
-        this.props.max
-      );
+    const percentage = this.getPercentage(
+      this.props.now,
+      this.props.min,
+      this.props.max
+    );
 
     let label;
 
     if (typeof this.props.label === 'string') {
       label = this.renderLabel(percentage);
-    } else if (this.props.label) {
+    } else {
       label = this.props.label;
     }
 
     if (this.props.srOnly) {
-      label = this.renderScreenReaderOnlyLabel(label);
+      label = (
+        <span className="sr-only">
+          {label}
+        </span>
+      );
     }
 
-    let classes = this.getBsClassSet();
-
     return (
-      <div {...this.props} className={classNames(this.props.className, classes)} role="progressbar"
+      <div
+        {...this.props}
+        className={classNames(this.props.className, this.getBsClassSet())}
+        role="progressbar"
         style={{width: percentage + '%'}}
         aria-valuenow={this.props.now}
         aria-valuemin={this.props.min}
@@ -105,7 +103,7 @@ const ProgressBar = React.createClass({
   },
 
   renderLabel(percentage) {
-    let InterpolateClass = this.props.interpolateClass || Interpolate;
+    const InterpolateClass = this.props.interpolateClass || Interpolate;
 
     return (
       <InterpolateClass
@@ -116,14 +114,6 @@ const ProgressBar = React.createClass({
         bsStyle={this.props.bsStyle}>
         {this.props.label}
       </InterpolateClass>
-    );
-  },
-
-  renderScreenReaderOnlyLabel(label) {
-    return (
-      <span className="sr-only">
-        {label}
-      </span>
     );
   }
 });

--- a/test/ProgressBarSpec.js
+++ b/test/ProgressBarSpec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactTestUtils from 'react/lib/ReactTestUtils';
 import ProgressBar from '../src/ProgressBar';
+import {shouldWarn} from './helpers';
 
 const getProgressBarNode = function (wrapper) {
   return React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithClass(wrapper, 'progress-bar'));
@@ -181,4 +182,15 @@ describe('ProgressBar', function () {
     assert.equal(bar2.style.width, '30%');
   });
 
+  it('allows only ProgressBar in children', function () {
+    ReactTestUtils.renderIntoDocument(
+      <ProgressBar>
+        <ProgressBar key={1} />
+        <div />
+        <ProgressBar key={2} />
+      </ProgressBar>
+    );
+
+    shouldWarn('Failed propType');
+  });
 });


### PR DESCRIPTION
And strip out some technical debt.

Checking is done like this
`if (child.type.displayName !== ProgressBar.displayName)`
because neither
`child instanceof ProgressBar`
nor
`React.PropTypes.instanceOf(ProgressBar)`
work.  (don't know why)
I've tried it all hard.

Custom propTypes checker `function onlyProgressBar()` placed after `const ProgressBar` is defined
because of using `!== ProgressBar.displayName` in it.

It is possible to place it at the beginning of file 
if do checking against string constant `!== 'ProgressBar'`.
But I like idea to use generated `displayName` whatever it can be.

--
**Question**: 
What is the purpose of mystical `this.props.interpolateClass` ?
It was added here
[commit#diffR96](https://github.com/react-bootstrap/react-bootstrap/commit/2e120f3c7ecf230c4188e8d0f5fd793ec7bdc250#diff-4c52b03c635c549e56ce5177eb6cb770R96)
Maybe deprecate it and then remove ?