### PR TITLE
Add missed 'type' property validator for 'Input'

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -18,4 +18,8 @@ class Input extends InputBase {
   }
 }
 
+Input.propTypes = {
+  type: React.PropTypes.string
+};
+
 export default Input;


### PR DESCRIPTION
the new version of `eslint-plugin-react@2.7.0` released recently
is able to recognize such patterns as addressed by this patch.
