### PR TITLE
Enable loose option for Babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "optional": [
     "es7.objectRestSpread"
-  ]
+  ],
+  "loose": ["all"]
 }


### PR DESCRIPTION
enable loose, mode for Babel. This transpiles with a slightly lower
level of spec "correctness" but in the vast majority of cases this
doesn't matter, and leads to better performance. Admittedly I am not
backing that up with numbers, but there is almost no downside to
enabling it. Specifically though it doesn't use DefineProperty in
classes which is notoriously slow

http://babeljs.io/docs/advanced/loose/

Everyone might want to take a look through the caveats in the above list. If folks think that we are unlikely to run into said caveats then its probably worth it to enable it.