### PR TITLE
Add documentation on support and issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,13 +10,27 @@ be interested in. Maybe somebody is trying to fix that stupid bug that bothers
 you. Review the PR. Do you have any better ideas how to fix this problem? Let us
 know...
 
-## Current Issues
+## Issues
 
-[![HuBoard][huboard-badge]][huboard]
+The issue tracker is the preferred channel for bug reports, features requests
+and submitting pull requests, but please respect the following restrictions:
 
-We use HuBoard to triage issues and prioritize the backlog for the core dev
-team. Feel free to tackle any currently open [issue][issues]. The issues tagged
-with "help wanted" and especially those high in the backlog are fair game.
+- Please do not use the issue tracker for personal support requests. Stack
+  Overflow ([react-bootstrap](http://stackoverflow.com/questions/tagged/react-bootstrap)
+  tag), [Slack](http://www.reactiflux.com/) or
+  [gitter](https://gitter.im/react-bootstrap/react-bootstrap) are better places
+  to get help.
+- Please do not open issues or pull requests regarding the code in React or
+  Bootstrap (open them in their respective repositories).
+
+_Note: Occasionally issues are opened that are unclear, or we cannot verify them. When
+the issue author has not responded to our questions for verification within 7
+days then we will close the issue._
+
+[![HuBoard][huboard-badge]][huboard] We use HuBoard to triage issues and
+prioritize the backlog for the core dev team. Feel free to tackle any currently
+open [issue][issues]. The issues tagged with "help wanted" and especially those
+high in the backlog are fair game.
 
 ## Tests
 

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -16,6 +16,11 @@ room of the urgent issues. We are using
 [HuBoard](https://huboard.com/react-bootstrap/react-bootstrap) which is a kanban
 style board to track and prioritize issues.
 
+Some issues are opened that are just too vague to do anything about. If after
+attempting to get feedback from issue authors fails after 7 days, then close the
+issue. Please inform the issue author that they may re-open if they are able to
+present the requested information.
+
 ## Merging a pull request
 
 Please, make sure:


### PR DESCRIPTION
We regularly encounter issues that we cannot verify, primarily due to issue authors not responding to our questions for clarity. This proposes a timeline we can all follow to know when it's a good time to close the
issue on our end.

Some of the documentation I acquired from [bootstrap's CONTRIBUTING.md](https://github.com/twbs/bootstrap/blob/master/CONTRIBUTING.md). I really like a lot of what they have in there and if I get more time in the future I may borrow more of what they have.