### PR TITLE
Use babel-runtime transformer for helpers

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "stage": 1
+  "stage": 1,
+  "optional": ["runtime"]
 }

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "yargs": "^3.5.4"
   },
   "dependencies": {
+    "babel-runtime": "^5.1.10",
     "classnames": "^2.0.0"
   }
 }


### PR DESCRIPTION
Fixes #579

Reduces size of `dist/react-bootstrap.min.js` from 121,221B to 116,282B at this commit.

Will need to resolve #840 or manually clear `.babel-cache` before building with this change.

As this is against v0.24 RC, no need to update e.g. Bower dependencies, but this is now a runtime dependency when using the standard build.