### PR TITLE
Small fixes for 'tools'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *~
 .DS_Store
-npm-debug.log
+npm-debug.log*
 node_modules
 amd/
 !tools/amd/

--- a/tools/amd/build.js
+++ b/tools/amd/build.js
@@ -10,9 +10,6 @@ const bowerTemplate = path.join(__dirname, 'bower.json');
 const bowerJson = path.join(bowerRoot, 'bower.json');
 
 const readme = path.join(__dirname, 'README.md');
-const license = path.join(repoRoot, 'LICENSE');
-
-const libDestination = path.join(bowerRoot, 'lib');
 
 function bowerConfig() {
   return Promise.all([
@@ -29,11 +26,10 @@ export default function BuildBower() {
   console.log('Building: '.cyan + 'bower module'.green);
 
   return exec(`rimraf ${bowerRoot}`)
-    .then(() => fsp.mkdirs(libDestination))
+    .then(() => fsp.mkdirs(bowerRoot))
     .then(() => Promise.all([
       bowerConfig(),
-      copy(readme, bowerRoot),
-      copy(license, bowerRoot)
+      copy(readme, bowerRoot)
     ]))
     .then(() => console.log('Built: '.cyan + 'bower module'.green));
 }

--- a/tools/release-scripts/changelog.js
+++ b/tools/release-scripts/changelog.js
@@ -26,7 +26,7 @@ export default (version) => {
   }
 
   return result
-    .then(() => exec(`node_modules/.bin/changelog --title v${version} --out ${output}${additionalArgs}`))
+    .then(() => exec(`changelog --title v${version} --out ${output}${additionalArgs}`))
     .then(() => safeExec(`git add ${changelog}`))
     .then(() => {
       if (removedAlphaChangelog || isPrerelease) {


### PR DESCRIPTION
Remove empty 'amd/lib' creation
Remove extraneous copying of 'LICENSE' for bower in building step
(release tool is doing it)
Simplify path to 'changelog' script