### PR TITLE
Fix commit history for Changelog and add first tests for Position

### DIFF
--- a/src/Position.js
+++ b/src/Position.js
@@ -19,6 +19,7 @@ class Position extends React.Component {
     this._needsFlush = true;
   }
 
+  // ToDo: add tests
   componentWillReceiveProps(){
     this._needsFlush = true;
   }

--- a/src/Position.js
+++ b/src/Position.js
@@ -19,7 +19,6 @@ class Position extends React.Component {
     this._needsFlush = true;
   }
 
-  // ToDo: add tests
   componentWillReceiveProps(){
     this._needsFlush = true;
   }

--- a/test/PositionSpec.js
+++ b/test/PositionSpec.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import ReactTestUtils from 'react/lib/ReactTestUtils';
+import Position from '../src/Position';
+
+describe('Position', function () {
+  it('Should output a child', function () {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Position>
+        <span>Text</span>
+      </Position>
+    );
+    assert.equal(React.findDOMNode(instance).nodeName, 'SPAN');
+  });
+
+  it('Should warn about several children', function () {
+    expect(() => {
+      ReactTestUtils.renderIntoDocument(
+        <Position>
+          <span>Text</span>
+          <span>Another Text</span>
+        </Position>
+      );
+    }).to.throw(Error, /onlyChild must be passed a children with exactly one child/);
+  });
+
+  // ToDo: add remaining tests
+});


### PR DESCRIPTION
I missed `[fixed]` for commit at https://github.com/react-bootstrap/react-bootstrap/pull/945 to reflect that fix in `Changelog`

The first commit is a stub exactly for this.
The second one is a basement for `PositionSpec` with ToDo in it.