### PR TITLE
Locking eslint-plugin-react to 2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "es5-shim": "^4.1.0",
     "eslint": "0.22.1",
     "eslint-plugin-mocha": "^0.2.2",
-    "eslint-plugin-react": "^2.1.0",
+    "eslint-plugin-react": "2.5.0",
     "express": "^4.12.3",
     "extract-text-webpack-plugin": "^0.8.0",
     "file-loader": "^0.8.1",


### PR DESCRIPTION
Due to breaking change in the 2.5.1 release.

See: yannickcr/eslint-plugin-react#110