### PR TITLE
Unlink babel internal api for build

### DIFF
--- a/tools/buildBabel.js
+++ b/tools/buildBabel.js
@@ -1,13 +1,12 @@
 import { transform } from 'babel-core';
-import resolveRc from 'babel-core/lib/babel/tools/resolve-rc';
-import * as babelUtil from 'babel-core/lib/babel/util';
 import glob from 'glob';
 import fs from 'fs';
 import path from 'path';
 import outputFileSync from 'output-file-sync';
 
 export function buildContent(content, filename, destination, babelOptions={}) {
-  const result = transform(content, resolveRc(filename, babelOptions));
+  babelOptions.filename = filename;
+  const result = transform(content, babelOptions);
   outputFileSync(destination, result.code, {encoding: 'utf8'});
 }
 
@@ -19,11 +18,9 @@ console.warn('You can read more about it at https://github.com/react-bootstrap/r
 ${content}`;
   }
 
-  if(babelUtil.canCompile(filename)) {
-    // Get file basename without the extension (in case not .js)
-    let outputName = path.basename(filename, path.extname(filename));
-    // append the file basename with extension .js
-    let outputPath = path.join(destination, outputName + '.js');
+  // We only have .js files that we need to build
+  if(path.extname(filename) === '.js') {
+    const outputPath = path.join(destination, path.basename(filename));
     // console.log('%s => %s', filename, outputPath);
     buildContent(content, filename, outputPath, babelOptions);
   }


### PR DESCRIPTION
Remove links to babel internal api and only use what we really need.
Addresses discussion at #762 
@sebmck Sorry for using your private api, I didn't know how to do what I needed at the time and I wanted to remain as close as possible to the original behavior. I should have asked to expose the api instead of using it like this. 

After some inspection, I realized that I didn't really need the internal api since our need is very simple.