### PR TITLE
Update eslint. Dev dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "colors": "^1.0.3",
     "css-loader": "^0.14.1",
     "es5-shim": "^4.1.0",
-    "eslint": "0.22.1",
+    "eslint": "0.23.0",
     "eslint-plugin-mocha": "^0.2.2",
     "eslint-plugin-react": "^2.1.0",
     "express": "^4.12.3",


### PR DESCRIPTION
changes https://github.com/eslint/eslint/releases/tag/v0.23.0

New:
[prefer-const](http://eslint.org/docs/rules/prefer-const) suggest using of const declaration for variables that are never modified after declared (off by default)

[spaced-comment](http://eslint.org/docs/rules/spaced-comment) require or disallow a space immediately following the // or /* in a comment (off by default)

p.s. what about  `v0.24-rc` ? cherry-pick it or create additional PR ?