### PR TITLE
Lock in npm at 2.11 until 2.12.1 is released

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ version: '{build}'
 install:
   # Get the latest stable version of io.js
   - ps: Install-Product node ''
-  - npm -g install npm@latest
+  - npm -g install npm@2.11.x
   - set PATH=%APPDATA%\npm;%PATH%
   - node --version
   - npm --version


### PR DESCRIPTION
Otherwise the AppVeyor build fails in all PRs. See: https://github.com/npm/npm/releases/tag/v2.12.1

I thought it would have been "released" much quicker than that... We only have to revert this PR once it's released.