### PR TITLE
Generate Prop Documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,34 @@ check out these [5 useful tips for a better commit message][commit-message]
 Please update the docs with any API changes, the code and docs should always be
 in sync.
 
+Component prop documentation is generated automatically from the React components 
+and their leading comments. Please make sure to provide comments for any `propTypes` you add 
+or change in a Component.
+
+```js
+propTypes: {
+    /**
+     * Sets the visibility of the Component
+     */
+    show: React.PropTypes.bool,
+
+    /**
+     * A callback fired when the visibility changes
+     * @type {func}
+     * @required
+     */
+    onHide: myCustomPropType
+}
+```
+
+There are a few caveats to this format that differ from conventional JSDoc comments.
+
+- Only specific doclets (the @ things) should be used, and only when the data cannot be parsed from the component itself
+    - `@type`: Override the "type", use the same names as the default React PropTypes: string, func, bool, number, object. You can express enum and oneOfType types, Like `{("optionA"|"optionB")}`.
+    - `@required`: to mark a prop as required (use the normal React isRequired if possible)
+    - `@private`: Will hide the prop in the documentation
+- All description text should be above the doclets.
+
 ## Implement additional components and features
 
 This project is seeking parity with the core Bootstrap library.

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -162,3 +162,10 @@ body {
   position: absolute;
 }
 
+.table .prop-table-row code {
+  color: #282828;
+  font-size: 15px;
+  margin: 0;
+  padding: 0;
+  background-color: transparent;
+}

--- a/docs/build.js
+++ b/docs/build.js
@@ -6,6 +6,7 @@ import Root from './src/Root';
 import fsp from 'fs-promise';
 import { copy } from '../tools/fs-utils';
 import { exec } from '../tools/exec';
+import metadata from './generate-metadata';
 
 const repoRoot = path.resolve(__dirname, '../');
 const docsBuilt = path.join(repoRoot, 'docs-built');
@@ -21,12 +22,12 @@ const readmeDest = path.join(docsBuilt, 'README.md');
  * @return {Promise} promise
  * @internal
  */
