### PR TITLE
[fixed] Create overlay target only when needed.

### DIFF
--- a/src/OverlayMixin.js
+++ b/src/OverlayMixin.js
@@ -7,8 +7,28 @@ export default {
     container: CustomPropTypes.mountable
   },
 
+  componentDidMount() {
+    this._renderOverlay();
+  },
+
   componentWillUnmount() {
     this._unrenderOverlay();
+    this._unmountOverlayTarget();
+  },
+
+  componentDidUpdate() {
+    this._renderOverlay();
+  },
+
+  _mountOverlayTarget() {
+    if (!this._overlayTarget) {
+      this._overlayTarget = document.createElement('div');
+      this.getContainerDOMNode()
+        .appendChild(this._overlayTarget);
+    }
+  },
+
+  _unmountOverlayTarget() {
     if (this._overlayTarget) {
       this.getContainerDOMNode()
         .removeChild(this._overlayTarget);
@@ -16,33 +36,23 @@ export default {
     }
   },
 
-  componentDidUpdate() {
-    this._renderOverlay();
-  },
-
-  componentDidMount() {
-    this._renderOverlay();
-  },
-
-  _mountOverlayTarget() {
-    this._overlayTarget = document.createElement('div');
-    this.getContainerDOMNode()
-      .appendChild(this._overlayTarget);
-  },
-
   _renderOverlay() {
-    if (!this._overlayTarget) {
+    if (this.state.isOverlayShown) {
       this._mountOverlayTarget();
+
+      let overlay = this.renderOverlay();
+
+      // Save reference to help testing
+      if (overlay !== null) {
+        this._overlayInstance = React.render(overlay, this._overlayTarget);
+      } else {
+        // Unrender if the component is null for transitions to null
+        this._unrenderOverlay();
+      }
     }
 
-    let overlay = this.renderOverlay();
-
-    // Save reference to help testing
-    if (overlay !== null) {
-      this._overlayInstance = React.render(overlay, this._overlayTarget);
-    } else {
-      // Unrender if the component is null for transitions to null
-      this._unrenderOverlay();
+    if (!this.state.isOverlayShown) {
+      this._unmountOverlayTarget();
     }
   },
 

--- a/test/OverlayMixinSpec.js
+++ b/test/OverlayMixinSpec.js
@@ -8,6 +8,12 @@ describe('OverlayMixin', function () {
   let Overlay = React.createClass({
     mixins: [OverlayMixin],
 
+    getInitialState() {
+      return {
+        isOverlayShown: true
+      };
+    },
+
     render() {
       return <div />;
     },
@@ -27,7 +33,7 @@ describe('OverlayMixin', function () {
     let container = document.createElement('div');
 
     instance = ReactTestUtils.renderIntoDocument(
-      <Overlay container={container} overlay={<div id="test1" />} />
+      <Overlay container={container} overlay={<div id="test1" />} isOverlayShown/>
     );
 
     assert.equal(container.querySelectorAll('#test1').length, 1);
@@ -64,6 +70,12 @@ describe('OverlayMixin', function () {
   it('Should render only an overlay', function() {
     let OnlyOverlay = React.createClass({
       mixins: [OverlayMixin],
+
+      getInitialState() {
+        return {
+          isOverlayShown: true
+        };
+      },
 
       render() {
         return null;


### PR DESCRIPTION
Currently react-bootstrap creates an empty div for every tooltip or popover, in an application that has many tooltips it slows down the rendering a lot and mess with the react dev tools; this aims to only create an empty div, the portal endpoint, when needed like the original jquery bootstrap. It also refers to the issue #353 that was closed without a solution.
Thanks for looking at it.