### PR TITLE
[fixed] Do not use Babel cache for release build

### DIFF
--- a/docs/build.js
+++ b/docs/build.js
@@ -32,8 +32,11 @@ function generateHTML(fileName) {
   });
 }
 
-export default function BuildDocs({ dev }) {
+export default function BuildDocs({useCache, dev}) {
   console.log('Building: '.cyan + 'docs'.green + (dev ? ' [DEV]'.grey : ''));
+
+  const useCacheOption = `--use-cache=${Boolean(useCache)}`;
+  const devOption = dev ? '' : '-p';
 
   return exec(`rimraf ${docsBuilt}`)
     .then(() => fsp.mkdir(docsBuilt))
@@ -41,7 +44,7 @@ export default function BuildDocs({ dev }) {
       let pagesGenerators = Root.getPages().map(generateHTML);
 
       return Promise.all(pagesGenerators.concat([
-        exec(`webpack --config webpack.docs.js ${dev ? '' : '-p '}--bail`),
+        exec(`webpack --config webpack.docs.js ${useCacheOption} --bail ${devOption}`),
         copy(license, docsBuilt),
         copy(readmeSrc, readmeDest)
       ]));

--- a/tools/build-cli.js
+++ b/tools/build-cli.js
@@ -8,9 +8,16 @@ import { setExecOptions } from './exec';
 import yargs from 'yargs';
 
 const argv = yargs
+  .help('h')
   .option('docs-only', {
     demand: false,
     default: false
+  })
+  .option('use-cache', {
+    type: 'boolean',
+    demand: false,
+    default: true,
+    describe: 'Use Babel cache when running webpack'
   })
   .option('verbose', {
     demand: false,
@@ -26,7 +33,7 @@ const argv = yargs
 
 setExecOptions(argv);
 
-let buildProcess = argv.docsOnly ? docs(argv) : build();
+let buildProcess = argv.docsOnly ? docs(argv) : build(argv);
 
 buildProcess
   .catch(err => {

--- a/tools/build.js
+++ b/tools/build.js
@@ -6,21 +6,22 @@ import { copy } from './fs-utils';
 import { distRoot, bowerRoot } from './constants';
 import { exec } from './exec';
 
-function forkAndBuildDocs(verbose) {
+function forkAndBuildDocs({verbose, useCache}) {
   console.log('Building: '.cyan + 'docs'.green);
 
-  let options = verbose ? ' -- --verbose' : '';
+  const verboseOption = verbose ? '--verbose' : '';
+  const useCacheOption = `--use-cache=${Boolean(useCache)}`;
 
-  return exec(`npm run docs-build${options}`)
+  return exec(`npm run docs-build -- ${verboseOption} ${useCacheOption}`)
     .then(() => console.log('Built: '.cyan + 'docs'.green));
 }
 
-export default function Build(verbose) {
+export default function Build({verbose, useCache} = {}) {
   return Promise.all([
       lib(),
       bower(),
-      dist(),
-      forkAndBuildDocs(verbose)
+      dist({useCache}),
+      forkAndBuildDocs({verbose, useCache})
     ])
     .then(() => copy(distRoot, bowerRoot));
 }

--- a/tools/dist/build.js
+++ b/tools/dist/build.js
@@ -1,13 +1,15 @@
 import { exec } from '../exec';
 import { distRoot } from '../constants';
 
-export default function BuildDistributable() {
+export default function BuildDistributable({useCache}) {
   console.log('Building: '.cyan + 'distributable'.green);
+
+  const useCacheOption = `--use-cache=${Boolean(useCache)}`;
 
   return exec(`rimraf ${distRoot}`)
     .then(() => Promise.all([
-      exec('webpack --bail'),
-      exec('webpack --bail -p')
+      exec(`webpack ${useCacheOption} --bail`),
+      exec(`webpack ${useCacheOption} --bail -p`)
     ]))
     .then(() => console.log('Built: '.cyan + 'distributable'.green));
 }

--- a/tools/release-scripts/release.js
+++ b/tools/release-scripts/release.js
@@ -15,6 +15,7 @@ import { bowerRepo, bowerRoot, tmpBowerRepo, docsRoot, docsRepo, tmpDocsRepo } f
 
 const yargsConf = yargs
   .usage('Usage: $0 <version> [--preid <identifier>]')
+  .help('h')
   .example('$0 minor --preid beta', 'Release with minor version bump with pre-release tag')
   .example('$0 major', 'Release with major version bump')
   .example('$0 major --dry-run', 'Release dry run with patch version bump')
@@ -32,7 +33,7 @@ const yargsConf = yargs
     alias: 'n',
     demand: false,
     default: false,
-    describe: 'Execute command in dry run mode. Will not commit, tag, push, or publish anything. Userful for testing.'
+    describe: 'Execute command in dry run mode. Will not commit, tag, push, or publish anything. Useful for testing.'
   })
   .option('verbose', {
     demand: false,
@@ -66,7 +67,8 @@ preConditions()
   .then(v => { version = v; })
   .then(() => addChangelog(version))
   .then(() => {
-    return build(argv.verbose)
+    // useCache implicitly defaults to false here.
+    return build(argv)
       .catch(err => {
         console.log('Build failed, reverting version bump'.red);
 

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -3,28 +3,35 @@ import path from 'path';
 import webpack from 'webpack';
 import yargs from 'yargs';
 
-const babelCache = path.resolve(path.join(__dirname, '../.babel-cache'));
-
-if (!fs.existsSync(babelCache)) {
-  try {
-    fs.mkdirSync(babelCache);
-  } catch (err) {
-    if (err.code !== 'EEXIST') {
-      console.error(err.stack);
-    }
-  }
-}
-
 export const options = yargs
   .alias('p', 'optimize-minimize')
   .alias('d', 'debug')
+  .option('use-cache', {
+    type: 'boolean',
+    default: true
+  })
   .option('port', {
     default: '8080',
     type: 'string'
   })
   .argv;
 
-export const jsLoader = `babel?cacheDirectory=${babelCache}`;
+export let jsLoader = 'babel';
+if (options.useCache) {
+  const babelCache = path.resolve(path.join(__dirname, '../.babel-cache'));
+
+  if (!fs.existsSync(babelCache)) {
+    try {
+      fs.mkdirSync(babelCache);
+    } catch (err) {
+      if (err.code !== 'EEXIST') {
+        console.error(err.stack);
+      }
+    }
+  }
+
+  jsLoader += `?cacheDirectory=${babelCache}`;
+}
 
 const baseConfig = {
   entry: undefined,


### PR DESCRIPTION
~~Also use default Babel cache directory~~

Fixes #840

I don't know if this is the best/clearest way to do this. What this does is

1. Use cache by default in `build-cli.js`
2. Use cache by default when running `webpack`
3. Do not use cache by default in exported function from `tools/build.js`, and implicitly call that without setting `useCache` from `release.js`