### PR TITLE
Fix bower template

### DIFF
--- a/tools/amd/bower.json
+++ b/tools/amd/bower.json
@@ -8,14 +8,12 @@
     "react-bootstrap.js"
   ],
   "keywords": [
-    "react",
-    "react-component",
-    "bootstrap"
+    <%= _.map(pkg.keywords, function(keyword) { return '"' + keyword + '"' }).join(',\n    ')%>
   ],
   "ignore": [
     "**/.*"
   ],
   "dependencies": {
-    "react": ">= 0.13.0"
+    "react": "<%= pkg.peerDependencies.react %>"
   }
 }


### PR DESCRIPTION
Removed "classnames" from dependencies because webpack bundles it.

https://github.com/react-bootstrap/react-bootstrap/pull/822#issuecomment-111721675