### PR TITLE
Fix bower template.

### DIFF
--- a/tools/amd/bower.json
+++ b/tools/amd/bower.json
@@ -8,15 +8,12 @@
     "react-bootstrap.js"
   ],
   "keywords": [
-    "react",
-    "react-component",
-    "bootstrap"
+    <%= _.map(pkg.keywords, function(keyword) { return '"' + keyword + '"' }).join(',\n    ')%>
   ],
   "ignore": [
     "**/.*"
   ],
   "dependencies": {
-    "react": ">= 0.13.0",
-    "classnames": "^2.0.0"
+    "react": "<%= pkg.peerDependencies.react %>"
   }
 }


### PR DESCRIPTION
Keywords are from one source now.
And "classnames" has been removed from dependencies because webpack bundles it.