### PR TITLE
Remove 'Collapsible Mixin' example from docs.

### DIFF
--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -247,10 +247,6 @@ const ComponentsPage = React.createClass({
                   <p><code>&lt;Accordion /&gt;</code> aliases <code>&lt;PanelGroup accordion /&gt;</code>.</p>
                   <ReactPlayground codeText={Samples.PanelGroupAccordion} />
 
-                  <h3><Anchor id='panels-collapsible'>Collapsible Mixin</Anchor></h3>
-                  <p><code>CollapsibleMixin</code> can be used to create your own components with collapse functionality.</p>
-                  <ReactPlayground codeText={Samples.CollapsibleParagraph} />
-
                   <h3><Anchor id='panels-props'>Props</Anchor></h3>
 
                   <h4><Anchor id='panels-props-accordion'>Panels, Accordion</Anchor></h4>


### PR DESCRIPTION
because it is deprecated

<img width="509" alt="screen shot 2015-07-17 at 3 45 13 pm" src="https://cloud.githubusercontent.com/assets/847572/8747367/e8c43a60-2c9a-11e5-9cc8-494fd7bdf3f9.png">
