### PR TITLE
[added] Created class prop for custom styling on ul in Dropdown Button

### DIFF
--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -1092,6 +1092,11 @@ h1[id] {
   margin-bottom: 5px;
   clear: left;
 }
+.custom-dropdown {
+  max-height: 150px;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
 
 /* Example tabbable tabs */
 .bs-example-tabs .nav-tabs {

--- a/docs/examples/DropdownButtonCustomList.js
+++ b/docs/examples/DropdownButtonCustomList.js
@@ -1,0 +1,24 @@
+const buttonInstance = (
+  <div>
+    <DropdownButton listClassName='custom-dropdown' title='Button with custom list styling'>
+      <MenuItem eventKey='1'>Action</MenuItem>
+      <MenuItem eventKey='2'>Another action</MenuItem>
+      <MenuItem eventKey='3'>Something else here</MenuItem>
+      <MenuItem eventKey='4'>Even more here</MenuItem>
+      <MenuItem eventKey='5'>Action</MenuItem>
+      <MenuItem eventKey='6'>Another action</MenuItem>
+      <MenuItem eventKey='7'>Something else here</MenuItem>
+      <MenuItem eventKey='8'>Even more here</MenuItem>
+      <MenuItem eventKey='9'>Action</MenuItem>
+      <MenuItem eventKey='10'>Another action</MenuItem>
+      <MenuItem eventKey='11'>Something else here</MenuItem>
+      <MenuItem eventKey='12'>Even more here</MenuItem>
+      <MenuItem eventKey='13'>Action</MenuItem>
+      <MenuItem eventKey='14'>Another action</MenuItem>
+      <MenuItem eventKey='15'>Something else here</MenuItem>
+      <MenuItem eventKey='16'>Even more here</MenuItem>
+    </DropdownButton>
+  </div>
+);
+
+React.render(buttonInstance, mountNode);

--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -157,6 +157,10 @@ const ComponentsPage = React.createClass({
                   <p>Button dropdowns work with buttons of all sizes.</p>
                   <ReactPlayground codeText={Samples.DropdownButtonSizes} />
 
+                  <h3 id='btn-dropdowns-custom-list'>Custom list styling</h3>
+                  <p>You can specify custom css to the ul tag itself by using the listClassName prop. Example uses custom css with a max-height and an overflow property.</p>
+                  <ReactPlayground codeText={Samples.DropdownButtonCustomList} />
+
                   <h3 id='btn-dropdown-nocaret'>No caret variation</h3>
                   <p>Remove the caret using the <code>noCaret</code> prop.</p>
                   <ReactPlayground codeText={Samples.DropdownButtonNoCaret} />

--- a/docs/src/Samples.js
+++ b/docs/src/Samples.js
@@ -18,6 +18,7 @@ export default {
   DropdownButtonBasic:           require('fs').readFileSync(__dirname + '/../examples/DropdownButtonBasic.js', 'utf8'),
   SplitButtonBasic:              require('fs').readFileSync(__dirname + '/../examples/SplitButtonBasic.js', 'utf8'),
   DropdownButtonSizes:           require('fs').readFileSync(__dirname + '/../examples/DropdownButtonSizes.js', 'utf8'),
+  DropdownButtonCustomList:      require('fs').readFileSync(__dirname + '/../examples/DropdownButtonCustomList.js', 'utf8'),
   DropdownButtonNoCaret:         require('fs').readFileSync(__dirname + '/../examples/DropdownButtonNoCaret.js', 'utf8'),
   SplitButtonDropup:             require('fs').readFileSync(__dirname + '/../examples/SplitButtonDropup.js', 'utf8'),
   SplitButtonRight:              require('fs').readFileSync(__dirname + '/../examples/SplitButtonRight.js', 'utf8'),

--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -21,7 +21,8 @@ const DropdownButton = React.createClass({
     onSelect:  React.PropTypes.func,
     navItem:   React.PropTypes.bool,
     noCaret:   React.PropTypes.bool,
-    buttonClassName: React.PropTypes.string
+    buttonClassName: React.PropTypes.string,
+    listClassName: React.PropTypes.string
   },
 
   render() {
@@ -50,7 +51,8 @@ const DropdownButton = React.createClass({
         ref="menu"
         aria-labelledby={this.props.id}
         pullRight={this.props.pullRight}
-        key={1}>
+        key={1}
+        className={this.props.listClassName}>
         {ValidComponentChildren.map(this.props.children, this.renderMenuItem)}
       </DropdownMenu>
     ]);

--- a/test/DropdownButtonSpec.js
+++ b/test/DropdownButtonSpec.js
@@ -231,4 +231,16 @@ describe('DropdownButton', function () {
       ReactTestUtils.findRenderedDOMComponentWithClass(button, 'dropdown-toggle')
     );
   });
+
+  it('should set ul class when listClassName is given', function() {
+    instance = ReactTestUtils.renderIntoDocument(
+        <DropdownButton listClassName="test-class">
+          <MenuItem eventKey="1">MenuItem 1 content</MenuItem>
+        </DropdownButton>
+    );
+
+    let list = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'ul'));
+    console.log(list.className);
+    assert.ok(list.className.match(/\btest-class\b/));
+  });
 });


### PR DESCRIPTION
I have a particular use case for this functionality. The dropdown is used for a set of checkboxes, and in certain scenarios, the dropdown would go off the screen and some content was inaccessible. This addition will allow users to apply styling rules to the <ul> tag, such as an overflow.