-function generateHTML(fileName) {
+function generateHTML(fileName, propData) {
   return new Promise((resolve, reject) => {
     const urlSlug = fileName === 'index.html' ? '/' : `/${fileName}`;
 
     Router.run(routes, urlSlug, Handler => {
-      let html = React.renderToString(React.createElement(Handler));
+      let html = React.renderToString(React.createElement(Handler, { propData }));
       html = '<!doctype html>' + html;
       let write = fsp.writeFile(path.join(docsBuilt, fileName), html);
       resolve(write);
@@ -39,8 +40,10 @@ export default function BuildDocs({ dev }) {
 
   return exec(`rimraf ${docsBuilt}`)
     .then(() => fsp.mkdir(docsBuilt))
-    .then(() => {
-      let pagesGenerators = Root.getPages().map(generateHTML);
+    .then(metadata)
+    .then(propData => {
+
+      let pagesGenerators = Root.getPages().map( page => generateHTML(page, propData));
 
       return Promise.all(pagesGenerators.concat([
         exec(`webpack --config webpack.docs.js ${dev ? '' : '-p '}--bail`),

--- a/docs/generate-metadata.js
+++ b/docs/generate-metadata.js
@@ -1,0 +1,97 @@
+import metadata from 'react-component-metadata';
+import glob from 'glob';
+import fsp from 'fs-promise';
+import promisify from '../tools/promisify';
+
+let globp = promisify(glob);
+
+// removes doclet syntax from comments
+let cleanDoclets = desc => {
+  let idx = desc.indexOf('@');
+  return (idx === -1 ? desc : desc.substr(0, idx )).trim();
+};
+
+let cleanDocletValue = str => str.replace(/^\{/, '').replace(/\}$/, '');
+
+let isLiteral = str => str.trim()[0] === '"' || str.trim()[0] === "'";
+
+/**
+ * parse out description doclets to an object and remove the comment
+ *
+ * @param  {ComponentMetadata|PropMetadata} obj
+ */
+function parseDoclets(obj){
+  obj.doclets = metadata.parseDoclets(obj.desc || '');
+  obj.desc = cleanDoclets(obj.desc || '');
+}
+
+/**
+ * Reads the JSDoc "doclets" and applies certain ones to the prop type data
+ * This allows us to "fix" parsing errors, or unparsable data with JSDoc style comments
+ *
+ * @param  {Object} props     Object Hash of the prop metadata
+ * @param  {String} propName
+ */
+function applyPropDoclets(props, propName){
+  let prop = props[propName];
+  let doclets = prop.doclets;
+  let value;
+
+  // the @type doclet to provide a prop type
+  // Also allows enums (oneOf) if string literals are provided
+  // ex: @type {("optionA"|"optionB")}
+  if (doclets.type) {
+    value = cleanDocletValue(doclets.type);
+    prop.type.name = value;
+
+    if ( value[0] === '(' ) {
+      value = value.substring(1, value.length - 1).split('|');
+
+      prop.type.value = value;
+      prop.type.name = value.every(isLiteral) ? 'enum' : 'union';
+    }
+  }
+
+  // Use @required to mark a prop as required
+  // useful for custom propTypes where there isn't a `.isRequired` addon
+  if ( doclets.required) {
+    prop.required = true;
+  }
+}
+
+
+export default function generate(destination, options = { mixins: true }){
+
+  return globp(__dirname + '/../src/**/*.js') //eslint-disable-line no-path-concat
+    .then( files => {
+
+      let results = files.map(
+        filename => fsp.readFile(filename).then(content => metadata(content, options)) );
+
+      return Promise.all(results)
+        .then( data => {
+          let result = {};
+
+          data.forEach(components => {
+            Object.keys(components).forEach(key => {
+              const component = components[key];
+
+              parseDoclets(component);
+
+              Object.keys(component.props).forEach( propName => {
+                const prop = component.props[propName];
+
+                parseDoclets(prop);
+                applyPropDoclets(component.props, propName);
+              });
+            });
+
+            //combine all the component metadata into one large object
+            result = { ...result, ...components };
+          });
+
+          return result;
+        })
+        .catch( e => setTimeout(()=> { throw e; }));
+    });
+}

--- a/docs/server.js
+++ b/docs/server.js
@@ -5,6 +5,8 @@ import path from 'path';
 import Router from 'react-router';
 import routes from './src/Routes';
 import httpProxy from 'http-proxy';
+
+import metadata from './generate-metadata';
 import ip from 'ip';
 
 const development = process.env.NODE_ENV !== 'production';
@@ -21,20 +23,27 @@ if (development) {
     proxy.web(req, res, { target });
   });
 
-  app.use(function renderApp(req, res) {
-    res.header('Access-Control-Allow-Origin', target);
-    res.header('Access-Control-Allow-Headers', 'X-Requested-With');
-
-    Router.run(routes, req.url, Handler => {
-      let html = React.renderToString(<Handler assetBaseUrl={target} />);
-      res.send('<!doctype html>' + html);
-    });
-  });
-
   proxy.on('error', function(e) {
     console.log('Could not connect to webpack proxy'.red);
     console.log(e.toString().red);
   });
+
+  console.log('Prop data generation started:'.green);
+
+  metadata().then( props => {
+    console.log('Prop data generation finished:'.green);
+
+    app.use(function renderApp(req, res) {
+      res.header('Access-Control-Allow-Origin', target);
+      res.header('Access-Control-Allow-Headers', 'X-Requested-With');
+
+      Router.run(routes, req.url, Handler => {
+        let html = React.renderToString(<Handler assetBaseUrl={target} propData={props}/>);
+        res.send('<!doctype html>' + html);
+      });
+    });
+  });
+
 } else {
   app.use(express.static(path.join(__dirname, '../docs-built')));
 }

--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -9,6 +9,7 @@ import NavItem from '../../src/NavItem';
 
 import NavMain from './NavMain';
 import PageHeader from './PageHeader';
+import PropTable from './PropTable';
 import PageFooter from './PageFooter';
 import ReactPlayground from './ReactPlayground';
 import Samples from './Samples';
@@ -67,6 +68,7 @@ const ComponentsPage = React.createClass({
                     flush against each other. To preserve the spacing between multiple inline buttons, wrap your
                     button group in <code>{'<ButtonToolbar />'}</code>.</p>
                   </div>
+
                   <h2 id='buttons-sizes'>Sizes</h2>
                   <p>Fancy larger or smaller buttons? Add <code>bsSize="large"</code>, <code>bsSize="small"</code>, or <code>bsSize="xsmall"</code> for additional sizes.</p>
                   <ReactPlayground codeText={Samples.ButtonSizes} />
@@ -99,6 +101,10 @@ const ComponentsPage = React.createClass({
                     feedback as to the loading state, this can easily be done by updating
                     your <code>{'<Button />'}</code>&#8217;s props from a state change like below.</p>
                   <ReactPlayground codeText={Samples.ButtonLoading} />
+
+                  <h3 id='buttons-props'>Props</h3>
+                  <PropTable component='Button'/>
+
                 </div>
 
                 {/* Button Groups */}
@@ -139,6 +145,9 @@ const ComponentsPage = React.createClass({
                   </div>
                   <p>Just add <code>justified</code> to the <code>{'<ButtonGroup />'}</code>.</p>
                   <ReactPlayground codeText={Samples.ButtonGroupJustified} />
+
+                  <h3 id='btn-groups-props'>Props</h3>
+                  <PropTable component='ButtonGroup'/>
                 </div>
 
                 <div className='bs-docs-section'>
@@ -168,11 +177,19 @@ const ComponentsPage = React.createClass({
                   <h3 id='btn-dropdowns-right'>Dropdown right variation</h3>
                   <p>Trigger dropdown menus that align to the right of the button using the <code>pullRight</code> prop.</p>
                   <ReactPlayground codeText={Samples.SplitButtonRight} />
+
+                  <h3 id='btn-dropdowns-props'>Props</h3>
+
+                  <h4>DropdownButton</h4>
+                  <PropTable component='DropdownButton'/>
+
+                  <h4>SplitButton</h4>
+                  <PropTable component='SplitButton'/>
                 </div>
 
                 {/* Menu Item */}
                 <div className='bs-docs-section'>
-                  <h1 id='menu-item' className='page-header'>Menu Item <small> MenudItem</small></h1>
+                  <h1 id='menu-item' className='page-header'>Menu Item <small> MenuItem</small></h1>
                   <p>This is a component used in other components (see <a href="buttons">Buttons</a>, <a href="#navbars">Navbars</a>).</p>
                   <p>It supports the basic anchor properties <code>href</code>, <code>target</code>, <code>title</code>.</p>
                   <p>It also supports different properties of the normal Bootstrap MenuItem.
@@ -186,6 +203,9 @@ const ComponentsPage = React.createClass({
                   <p>The callback is called with the following arguments: <code>eventKey</code>, <code>href</code> and <code>target</code></p>
                   </p>
                   <ReactPlayground codeText={Samples.MenuItem} />
+
+                  <h3 id='menu-item-props'>Props</h3>
+                  <PropTable component='MenuItem'/>
                 </div>
 
               {/* Panels */}
@@ -227,6 +247,15 @@ const ComponentsPage = React.createClass({
                   <h3 id='panels-collapsible'>Collapsible Mixin</h3>
                   <p><code>CollapsibleMixin</code> can be used to create your own components with collapse functionality.</p>
                   <ReactPlayground codeText={Samples.CollapsibleParagraph} />
+
+                  <h3 id='panels-props'>Props</h3>
+
+                  <h4>Panels, Accordion</h4>
+                  <PropTable component='Panel'/>
+
+                  <h4>PanelGroup</h4>
+                  <PropTable component='PanelGroup'/>
+
                 </div>
 
                 <div className='bs-docs-section'>
@@ -266,6 +295,15 @@ const ComponentsPage = React.createClass({
                   <h3 id='modal-custom-sizing'>Sizing modals using custom css</h3>
                   <p>You can apply custom css to the modal dialog div using the "dialogClassName" prop. Example is using a custom css class with width set to 90%.</p>
                   <ReactPlayground codeText={Samples.ModalCustomSizing} />
+
+                  <h3 id='modals-props'>Props</h3>
+
+                  <h4>Modal</h4>
+                  <PropTable component='Modal'/>
+
+                  <h4>ModalTrigger</h4>
+                  <PropTable component='ModalTrigger'/>
+
                 </div>
 
                 {/* Tooltip */}
@@ -281,6 +319,11 @@ const ComponentsPage = React.createClass({
 
                   <p>Positioned tooltip in copy.</p>
                   <ReactPlayground codeText={Samples.TooltipInCopy} />
+
+                  <h3 id='tooltip-props'>Props</h3>
+
+                  <PropTable component='Tooltip'/>
+
                 </div>
 
                 {/* Popover */}
@@ -302,6 +345,10 @@ const ComponentsPage = React.createClass({
 
                   <p>Positioned popover components in scrolling container.</p>
                   <ReactPlayground codeText={Samples.PopoverPositionedScrolling} exampleClassName='bs-example-popover-scroll' />
+
+                  <h3 id='popover-props'>Props</h3>
+
+                  <PropTable component='Popover'/>
                 </div>
 
                 {/* Progress Bar */}
@@ -338,6 +385,10 @@ const ComponentsPage = React.createClass({
                   <h2 id='progress-stacked'>Stacked</h2>
                   <p>Nest <code>&lt;ProgressBar /&gt;</code>s to stack them.</p>
                   <ReactPlayground codeText={Samples.ProgressBarStacked} />
+
+                  <h3 id='progress-props'>ProgressBar</h3>
+
+                  <PropTable component='ProgressBar'/>
                 </div>
 
                 {/* Nav */}
@@ -359,6 +410,15 @@ const ComponentsPage = React.createClass({
                   <h3>Justified</h3>
                   <p>They can be <code>justified</code> to take the full width of their parent.</p>
                   <ReactPlayground codeText={Samples.NavJustified} />
+
+                  <h3 id='navs-props'>Props</h3>
+
+                  <h4>Nav</h4>
+                  <PropTable component='Nav'/>
+
+                  <h4>NavItem</h4>
+                  <PropTable component='NavItem'/>
+
                 </div>
 
                 {/* Navbar */}
@@ -401,6 +461,10 @@ const ComponentsPage = React.createClass({
                   </div>
 
                   <ReactPlayground codeText={Samples.CollapsibleNav} />
+                  <h3 id='navbar-props'>Props</h3>
+
+                  <h4>Navbar</h4>
+                  <PropTable component='Navbar'/>
                 </div>
 
                 {/* Tabbed Areas */}
@@ -425,6 +489,14 @@ const ComponentsPage = React.createClass({
                     <h4>Extends tabbed navigation</h4>
                     <p>This plugin extends the <a href='#navs'>tabbed navigation component</a> to add tabbable areas.</p>
                   </div>
+
+                  <h3 id='tabs-props'>Tabs</h3>
+
+                  <h4>TabbedArea</h4>
+                  <PropTable component='TabbedArea'/>
+
+                  <h4>TabPane</h4>
+                  <PropTable component='TabPane'/>
                 </div>
 
                 {/* Pager */}
@@ -443,6 +515,14 @@ const ComponentsPage = React.createClass({
                   <h3>Disabled</h3>
                   <p>Set the <code>disabled</code> prop to <code>true</code> to disable the link.</p>
                   <ReactPlayground codeText={Samples.PagerDisabled} />
+
+                  <h3 id='pager-props'>Pager</h3>
+
+                  <h4>Pager</h4>
+                  <PropTable component='Pager'/>
+
+                  <h4>PageItem</h4>
+                  <PropTable component='PageItem'/>
                 </div>
 
                 {/* Pagination */}
@@ -456,6 +536,9 @@ const ComponentsPage = React.createClass({
                   <p>More options such as <code>first</code>, <code>last</code>, <code>previous</code>, <code>next</code> and <code>ellipsis</code>.</p>
                   <ReactPlayground codeText={Samples.PaginationAdvanced} />
 
+                  <h3 id='pagination-props'>Pagination</h3>
+
+                  <PropTable component='Pagination'/>
                 </div>
 
                 {/* Alerts */}
@@ -471,6 +554,10 @@ const ComponentsPage = React.createClass({
 
                   <p>Auto close after a set time with <code>dismissAfter</code> prop.</p>
                   <ReactPlayground codeText={Samples.AlertAutoDismissable} />
+
+                  <h3 id='alert-props'>Alert</h3>
+
+                  <PropTable component='Alert'/>
                 </div>
 
                 {/* Carousels */}
@@ -485,6 +572,15 @@ const ComponentsPage = React.createClass({
                   <h3>Controlled</h3>
                   <p>Pass down the active state on render via props.</p>
                   <ReactPlayground codeText={Samples.CarouselControlled} exampleClassName='bs-example-tabs' />
+
+                  <h3 id='carousels-props'>Props</h3>
+
+                  <h4>Carousel</h4>
+                  <PropTable component='Carousel'/>
+
+                  <h4>CarouselItem</h4>
+                  <PropTable component='CarouselItem'/>
+
                 </div>
 
                 {/* Grids */}
@@ -493,6 +589,17 @@ const ComponentsPage = React.createClass({
                   <h2 id='grids-examples'>Example grids</h2>
 
                   <ReactPlayground codeText={Samples.GridBasic} exampleClassName='bs-example-tabs' />
+
+                  <h3 id='grids-props'>Props</h3>
+
+                  <h4>Grid</h4>
+                  <PropTable component='Grid'/>
+
+                  <h4>Row</h4>
+                  <PropTable component='Row'/>
+
+                  <h4>Col</h4>
+                  <PropTable component='Col'/>
                 </div>
 
                 {/* Thumbnail */}
@@ -507,6 +614,11 @@ const ComponentsPage = React.createClass({
                   <h3>Divider Thumbnail</h3>
                   <p>Creates a divider wrapping an image and other children elements.</p>
                   <ReactPlayground codeText={Samples.ThumbnailDiv} />
+
+                  <h3 id='grids-props'>Props</h3>
+
+                  <PropTable component='Thumbnail'/>
+
                 </div>
 
                 {/* ListGroup */}
@@ -531,6 +643,14 @@ const ComponentsPage = React.createClass({
                   <h3>With header</h3>
                   <p>Set the <code>header</code> prop to create a structured item, with a heading and a body area.</p>
                   <ReactPlayground codeText={Samples.ListGroupHeader} />
+
+                  <h3 id='listgroup-props'>Props</h3>
+
+                  <h4>ListGroup</h4>
+                  <PropTable component='ListGroup'/>
+
+                  <h4>ListGroupItem</h4>
+                  <PropTable component='ListGroupItem'/>
                 </div>
 
                 {/* Labels */}
@@ -543,6 +663,10 @@ const ComponentsPage = React.createClass({
                   <h2 id='label-static'>Available variations</h2>
                   <p>Add any of the below mentioned modifier classes to change the appearance of a label.</p>
                   <ReactPlayground codeText={Samples.LabelVariations} />
+
+                  <h3 id='label-props'>Props</h3>
+
+                  <PropTable component='Label'/>
                 </div>
 
                 {/* Badges */}
@@ -555,6 +679,10 @@ const ComponentsPage = React.createClass({
                     <h4>Cross-browser compatibility</h4>
                     <p>Unlike regular Bootstrap badges self collapse even in Internet Explorer 8.</p>
                   </div>
+
+                  <h3 id='badges-props'>Props</h3>
+
+                  <PropTable component='Badge'/>
                 </div>
 
                 {/* Jumbotron */}
@@ -563,6 +691,10 @@ const ComponentsPage = React.createClass({
                   <p>A lightweight, flexible component that can optionally extend the entire viewport to showcase key content on your site.</p>
                   <h2 id='page-header-static'>Example</h2>
                   <ReactPlayground codeText={Samples.Jumbotron} />
+
+                  <h3 id='jumbotron-props'>Props</h3>
+
+                  <PropTable component='Jumbotron'/>
                 </div>
 
                 {/* Page Header */}
@@ -582,6 +714,10 @@ const ComponentsPage = React.createClass({
                   <h2 id='well-optins-static'>Optional classes</h2>
                   <p>Control padding and rounded corners with two optional modifier classes.</p>
                   <ReactPlayground codeText={Samples.WellSizes} />
+
+                  <h3 id='wells-props'>Props</h3>
+
+                  <PropTable component='Well'/>
                 </div>
 
                 {/* Glyphicons */}
@@ -590,6 +726,10 @@ const ComponentsPage = React.createClass({
                   <p>Use them in buttons, button groups for a toolbar, navigation, or prepended form inputs.</p>
                   <h2 id='glyphicon-static'>Example</h2>
                   <ReactPlayground codeText={Samples.Glyphicon} />
+
+                  <h3 id='glyphicons-props'>Props</h3>
+
+                  <PropTable component='Glyphicon'/>
                 </div>
 
                 {/* Tables */}
@@ -602,6 +742,10 @@ const ComponentsPage = React.createClass({
                   <h2 id='table-responsive'>Responsive</h2>
                   <p>Add <code>responsive</code> prop to make them scroll horizontally up to small devices (under 768px). When viewing on anything larger than 768px wide, you will not see any difference in these tables.</p>
                   <ReactPlayground codeText={Samples.TableResponsive} />
+
+                  <h3 id='table-props'>Props</h3>
+
+                  <PropTable component='Table'/>
                 </div>
 
                 {/* Input */}
@@ -638,6 +782,10 @@ const ComponentsPage = React.createClass({
                   <p>If <code>type</code> is not set, child element(s) will be rendered instead of an input element.
                   <code>getValue()</code> will not work when used this way.</p>
                   <ReactPlayground codeText={Samples.InputWrapper} />
+
+                  <h3 id='input-props'>Props</h3>
+
+                  <PropTable component='InputBase'/>
                 </div>
 
               </div>

--- a/docs/src/PropTable.js
+++ b/docs/src/PropTable.js
@@ -1,0 +1,103 @@
+import React from 'react';
+import Table from '../../src/Table';
+import merge from 'lodash/object/merge';
+
+let cleanDocletValue = str => str.replace(/^\{/, '').replace(/\}$/, '');
+
+const PropTable = React.createClass({
+
+  contextTypes: {
+    metadata: React.PropTypes.object
+  },
+
+  render(){
+    let metadata = this.context.metadata[this.props.component] || {};
+
+    if ( !Object.keys(metadata.props || {}).length){
+      return <span/>;
+    }
+
+    return (
+      <Table bordered striped>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Type</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          { this._renderRows() }
+        </tbody>
+      </Table>
+    );
+  },
+
+  _renderRows(){
+    let metadata = this.context.metadata[this.props.component] || {};
+    let props = metadata.props || {};
+
+    if (metadata.composes) {
+      metadata.composes.forEach( other => {
+        props = merge(props, (this.context.metadata[other] || {}).props);
+      });
+    }
+
+    if (metadata.mixins) {
+      metadata.mixins.forEach( other => {
+        if ( metadata.composes.indexOf(other) === -1) {
+          props = merge(props, (this.context.metadata[other] || {}).props);
+        }
+      });
+    }
+
+    return Object.keys(props)
+      .sort()
+      .filter(propName => props[propName].type && !props[propName].doclets.private )
+      .map(propName => {
+        let prop = props[propName];
+
+        return (
+          <tr key={propName} className='prop-table-row'>
+            <td><code>{propName}</code></td>
+            <td>
+              <div><code>{ this.getType(prop)}</code></div>
+              <div>
+                <strong>
+                  { prop.required && <small>(required) </small> }
+                  { prop.defaultValue && <small><em>{'default: ' + prop.defaultValue }</em></small> }
+                </strong>
+              </div>
+            </td>
+            <td>{prop.desc}</td>
+          </tr>
+        );
+      });
+  },
+
+  getType(prop){
+    let type = prop.type;
+    let name = type.name;
+    let doclets = prop.doclets || {};
+
+    switch (name) {
+      case 'object':
+        return name;
+      case 'union':
+        return type.value.map(val => this.getType({ type: val })).join(' | ');
+
+      case 'array':
+        return 'Array<' + type.value.name + '>';
+      case 'enum':
+        return 'One Of: ' + (type.value || []).join(', ');
+      case 'custom':
+        return cleanDocletValue(doclets.type || name);
+      default:
+        return name;
+    }
+  }
+});
+
+
+
+export default PropTable;

--- a/docs/src/Root.js
+++ b/docs/src/Root.js
@@ -26,6 +26,14 @@ const Root = React.createClass({
     };
   },
 
+  childContextTypes: {
+    metadata: React.PropTypes.object
+  },
+
+  getChildContext(){
+    return { metadata: this.props.propData };
+  },
+
   render() {
     // Dump out our current props to a global object via a script tag so
     // when initialising the browser environment we can bootstrap from the
@@ -65,7 +73,7 @@ const Root = React.createClass({
         <head dangerouslySetInnerHTML={head} />
 
         <body>
-          <Router.RouteHandler />
+          <Router.RouteHandler propData={this.props.propData} />
 
           <script dangerouslySetInnerHTML={browserInitScriptObj} />
           <script src={`${this.props.assetBaseUrl}/assets/bundle.js`} />

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "phantomjs": "^1.9.17",
     "portfinder": "^0.4.0",
     "react": "^0.13.1",
+    "react-component-metadata": "^1.1.1",
     "react-hot-loader": "^1.2.7",
     "react-router": "^0.13.1",
     "rimraf": "^2.3.2",

--- a/src/BootstrapMixin.js
+++ b/src/BootstrapMixin.js
@@ -3,8 +3,20 @@ import CustomPropTypes from './utils/CustomPropTypes';
 
 const BootstrapMixin = {
   propTypes: {
+    /**
+     * bootstrap className
+     * @private
+     */
     bsClass: CustomPropTypes.keyOf(styleMaps.CLASSES),
+    /**
+     * Style variants
+     * @type {("default"|"primary"|"success"|"info"|"warning"|"danger"|"link")}
+     */
     bsStyle: CustomPropTypes.keyOf(styleMaps.STYLES),
+    /**
+     * Size variants
+     * @type {("xsmall"|"small"|"medium"|"large")}
+     */
     bsSize: CustomPropTypes.keyOf(styleMaps.SIZES)
   },
 

--- a/src/ButtonGroup.js
+++ b/src/ButtonGroup.js
@@ -9,6 +9,10 @@ const ButtonGroup = React.createClass({
   propTypes: {
     vertical:  React.PropTypes.bool,
     justified: React.PropTypes.bool,
+    /**
+     * Display block buttons, only useful when used with the "vertical" prop.
+     * @type {bool}
+     */
     block: CustomPropTypes.all([
       React.PropTypes.bool,
       function(props, propName, componentName) {

--- a/tools/promisify.js
+++ b/tools/promisify.js
@@ -1,0 +1,17 @@
+
+export default function promisify(fn){
+  return function (...args){
+    return new Promise(function(resolve, reject){
+
+      function finish(err, result){
+        if (err) {
+          return reject(err);
+        }
+        resolve(result);
+      }
+
+      fn.apply(null, args.concat(finish));
+    });
+
+  };
+}


### PR DESCRIPTION
This is a first pass at getting some of the doc info generated. Not having prop lists in our docs was really getting to me. So this is an attempt at a "good enough for now" solution that we can build on. 

you can see that a bunch of info is still missing from the doc info, mostly because there are no doc comments on any Props, but also b/c some stuff isn't statically analyzable. For those cases we can use the jsDoc "doclets" (like @private) to tell the generator how to display the info.

This isn't meant to be a complete solution, but one that is better than what we currently have. I am hoping that others will help start documenting our props as we go.

It should also be said that I am not sure this is working with the doc build command. It does work with the dev server version though