### PR TITLE
Add missed prop types validations.

### DIFF
--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -1,3 +1,6 @@
+/* eslint react/prop-types: [2, {ignore: "bsSize"}] */
+/* BootstrapMixin contains `bsSize` type validation */
+
 import React, { cloneElement } from 'react';
 import classNames from 'classnames';
 
@@ -17,11 +20,14 @@ const DropdownButton = React.createClass({
     dropup:    React.PropTypes.bool,
     title:     React.PropTypes.node,
     href:      React.PropTypes.string,
+    id:        React.PropTypes.string,
     onClick:   React.PropTypes.func,
     onSelect:  React.PropTypes.func,
     navItem:   React.PropTypes.bool,
     noCaret:   React.PropTypes.bool,
-    buttonClassName: React.PropTypes.string
+    buttonClassName: React.PropTypes.string,
+    className: React.PropTypes.string,
+    children:  React.PropTypes.node
   },
 
   render() {

--- a/src/Interpolate.js
+++ b/src/Interpolate.js
@@ -10,7 +10,9 @@ const Interpolate = React.createClass({
   displayName: 'Interpolate',
 
   propTypes: {
-    format: React.PropTypes.string
+    component: React.PropTypes.node,
+    format: React.PropTypes.string,
+    unsafe: React.PropTypes.bool
   },
 
   getDefaultProps() {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -84,6 +84,7 @@ const Modal = React.createClass({
     backdrop: React.PropTypes.oneOf(['static', true, false]),
     keyboard: React.PropTypes.bool,
     closeButton: React.PropTypes.bool,
+    container: React.PropTypes.object,
     animation: React.PropTypes.bool,
     onRequestHide: React.PropTypes.func.isRequired,
     dialogClassName: React.PropTypes.string,

--- a/src/ModalTrigger.js
+++ b/src/ModalTrigger.js
@@ -8,7 +8,11 @@ const ModalTrigger = React.createClass({
   mixins: [OverlayMixin],
 
   propTypes: {
-    modal: React.PropTypes.node.isRequired
+    modal: React.PropTypes.node.isRequired,
+    onBlur: React.PropTypes.func,
+    onFocus: React.PropTypes.func,
+    onMouseOut: React.PropTypes.func,
+    onMouseOver: React.PropTypes.func
   },
 
   getInitialState() {

--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -35,6 +35,11 @@ const OverlayTrigger = React.createClass({
     delayHide: React.PropTypes.number,
     defaultOverlayShown: React.PropTypes.bool,
     overlay: React.PropTypes.node.isRequired,
+    onBlur: React.PropTypes.func,
+    onClick: React.PropTypes.func,
+    onFocus: React.PropTypes.func,
+    onMouseEnter: React.PropTypes.func,
+    onMouseLeave: React.PropTypes.func,
     containerPadding: React.PropTypes.number,
     rootClose: React.PropTypes.bool
   },

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -1,5 +1,6 @@
-/* eslint react/prop-types: [1, {ignore: ["children", "className", "bsStyle"]}]*/
+/* eslint react/prop-types: [2, {ignore: "bsStyle"}] */
 /* BootstrapMixin contains `bsStyle` type validation */
+
 import React, { cloneElement } from 'react';
 import classNames from 'classnames';
 
@@ -12,6 +13,8 @@ const PanelGroup = React.createClass({
   propTypes: {
     accordion: React.PropTypes.bool,
     activeKey: React.PropTypes.any,
+    className: React.PropTypes.string,
+    children: React.PropTypes.node,
     defaultActiveKey: React.PropTypes.any,
     onSelect: React.PropTypes.func
   },

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -1,4 +1,4 @@
-/* eslint react/prop-types: [1, {ignore: ["className", "bsStyle"]}]*/
+/* eslint react/prop-types: [2, {ignore: "bsStyle"}] */
 /* BootstrapMixin contains `bsStyle` type validation */
 
 import React, { cloneElement, PropTypes } from 'react';
@@ -18,6 +18,7 @@ const ProgressBar = React.createClass({
     striped: PropTypes.bool,
     active: PropTypes.bool,
     children: onlyProgressBar,
+    className: React.PropTypes.string,
     interpolateClass: PropTypes.node,
     isChild: PropTypes.bool
   },

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -1,5 +1,6 @@
-/* eslint react/prop-types: [1, {ignore: ["children", "className", "bsSize"]}]*/
+/* eslint react/prop-types: [2, {ignore: "bsSize"}] */
 /* BootstrapMixin contains `bsSize` type validation */
+
 import React from 'react';
 import classNames from 'classnames';
 import BootstrapMixin from './BootstrapMixin';
@@ -21,7 +22,9 @@ const SplitButton = React.createClass({
     dropup:        React.PropTypes.bool,
     onClick:       React.PropTypes.func,
     onSelect:      React.PropTypes.func,
-    disabled:      React.PropTypes.bool
+    disabled:      React.PropTypes.bool,
+    className:     React.PropTypes.string,
+    children:      React.PropTypes.node
   },
 
   getDefaultProps() {

--- a/src/Thumbnail.js
+++ b/src/Thumbnail.js
@@ -5,6 +5,12 @@ import BootstrapMixin from './BootstrapMixin';
 const Thumbnail = React.createClass({
   mixins: [BootstrapMixin],
 
+  propTypes: {
+    alt: React.PropTypes.string,
+    href: React.PropTypes.string,
+    src: React.PropTypes.string
+  },
+
   getDefaultProps() {
     return {
       bsClass: 'thumbnail'


### PR DESCRIPTION
The Future :sparkle:  Yey :raised_hands: :smile: 

Thanks to these
https://github.com/yannickcr/eslint-plugin-react/pull/124
https://github.com/yannickcr/eslint-plugin-react/pull/127
@Cellule additions into `eslint-plugin-react` (yet to be released in v2.5.3)

It became possible to detect these additional `prop types` warnings.