### PR TITLE
Add ModalTrigger children refs test to prevent future regressions.

### DIFF
--- a/test/ModalTriggerSpec.js
+++ b/test/ModalTriggerSpec.js
@@ -101,4 +101,19 @@ describe('ModalTrigger', function() {
 
     contextSpy.calledWith('value').should.be.true;
   });
+
+  it('Should pass children refs through', function () {
+    const TestComponent = React.createClass({
+      render() {
+        return (
+          <ModalTrigger modal={<div>test</div>}>
+            <button ref='customRef' />
+          </ModalTrigger>
+        );
+      }
+    });
+
+    const instance = ReactTestUtils.renderIntoDocument(<TestComponent />);
+    assert.isDefined(instance.refs.customRef);
+  });
 });


### PR DESCRIPTION
https://github.com/react-bootstrap/react-bootstrap/issues/297
`1. ref does not work on ModalTrigger children`