### PR TITLE
Tabbed area. Fix for animated panes rendering.

### DIFF
--- a/test/TabbedAreaSpec.js
+++ b/test/TabbedAreaSpec.js
@@ -4,6 +4,7 @@ import TabbedArea from '../src/TabbedArea';
 import NavItem from '../src/NavItem';
 import TabPane from '../src/TabPane';
 import ValidComponentChildren from '../src/utils/ValidComponentChildren';
+import { render } from './helpers';
 
 describe('TabbedArea', function () {
   it('Should show the correct tab', function () {
@@ -228,6 +229,48 @@ describe('TabbedArea', function () {
     assert.equal(panes[0].props.active, false);
     assert.equal(panes[1].props.active, true);
     assert.equal(tabbedArea.refs.tabs.props.activeKey, 2);
+  });
+
+  describe('animation', function () {
+    let mountPoint;
+
+    beforeEach(()=>{
+      mountPoint = document.createElement('div');
+      document.body.appendChild(mountPoint);
+    });
+
+    afterEach(function () {
+      React.unmountComponentAtNode(mountPoint);
+      document.body.removeChild(mountPoint);
+    });
+
+    function checkTabRemovingWithAnimation(animation) {
+      it(`should correctly set "active" after tabPane is removed with "animation=${animation}"`, function() {
+        let instance = render(
+          <TabbedArea activeKey={2} animation={animation}>
+            <TabPane tab="Tab 1" eventKey={1}>Tab 1 content</TabPane>
+            <TabPane tab="Tab 2" eventKey={2}>Tab 2 content</TabPane>
+          </TabbedArea>
+        , mountPoint);
+
+        let panes = ReactTestUtils.scryRenderedComponentsWithType(instance, TabPane);
+
+        assert.equal(panes[0].props.active, false);
+        assert.equal(panes[1].props.active, true);
+
+        // second tab has been removed
+        render(
+          <TabbedArea activeKey={1} animation={animation}>
+            <TabPane tab="Tab 1" eventKey={1}>Tab 1 content</TabPane>
+          </TabbedArea>
+        , mountPoint);
+
+        assert.equal(panes[0].props.active, true);
+      });
+    }
+
+    checkTabRemovingWithAnimation(true);
+    checkTabRemovingWithAnimation(false);
   });
 
   describe('Web Accessibility', function(){


### PR DESCRIPTION
Bug is confirmed:
With `animation={false}` all is OK
<img width="871" alt="screen shot 2015-07-18 at 6 42 58 pm" src="https://cloud.githubusercontent.com/assets/847572/8762973/d83000f6-2d91-11e5-93a8-e1eae7687053.png">

With `animation={true}` `active` property did not set
<img width="878" alt="screen shot 2015-07-18 at 6 43 31 pm" src="https://cloud.githubusercontent.com/assets/847572/8762975/f3c15df6-2d91-11e5-9d77-a87bac30eecd.png">
<img width="522" alt="screen shot 2015-07-18 at 6 44 22 pm" src="https://cloud.githubusercontent.com/assets/847572/8762976/f826324a-2d91-11e5-99ec-cf73f739fd2b.png">

--
I've made tests reproducing this bug:
<img width="731" alt="screen shot 2015-07-18 at 8 10 36 pm" src="https://cloud.githubusercontent.com/assets/847572/8762979/1b2172fa-2d92-11e5-9bb4-2ada19d4f543.png">

--
Fixes #287 and #557
