### PR TITLE
Simplify tools/exec

### DIFF
--- a/tools/build-cli.js
+++ b/tools/build-cli.js
@@ -30,9 +30,10 @@ let buildProcess = argv.docsOnly ? docs(argv) : build();
 
 buildProcess
   .catch(err => {
-    console.error(err.toString().red);
     if (err.stack) {
       console.error(err.stack.red);
+    } else {
+      console.error(err.toString().red);
     }
     process.exit(1);
   });


### PR DESCRIPTION
the part of #819

then('return result') is extraneous.

catch() is extraneous. (there is downstream catch)
removeing it prevents duplicate printing of errors.