### PR TITLE
Add community resources and support page to docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,9 +17,10 @@ and submitting pull requests, but please respect the following restrictions:
 
 - Please do not use the issue tracker for personal support requests. Stack
   Overflow ([react-bootstrap](http://stackoverflow.com/questions/tagged/react-bootstrap)
-  tag), [Slack](http://www.reactiflux.com/) or
-  [gitter](https://gitter.im/react-bootstrap/react-bootstrap) are better places
-  to get help.
+  tag), [Slack](http://www.reactiflux.com/), 
+  [gitter](https://gitter.im/react-bootstrap/react-bootstrap), or 
+  [Thinkful](http://start.thinkful.com/react/?utm_source=github&utm_medium=badge&utm_campaign=react-bootstrap) 
+  are better places to get help.
 - Please do not open issues or pull requests regarding the code in React or
   Bootstrap (open them in their respective repositories).
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 [![HuBoard][huboard-badge]][huboard]
 [![Gitter][gitter-badge]][gitter]
+[![Thinkful][thinkful-badge]][thinkful]
 
 [![NPM version][npm-badge]][npm]
 [![Bower version][bower-badge]][bower]
@@ -74,6 +75,9 @@ Yes please! See the [contributing guidelines][contributing] for details.
 
 [huboard-badge]: https://img.shields.io/badge/Hu-Board-7965cc.svg
 [huboard]: https://huboard.com/react-bootstrap/react-bootstrap
+
+[thinkful-badge]: https://tf-assets-staging.s3.amazonaws.com/badges/thinkful_repo_badge.svg
+[thinkful]: http://start.thinkful.com/react/?utm_source=github&utm_medium=badge&utm_campaign=react-bootstrap
 
 [appveyor-badge]: https://ci.appveyor.com/api/projects/status/ylitpyo6n5yq1s6i/branch/master?svg=true
 [appveyor]: https://ci.appveyor.com/project/react-bootstrap/react-bootstrap/branch/master

--- a/docs/src/NavMain.js
+++ b/docs/src/NavMain.js
@@ -15,6 +15,10 @@ const NAV_LINKS = {
   'components': {
     link: 'components',
     title: 'Components'
+  },
+  'support': {
+    link: 'support',
+    title: 'Support'
   }
 };
 

--- a/docs/src/Root.js
+++ b/docs/src/Root.js
@@ -14,7 +14,8 @@ const Root = React.createClass({
         'index.html',
         'introduction.html',
         'getting-started.html',
-        'components.html'
+        'components.html',
+        'support.html'
       ];
     }
   },

--- a/docs/src/Routes.js
+++ b/docs/src/Routes.js
@@ -5,6 +5,7 @@ import HomePage from './HomePage';
 import IntroductionPage from './IntroductionPage';
 import GettingStartedPage from './GettingStartedPage';
 import ComponentsPage from './ComponentsPage';
+import SupportPage from './SupportPage';
 import NotFoundPage from './NotFoundPage';
 
 import {Route, DefaultRoute, NotFoundRoute} from 'react-router';
@@ -17,5 +18,6 @@ export default (
     <Route name='introduction' path='introduction.html' handler={IntroductionPage} />
     <Route name='getting-started' path='getting-started.html' handler={GettingStartedPage} />
     <Route name='components' path='components.html' handler={ComponentsPage} />
+    <Route name='support' path='support.html' handler={SupportPage} />
   </Route>
 );

--- a/docs/src/SupportPage.js
+++ b/docs/src/SupportPage.js
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import NavMain from './NavMain';
+import PageHeader from './PageHeader';
+import PageFooter from './PageFooter';
+
+export default class Page extends React.Component {
+  render() {
+    return (
+        <div>
+          <NavMain activePage="support" />
+
+          <PageHeader
+            title="Need help?"
+            subTitle="Community resources for answering your React-Bootstrap questions." />
+
+          <div className="container bs-docs-container">
+            <div className="row">
+              <div className="col-md-9" role="main">
+                <div className="bs-docs-section">
+                  <p className="lead">Stay up to date on the development of React-Bootstrap and reach out to the community with these helpful resources.</p>
+
+                  <h3>Stack Overflow</h3>
+                  <p><a href="http://stackoverflow.com/questions/ask">Ask questions</a> about specific problems you have faced, including details about what exactly you are trying to do. Make sure you tag your question with <code className="js">react-bootstrap</code>. You can also read through <a href="http://stackoverflow.com/questions/tagged/react-bootstrap">existing React-Bootstrap questions</a>.</p>
+
+                  <h3>Live help</h3>
+                  <p>Bring your questions and pair with other react-bootstrap users in a <a href="http://start.thinkful.com/react/?utm_source=github&utm_medium=badge&utm_campaign=react-bootstrap">live Thinkful hangout</a>. Hear about the challenges other developers are running into, or screenshare your own code with the group for feedback.</p>
+
+                  <h3>Chat rooms</h3>
+                  <p>Discuss questions in the <code className="js">#react-bootstrap</code> channel on the <a href="http://www.reactiflux.com/">Reactiflux Slack</a> or on <a href="https://gitter.im/react-bootstrap/react-bootstrap">Gitter</a>.</p>
+
+                  <h3>GitHub issues</h3>
+                  <p>The issue tracker is the preferred channel for bug reports, features requests and submitting pull requests. See more about how we use issues in the <a href="https://github.com/react-bootstrap/react-bootstrap/blob/master/CONTRIBUTING.md#issues">contribution guidelines</a>.</p>
+
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <PageFooter />
+        </div>
+      );
+  }
+
+  shouldComponentUpdate() {
+    return false;
+  }
+}


### PR DESCRIPTION
Hi again @mtscout6 @mathieumg @AlexKVal and team —

I added a support page to the docs and links to Thinkful in `README` and `CONTRIBUTING` to close #783. Let me know what you think!

Also, in line with feedback from @mtscout6 [here](https://github.com/react-bootstrap/react-bootstrap/issues/783#issuecomment-108999315) and a few other folks — Thinkful will be formalizing our Code of Conduct when we roll out a broader update to Thinkful in the next couple of months (although so far we haven't run into any issues in the sessions). Stay tuned!