### PR TITLE
Add missed propType validation for Button 'type' property

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import BootstrapMixin from './BootstrapMixin';
 import CustomPropTypes from './utils/CustomPropTypes';
+import ButtonInput from './ButtonInput';
 
 const Button = React.createClass({
   mixins: [BootstrapMixin],
@@ -14,14 +15,18 @@ const Button = React.createClass({
     navDropdown: React.PropTypes.bool,
     componentClass: CustomPropTypes.elementType,
     href: React.PropTypes.string,
-    target: React.PropTypes.string
+    target: React.PropTypes.string,
+    /**
+     * Defines HTML button type Attribute
+     * @type {("button"|"reset"|"submit")}
+     */
+    type: React.PropTypes.oneOf(ButtonInput.types)
   },
 
   getDefaultProps() {
     return {
       bsClass: 'button',
-      bsStyle: 'default',
-      type: 'button'
+      bsStyle: 'default'
     };
   },
 
@@ -68,6 +73,7 @@ const Button = React.createClass({
     return (
       <Component
         {...this.props}
+        type={this.props.type || 'button'}
         className={classNames(this.props.className, classes)}>
         {this.props.children}
       </Component>


### PR DESCRIPTION
To document this property.

With this patch:
![screen shot 2015-06-30 at 10 56 51 pm](https://cloud.githubusercontent.com/assets/847572/8440815/5ccb208e-1f7d-11e5-9086-5dfc4342500d.png)

I've tried to re-use values from [src/ButtonInput.js#L20](https://github.com/AlexKVal/react-bootstrap/blob/8188f39086d5419838fe5a87671151e4111119a4/src/ButtonInput.js#L20)
like this:
```js
import ButtonInput from './ButtonInput';
...
ButtonInput.propTypes = {
  type: React.PropTypes.oneOf(ButtonInput.types),
```
but it doesn't document them
![screen shot 2015-06-30 at 10 55 01 pm](https://cloud.githubusercontent.com/assets/847572/8440861/b5d24f9a-1f7d-11e5-96bd-5a803dda7507.png)

Closes #925