### PR TITLE
Update css-loader dev dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "child-process-promise": "^1.0.1",
     "codemirror": "^5.0.0",
     "colors": "^1.0.3",
-    "css-loader": "^0.14.1",
+    "css-loader": "^0.15.2",
     "es5-shim": "^4.1.0",
     "eslint": "0.24.0",
     "eslint-plugin-babel": "^1.0.0",


### PR DESCRIPTION
With 
`css-loader@0.15.2`
`webpack@1.10.1`
all works fine again.

Closes https://github.com/react-bootstrap/react-bootstrap/issues/861


> @mathieumg ...probably broke Glyphicon as well.

It looks like glyphs are ok.
`npm run docs`
<img width="359" alt="screen shot 2015-07-08 at 1 01 34 pm" src="https://cloud.githubusercontent.com/assets/847572/8567906/ad4dd872-2571-11e5-8cf3-4cb8f7c9d813.png">