### PR TITLE
[changed] only autofocus modals when enforceFocus is true (the default)

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -269,9 +269,12 @@ const Modal = React.createClass({
   },
 
   focusModalContent () {
-    this.lastFocus = domUtils.activeElement(this);
-    let modalContent = React.findDOMNode(this.refs.modal);
-    modalContent.focus();
+    if (this.props.enforceFocus) {
+      this.lastFocus = domUtils.activeElement(this);
+
+      let modalContent = React.findDOMNode(this.refs.modal);
+      modalContent.focus();
+    }
   },
 
   restoreLastFocus () {

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -156,6 +156,36 @@ describe('Modal', function () {
       }, 0);
     });
 
+    it('Should not focus on the Modal when enforceFocus is false', function (done) {
+
+      document.activeElement.should.equal(focusableContainer);
+
+      let Container = React.createClass({
+        getInitialState() {
+          return {modalOpen: true};
+        },
+        render() {
+          if (this.state.modalOpen) {
+            return (
+              <Modal enforceFocus={false} onRequestHide={()=>{}} container={this}>
+                <strong>Message</strong>
+              </Modal>
+            );
+          } else {
+            return <span/>;
+          }
+        }
+      });
+
+      React.render(<Container />, focusableContainer);
+
+      setTimeout(function () {
+        // modal should be focused when opened
+        document.activeElement.should.equal(focusableContainer);
+        done();
+      }, 0);
+    });
   });
+
 
 });


### PR DESCRIPTION
fixes #842, only move focus to the Modal if `enforceFocus` is true