### PR TITLE
Document Grid, Row and Col properties

### DIFF
--- a/src/Col.js
+++ b/src/Col.js
@@ -5,22 +5,137 @@ import CustomPropTypes from './utils/CustomPropTypes';
 
 const Col = React.createClass({
   propTypes: {
+    /**
+     * The number of columns you wish to span
+     *
+     * for Extra small devices Phones (<768px)
+     *
+     * class-prefix `col-xs-`
+     */
     xs: React.PropTypes.number,
+    /**
+     * The number of columns you wish to span
+     *
+     * for Small devices Tablets (≥768px)
+     *
+     * class-prefix `col-sm-`
+     */
     sm: React.PropTypes.number,
+    /**
+     * The number of columns you wish to span
+     *
+     * for Medium devices Desktops (≥992px)
+     *
+     * class-prefix `col-md-`
+     */
     md: React.PropTypes.number,
+    /**
+     * The number of columns you wish to span
+     *
+     * for Large devices Desktops (≥1200px)
+     *
+     * class-prefix `col-lg-`
+     */
     lg: React.PropTypes.number,
+    /**
+     * Move columns to the right
+     *
+     * for Extra small devices Phones
+     *
+     * class-prefix `col-xs-offset-`
+     */
     xsOffset: React.PropTypes.number,
+    /**
+     * Move columns to the right
+     *
+     * for Small devices Tablets
+     *
+     * class-prefix `col-sm-offset-`
+     */
     smOffset: React.PropTypes.number,
+    /**
+     * Move columns to the right
+     *
+     * for Medium devices Desktops
+     *
+     * class-prefix `col-md-offset-`
+     */
     mdOffset: React.PropTypes.number,
+    /**
+     * Move columns to the right
+     *
+     * for Large devices Desktops
+     *
+     * class-prefix `col-lg-offset-`
+     */
     lgOffset: React.PropTypes.number,
+    /**
+     * Change the order of grid columns to the right
+     *
+     * for Extra small devices Phones
+     *
+     * class-prefix `col-xs-push-`
+     */
     xsPush: React.PropTypes.number,
+    /**
+     * Change the order of grid columns to the right
+     *
+     * for Small devices Tablets
+     *
+     * class-prefix `col-sm-push-`
+     */
     smPush: React.PropTypes.number,
+    /**
+     * Change the order of grid columns to the right
+     *
+     * for Medium devices Desktops
+     *
+     * class-prefix `col-md-push-`
+     */
     mdPush: React.PropTypes.number,
+    /**
+     * Change the order of grid columns to the right
+     *
+     * for Large devices Desktops
+     *
+     * class-prefix `col-lg-push-`
+     */
     lgPush: React.PropTypes.number,
+    /**
+     * Change the order of grid columns to the left
+     *
+     * for Extra small devices Phones
+     *
+     * class-prefix `col-xs-pull-`
+     */
     xsPull: React.PropTypes.number,
+    /**
+     * Change the order of grid columns to the left
+     *
+     * for Small devices Tablets
+     *
+     * class-prefix `col-sm-pull-`
+     */
     smPull: React.PropTypes.number,
+    /**
+     * Change the order of grid columns to the left
+     *
+     * for Medium devices Desktops
+     *
+     * class-prefix `col-md-pull-`
+     */
     mdPull: React.PropTypes.number,
+    /**
+     * Change the order of grid columns to the left
+     *
+     * for Large devices Desktops
+     *
+     * class-prefix `col-lg-pull-`
+     */
     lgPull: React.PropTypes.number,
+    /**
+     * You can use a custom element for this component
+     */
     componentClass: CustomPropTypes.elementType
   },
 

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -4,7 +4,15 @@ import CustomPropTypes from './utils/CustomPropTypes';
 
 const Grid = React.createClass({
   propTypes: {
+    /**
+     * Turn any fixed-width grid layout into a full-width layout by this property.
+     *
+     * Adds `container-fluid` class.
+     */
     fluid: React.PropTypes.bool,
+    /**
+     * You can use a custom element for this component
+     */
     componentClass: CustomPropTypes.elementType
   },
 

--- a/src/Row.js
+++ b/src/Row.js
@@ -4,6 +4,9 @@ import CustomPropTypes from './utils/CustomPropTypes';
 
 const Row = React.createClass({
   propTypes: {
+    /**
+     * You can use a custom element for this component
+     */
     componentClass: CustomPropTypes.elementType
   },
 


### PR DESCRIPTION
Closes https://github.com/react-bootstrap/react-bootstrap/issues/387

This looks like:
<img width="904" alt="screen shot 2015-07-06 at 6 25 45 pm" src="https://cloud.githubusercontent.com/assets/847572/8526055/d83671c2-240c-11e5-85b7-d893e812cfe0.png">

and Col:
<img width="869" alt="screen shot 2015-07-06 at 6 25 38 pm" src="https://cloud.githubusercontent.com/assets/847572/8526059/df690a2c-240c-11e5-9069-4e5a6d86b60f.png">
