### PR TITLE
Update eslint-plugin-mocha.

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "es5-shim": "^4.1.0",
     "eslint": "0.23.0",
     "eslint-plugin-babel": "^1.0.0",
-    "eslint-plugin-mocha": "^0.3.0",
+    "eslint-plugin-mocha": "^0.4.0",
     "eslint-plugin-react": "^2.1.0",
     "express": "^4.12.3",
     "extract-text-webpack-plugin": "^0.8.0",


### PR DESCRIPTION
Again :smile: 

I agree with @taion proposal to not adding `[changed]` to such kind commits.
(which have no an impact to code or API.
`eslint-plugin-mocha` is used only by testing framework in contrast to `babel`.