### PR TITLE
Transitions Components

### DIFF
--- a/docs/examples/.eslintrc
+++ b/docs/examples/.eslintrc
@@ -52,6 +52,8 @@
     "TabPane",
     "Tooltip",
     "Well",
-    "Thumbnail"
+    "Thumbnail",
+    "Collapse",
+    "Fade"
   }
 }

--- a/docs/examples/Collapse.js
+++ b/docs/examples/Collapse.js
@@ -1,0 +1,28 @@
+class Example extends React.Component {
+  constructor(...args){
+    super(...args);
+
+    this.state = {};
+  }
+
+  render(){
+
+    return (
+      <div>
+        <Button onClick={ ()=> this.setState({ open: !this.state.open })}>
+          click
+        </Button>
+        <Collapse in={this.state.open}>
+          <div>
+            <Well>
+              Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid.
+              Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident.
+            </Well>
+          </div>
+        </Collapse>
+      </div>
+    );
+  }
+}
+
+React.render(<Example/>, mountNode);

--- a/docs/examples/Fade.js
+++ b/docs/examples/Fade.js
@@ -1,0 +1,29 @@
+
+class Example extends React.Component {
+
+  constructor(...args){
+    super(...args);
+    this.state = {};
+  }
+
+  render(){
+
+    return (
+      <div>
+        <Button onClick={()=> this.setState({ open: !this.state.open })}>
+          click
+        </Button>
+        <Fade in={this.state.open}>
+          <div>
+            <Well>
+              Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid.
+              Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident.
+            </Well>
+          </div>
+        </Fade>
+      </div>
+    );
+  }
+}
+
+React.render(<Example/>, mountNode);

