### PR TITLE
'stacked' progress bar renders correctrly 'active' and 'striped' children

### DIFF
--- a/docs/examples/ProgressBarStacked.js
+++ b/docs/examples/ProgressBarStacked.js
@@ -1,8 +1,8 @@
 const progressInstance = (
   <ProgressBar>
-    <ProgressBar bsStyle='success' now={35} key={1} />
+    <ProgressBar striped bsStyle='success' now={35} key={1} />
     <ProgressBar bsStyle='warning' now={20} key={2} />
-    <ProgressBar bsStyle='danger' now={10} key={3} />
+    <ProgressBar active bsStyle='danger' now={10} key={3} />
   </ProgressBar>
 );
 

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -43,12 +43,6 @@ const ProgressBar = React.createClass({
       return this.renderProgressBar();
     }
 
-    const classes = {
-      active: this.props.active,
-      progress: true,
-      'progress-striped': this.props.active || this.props.striped
-    };
-
     let content;
 
     if (this.props.children) {
@@ -58,7 +52,7 @@ const ProgressBar = React.createClass({
     }
 
     return (
-      <div {...this.props} className={classNames(this.props.className, classes)}>
+      <div {...this.props} className={classNames(this.props.className, 'progress')}>
         {content}
       </div>
     );
@@ -94,10 +88,15 @@ const ProgressBar = React.createClass({
       );
     }
 
+    const classes = classNames(this.props.className, this.getBsClassSet(), {
+      active: this.props.active,
+      'progress-bar-striped': this.props.active || this.props.striped
+    });
+
     return (
       <div
         {...this.props}
-        className={classNames(this.props.className, this.getBsClassSet())}
+        className={classes}
         role="progressbar"
         style={{width: percentage + '%'}}
         aria-valuenow={this.props.now}

--- a/test/ProgressBarSpec.js
+++ b/test/ProgressBarSpec.js
@@ -152,7 +152,7 @@ describe('ProgressBar', function () {
       <ProgressBar min={1} max={11} now={6} striped />
     );
 
-    assert.ok(React.findDOMNode(instance).className.match(/\bprogress-striped\b/));
+    assert.ok(React.findDOMNode(instance).firstChild.className.match(/\bprogress-bar-striped\b/));
   });
 
   it('Should show animated striped bar', function () {
@@ -160,8 +160,10 @@ describe('ProgressBar', function () {
       <ProgressBar min={1} max={11} now={6} active />
     );
 
-    assert.ok(React.findDOMNode(instance).className.match(/\bprogress-striped\b/));
-    assert.ok(React.findDOMNode(instance).className.match(/\bactive\b/));
+    const barClassName = React.findDOMNode(instance).firstChild.className;
+
+    assert.ok(barClassName.match(/\bprogress-bar-striped\b/));
+    assert.ok(barClassName.match(/\bactive\b/));
   });
 
   it('Should show stacked bars', function () {
@@ -180,6 +182,28 @@ describe('ProgressBar', function () {
     assert.equal(bar1.style.width, '50%');
     assert.ok(bar2.className.match(/\bprogress-bar\b/));
     assert.equal(bar2.style.width, '30%');
+  });
+
+  it('Should render active and striped children in stacked bar too', function () {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <ProgressBar>
+        <ProgressBar active key={1} now={50} />
+        <ProgressBar striped key={2} now={30} />
+      </ProgressBar>
+    );
+    let wrapper = React.findDOMNode(instance);
+    let bar1 = wrapper.firstChild;
+    let bar2 = wrapper.lastChild;
+
+    assert.ok(wrapper.className.match(/\bprogress\b/));
+
+    assert.ok(bar1.className.match(/\bprogress-bar\b/));
+    assert.ok(bar1.className.match(/\bactive\b/));
+    assert.ok(bar1.className.match(/\bprogress-bar-striped\b/));
+
+    assert.ok(bar2.className.match(/\bprogress-bar\b/));
+    assert.ok(bar2.className.match(/\bprogress-bar-striped\b/));
+    assert.notOk(bar2.className.match(/\bactive\b/));
   });
 
   it('allows only ProgressBar in children', function () {


### PR DESCRIPTION
Fixes https://github.com/react-bootstrap/react-bootstrap/issues/968

My "cool" and very "animated" screenshot :smile: 

<img width="745" alt="screen shot 2015-07-11 at 7 02 03 pm" src="https://cloud.githubusercontent.com/assets/847572/8634390/88d00304-27ff-11e5-9bf4-db52723af44e.png">


Need one more approval from a member of @react-bootstrap/collaborators