### PR TITLE
Fix null children

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -245,7 +245,7 @@ const ModalMarkup = React.createClass({
 
     return React.Children.map(children, child => {
       // TODO: use context in 0.14
-      if (child.type.__isModalHeader) {
+      if (child && child.type.__isModalHeader) {
         return cloneElement(child, {
           onHide: createChainedFunction(this._getHide(), child.props.onHide)
         });


### PR DESCRIPTION
This fixes the following case:

```javascript
  getModalFooter() {
    if (something) return null;

    return <ModalFooter> ... </ModalFooter>;
  }

  render() {
    // ...
      <Modal>
          <Modal.Header closeButton>
            <Modal.Title id='contained-modal-title'>{ this.props.title }</Modal.Title>
          </Modal.Header>

          <Modal.Body>
            { this.getModalBody() }
          </Modal.Body>

          { this.getModalFooter() }
      <Modal>
  }
```