### PR TITLE
Simplify 'aria-expanded' values for 'Panel'

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -80,7 +80,7 @@ const Panel = React.createClass({
           className={collapseClass}
           id={this.props.id}
           ref='panel'
-          aria-expanded={this.isExpanded() ? 'true' : 'false'}>
+          aria-expanded={this.isExpanded()}>
           {this.renderBody()}
 
         </div>
@@ -187,7 +187,7 @@ const Panel = React.createClass({
         href={'#' + (this.props.id || '')}
         aria-controls={this.props.collapsible ? this.props.id : null}
         className={this.isExpanded() ? null : 'collapsed'}
-        aria-expanded={this.isExpanded() ? 'true' : 'false'}
+        aria-expanded={this.isExpanded()}
         onClick={this.handleSelect}>
         {header}
       </a>


### PR DESCRIPTION
http://www.w3.org/TR/wai-aria/states_and_properties#aria-expanded

It is not necessary to set them explicitly to strings.

Here [src/Collapse.js#L51](https://github.com/react-bootstrap/react-bootstrap/blob/c3b41af621e9b4d4fbdc8a095b2d666420735534/src/Collapse.js#L51)
we already do it like this:
`aria-expanded={this.props.in}`

Tests are asserting this
[test/PanelSpec.js#L196](https://github.com/react-bootstrap/react-bootstrap/blob/ccc50e01917ba75e5a983ba068c1db4b790bb85d/test/PanelSpec.js#L196)
[test/PanelSpec.js#L206](https://github.com/react-bootstrap/react-bootstrap/blob/ccc50e01917ba75e5a983ba068c1db4b790bb85d/test/PanelSpec.js#L206)