### PR TITLE
Update BootstrapMixin.js

### DIFF
--- a/src/BootstrapMixin.js
+++ b/src/BootstrapMixin.js
@@ -35,7 +35,7 @@ const BootstrapMixin = {
       }
 
       let bsStyle = this.props.bsStyle && styleMaps.STYLES[this.props.bsStyle];
-      if (this.props.bsStyle) {
+      if (bsStyle) {
         classes[prefix + bsStyle] = true;
       }
     }


### PR DESCRIPTION
a wield class will be added if `styleMaps.STYLES` does not contain key `this.props.bsStyle`