### PR TITLE
Load custom eslint rules, including a spread aware shorthand rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,7 +8,8 @@
   },
   "parser": "babel-eslint",
   "plugins": [
-    "react"
+    "react",
+    "react-bootstrap-internal"
   ],
   "rules": {
     "comma-spacing": 2,
@@ -18,7 +19,7 @@
     "no-underscore-dangle": 0,
     "no-unused-vars": [2, { "vars": "all", "args": "none" }],
     "no-var": 2,
-    "object-shorthand": 2,
+    "react-bootstrap-internal/object-shorthand": 2,
     "quotes": [2, "single", "avoid-escape"],
     "react/display-name": 0,
     "react/jsx-no-undef": 2,

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint": "0.23.0",
     "eslint-plugin-mocha": "^0.2.2",
     "eslint-plugin-react": "^2.1.0",
+    "eslint-plugin-react-bootstrap-internal": "file:tools/eslint-rules",
     "express": "^4.12.3",
     "extract-text-webpack-plugin": "^0.8.0",
     "file-loader": "^0.8.1",

--- a/tools/eslint-rules/README.md
+++ b/tools/eslint-rules/README.md
@@ -1,0 +1,5 @@
+# Custom ESLint Rules
+
+This is a dummy npm package that allows us to treat it as an eslint-plugin. It's not actually published, nor are the rules here useful for users of react-bootstrap. If you want to lint your react code, try <https://github.com/yannickcr/eslint-plugin-react>.
+
+**If you modify this rule, you must re-run `npm install ./tools/eslint-rules` for it to take effect.**

--- a/tools/eslint-rules/index.js
+++ b/tools/eslint-rules/index.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+  rules: {
+    'object-shorthand': require('./object-shorthand-spread')
+  }
+};

--- a/tools/eslint-rules/object-shorthand-spread.js
+++ b/tools/eslint-rules/object-shorthand-spread.js
@@ -1,0 +1,80 @@
+/*eslint-disable */
+/**
+ * @fileoverview Rule to enforce concise object methods and properties.
+ * @author Jamund Ferguson
+ * @copyright 2015 Jamund Ferguson. All rights reserved.
+ */
+
+'use strict';
+
+var OPTIONS = {
+    always: 'always',
+    never: 'never',
+    methods: 'methods',
+    properties: 'properties'
+};
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    var APPLY = context.options[0] || OPTIONS.always;
+    var APPLY_TO_METHODS = APPLY === OPTIONS.methods || APPLY === OPTIONS.always;
+    var APPLY_TO_PROPS = APPLY === OPTIONS.properties || APPLY === OPTIONS.always;
+    var APPLY_NEVER = APPLY === OPTIONS.never;
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+        Property: function(node) {
+            var isConciseProperty = node.method || node.shorthand
+              , isSpreadProperty = !!this.getSource(node).match(/^\.\.\./)
+              , type;
+
+            // if we're 'never' and concise we should warn now
+            if (APPLY_NEVER && isConciseProperty) {
+                type = node.method ? 'method' : 'property';
+                context.report(node, 'Expected longform ' + type + ' syntax.');
+            }
+
+            // at this point if we're concise or if we're 'never' we can leave
+            if (APPLY_NEVER || isConciseProperty) {
+                return;
+            }
+
+            if (node.kind === 'get' || node.kind === 'set') {
+                return;
+            }
+
+            if ( isSpreadProperty ) {
+                return;
+            }
+
+
+            if (node.value.type === 'FunctionExpression' && APPLY_TO_METHODS) {
+
+                // {x: function(){}} should be written as {x() {}}
+                context.report(node, 'Expected method shorthand.');
+            } else if (node.value.type === 'Identifier' && node.key.name === node.value.name && APPLY_TO_PROPS) {
+                console.log(context.getSource(node))
+                // {x: x} should be written as {x}
+                context.report(node, 'Expected property shorthand.');
+            } else if (node.value.type === 'Identifier' && node.key.type === 'Literal' && node.key.value === node.value.name && APPLY_TO_PROPS) {
+
+                // {'x': x} should be written as {x}
+                context.report(node, 'Expected property shorthand.');
+            }
+        }
+    };
+
+};
+
+module.exports.schema = [
+    {
+        'enum': ['always', 'methods', 'properties', 'never']
+    }
+];

--- a/tools/eslint-rules/package.json
+++ b/tools/eslint-rules/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "eslint-plugin-react-bootstrap-internal",
+  "version": "0.0.0"
+}


### PR DESCRIPTION
Fixes that dang false eslint warning about using spread properties in an object.

Prior art on this: https://github.com/facebook/react/pull/4034