### PR TITLE
[fixed] SafeAnchor event ordering

### DIFF
--- a/src/SafeAnchor.js
+++ b/src/SafeAnchor.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import createChainedFunction from './utils/createChainedFunction';
 
 /**
  * Note: This is intended as a stop-gap for accessibility concerns that the
@@ -16,17 +17,13 @@ export default class SafeAnchor extends React.Component {
     if (this.props.href === undefined) {
       event.preventDefault();
     }
-
-    if (this.props.onClick) {
-      this.props.onClick(event);
-    }
   }
 
   render() {
     return (
       <a role={this.props.href ? undefined : 'button'}
         {...this.props}
-        onClick={this.handleClick}
+        onClick={createChainedFunction(this.props.onClick, this.handleClick)}
         href={this.props.href || ''}/>
     );
   }

--- a/test/SafeAnchorSpec.js
+++ b/test/SafeAnchorSpec.js
@@ -43,8 +43,12 @@ describe('SafeAnchor', function() {
 
   it('prevents default when no href is provided', function(done) {
     const handleClick = (event) => {
-      event.defaultPrevented.should.be.true;
-      done();
+      expect(event.isDefaultPrevented()).to.not.be.ok;
+
+      setTimeout(() => {
+        event.isDefaultPrevented().should.be.true;
+        done();
+      }, 100);
     };
     const instance = ReactTestUtils.renderIntoDocument(<SafeAnchor onClick={handleClick} />);
     const anchor = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'A');
@@ -54,8 +58,12 @@ describe('SafeAnchor', function() {
 
   it('does not prevent default when href is provided', function(done) {
     const handleClick = (event) => {
-      expect(event.defaultPrevented).to.not.be.ok;
-      done();
+      expect(event.isDefaultPrevented()).to.not.be.ok;
+
+      setTimeout(() => {
+        expect(event.isDefaultPrevented()).to.not.be.ok;
+        done();
+      });
     };
     const instance = ReactTestUtils.renderIntoDocument(<SafeAnchor href='#' onClick={handleClick} />);
     const anchor = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'A');


### PR DESCRIPTION
If we prevent default before applying the `onClick` function provided in
props then we prevent elements from using the `event.preventDefault()`
mechanics for anchors as buttons. For example in the Dropdown re-work
this prevented me from having the Dropdown work when in a Nav since the
toggle is an anchor. Yet that functionality should allow uses to prevent
the Dropdown if they want in their own `onClick` handler. This will
enable such a use case.