### PR TITLE
fixed flickering when moving between trigger element and children of trigger element in hover mode

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -122,8 +122,8 @@ const OverlayTrigger = React.createClass({
     }
 
     if (isOneOf('hover', this.props.trigger)) {
-      props.onMouseOver = createChainedFunction(this.handleDelayedShow, this.props.onMouseOver);
-      props.onMouseOut = createChainedFunction(this.handleDelayedHide, this.props.onMouseOut);
+      props.onMouseEnter = createChainedFunction(this.handleDelayedShow, this.props.onMouseEnter);
+      props.onMouseLeave = createChainedFunction(this.handleDelayedHide, this.props.onMouseLeave);
     }
 
     if (isOneOf('focus', this.props.trigger)) {


### PR DESCRIPTION
Switched to using onMouseEnter and onMouseLeave so that the overlay doesn't redraw every time you cross borders of children elements contained within the trigger.