--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -56,6 +56,7 @@ const ComponentsPage = React.createClass({
             <div className='row'>
               <div className='col-md-9' role='main'>
 
+
                 {/* Buttons */}
                 <div className='bs-docs-section'>
                   <h1 id='buttons' className='page-header'>Buttons <small>Button</small></h1>
@@ -843,7 +844,7 @@ const ComponentsPage = React.createClass({
                     equivalent to jQuery's <code>.appendTo()</code>, which is helpful for components that need to be appended to a DOM node other than
                     the component's direct parent. The Modal, and Overlay components use the Portal component internally.
                   </p>
-                  <h3 id='utilities-props'>Props</h3>
+                  <h3 id='utilities-portal-props'>Props</h3>
 
                   <PropTable component='Portal'/>
 
@@ -852,9 +853,25 @@ const ComponentsPage = React.createClass({
                     A Component that absolutely positions its child to a <code>target</code> component or DOM node. Useful for creating custom
                     popups or tooltips. Used by the Overlay Components.
                   </p>
-                  <h3 id='utilities-props'>Props</h3>
+                  <h3 id='utilities-position-props'>Props</h3>
 
                   <PropTable component='Position'/>
+
+                  <h2 id='utilities-transitions'>Transitions</h2>
+
+                  <h3 id='utilities-collapse'>Collapse</h3>
+                  <p>Add a collapse toggle animation to an element or component.</p>
+                  <ReactPlayground codeText={Samples.Collapse} />
+
+                  <h4 id='utilities-collapse-props'>Props</h4>
+                  <PropTable component='Collapse'/>
+
+                  <h3 id='utilities-fade'>Fade</h3>
+                  <p>Add a fade animation to a child element or component.</p>
+                  <ReactPlayground codeText={Samples.Fade} />
+
+                  <h4 id='utilities-fade-props'>Props</h4>
+                  <PropTable component='Fade'/>
                 </div>
               </div>
 

--- a/docs/src/ReactPlayground.js
+++ b/docs/src/ReactPlayground.js
@@ -6,13 +6,19 @@ import * as modBadge from '../../src/Badge';
 import * as modButton from '../../src/Button';
 import * as modButtonGroup from '../../src/ButtonGroup';
 import * as modButtonInput from '../../src/ButtonInput';
+
 import * as modButtonToolbar from '../../src/ButtonToolbar';
+import * as modCollapse from '../../src/Collapse';
+
 import * as modCollapsibleNav from '../../src/CollapsibleNav';
 import * as modCollapsibleMixin from '../../src/CollapsibleMixin';
 import * as modCarousel from '../../src/Carousel';
 import * as modCarouselItem from '../../src/CarouselItem';
 import * as modCol from '../../src/Col';
 import * as modDropdownButton from '../../src/DropdownButton';
+
+import * as modFade from '../../src/Fade';
+
 import * as modFormControls from '../../src/FormControls';
 import * as modGlyphicon from '../../src/Glyphicon';
 import * as modGrid from '../../src/Grid';
@@ -57,8 +63,13 @@ import CodeExample from './CodeExample';
 
 
 const classNames = modClassNames.default;
+
 /* eslint-disable */
+
 const Portal = modPortal.default;
+const Collapse = modCollapse.default;
+const Fade = modFade.default;
+
 
 const React = modReact.default;
 const Accordion = modAccordion.default;

--- a/docs/src/Samples.js
+++ b/docs/src/Samples.js
@@ -1,6 +1,9 @@
 /* eslint no-path-concat: 0, no-var: 0 */
 
 export default {
+  Collapse:                      require('fs').readFileSync(__dirname + '/../examples/Collapse.js', 'utf8'),
+  Fade:                          require('fs').readFileSync(__dirname + '/../examples/Fade.js', 'utf8'),
+
   ButtonTypes:                   require('fs').readFileSync(__dirname + '/../examples/ButtonTypes.js', 'utf8'),
   ButtonSizes:                   require('fs').readFileSync(__dirname + '/../examples/ButtonSizes.js', 'utf8'),
   ButtonBlock:                   require('fs').readFileSync(__dirname + '/../examples/ButtonBlock.js', 'utf8'),

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -1,5 +1,3 @@
-/*eslint-disable react/prop-types */
-'use strict';
 import React from 'react';
 import Transition from './Transition';
 import domUtils from './utils/domUtils';
@@ -122,7 +120,7 @@ Collapse.propTypes = {
   in:       React.PropTypes.bool,
 
   /**
-   * Provide the durration of the animation in milliseconds, used to ensure that finishing callbacks are fired even if the
+   * Provide the duration of the animation in milliseconds, used to ensure that finishing callbacks are fired even if the
    * original browser transition end events are canceled.
    */
   duration:          React.PropTypes.number,
@@ -140,7 +138,7 @@ Collapse.propTypes = {
 
   /**
    * A function that returns the height or width of the animating DOM node. Allows for providing some custom logic how much
-   * Collapse component should animation in its specified dimension.
+   * Collapse component should animate in its specified dimension.
    *
    * `getDimensionValue` is called with the current dimension prop value and the DOM node.
    */

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -1,0 +1,200 @@
+/*eslint-disable react/prop-types */
+'use strict';
+import React from 'react';
+import Transition from './Transition';
+import domUtils from './utils/domUtils';
+import createChainedFunction from './utils/createChainedFunction';
+
+let capitalize = str => str[0].toUpperCase() + str.substr(1);
+
+// reading a dimension prop will cause the browser to recalculate,
+// which will let our animations work
+let triggerBrowserReflow = node => node.offsetHeight; //eslint-disable-line no-unused-expressions
+
+const MARGINS = {
+  height: ['marginTop', 'marginBottom'],
+  width:  ['marginLeft', 'marginRight']
+};
+
+function getDimensionValue(dimension, elem){
+  let value = elem[`offset${capitalize(dimension)}`];
+  let computedStyles = domUtils.getComputedStyles(elem);
+  let margins = MARGINS[dimension];
+
+  return (value +
+    parseInt(computedStyles[margins[0]], 10) +
+    parseInt(computedStyles[margins[1]], 10)
+  );
+}
+
+class Collapse extends React.Component {
+
+  constructor(props, context){
+    super(props, context);
+
+    this.onEnterListener = this.handleEnter.bind(this);
+    this.onEnteringListener = this.handleEntering.bind(this);
+    this.onEnteredListener = this.handleEntered.bind(this);
+    this.onExitListener = this.handleExit.bind(this);
+    this.onExitingListener = this.handleExiting.bind(this);
+  }
+
+  render() {
+    let enter = createChainedFunction(this.onEnterListener, this.props.onEnter);
+    let entering = createChainedFunction(this.onEnteringListener, this.props.onEntering);
+    let entered = createChainedFunction(this.onEnteredListener, this.props.onEntered);
+    let exit = createChainedFunction(this.onExitListener, this.props.onExit);
+    let exiting = createChainedFunction(this.onExitingListener, this.props.onExiting);
+
+    return (
+      <Transition
+        ref='transition'
+        {...this.props}
+        aria-expanded={this.props.in}
+        className={this._dimension() === 'width' ? 'width' : ''}
+        exitedClassName='collapse'
+        exitingClassName='collapsing'
+        enteredClassName='collapse in'
+        enteringClassName='collapsing'
+        onEnter={enter}
+        onEntering={entering}
+        onEntered={entered}
+        onExit={exit}
+        onExiting={exiting}
+        onExited={this.props.onExited}
+      >
+        { this.props.children }
+      </Transition>
+    );
+  }
+
+  /* -- Expanding -- */
+  handleEnter(elem){
+    let dimension = this._dimension();
+    elem.style[dimension] = '0';
+  }
+
+  handleEntering(elem){
+    let dimension = this._dimension();
+
+    elem.style[dimension] = this._getScrollDimensionValue(elem, dimension);
+  }
+
+  handleEntered(elem){
+    let dimension = this._dimension();
+    elem.style[dimension] = null;
+  }
+
+  /* -- Collapsing -- */
+  handleExit(elem){
+    let dimension = this._dimension();
+
+    elem.style[dimension] = this.props.getDimensionValue(dimension, elem) + 'px';
+  }
+
+  handleExiting(elem){
+    let dimension = this._dimension();
+
+    triggerBrowserReflow(elem);
+    elem.style[dimension] = '0';
+  }
+
+  _dimension(){
+    return typeof this.props.dimension === 'function'
+      ? this.props.dimension()
+      : this.props.dimension;
+  }
+
+  //for testing
+  _getTransitionInstance(){
+    return this.refs.transition;
+  }
+
+  _getScrollDimensionValue(elem, dimension){
+    return elem[`scroll${capitalize(dimension)}`] + 'px';
+  }
+}
+
+Collapse.propTypes = {
+  /**
+   * Collapse the Component in or out.
+   */
+  in:       React.PropTypes.bool,
+
+  /**
+   * Provide the durration of the animation in milliseconds, used to ensure that finishing callbacks are fired even if the
+   * original browser transition end events are canceled.
+   */
+  duration:          React.PropTypes.number,
+
+  /**
+   * Specifies the dimension used when collapsing.
+   *
+   * _Note: Bootstrap only partially supports this!
+   * You will need to supply your own css animation for the `.width` css class._
+   */
+  dimension: React.PropTypes.oneOfType([
+    React.PropTypes.oneOf(['height', 'width']),
+    React.PropTypes.func
+  ]),
+
+  /**
+   * A function that returns the height or width of the animating DOM node. Allows for providing some custom logic how much
+   * Collapse component should animation in its specified dimension.
+   *
+   * `getDimensionValue` is called with the current dimension prop value and the DOM node.
+   */
+  getDimensionValue: React.PropTypes.func,
+
+  /**
+   * A Callback fired before the component starts to expand.
+   */
+  onEnter: React.PropTypes.func,
+
+  /**
+   * A Callback fired immediately after the component starts to expand.
+   */
+  onEntering: React.PropTypes.func,
+
+  /**
+   * A Callback fired after the component has expanded.
+   */
+  onEntered: React.PropTypes.func,
+
+  /**
+   * A Callback fired before the component starts to collapse.
+   */
+  onExit: React.PropTypes.func,
+
+  /**
+   * A Callback fired immediately after the component starts to collapse.
+   */
+  onExiting: React.PropTypes.func,
+
+  /**
+   * A Callback fired after the component has collapsed.
+   */
+  onExited: React.PropTypes.func,
+
+  /**
+   * Specify whether the transitioning component should be unmounted (removed from the DOM) once the exit animation finishes.
+   */
+  unmountOnExit:     React.PropTypes.bool,
+
+  /**
+   * Specify whether the component should collapse or expand when it mounts.
+   */
+  transitionAppear: React.PropTypes.bool
+};
+
+Collapse.defaultProps = {
+  in:       false,
+  duration: 300,
+  dimension: 'height',
+  transitionAppear: false,
+  unmountOnExit: false,
+  getDimensionValue
+};
+
+export default Collapse;
+

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -130,7 +130,7 @@ Collapse.propTypes = {
   /**
    * Specifies the dimension used when collapsing.
    *
-   * _Note: Bootstrap only partially supports this!
+   * _Note: Bootstrap only partially supports 'width'!
    * You will need to supply your own css animation for the `.width` css class._
    */
   dimension: React.PropTypes.oneOfType([

--- a/src/CollapsibleMixin.js
+++ b/src/CollapsibleMixin.js
@@ -1,5 +1,8 @@
 import React from 'react';
 import TransitionEvents from './utils/TransitionEvents';
+import deprecationWarning from './utils/deprecationWarning';
+
+let warned = false;
 
 const CollapsibleMixin = {
 
@@ -19,6 +22,13 @@ const CollapsibleMixin = {
       expanded: defaultExpanded,
       collapsing: false
     };
+  },
+
+  componentWillMount(){
+    if ( !warned ){
+      deprecationWarning('CollapsibleMixin', 'Collapse Component');
+      warned = true;
+    }
   },
 
   componentWillUpdate(nextProps, nextState){

--- a/src/CollapsibleNav.js
+++ b/src/CollapsibleNav.js
@@ -1,14 +1,13 @@
 import React, { cloneElement } from 'react';
 import BootstrapMixin from './BootstrapMixin';
-import CollapsibleMixin from './CollapsibleMixin';
+import Collapse from './Collapse';
 import classNames from 'classnames';
-import domUtils from './utils/domUtils';
 
 import ValidComponentChildren from './utils/ValidComponentChildren';
 import createChainedFunction from './utils/createChainedFunction';
 
 const CollapsibleNav = React.createClass({
-  mixins: [BootstrapMixin, CollapsibleMixin],
+  mixins: [BootstrapMixin],
 
   propTypes: {
     onSelect: React.PropTypes.func,
@@ -19,41 +18,48 @@ const CollapsibleNav = React.createClass({
     eventKey: React.PropTypes.any
   },
 
-  getCollapsibleDOMNode() {
-    return React.findDOMNode(this);
-  },
 
-  getCollapsibleDimensionValue() {
-    let height = 0;
-    let nodes = this.refs;
-    for (let key in nodes) {
-      if (nodes.hasOwnProperty(key)) {
+  // getCollapsibleDimensionValue() {
+  //   let height = 0;
+  //   let nodes = this.refs;
+  //   for (let key in nodes) {
+  //     if (nodes.hasOwnProperty(key)) {
 
-        let n = React.findDOMNode(nodes[key]);
-        let h = n.offsetHeight;
-        let computedStyles = domUtils.getComputedStyles(n);
+  //       let n = React.findDOMNode(nodes[key]);
+  //       let h = n.offsetHeight;
+  //       let computedStyles = domUtils.getComputedStyles(n);
 
-        height += (h +
-          parseInt(computedStyles.marginTop, 10) +
-          parseInt(computedStyles.marginBottom, 10)
-        );
-      }
-    }
-    return height;
-  },
+  //       height += (h +
+  //         parseInt(computedStyles.marginTop, 10) +
+  //         parseInt(computedStyles.marginBottom, 10)
+  //       );
+  //     }
+  //   }
+  //   return height;
+  // },
 
   render() {
     /*
      * this.props.collapsible is set in NavBar when an eventKey is supplied.
      */
-    const classes = this.props.collapsible ? this.getCollapsibleClassSet('navbar-collapse') : null;
+    const classes = this.props.collapsible ? 'navbar-collapse' : null;
     const renderChildren = this.props.collapsible ? this.renderCollapsibleNavChildren : this.renderChildren;
 
-    return (
+    let nav = (
       <div eventKey={this.props.eventKey} className={classNames(this.props.className, classes)} >
         {ValidComponentChildren.map(this.props.children, renderChildren)}
       </div>
     );
+
+    if ( this.props.collapsible ){
+      return (
+        <Collapse in={this.props.expanded}>
+          { nav }
+        </Collapse>
+      );
+    } else {
+      return nav;
+    }
   },
 
   getChildActiveProp(child) {

--- a/src/CollapsibleNav.js
+++ b/src/CollapsibleNav.js
@@ -19,25 +19,6 @@ const CollapsibleNav = React.createClass({
   },
 
 
-  // getCollapsibleDimensionValue() {
-  //   let height = 0;
-  //   let nodes = this.refs;
-  //   for (let key in nodes) {
-  //     if (nodes.hasOwnProperty(key)) {
-
-  //       let n = React.findDOMNode(nodes[key]);
-  //       let h = n.offsetHeight;
-  //       let computedStyles = domUtils.getComputedStyles(n);
-
-  //       height += (h +
-  //         parseInt(computedStyles.marginTop, 10) +
-  //         parseInt(computedStyles.marginBottom, 10)
-  //       );
-  //     }
-  //   }
-  //   return height;
-  // },
-
   render() {
     /*
      * this.props.collapsible is set in NavBar when an eventKey is supplied.

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -1,0 +1,90 @@
+'use strict';
+import React from 'react';
+import Transition from './Transition';
+
+class Fade extends React.Component {
+
+  constructor(props, context){
+    super(props, context);
+  }
+
+  render() {
+    return (
+      <Transition
+        {...this.props}
+        in={this.props.in}
+        className='fade'
+        enteredClassName='in'
+        enteringClassName='in'
+      >
+        { this.props.children }
+      </Transition>
+    );
+  }
+}
+
+Fade.propTypes = {
+  /**
+   * Fade the Component in or out.
+   */
+  in:       React.PropTypes.bool,
+
+  /**
+   * Provide the durration of the animation in milliseconds, used to ensure that finishing callbacks are fired even if the
+   * original browser transition end events are canceled.
+   */
+  duration:          React.PropTypes.number,
+
+  /**
+   * A Callback fired before the component starts to fade in.
+   */
+  onEnter: React.PropTypes.func,
+
+  /**
+   * A Callback fired immediately after the component has started to faded in.
+   */
+  onEntering: React.PropTypes.func,
+
+  /**
+   * A Callback fired after the component has faded in.
+   */
+  onEntered: React.PropTypes.func,
+
+  /**
+   * A Callback fired before the component starts to fade out.
+   */
+  onExit: React.PropTypes.func,
+
+  /**
+   * A Callback fired immediately after the component has started to faded out.
+   */
+  onExiting: React.PropTypes.func,
+
+  /**
+   * A Callback fired after the component has faded out.
+   */
+  onExited: React.PropTypes.func,
+
+
+  /**
+   * Specify whether the transitioning component should be unmounted (removed from the DOM) once the exit animation finishes.
+   */
+  unmountOnExit:     React.PropTypes.bool,
+
+  /**
+   * Specify whether the component should fade in or out when it mounts.
+   */
+  transitionAppear: React.PropTypes.bool
+
+};
+
+Fade.defaultProps = {
+  in:       false,
+  duration: 300,
+  dimension: 'height',
+  transitionAppear: false,
+  unmountOnExit: false
+};
+
+export default Fade;
+

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -1,4 +1,3 @@
-'use strict';
 import React from 'react';
 import Transition from './Transition';
 
@@ -30,7 +29,7 @@ Fade.propTypes = {
   in:       React.PropTypes.bool,
 
   /**
-   * Provide the durration of the animation in milliseconds, used to ensure that finishing callbacks are fired even if the
+   * Provide the duration of the animation in milliseconds, used to ensure that finishing callbacks are fired even if the
    * original browser transition end events are canceled.
    */
   duration:          React.PropTypes.number,

--- a/src/FadeMixin.js
+++ b/src/FadeMixin.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import domUtils from './utils/domUtils';
+import deprecationWarning from './utils/deprecationWarning';
 
 // TODO: listen for onTransitionEnd to remove el
 function getElementsAndSelf (root, classes){
@@ -16,7 +17,16 @@ function getElementsAndSelf (root, classes){
   return els;
 }
 
+let warned = false;
+
 export default {
+  componentWillMount(){
+    if ( !warned ){
+      deprecationWarning('FadeMixin', 'Fade Component');
+      warned = true;
+    }
+  },
+
   _fadeIn() {
     let els;
 

--- a/src/Input.js
+++ b/src/Input.js
@@ -5,7 +5,7 @@ import deprecationWarning from './utils/deprecationWarning';
 
 class Input extends InputBase {
   render() {
-    if (this.props.type === 'static') { //eslint-disable-line react/prop-types
+    if (this.props.type === 'static') { // eslint-disable-line react/prop-types
       deprecationWarning('Input type=static', 'StaticText');
       return <FormControls.Static {...this.props} />;
     }

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -4,11 +4,11 @@ import React, { cloneElement } from 'react';
 import classNames from 'classnames';
 import createChainedFunction from './utils/createChainedFunction';
 import BootstrapMixin from './BootstrapMixin';
-import FadeMixin from './FadeMixin';
 import domUtils from './utils/domUtils';
 import EventListener from './utils/EventListener';
 
 import Portal from './Portal';
+import Fade from './Fade';
 
 import Body from './ModalBody';
 import Header from './ModalHeader';
@@ -90,12 +90,17 @@ function getScrollbarSize(){
   document.body.removeChild(scrollDiv);
 
   scrollDiv = null;
+  return scrollbarSize;
 }
 
 
 const ModalMarkup = React.createClass({
 
+<<<<<<< HEAD
   mixins: [ BootstrapMixin, FadeMixin ],
+=======
+  mixins: [ BootstrapMixin ],
+>>>>>>> [added] Fade Component, replaces FadeMixin
 
   propTypes: {
 
@@ -166,8 +171,7 @@ const ModalMarkup = React.createClass({
 
     let classes = {
       modal: true,
-      fade: this.props.animation,
-      'in': !this.props.animation
+      in: this.props.show && !this.props.animation
     };
 
     let modal = (
@@ -206,18 +210,22 @@ const ModalMarkup = React.createClass({
   },
 
   renderBackdrop(modal) {
-    let classes = {
-      'modal-backdrop': true,
-      fade: this.props.animation,
-      'in': !this.props.animation
-    };
+    let { animation } = this.props;
+    let duration = Modal.BACKDROP_TRANSITION_DURATION; //eslint-disable-line no-use-before-define
 
-    let onClick = this.props.backdrop === true ?
-      this.handleBackdropClick : null;
+    let backdrop = (
+      <div ref="backdrop"
+       className={classNames('modal-backdrop', { in: this.props.show && !animation })}
+       onClick={this.handleBackdropClick}
+      />
+    );
 
     return (
       <div>
-        <div className={classNames(classes)} ref="backdrop" onClick={onClick} />
+        { animation
+            ? <Fade transitionAppear in={this.props.show} duration={duration}>{backdrop}</Fade>
+            : backdrop
+        }
         {modal}
       </div>
     );
@@ -381,16 +389,40 @@ const Modal = React.createClass({
     ...ModalMarkup.propTypes
   },
 
+  getDefaultProps(){
+    return {
+      show: false,
+      animation: true
+    };
+  },
+
   render() {
-    let { show, ...props } = this.props;
+    let { children, ...props } = this.props;
+
+    let show = !!props.show;
 
     let modal = (
-      <ModalMarkup {...props} ref='modal'>{this.props.children}</ModalMarkup>
+      <ModalMarkup {...props} ref='modal'>
+        { children }
+      </ModalMarkup>
     );
 
     return (
-      <Portal container={props.container} >
-        { show && modal }
+      <Portal container={props.container}>
+        { props.animation
+            ? (
+              <Fade
+                in={show}
+                transitionAppear={show}
+                duration={Modal.TRANSITION_DURATION}
+                unmountOnExit
+              >
+                { modal }
+              </Fade>
+            )
+            : show && modal
+        }
+
       </Portal>
     );
   }
@@ -400,5 +432,8 @@ Modal.Body = Body;
 Modal.Header = Header;
 Modal.Title = Title;
 Modal.Footer = Footer;
+
+Modal.TRANSITION_DURATION = 300;
+Modal.BACKDROP_TRANSITION_DURATION = 150;
 
 export default Modal;

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -96,11 +96,7 @@ function getScrollbarSize(){
 
 const ModalMarkup = React.createClass({
 
-<<<<<<< HEAD
-  mixins: [ BootstrapMixin, FadeMixin ],
-=======
   mixins: [ BootstrapMixin ],
->>>>>>> [added] Fade Component, replaces FadeMixin
 
   propTypes: {
 

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -1,14 +1,13 @@
 import React, { cloneElement } from 'react';
 import BootstrapMixin from './BootstrapMixin';
-import CollapsibleMixin from './CollapsibleMixin';
+import Collapse from './Collapse';
 import classNames from 'classnames';
-import domUtils from './utils/domUtils';
 
 import ValidComponentChildren from './utils/ValidComponentChildren';
 import createChainedFunction from './utils/createChainedFunction';
 
 const Nav = React.createClass({
-  mixins: [BootstrapMixin, CollapsibleMixin],
+  mixins: [BootstrapMixin],
 
   propTypes: {
     activeHref: React.PropTypes.string,
@@ -27,33 +26,24 @@ const Nav = React.createClass({
 
   getDefaultProps() {
     return {
-      bsClass: 'nav'
+      bsClass: 'nav',
+      expanded: true
     };
   },
 
-  getCollapsibleDOMNode() {
-    return React.findDOMNode(this);
-  },
-
-  getCollapsibleDimensionValue() {
-    let node = React.findDOMNode(this.refs.ul);
-    let height = node.offsetHeight;
-    let computedStyles = domUtils.getComputedStyles(node);
-
-    return height + parseInt(computedStyles.marginTop, 10) + parseInt(computedStyles.marginBottom, 10);
-  },
-
   render() {
-    const classes = this.props.collapsible ? this.getCollapsibleClassSet('navbar-collapse') : null;
+    const classes = this.props.collapsible ? 'navbar-collapse' : null;
 
     if (this.props.navbar && !this.props.collapsible) {
       return (this.renderUl());
     }
 
     return (
-      <nav {...this.props} className={classNames(this.props.className, classes)}>
-        { this.renderUl() }
-      </nav>
+      <Collapse in={this.props.expanded}>
+        <nav {...this.props} className={classNames(this.props.className, classes)}>
+          {this.renderUl()}
+        </nav>
+      </Collapse>
     );
   },
 

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -1,13 +1,26 @@
 /*eslint-disable object-shorthand, react/prop-types */
-import React from 'react';
+import React, { cloneElement } from 'react';
 import Portal from './Portal';
 import Position from './Position';
 import RootCloseWrapper from './RootCloseWrapper';
+import CustomPropTypes from './utils/CustomPropTypes';
+import Fade from './Fade';
+import classNames from 'classnames';
+
 
 class Overlay extends React.Component {
 
   constructor(props, context){
     super(props, context);
+
+    this.state = { exited: false };
+    this.onHiddenListener = this.handleHidden.bind(this);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.show){
+      this.setState({ exited: false });
+    }
   }
 
   render(){
@@ -17,29 +30,59 @@ class Overlay extends React.Component {
       , target
       , placement
       , rootClose
+      , children
+      , animation: Transition
       , ...props } = this.props;
 
-    let positionedChild = (
-      <Position {...{ container, containerPadding, target, placement }}>
-        { this.props.children }
-      </Position>
-    );
+    let child = null;
 
-    if (rootClose) {
-      positionedChild = (
-        <RootCloseWrapper onRootClose={this.props.onHide}>
-          { positionedChild }
-        </RootCloseWrapper>
+    if ( Transition === true ){
+      Transition = Fade;
+    }
+
+    if (props.show || (Transition && !this.state.exited)) {
+
+      child = children;
+
+      // Position the child before the animation to avoid `null` DOM nodes
+      child = (
+        <Position {...{ container, containerPadding, target, placement }}>
+          { child }
+        </Position>
       );
+
+      child = Transition
+          ? (
+            <Transition
+              unmountOnExit
+              in={props.show}
+              transitionAppear={props.show}
+              onHidden={this.onHiddenListener}
+            >
+              { child }
+            </Transition>
+          )
+          : cloneElement(child, { className: classNames('in', child.className) });
+
+
+      if (rootClose) {
+        child = (
+          <RootCloseWrapper onRootClose={props.onHide}>
+            { child }
+          </RootCloseWrapper>
+        );
+      }
     }
 
     return (
-      <Portal container={container} rootClose={rootClose} onRootClose={this.props.onHide}>
-      { props.show &&
-          positionedChild
-      }
+      <Portal container={container}>
+        { child }
       </Portal>
     );
+  }
+
+  handleHidden(){
+    this.setState({ exited: true });
   }
 }
 
@@ -57,7 +100,19 @@ Overlay.propTypes = {
   /**
    * A Callback fired by the Overlay when it wishes to be hidden.
    */
-  onHide: React.PropTypes.func
+  onHide: React.PropTypes.func,
+
+  /**
+   * Use animation
+   */
+  animation: React.PropTypes.oneOfType([
+      React.PropTypes.bool,
+      CustomPropTypes.elementType
+  ])
+};
+
+Overlay.defaultProps = {
+  animation: Fade
 };
 
 export default Overlay;

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -2,10 +2,10 @@ import React, { cloneElement } from 'react';
 import classNames from 'classnames';
 
 import BootstrapMixin from './BootstrapMixin';
-import CollapsibleMixin from './CollapsibleMixin';
+import Collapse from './Collapse';
 
 const Panel = React.createClass({
-  mixins: [BootstrapMixin, CollapsibleMixin],
+  mixins: [BootstrapMixin],
 
   propTypes: {
     collapsible: React.PropTypes.bool,
@@ -13,6 +13,8 @@ const Panel = React.createClass({
     header: React.PropTypes.node,
     id: React.PropTypes.string,
     footer: React.PropTypes.node,
+    defaultExpanded: React.PropTypes.bool,
+    expanded: React.PropTypes.bool,
     eventKey: React.PropTypes.any
   },
 
@@ -20,6 +22,18 @@ const Panel = React.createClass({
     return {
       bsClass: 'panel',
       bsStyle: 'default'
+    };
+  },
+
+  getInitialState(){
+    let defaultExpanded = this.props.defaultExpanded != null ?
+      this.props.defaultExpanded :
+        this.props.expanded != null ?
+        this.props.expanded :
+        false;
+
+    return {
+      expanded: defaultExpanded
     };
   },
 
@@ -38,19 +52,11 @@ const Panel = React.createClass({
   },
 
   handleToggle(){
-    this.setState({expanded:!this.state.expanded});
+    this.setState({ expanded: !this.state.expanded});
   },
 
-  getCollapsibleDimensionValue() {
-    return React.findDOMNode(this.refs.panel).scrollHeight;
-  },
-
-  getCollapsibleDOMNode() {
-    if (!this.isMounted() || !this.refs || !this.refs.panel) {
-      return null;
-    }
-
-    return React.findDOMNode(this.refs.panel);
+  isExpanded(){
+    return this.props.expanded != null ? this.props.expanded : this.state.expanded;
   },
 
   render() {
@@ -69,13 +75,16 @@ const Panel = React.createClass({
     let collapseClass = this.prefixClass('collapse');
 
     return (
-      <div
-        className={classNames(this.getCollapsibleClassSet(collapseClass))}
-        id={this.props.id}
-        ref='panel'
-        aria-expanded={this.isExpanded() ? 'true' : 'false'}>
-        {this.renderBody()}
-      </div>
+      <Collapse in={this.isExpanded()}>
+        <div
+          className={collapseClass}
+          id={this.props.id}
+          ref='panel'
+          aria-expanded={this.isExpanded() ? 'true' : 'false'}>
+          {this.renderBody()}
+
+        </div>
+      </Collapse>
     );
   },
 

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -2,12 +2,11 @@
 import React from 'react';
 import classNames from 'classnames';
 import BootstrapMixin from './BootstrapMixin';
-import FadeMixin from './FadeMixin';
 import CustomPropTypes from './utils/CustomPropTypes';
 
 const Popover = React.createClass({
 
-  mixins: [BootstrapMixin, FadeMixin],
+  mixins: [ BootstrapMixin ],
 
   propTypes: {
     /**
@@ -42,15 +41,11 @@ const Popover = React.createClass({
     arrowOffsetTop: React.PropTypes.oneOfType([
       React.PropTypes.number, React.PropTypes.string
     ]),
+
     /**
      * Title text
      */
-    title: React.PropTypes.node,
-    /**
-     * Specify whether the Popover should be use show and hide animations.
-     */
-    animation: React.PropTypes.bool
-
+    title: React.PropTypes.node
 
   },
 
@@ -64,10 +59,7 @@ const Popover = React.createClass({
   render() {
     const classes = {
       'popover': true,
-      [this.props.placement]: true,
-      // in class will be added by the FadeMixin when the animation property is true
-      'in': !this.props.animation && (this.props.positionLeft != null || this.props.positionTop != null),
-      'fade': this.props.animation
+      [this.props.placement]: true
     };
 
     const style = {

--- a/src/Position.js
+++ b/src/Position.js
@@ -31,13 +31,13 @@ class Position extends React.Component {
   }
 
   render() {
-    let { placement, children } = this.props;
+    let { children, ...props } = this.props;
     let { positionLeft, positionTop, ...arrows } = this.props.target ? this.state : {};
 
     return cloneElement(
       React.Children.only(children), {
+        ...props,
         ...arrows,
-        placement,
         positionTop,
         positionLeft,
         style: {
@@ -61,13 +61,18 @@ class Position extends React.Component {
       return;
     }
 
+    let overlay = React.findDOMNode(this);
     let target = React.findDOMNode(this.props.target(this.props));
     let container = React.findDOMNode(this.props.container) || domUtils.ownerDocument(this).body;
+
+    // if ( !overlay || !target || !container ){
+    //   return;
+    // }
 
     this.setState(
       calcOverlayPosition(
           this.props.placement
-        , React.findDOMNode(this)
+        , overlay
         , target
         , container
         , this.props.containerPadding));

--- a/src/Position.js
+++ b/src/Position.js
@@ -65,10 +65,6 @@ class Position extends React.Component {
     let target = React.findDOMNode(this.props.target(this.props));
     let container = React.findDOMNode(this.props.container) || domUtils.ownerDocument(this).body;
 
-    // if ( !overlay || !target || !container ){
-    //   return;
-    // }
-
     this.setState(
       calcOverlayPosition(
           this.props.placement

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -2,11 +2,10 @@
 import React from 'react';
 import classNames from 'classnames';
 import BootstrapMixin from './BootstrapMixin';
-import FadeMixin from './FadeMixin';
 import CustomPropTypes from './utils/CustomPropTypes';
 
 const Tooltip = React.createClass({
-  mixins: [BootstrapMixin, FadeMixin],
+  mixins: [BootstrapMixin],
 
   propTypes: {
     /**
@@ -44,11 +43,7 @@ const Tooltip = React.createClass({
     /**
      * Title text
      */
-    title: React.PropTypes.node,
-    /**
-     * Specify whether the Tooltip should be use show and hide animations.
-     */
-    animation: React.PropTypes.bool
+    title: React.PropTypes.node
   },
 
   getDefaultProps() {
@@ -61,10 +56,7 @@ const Tooltip = React.createClass({
   render() {
     const classes = {
       'tooltip': true,
-      [this.props.placement]: true,
-      // in class will be added by the FadeMixin when the animation property is true
-      'in': !this.props.animation && (this.props.positionLeft != null || this.props.positionTop != null),
-      'fade': this.props.animation
+      [this.props.placement]: true
     };
 
     const style = {

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -1,4 +1,3 @@
-'use strict';
 import React from 'react';
 import TransitionEvents from './utils/TransitionEvents';
 import classnames from 'classnames';
@@ -163,8 +162,8 @@ class Transition extends React.Component {
 
     let classes = '';
 
-    // for whatever reason classnames() doesn't actually work here,
-    // maybe because they aren't always single classes?
+    // using `classnames()` here causes a subtle bug,
+    // hence the verbose if/else if sequence.
     if (this.state.in && !this.state.transitioning) {
       classes = this.props.enteredClassName;
     }
@@ -184,9 +183,9 @@ class Transition extends React.Component {
     return React.cloneElement(child, {
       ...childProps,
       className: classnames(
-          child.props.className
-        , this.props.className
-        , classes)
+        child.props.className,
+        this.props.className,
+        classes)
     });
   }
 }
@@ -208,7 +207,7 @@ Transition.propTypes = {
   transitionAppear: React.PropTypes.bool,
 
   /**
-   * Provide the durration of the animation in milliseconds, used to ensure that finishing callbacks are fired even if the
+   * Provide the duration of the animation in milliseconds, used to ensure that finishing callbacks are fired even if the
    * original browser transition end events are canceled.
    */
   duration:          React.PropTypes.number,

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -1,0 +1,286 @@
+'use strict';
+import React from 'react';
+import TransitionEvents from './utils/TransitionEvents';
+import classnames from 'classnames';
+
+function omit(obj, keys) {
+  let included = Object.keys(obj).filter( k => keys.indexOf(k) === -1);
+  let newObj = {};
+
+  included.forEach( key => newObj[key] = obj[key] );
+  return newObj;
+}
+
+function ensureTransitionEnd(node, handler, duration){
+  let fired = false;
+  let done = e => {
+        if (!fired) {
+          fired = true;
+          handler(e);
+        }
+      };
+
+  if ( node ) {
+    TransitionEvents.addEndEventListener(node, done);
+    setTimeout(done, duration);
+  } else {
+    setTimeout(done, 0);
+  }
+}
+
+// reading a dimension prop will cause the browser to recalculate,
+// which will let our animations work
+let triggerBrowserReflow = node => node.offsetHeight; //eslint-disable-line no-unused-expressions
+
+class Transition extends React.Component {
+
+  constructor(props, context){
+    super(props, context);
+
+    this.state = {
+      in: !props.in,
+      transitioning: false
+    };
+
+    this.needsTransition = true;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.in !== this.props.in) {
+      this.needsTransition = true;
+    }
+  }
+
+  componentDidUpdate() {
+    this.processChild();
+  }
+
+  componentWillMount() {
+    this._mounted = true;
+
+    if (!this.props.transitionAppear) {
+      this.needsTransition = false;
+      this.setState({ in: this.props.in });
+    }
+  }
+
+  componentWillUnmount(){
+    this._mounted = false;
+  }
+
+  componentDidMount() {
+    if (this.props.transitionAppear) {
+      this.processChild();
+    }
+  }
+
+  processChild(){
+    let needsTransition = this.needsTransition;
+    let enter = this.props.in;
+
+    if (needsTransition) {
+      this.needsTransition = false;
+      this[enter ? 'performEnter' : 'performLeave']();
+    }
+  }
+
+  performEnter() {
+    let maybeNode = React.findDOMNode(this);
+
+    let enter = node => {
+      node = this.props.transitioningNode(node) || node;
+
+      this.props.onEnter(node);
+
+      this.safeSetState({ in: true, transitioning: true, needInitialRender: false }, ()=> {
+
+        this.props.onEntering(node);
+
+        ensureTransitionEnd(node, () => {
+          if ( this.state.in ){
+            this.safeSetState({
+              transitioning: false
+            }, () => this.props.onEntered(node));
+          }
+
+        }, this.props.duration);
+      });
+    };
+
+    if (maybeNode) {
+      enter(maybeNode);
+    }
+    else if (this.props.unmountOnExit) {
+      this._ensureNode(enter);
+    }
+  }
+
+  performLeave() {
+    let node = React.findDOMNode(this);
+
+    node = this.props.transitioningNode(node) || node;
+
+    this.props.onExit(node);
+
+    this.setState({ in: false, transitioning: true }, () => {
+      this.props.onExiting(node);
+
+      ensureTransitionEnd(node, () => {
+        if ( !this.state.in ){
+          this.safeSetState({ transitioning: false }, ()=> this.props.onExited(node));
+        }
+      }, this.props.duration);
+    });
+  }
+
+  _ensureNode(callback) {
+
+    this.setState({ needInitialRender: true }, ()=> {
+      let node = React.findDOMNode(this);
+
+      triggerBrowserReflow(node);
+
+      callback(node);
+    });
+  }
+
+  safeSetState(newState, cb){
+    if (this._mounted) {
+      this.setState(newState, cb);
+    }
+  }
+
+  render() {
+    let childProps = omit(this.props, Object.keys(Transition.propTypes).concat('children'));
+
+    let child = this.props.children;
+    let starting = this.state.needInitialRender;
+    let out = !this.state.in && !this.state.transitioning;
+
+    if ( !child || (this.props.unmountOnExit && out && !starting) ){
+      return null;
+    }
+
+    let classes = '';
+
+    // for whatever reason classnames() doesn't actually work here,
+    // maybe because they aren't always single classes?
+    if (this.state.in && !this.state.transitioning) {
+      classes = this.props.enteredClassName;
+    }
+
+    else if (this.state.in && this.state.transitioning) {
+      classes = this.props.enteringClassName;
+    }
+
+    else if (!this.state.in && !this.state.transitioning) {
+      classes = this.props.exitedClassName;
+    }
+
+    else if (!this.state.in && this.state.transitioning) {
+      classes = this.props.exitingClassName;
+    }
+
+    return React.cloneElement(child, {
+      ...childProps,
+      className: classnames(
+          child.props.className
+        , this.props.className
+        , classes)
+    });
+  }
+}
+
+Transition.propTypes = {
+  /**
+   * Triggers the Enter or Exit animation
+   */
+  in:                React.PropTypes.bool,
+
+  /**
+   * Specify whether the transitioning component should be unmounted (removed from the DOM) once the exit animation finishes.
+   */
+  unmountOnExit:     React.PropTypes.bool,
+
+  /**
+   * Specify whether transitions should run when the Transition component mounts.
+   */
+  transitionAppear: React.PropTypes.bool,
+
+  /**
+   * Provide the durration of the animation in milliseconds, used to ensure that finishing callbacks are fired even if the
+   * original browser transition end events are canceled.
+   */
+  duration:          React.PropTypes.number,
+
+  /**
+   * A css class or classes applied once the Component has exited.
+   */
+  exitedClassName:     React.PropTypes.string,
+  /**
+   * A css class or classes applied while the Component is exiting.
+   */
+  exitingClassName:  React.PropTypes.string,
+  /**
+   * A css class or classes applied once the Component has entered.
+   */
+  enteredClassName:    React.PropTypes.string,
+  /**
+   * A css class or classes applied while the Component is entering.
+   */
+  enteringClassName: React.PropTypes.string,
+
+  /**
+   * A function that returns the DOM node to animate. This Node will have the transition classes applied to it.
+   * When left out, the Component will use its immediate child.
+   *
+   * @private
+   */
+  transitioningNode: React.PropTypes.func,
+
+  /**
+   * A callback fired just before the "entering" classes are applied
+   */
+  onEnter:     React.PropTypes.func,
+  /**
+   * A callback fired just after the "entering" classes are applied
+   */
+  onEntering:  React.PropTypes.func,
+  /**
+   * A callback fired after "enter" classes are applied
+   */
+  onEntered:   React.PropTypes.func,
+  /**
+   * A callback fired after "exiting" classes are applied
+   */
+  onExit:      React.PropTypes.func,
+  /**
+   * A callback fired after "exiting" classes are applied
+   */
+  onExiting:   React.PropTypes.func,
+  /**
+   * A callback fired after "exit" classes are applied
+   */
+  onExited:    React.PropTypes.func
+};
+
+// name the function so it is clearer in the documentation
+const noop = ()=>{};
+
+Transition.defaultProps = {
+  in:       false,
+  duration: 300,
+  unmountOnExit: false,
+  transitionAppear: false,
+  transitioningNode: noop,
+
+  onEnter:    noop,
+  onEntering: noop,
+  onEntered:  noop,
+
+  onExit:     noop,
+  onExiting:  noop,
+  onExited:   noop
+};
+
+export default Transition;

--- a/src/index.js
+++ b/src/index.js
@@ -63,5 +63,8 @@ export Well from './Well';
 export Portal from './Portal';
 export Position from './Position';
 
+export Collapse from './Collapse';
+export Fade from './Collapse';
+
 export * as FormControls from './FormControls';
 export * as utils from './utils';

--- a/test/CollapseSpec.js
+++ b/test/CollapseSpec.js
@@ -1,0 +1,216 @@
+import React from 'react';
+import ReactTestUtils from 'react/lib/ReactTestUtils';
+import Collapse from '../src/Collapse';
+
+describe('Collapse', function () {
+
+  let Component, instance;
+
+  beforeEach(function(){
+
+    Component = React.createClass({
+      render(){
+        let { children, ...props } = this.props;
+
+        return (
+          <Collapse
+            ref={r => this.collapse = r}
+            getDimensionValue={()=> 15 }
+            {...props}
+          >
+            <div>
+              <div ref="panel">
+                {children}
+              </div>
+            </div>
+          </Collapse>
+        );
+      }
+    });
+  });
+
+  it('Should default to collapsed', function () {
+    instance = ReactTestUtils.renderIntoDocument(
+      <Component>Panel content</Component>
+    );
+
+    assert.ok(
+      instance.collapse.props.in === false);
+  });
+
+
+  describe('collapsed', function(){
+
+    it('Should have collapse class', function () {
+      instance = ReactTestUtils.renderIntoDocument(
+        <Component>Panel content</Component>
+      );
+
+      assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'collapse'));
+    });
+  });
+
+  describe('from collapsed to expanded', function(){
+    let scrollHeightStub;
+
+    beforeEach(function(){
+      instance = ReactTestUtils.renderIntoDocument(
+        <Component>Panel content</Component>
+      );
+
+      // since scrollHeight is gonna be 0 detached from the DOM
+      scrollHeightStub = sinon.stub(instance.collapse, '_getScrollDimensionValue');
+      scrollHeightStub.returns('15px');
+    });
+
+
+    it('Should have collapsing class', function () {
+      instance.setProps({ in: true });
+
+      let node = React.findDOMNode(instance);
+
+      assert.equal(node.className, 'collapsing');
+    });
+
+    it('Should set initial 0px height', function (done) {
+      let node = React.findDOMNode(instance);
+
+      function onEnter(){
+        assert.equal(node.style.height, '0px');
+        done();
+      }
+
+      assert.equal(node.style.height, '');
+
+      instance.setProps({ in: true, onEnter });
+    });
+
+    it('Should set node to height', function () {
+      let node = React.findDOMNode(instance);
+
+      assert.equal(node.styled, undefined);
+
+      instance.setProps({ in: true });
+      assert.equal(node.style.height, '15px');
+    });
+
+    it('Should transition from collapsing to not collapsing', function (done) {
+      let node = React.findDOMNode(instance);
+
+      function onEntered(){
+        assert.equal(node.className, 'collapse in');
+        done();
+      }
+
+      instance.setProps({ in: true, onEntered });
+
+      assert.equal(node.className, 'collapsing');
+    });
+
+    it('Should clear height after transition complete', function (done) {
+      let node = React.findDOMNode(instance);
+
+      function onEntered(){
+        assert.equal(node.style.height, '');
+        done();
+      }
+
+      assert.equal(node.style.height, '');
+
+      instance.setProps({ in: true, onEntered });
+      assert.equal(node.style.height, '15px');
+    });
+  });
+
+  describe('from expanded to collapsed', function(){
+    beforeEach(function(){
+      instance = ReactTestUtils.renderIntoDocument(
+        <Component in>Panel content</Component>
+      );
+    });
+
+    it('Should have collapsing class', function () {
+      instance.setProps({ in: false });
+      let node = React.findDOMNode(instance);
+      assert.equal(node.className, 'collapsing');
+    });
+
+    it('Should set initial height', function () {
+      let node = React.findDOMNode(instance);
+
+      function onExit(){
+        assert.equal(node.style.height, '15px');
+      }
+
+      assert.equal(node.style.height, '');
+      instance.setProps({ in: false, onExit });
+    });
+
+    it('Should set node to height', function () {
+      let node = React.findDOMNode(instance);
+      assert.equal(node.style.height, '');
+
+      instance.setProps({ in: false });
+      assert.equal(node.style.height, '0px');
+    });
+
+    it('Should transition from collapsing to not collapsing', function (done) {
+      let node = React.findDOMNode(instance);
+
+      function onExited(){
+        assert.equal(node.className, 'collapse');
+        done();
+      }
+
+      instance.setProps({ in: false, onExited });
+
+      assert.equal(node.className, 'collapsing');
+    });
+
+    it('Should have 0px height after transition complete', function (done) {
+      let node = React.findDOMNode(instance);
+
+      function onExited(){
+        assert.ok(node.style.height === '0px');
+        done();
+      }
+
+      assert.equal(node.style.height, '');
+
+      instance.setProps({ in: false, onExited });
+    });
+  });
+
+  describe('expanded', function(){
+
+    it('Should have collapse and in class', function () {
+      instance = ReactTestUtils.renderIntoDocument(
+        <Component in >Panel content</Component>
+      );
+      assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'collapse in'));
+    });
+  });
+
+  describe('dimension', function(){
+    beforeEach(function(){
+      instance = ReactTestUtils.renderIntoDocument(
+        <Component>Panel content</Component>
+      );
+    });
+
+    it('Defaults to height', function(){
+      assert.equal(instance.collapse._dimension(), 'height');
+    });
+
+    it('Uses getCollapsibleDimension if exists', function(){
+
+      function dimension(){
+        return 'whatevs';
+      }
+
+      instance.setProps({ dimension });
+
+      assert.equal(instance.collapse._dimension(), 'whatevs');
+    });
+  });
+});

--- a/test/CollapsibleMixinSpec.js
+++ b/test/CollapsibleMixinSpec.js
@@ -32,6 +32,12 @@ describe('CollapsibleMixin', function () {
     });
   });
 
+  afterEach(()=> {
+    if (console.warn.calledWithMatch('CollapsibleMixin is deprecated')){
+      console.warn.reset();
+    }
+  });
+
   describe('getInitialState', function(){
     it('Should check defaultExpanded', function () {
       instance = ReactTestUtils.renderIntoDocument(

--- a/test/FadeMixinSpec.js
+++ b/test/FadeMixinSpec.js
@@ -19,6 +19,13 @@ describe('FadeMixin', function () {
     });
   });
 
+  afterEach(()=> {
+    if (console.warn.calledWithMatch('FadeMixin is deprecated')){
+      console.warn.reset();
+    }
+  });
+
+
   it('Should add the in class to all elements', function (done) {
     let instance = ReactTestUtils.renderIntoDocument(<Component />);
 

--- a/test/FadeSpec.js
+++ b/test/FadeSpec.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ReactTestUtils from 'react/lib/ReactTestUtils';
 import Fade from '../src/Fade';
-//import classNames from 'classnames';
 
 describe('Fade', function () {
 

--- a/test/FadeSpec.js
+++ b/test/FadeSpec.js
@@ -1,0 +1,82 @@
+import React from 'react';
+import ReactTestUtils from 'react/lib/ReactTestUtils';
+import Fade from '../src/Fade';
+//import classNames from 'classnames';
+
+describe('Fade', function () {
+
+  let Component, instance;
+
+  beforeEach(function(){
+
+    Component = React.createClass({
+      render(){
+        let { children, ...props } = this.props;
+
+        return (
+          <Fade ref={r => this.fade = r}
+            {...props}
+          >
+            <div>
+              {children}
+            </div>
+          </Fade>
+        );
+      }
+    });
+  });
+
+  it('Should default to hidden', function () {
+    instance = ReactTestUtils.renderIntoDocument(
+      <Component>Panel content</Component>
+    );
+
+    assert.ok(
+      instance.fade.props.in === false);
+  });
+
+  it('Should always have the "fade" class', () => {
+    instance = ReactTestUtils.renderIntoDocument(
+      <Component>Panel content</Component>
+    );
+
+    assert.ok(
+      instance.fade.props.in === false);
+
+    assert.equal(
+      React.findDOMNode(instance).className, 'fade');
+
+  });
+
+  it('Should add "in" class when entering', done => {
+    instance = ReactTestUtils.renderIntoDocument(
+      <Component>Panel content</Component>
+    );
+
+    function onEntering(){
+      assert.equal(React.findDOMNode(instance).className, 'fade in');
+      done();
+    }
+
+    assert.ok(
+      instance.fade.props.in === false);
+
+    instance.setProps({ in: true, onEntering });
+  });
+
+  it('Should remove "in" class when exiting', done => {
+    instance = ReactTestUtils.renderIntoDocument(
+      <Component in>Panel content</Component>
+    );
+
+    function onExiting(){
+      assert.equal(React.findDOMNode(instance).className, 'fade');
+      done();
+    }
+
+    assert.equal(
+      React.findDOMNode(instance).className, 'fade in');
+
+    instance.setProps({ in: false, onExiting });
+  });
+});

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -3,6 +3,7 @@ import ReactTestUtils from 'react/lib/ReactTestUtils';
 import Modal from '../src/Modal';
 import { render } from './helpers';
 
+
 describe('Modal', function () {
   let mountPoint;
 
@@ -172,10 +173,8 @@ describe('Modal', function () {
       document.activeElement.should.equal(focusableContainer);
     });
 
+
     it('Should not focus on the Modal when autoFocus is false', function () {
-
-      document.activeElement.should.equal(focusableContainer);
-
       render(
         <Modal show autoFocus={false} onHide={()=>{}} animation={false}>
           <strong>Message</strong>

--- a/test/PopoverSpec.js
+++ b/test/PopoverSpec.js
@@ -15,12 +15,4 @@ describe('Popover', function () {
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'strong'));
   });
 
-  // it('Should not have the fade class if animation is false', function () {
-  //   let instance = ReactTestUtils.renderIntoDocument(
-  //     <Popover title="Popover title" animation={false}>
-  //       <strong>Popover Content</strong>
-  //     </Popover>
-  //   );
-  //   assert.equal(React.findDOMNode(instance).className.match(/\bfade\b/), null, 'The fade class should not be present');
-  // });
 });

--- a/test/PopoverSpec.js
+++ b/test/PopoverSpec.js
@@ -11,16 +11,16 @@ describe('Popover', function () {
     );
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'popover-title'));
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'popover-content'));
-    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'fade'));
+
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'strong'));
   });
 
-  it('Should not have the fade class if animation is false', function () {
-    let instance = ReactTestUtils.renderIntoDocument(
-      <Popover title="Popover title" animation={false}>
-        <strong>Popover Content</strong>
-      </Popover>
-    );
-    assert.equal(React.findDOMNode(instance).className.match(/\bfade\b/), null, 'The fade class should not be present');
-  });
+  // it('Should not have the fade class if animation is false', function () {
+  //   let instance = ReactTestUtils.renderIntoDocument(
+  //     <Popover title="Popover title" animation={false}>
+  //       <strong>Popover Content</strong>
+  //     </Popover>
+  //   );
+  //   assert.equal(React.findDOMNode(instance).className.match(/\bfade\b/), null, 'The fade class should not be present');
+  // });
 });

--- a/test/TooltipSpec.js
+++ b/test/TooltipSpec.js
@@ -10,15 +10,15 @@ describe('Tooltip', function () {
       </Tooltip>
     );
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'strong'));
-    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'fade'));
+
   });
 
-  it('Should not have the fade class if animation is false', function () {
-    let instance = ReactTestUtils.renderIntoDocument(
-      <Tooltip animation={false}>
-        <strong>Tooltip Content</strong>
-      </Tooltip>
-    );
-    assert.equal(React.findDOMNode(instance).className.match(/\bfade\b/), null, 'The fade class should not be present');
-  });
+  // it('Should not have the fade class if animation is false', function () {
+  //   let instance = ReactTestUtils.renderIntoDocument(
+  //     <Tooltip animation={false}>
+  //       <strong>Tooltip Content</strong>
+  //     </Tooltip>
+  //   );
+  //   assert.equal(React.findDOMNode(instance).className.match(/\bfade\b/), null, 'The fade class should not be present');
+  // });
 });

--- a/test/TooltipSpec.js
+++ b/test/TooltipSpec.js
@@ -13,12 +13,4 @@ describe('Tooltip', function () {
 
   });
 
-  // it('Should not have the fade class if animation is false', function () {
-  //   let instance = ReactTestUtils.renderIntoDocument(
-  //     <Tooltip animation={false}>
-  //       <strong>Tooltip Content</strong>
-  //     </Tooltip>
-  //   );
-  //   assert.equal(React.findDOMNode(instance).className.match(/\bfade\b/), null, 'The fade class should not be present');
-  // });
 });

--- a/test/TransitionSpec.js
+++ b/test/TransitionSpec.js
@@ -1,0 +1,231 @@
+import React from 'react';
+import ReactTestUtils from 'react/lib/ReactTestUtils';
+import { render } from './helpers';
+import Transition from '../src/Transition';
+//import classNames from 'classnames';
+
+describe('Transition', function () {
+
+
+  it('should not transition on mount', function(){
+    let instance = render(
+          <Transition in onEnter={()=> { throw new Error('should not Enter'); }}>
+            <div></div>
+          </Transition>
+        );
+
+    instance.state.in.should.equal(true);
+    assert.ok(!instance.state.transitioning);
+  });
+
+  it('should transition on mount with transitionAppear', done =>{
+    let instance = ReactTestUtils.renderIntoDocument(
+          <Transition in
+            transitionAppear
+            onEnter={()=> done()}
+          >
+            <div></div>
+          </Transition>
+        );
+
+    instance.state.in.should.equal(true);
+    instance.state.transitioning.should.equal(true);
+  });
+
+  describe('entering', ()=> {
+    let instance;
+
+    beforeEach(function(){
+      instance = render(
+        <Transition
+          duration={10}
+          enteredClassName='test-enter'
+          enteringClassName='test-entering'
+        >
+          <div/>
+        </Transition>
+      );
+    });
+
+    it('should fire callbacks', done => {
+      let onEnter = sinon.spy();
+      let onEntering = sinon.spy();
+
+      instance.state.in.should.equal(false);
+
+      instance = instance.renderWithProps({
+
+        in: true,
+
+        onEnter,
+
+        onEntering,
+
+        onEntered(){
+          assert.ok(onEnter.calledOnce);
+          assert.ok(onEntering.calledOnce);
+          assert.ok(onEnter.calledBefore(onEntering));
+          done();
+        }
+      });
+    });
+
+    it('should move to each transition state', done => {
+      let count = 0;
+
+      instance.state.in.should.equal(false);
+
+      instance = instance.renderWithProps({
+
+        in: true,
+
+        onEnter(){
+          count++;
+          instance.state.in.should.equal(false);
+          instance.state.transitioning.should.equal(false);
+        },
+
+        onEntering(){
+          count++;
+          instance.state.in.should.equal(true);
+          instance.state.transitioning.should.equal(true);
+        },
+
+        onEntered(){
+          instance.state.in.should.equal(true);
+          instance.state.transitioning.should.equal(false);
+          assert.ok(count === 2);
+          done();
+        }
+      });
+    });
+
+    it('should apply classes at each transition state', done => {
+      let count = 0;
+
+      instance.state.in.should.equal(false);
+
+      instance = instance.renderWithProps({
+
+        in: true,
+
+        onEnter(node){
+          count++;
+          assert.equal(node.className, '');
+        },
+
+        onEntering(node){
+          count++;
+          assert.equal(node.className, 'test-entering');
+        },
+
+        onEntered(node){
+          assert.equal(node.className, 'test-enter');
+          assert.ok(count === 2);
+          done();
+        }
+      });
+    });
+
+  });
+
+
+  describe('exiting', ()=> {
+    let instance;
+
+    beforeEach(function(){
+      instance = render(
+        <Transition
+          in={true}
+          duration={10}
+          exitedClassName='test-exit'
+          exitingClassName='test-exiting'
+        >
+          <div/>
+        </Transition>
+      );
+    });
+
+    it('should fire callbacks', done => {
+      let onExit = sinon.spy();
+      let onExiting = sinon.spy();
+
+      instance.state.in.should.equal(true);
+
+      instance = instance.renderWithProps({
+
+        in: false,
+
+        onExit,
+
+        onExiting,
+
+        onExited(){
+          assert.ok(onExit.calledOnce);
+          assert.ok(onExiting.calledOnce);
+          assert.ok(onExit.calledBefore(onExiting));
+          done();
+        }
+      });
+    });
+
+    it('should move to each transition state', done => {
+      let count = 0;
+
+      instance.state.in.should.equal(true);
+
+      instance = instance.renderWithProps({
+
+        in: false,
+
+        onExit(){
+          count++;
+          instance.state.in.should.equal(true);
+          instance.state.transitioning.should.equal(false);
+        },
+
+        onExiting(){
+          count++;
+          instance.state.in.should.equal(false);
+          instance.state.transitioning.should.equal(true);
+        },
+
+        onExited(){
+          instance.state.in.should.equal(false);
+          instance.state.transitioning.should.equal(false);
+          //assert.ok(count === 2);
+          done();
+        }
+      });
+    });
+
+    it('should apply classes at each transition state', done => {
+      let count = 0;
+
+      instance.state.in.should.equal(true);
+
+      instance = instance.renderWithProps({
+
+        in: false,
+
+        onExit(node){
+          count++;
+          assert.equal(node.className, '');
+        },
+
+        onExiting(node){
+          count++;
+          assert.equal(node.className, 'test-exiting');
+        },
+
+        onExited(node){
+          assert.equal(node.className, 'test-exit');
+          assert.ok(count === 2);
+          done();
+        }
+      });
+    });
+
+  });
+
+});

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -12,7 +12,7 @@ export function shouldWarn(about) {
  * since `setProps` is deprecated.
  * @param  {ReactElement} element     Root element to render
  * @param  {HTMLElement?} mountPoint  Optional mount node, when empty it uses an unattached div like `renderIntoDocument()`
- * @return {ComponentInstance}        The instance, with a new method `renderWithProps` which will return a new instance wiht updated props
+ * @return {ComponentInstance}        The instance, with a new method `renderWithProps` which will return a new instance with updated props
  */
 export function render(element, mountPoint){
   let mount = mountPoint || document.createElement('div');


### PR DESCRIPTION
__EDIT__: Should be good to go now!

An experiment in mixin alternatives for transitions. I was already working on a generic version for a project at work and thought it might be valuable upstream here.

`Transition` component is sort of like a streamlined CSSTransitionGroup from react.addons, but expects a single child and doesn't depend on components mounting/unmounting.

If it looks like the sort of thing we might like in core here I'll clean it up and add tests. Feedback appreciated, I added examples to the Component page for easy viewing :P.

Benefits in my eyes:
- Fade doesn't need to clone its element anymore, and we have proper callbacks
- Collapse feels a bit more manageable in component form, rather than having to mixin the behavior
- Transition is nice and extensible for its specific purpose.
- no mixins means non createClass consumers can use em
- looks like there is no need for breaking changes for components that use the new components, and mixins could be depreciated reasonably