### PR TITLE
[fixed] Only calculate overlay position on display

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -118,18 +118,18 @@ class Collapse extends React.Component {
 
 Collapse.propTypes = {
   /**
-   * Whether the component is expanded
+   * Show the component; triggers the expand or collapse animation
    */
   in: React.PropTypes.bool,
 
   /**
-   * Whether the component should be unmounted (removed from DOM) when
-   * collapsed
+   * Unmount the component (remove it from the DOM) when it is collapsed
    */
   unmountOnExit: React.PropTypes.bool,
 
   /**
-   * Whether the component should expand after mounting
+   * Run the expand animation when the component mounts, if it is initially
+   * shown
    */
   transitionAppear: React.PropTypes.bool,
 

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -113,57 +113,61 @@ class Collapse extends React.Component {
   }
 }
 
+// Explicitly copied from Transition for doc generation.
+// TODO: Remove duplication once #977 is resolved.
+
 Collapse.propTypes = {
   /**
-   * Whether the component is entered; triggers the enter or exit animation
+   * Whether the component is expanded
    */
   in: React.PropTypes.bool,
 
   /**
-   * Whether the component should be unmounted (removed from DOM) when exited
+   * Whether the component should be unmounted (removed from DOM) when
+   * collapsed
    */
   unmountOnExit: React.PropTypes.bool,
 
   /**
-   * Whether transition in should run when the Transition component mounts, if
-   * the component is initially entered
+   * Whether the component should expand after mounting
    */
   transitionAppear: React.PropTypes.bool,
 
   /**
-   * Duration of the animation in milliseconds, to ensure that finishing
-   * callbacks are fired even if the original browser transition end events are
-   * canceled
+   * Duration of the collapse animation in milliseconds, to ensure that
+   * finishing callbacks are fired even if the original browser transition end
+   * events are canceled
    */
   duration: React.PropTypes.number,
 
   /**
-   * Callback fired before the "entering" classes are applied
+   * Callback fired before the component expands
    */
   onEnter: React.PropTypes.func,
   /**
-   * Callback fired after the "entering" classes are applied
+   * Callback fired after the component starts to expand
    */
   onEntering: React.PropTypes.func,
   /**
-   * Callback fired after the "enter" classes are applied
+   * Callback fired after the component has expanded
    */
   onEntered: React.PropTypes.func,
   /**
-   * Callback fired before the "exiting" classes are applied
+   * Callback fired before the component collapses
    */
   onExit: React.PropTypes.func,
   /**
-   * Callback fired after the "exiting" classes are applied
+   * Callback fired after the component starts to collapse
    */
   onExiting: React.PropTypes.func,
   /**
-   * Callback fired after the "exited" classes are applied
+   * Callback fired after the component has collapsed
    */
   onExited: React.PropTypes.func,
 
   /**
-   * The dimension used when collapsing
+   * The dimension used when collapsing, or a function that returns the
+   * dimension
    *
    * _Note: Bootstrap only partially supports 'width'!
    * You will need to supply your own CSS animation for the `.width` CSS class._

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -115,21 +115,58 @@ class Collapse extends React.Component {
 
 Collapse.propTypes = {
   /**
-   * Collapse the Component in or out.
+   * Whether the component is entered; triggers the enter or exit animation
    */
-  in:       React.PropTypes.bool,
+  in: React.PropTypes.bool,
 
   /**
-   * Provide the duration of the animation in milliseconds, used to ensure that finishing callbacks are fired even if the
-   * original browser transition end events are canceled.
+   * Whether the component should be unmounted (removed from DOM) when exited
    */
-  duration:          React.PropTypes.number,
+  unmountOnExit: React.PropTypes.bool,
 
   /**
-   * Specifies the dimension used when collapsing.
+   * Whether transition in should run when the Transition component mounts, if
+   * the component is initially entered
+   */
+  transitionAppear: React.PropTypes.bool,
+
+  /**
+   * Duration of the animation in milliseconds, to ensure that finishing
+   * callbacks are fired even if the original browser transition end events are
+   * canceled
+   */
+  duration: React.PropTypes.number,
+
+  /**
+   * Callback fired before the "entering" classes are applied
+   */
+  onEnter: React.PropTypes.func,
+  /**
+   * Callback fired after the "entering" classes are applied
+   */
+  onEntering: React.PropTypes.func,
+  /**
+   * Callback fired after the "enter" classes are applied
+   */
+  onEntered: React.PropTypes.func,
+  /**
+   * Callback fired before the "exiting" classes are applied
+   */
+  onExit: React.PropTypes.func,
+  /**
+   * Callback fired after the "exiting" classes are applied
+   */
+  onExiting: React.PropTypes.func,
+  /**
+   * Callback fired after the "exited" classes are applied
+   */
+  onExited: React.PropTypes.func,
+
+  /**
+   * The dimension used when collapsing
    *
    * _Note: Bootstrap only partially supports 'width'!
-   * You will need to supply your own css animation for the `.width` css class._
+   * You will need to supply your own CSS animation for the `.width` CSS class._
    */
   dimension: React.PropTypes.oneOfType([
     React.PropTypes.oneOf(['height', 'width']),
@@ -137,62 +174,23 @@ Collapse.propTypes = {
   ]),
 
   /**
-   * A function that returns the height or width of the animating DOM node. Allows for providing some custom logic how much
-   * Collapse component should animate in its specified dimension.
+   * Function that returns the height or width of the animating DOM node
    *
-   * `getDimensionValue` is called with the current dimension prop value and the DOM node.
+   * Allows for providing some custom logic for how much the Collapse component
+   * should animate in its specified dimension. Called with the current
+   * dimension prop value and the DOM node.
    */
-  getDimensionValue: React.PropTypes.func,
-
-  /**
-   * A Callback fired before the component starts to expand.
-   */
-  onEnter: React.PropTypes.func,
-
-  /**
-   * A Callback fired immediately after the component starts to expand.
-   */
-  onEntering: React.PropTypes.func,
-
-  /**
-   * A Callback fired after the component has expanded.
-   */
-  onEntered: React.PropTypes.func,
-
-  /**
-   * A Callback fired before the component starts to collapse.
-   */
-  onExit: React.PropTypes.func,
-
-  /**
-   * A Callback fired immediately after the component starts to collapse.
-   */
-  onExiting: React.PropTypes.func,
-
-  /**
-   * A Callback fired after the component has collapsed.
-   */
-  onExited: React.PropTypes.func,
-
-  /**
-   * Specify whether the transitioning component should be unmounted (removed from the DOM) once the exit animation finishes.
-   */
-  unmountOnExit:     React.PropTypes.bool,
-
-  /**
-   * Specify whether the component should collapse or expand when it mounts.
-   */
-  transitionAppear: React.PropTypes.bool
+  getDimensionValue: React.PropTypes.func
 };
 
 Collapse.defaultProps = {
-  in:       false,
+  in: false,
   duration: 300,
-  dimension: 'height',
-  transitionAppear: false,
   unmountOnExit: false,
+  transitionAppear: false,
+
+  dimension: 'height',
   getDimensionValue
 };
 
 export default Collapse;
-

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -21,18 +21,18 @@ class Fade extends React.Component {
 
 Fade.propTypes = {
   /**
-   * Whether the component is faded in
+   * Show the component; triggers the fade in or fade out animation
    */
   in: React.PropTypes.bool,
 
   /**
-   * Whether the component should be unmounted (removed from DOM) when faded
-   * out
+   * Unmount the component (remove it from the DOM) when it is faded out
    */
   unmountOnExit: React.PropTypes.bool,
 
   /**
-   * Whether the component should fade in after mounting
+   * Run the fade in animation when the component mounts, if it is initially
+   * shown
    */
   transitionAppear: React.PropTypes.bool,
 

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -17,53 +17,54 @@ class Fade extends React.Component {
 }
 
 // Explicitly copied from Transition for doc generation.
+// TODO: Remove duplication once #977 is resolved.
 
 Fade.propTypes = {
   /**
-   * Whether the component is entered; triggers the enter or exit animation
+   * Whether the component is faded in
    */
   in: React.PropTypes.bool,
 
   /**
-   * Whether the component should be unmounted (removed from DOM) when exited
+   * Whether the component should be unmounted (removed from DOM) when faded
+   * out
    */
   unmountOnExit: React.PropTypes.bool,
 
   /**
-   * Whether transition in should run when the Transition component mounts, if
-   * the component is initially entered
+   * Whether the component should fade in after mounting
    */
   transitionAppear: React.PropTypes.bool,
 
   /**
-   * Duration of the animation in milliseconds, to ensure that finishing
+   * Duration of the fade animation in milliseconds, to ensure that finishing
    * callbacks are fired even if the original browser transition end events are
    * canceled
    */
   duration: React.PropTypes.number,
 
   /**
-   * Callback fired before the "entering" classes are applied
+   * Callback fired before the component fades in
    */
   onEnter: React.PropTypes.func,
   /**
-   * Callback fired after the "entering" classes are applied
+   * Callback fired after the component starts to fade in
    */
   onEntering: React.PropTypes.func,
   /**
-   * Callback fired after the "enter" classes are applied
+   * Callback fired after the has component faded in
    */
   onEntered: React.PropTypes.func,
   /**
-   * Callback fired before the "exiting" classes are applied
+   * Callback fired before the component fades out
    */
   onExit: React.PropTypes.func,
   /**
-   * Callback fired after the "exiting" classes are applied
+   * Callback fired after the component starts to fade out
    */
   onExiting: React.PropTypes.func,
   /**
-   * Callback fired after the "exited" classes are applied
+   * Callback fired after the component has faded out
    */
   onExited: React.PropTypes.func
 };

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -2,87 +2,77 @@ import React from 'react';
 import Transition from './Transition';
 
 class Fade extends React.Component {
-
-  constructor(props, context){
-    super(props, context);
-  }
-
   render() {
     return (
       <Transition
         {...this.props}
-        in={this.props.in}
         className='fade'
         enteredClassName='in'
         enteringClassName='in'
       >
-        { this.props.children }
+        {this.props.children}
       </Transition>
     );
   }
 }
 
+// Explicitly copied from Transition for doc generation.
+
 Fade.propTypes = {
   /**
-   * Fade the Component in or out.
+   * Whether the component is entered; triggers the enter or exit animation
    */
-  in:       React.PropTypes.bool,
+  in: React.PropTypes.bool,
 
   /**
-   * Provide the duration of the animation in milliseconds, used to ensure that finishing callbacks are fired even if the
-   * original browser transition end events are canceled.
+   * Whether the component should be unmounted (removed from DOM) when exited
    */
-  duration:          React.PropTypes.number,
+  unmountOnExit: React.PropTypes.bool,
 
   /**
-   * A Callback fired before the component starts to fade in.
+   * Whether transition in should run when the Transition component mounts, if
+   * the component is initially entered
+   */
+  transitionAppear: React.PropTypes.bool,
+
+  /**
+   * Duration of the animation in milliseconds, to ensure that finishing
+   * callbacks are fired even if the original browser transition end events are
+   * canceled
+   */
+  duration: React.PropTypes.number,
+
+  /**
+   * Callback fired before the "entering" classes are applied
    */
   onEnter: React.PropTypes.func,
-
   /**
-   * A Callback fired immediately after the component has started to faded in.
+   * Callback fired after the "entering" classes are applied
    */
   onEntering: React.PropTypes.func,
-
   /**
-   * A Callback fired after the component has faded in.
+   * Callback fired after the "enter" classes are applied
    */
   onEntered: React.PropTypes.func,
-
   /**
-   * A Callback fired before the component starts to fade out.
+   * Callback fired before the "exiting" classes are applied
    */
   onExit: React.PropTypes.func,
-
   /**
-   * A Callback fired immediately after the component has started to faded out.
+   * Callback fired after the "exiting" classes are applied
    */
   onExiting: React.PropTypes.func,
-
   /**
-   * A Callback fired after the component has faded out.
+   * Callback fired after the "exited" classes are applied
    */
-  onExited: React.PropTypes.func,
-
-
-  /**
-   * Specify whether the transitioning component should be unmounted (removed from the DOM) once the exit animation finishes.
-   */
-  unmountOnExit:     React.PropTypes.bool,
-
-  /**
-   * Specify whether the component should fade in or out when it mounts.
-   */
-  transitionAppear: React.PropTypes.bool
-
+  onExited: React.PropTypes.func
 };
 
 Fade.defaultProps = {
-  in:       false,
+  in: false,
   duration: 300,
-  dimension: 'height',
-  transitionAppear: false,
-  unmountOnExit: false
+  unmountOnExit: false,
+  transitionAppear: false
 };
 
 export default Fade;

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -41,7 +41,6 @@ class Overlay extends React.Component {
 
     // Don't un-render the overlay while it's transitioning out.
     const mountOverlay = props.show || (Transition && !this.state.exited);
-
     if (!mountOverlay) {
       // Don't bother showing anything if we don't have to.
       return null;
@@ -49,8 +48,17 @@ class Overlay extends React.Component {
 
     let child = children;
 
+    // Position is be inner-most because it adds inline styles into the child,
+    // which the other wrappers don't forward correctly.
+    child = (
+      <Position {...{container, containerPadding, target, placement}}>
+        {child}
+      </Position>
+    );
+
     if (Transition) {
-      // This animates the child by injecting props, so it must be inner-most.
+      // This animates the child node by injecting props, so it must precede
+      // anything that adds a wrapping div.
       child = (
         <Transition
           in={props.show}
@@ -66,13 +74,6 @@ class Overlay extends React.Component {
         {className: classNames('in', child.className)}
       );
     }
-
-    // This must wrap the transition to avoid position recalculations.
-    child = (
-      <Position {...{container, containerPadding, target, placement}}>
-        {child}
-      </Position>
-    );
 
     // This goes after everything else because it adds a wrapping div.
     if (rootClose) {

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -7,31 +7,24 @@ import CustomPropTypes from './utils/CustomPropTypes';
 import Fade from './Fade';
 import classNames from 'classnames';
 
-
 class Overlay extends React.Component {
-
-  constructor(props, context){
+  constructor(props, context) {
     super(props, context);
 
-    this.state = { exited: false };
+    this.state = {exited: !props.show};
     this.onHiddenListener = this.handleHidden.bind(this);
   }
 
   componentWillReceiveProps(nextProps) {
-    let state = {};
-
-    if ( !nextProps.show && this.props.show ){
-      state.exiting = true;
-    }
-
     if (nextProps.show) {
-      state = { exited: false, exiting: false };
+      this.setState({exited: false});
+    } else if (!nextProps.animation) {
+      // Otherwise let handleHidden take care of marking exited.
+      this.setState({exited: true});
     }
-
-    this.setState(state);
   }
 
-  render(){
+  render() {
     let {
         container
       , containerPadding
@@ -42,56 +35,63 @@ class Overlay extends React.Component {
       , animation: Transition
       , ...props } = this.props;
 
-    let child = null;
-
-    if ( Transition === true ){
+    if (Transition === true) {
       Transition = Fade;
     }
 
-    if (props.show || (Transition && this.state.exiting && !this.state.exited)) {
+    // Don't un-render the overlay while it's transitioning out.
+    const mountOverlay = props.show || (Transition && !this.state.exited);
 
-      child = children;
-
-      // Position the child before the animation to avoid `null` DOM nodes
-      child = (
-        <Position {...{ container, containerPadding, target, placement }}>
-          { child }
-        </Position>
-      );
-
-      child = Transition
-          ? (
-            <Transition
-              unmountOnExit
-              in={props.show}
-              transitionAppear={props.show}
-              onExited={this.onHiddenListener}
-            >
-              { child }
-            </Transition>
-          )
-          : cloneElement(child, { className: classNames('in', child.className) });
-
-      //Adds a wrapping div so it cannot be before Transition
-      if (rootClose) {
-        child = (
-          <RootCloseWrapper onRootClose={props.onHide}>
-            { child }
-          </RootCloseWrapper>
-        );
-      }
+    if (!mountOverlay) {
+      // Don't bother showing anything if we don't have to.
+      return null;
     }
 
+    let child = children;
+
+    if (Transition) {
+      // This animates the child by injecting props, so it must be inner-most.
+      child = (
+        <Transition
+          in={props.show}
+          transitionAppear
+          onExited={this.onHiddenListener}
+        >
+          {child}
+        </Transition>
+      );
+    } else {
+      child = cloneElement(
+        child,
+        {className: classNames('in', child.className)}
+      );
+    }
+
+    // This must wrap the transition to avoid position recalculations.
+    child = (
+      <Position {...{container, containerPadding, target, placement}}>
+        {child}
+      </Position>
+    );
+
+    // This goes after everything else because it adds a wrapping div.
+    if (rootClose) {
+      child = (
+        <RootCloseWrapper onRootClose={props.onHide}>
+          {child}
+        </RootCloseWrapper>
+      );
+    }
 
     return (
       <Portal container={container}>
-        { child }
+        {child}
       </Portal>
     );
   }
 
-  handleHidden(){
-    this.setState({ exited: true, exiting: false });
+  handleHidden() {
+    this.setState({exited: true});
   }
 }
 

--- a/src/Position.js
+++ b/src/Position.js
@@ -13,20 +13,24 @@ class Position extends React.Component {
       arrowOffsetLeft: null,
       arrowOffsetTop: null
     };
+
+    this._needsFlush = false;
   }
 
   componentDidMount() {
-    this.updatePosition(this.props, this.getTargetSafe(this.props));
+    this.updatePosition();
   }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.target !== this.props.target) {
-      const target = this.getTargetSafe(this.props);
-      const nextTarget = this.getTargetSafe(nextProps);
+      this._needsFlush = true;
+    }
+  }
 
-      if (nextTarget !== target) {
-        this.updatePosition(nextProps, nextTarget);
-      }
+  componentDidUpdate() {
+    if (this._needsFlush) {
+      this._needsFlush = false;
+      this.updatePosition();
     }
   }
 
@@ -51,15 +55,17 @@ class Position extends React.Component {
     );
   }
 
-  getTargetSafe(props) {
-    if (!props.target) {
+  getTargetSafe() {
+    if (!this.props.target) {
       return null;
     }
 
-    return props.target(props);
+    return this.props.target(this.props);
   }
 
-  updatePosition(props, target) {
+  updatePosition() {
+    const target = this.getTargetSafe();
+
     if (!target) {
       this.setState({
         positionLeft: null,
@@ -73,14 +79,15 @@ class Position extends React.Component {
 
     const overlay = React.findDOMNode(this);
     const container =
-      React.findDOMNode(props.container) || domUtils.ownerDocument(this).body;
+      React.findDOMNode(this.props.container) ||
+      domUtils.ownerDocument(this).body;
 
     this.setState(calcOverlayPosition(
-      props.placement,
+      this.props.placement,
       overlay,
       target,
       container,
-      props.containerPadding
+      this.props.containerPadding
     ));
   }
 }

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -187,18 +187,18 @@ class Transition extends React.Component {
 
 Transition.propTypes = {
   /**
-   * Whether the component is shown; triggers the enter or exit animation
+   * Show the component; triggers the enter or exit animation
    */
   in: React.PropTypes.bool,
 
   /**
-   * Whether the component should be unmounted (removed from DOM) when exited
+   * Unmount the component (remove it from the DOM) when it is not shown
    */
   unmountOnExit: React.PropTypes.bool,
 
   /**
-   * Whether transition in should run when the Transition component mounts, if
-   * the component is initially shown
+   * Run the enter animation when the component mounts, if it is initially
+   * shown
    */
   transitionAppear: React.PropTypes.bool,
 

--- a/src/Transition.js
+++ b/src/Transition.js
@@ -2,7 +2,7 @@ import React from 'react';
 import TransitionEvents from './utils/TransitionEvents';
 import classnames from 'classnames';
 
-const UNMOUNTED = 0;
+export const UNMOUNTED = 0;
 export const EXITED = 1;
 export const ENTERING = 2;
 export const ENTERED = 3;

--- a/test/PositionSpec.js
+++ b/test/PositionSpec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactTestUtils from 'react/lib/ReactTestUtils';
 import Position from '../src/Position';
+import overlayPositionUtils from '../src/utils/overlayPositionUtils';
 
 describe('Position', function () {
   it('Should output a child', function () {
@@ -21,6 +22,95 @@ describe('Position', function () {
         </Position>
       );
     }).to.throw(Error, /onlyChild must be passed a children with exactly one child/);
+  });
+
+  describe('position recalculation', function () {
+    beforeEach(function () {
+      sinon.spy(overlayPositionUtils, 'calcOverlayPosition');
+      sinon.spy(Position.prototype, 'render');
+    });
+
+    afterEach(function () {
+      overlayPositionUtils.calcOverlayPosition.restore();
+      Position.prototype.render.restore();
+    });
+
+    it('should recalculate when target changes', function () {
+      class TargetChanger extends React.Component {
+        constructor(props) {
+          super(props);
+
+          this.state = {target: 'foo'};
+        }
+
+        render() {
+          return (
+            <div>
+              {this.renderTarget()}
+
+              <Position target={() => this.refs[this.state.target]}>
+                <div />
+              </Position>
+            </div>
+          );
+        }
+
+        renderTarget() {
+          if (this.state.target === 'foo') {
+            return (<div ref="foo" style={{width: 100}} />);
+          } else if (this.state.target === 'bar') {
+            return (<div ref="bar" style={{width: 200}} />);
+          }
+        }
+      }
+
+      const instance = ReactTestUtils.renderIntoDocument(<TargetChanger />);
+
+      expect(overlayPositionUtils.calcOverlayPosition).to.have.been.calledOnce;
+
+      instance.setState({target: 'bar'});
+
+      expect(overlayPositionUtils.calcOverlayPosition)
+        .to.have.been.calledTwice;
+    });
+
+    it('should not recalculate when target doesn\'t change', function () {
+      class FooChanger extends React.Component {
+        constructor(props) {
+          super(props);
+
+          this.getTarget = this.getTarget.bind(this);
+
+          this.state = {foo: 0};
+        }
+
+        getTarget() {
+          return this.refs.target;
+        }
+
+        render() {
+          return (
+            <div>
+              <div ref="target" style={{width: 100}} />
+
+              <Position target={this.getTarget} foo={this.state.foo}>
+                <div target="positioned" />
+              </Position>
+            </div>
+          );
+        }
+      }
+
+      const instance = ReactTestUtils.renderIntoDocument(<FooChanger />);
+
+      expect(overlayPositionUtils.calcOverlayPosition).to.have.been.calledOnce;
+      expect(Position.prototype.render).to.have.been.calledTwice;
+
+      instance.setState({foo: 1});
+
+      expect(overlayPositionUtils.calcOverlayPosition).to.have.been.calledOnce;
+      expect(Position.prototype.render).to.have.been.calledThrice;
+    });
   });
 
   // ToDo: add remaining tests

--- a/test/TransitionSpec.js
+++ b/test/TransitionSpec.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactTestUtils from 'react/lib/ReactTestUtils';
 import { render } from './helpers';
-import Transition, {EXITED, ENTERING, ENTERED, EXITING} from
+import Transition, {UNMOUNTED, EXITED, ENTERING, ENTERED, EXITING} from
   '../src/Transition';
 
 describe('Transition', function () {
@@ -12,7 +12,7 @@ describe('Transition', function () {
           </Transition>
         );
 
-    instance.state.status.should.equal(ENTERED);
+    expect(instance.state.status).to.equal(ENTERED);
   });
 
   it('should transition on mount with transitionAppear', done =>{
@@ -25,7 +25,7 @@ describe('Transition', function () {
           </Transition>
         );
 
-    instance.state.status.should.equal(EXITED);
+    expect(instance.state.status).to.equal(EXITED);
   });
 
   describe('entering', ()=> {
@@ -47,7 +47,7 @@ describe('Transition', function () {
       let onEnter = sinon.spy();
       let onEntering = sinon.spy();
 
-      instance.state.status.should.equal(EXITED);
+      expect(instance.state.status).to.equal(EXITED);
 
       instance = instance.renderWithProps({
         in: true,
@@ -57,9 +57,9 @@ describe('Transition', function () {
         onEntering,
 
         onEntered(){
-          assert.ok(onEnter.calledOnce);
-          assert.ok(onEntering.calledOnce);
-          assert.ok(onEnter.calledBefore(onEntering));
+          expect(onEnter.calledOnce).to.be.ok;
+          expect(onEntering.calledOnce).to.be.ok;
+          expect(onEnter.calledBefore(onEntering)).to.be.ok;
           done();
         }
       });
@@ -68,24 +68,24 @@ describe('Transition', function () {
     it('should move to each transition state', done => {
       let count = 0;
 
-      instance.state.status.should.equal(EXITED);
+      expect(instance.state.status).to.equal(EXITED);
 
       instance = instance.renderWithProps({
         in: true,
 
         onEnter(){
           count++;
-          instance.state.status.should.equal(EXITED);
+          expect(instance.state.status).to.equal(EXITED);
         },
 
         onEntering(){
           count++;
-          instance.state.status.should.equal(ENTERING);
+          expect(instance.state.status).to.equal(ENTERING);
         },
 
         onEntered(){
-          instance.state.status.should.equal(ENTERED);
-          assert.ok(count === 2);
+          expect(instance.state.status).to.equal(ENTERED);
+          expect(count).to.equal(2);
           done();
         }
       });
@@ -94,24 +94,24 @@ describe('Transition', function () {
     it('should apply classes at each transition state', done => {
       let count = 0;
 
-      instance.state.status.should.equal(EXITED);
+      expect(instance.state.status).to.equal(EXITED);
 
       instance = instance.renderWithProps({
         in: true,
 
         onEnter(node){
           count++;
-          assert.equal(node.className, '');
+          expect(node.className).to.equal('');
         },
 
         onEntering(node){
           count++;
-          assert.equal(node.className, 'test-entering');
+          expect(node.className).to.equal('test-entering');
         },
 
         onEntered(node){
-          assert.equal(node.className, 'test-enter');
-          assert.ok(count === 2);
+          expect(node.className).to.equal('test-enter');
+          expect(count).to.equal(2);
           done();
         }
       });
@@ -138,7 +138,7 @@ describe('Transition', function () {
       let onExit = sinon.spy();
       let onExiting = sinon.spy();
 
-      instance.state.status.should.equal(ENTERED);
+      expect(instance.state.status).to.equal(ENTERED);
 
       instance = instance.renderWithProps({
         in: false,
@@ -148,9 +148,9 @@ describe('Transition', function () {
         onExiting,
 
         onExited(){
-          assert.ok(onExit.calledOnce);
-          assert.ok(onExiting.calledOnce);
-          assert.ok(onExit.calledBefore(onExiting));
+          expect(onExit.calledOnce).to.be.ok;
+          expect(onExiting.calledOnce).to.be.ok;
+          expect(onExit.calledBefore(onExiting)).to.be.ok;
           done();
         }
       });
@@ -159,24 +159,24 @@ describe('Transition', function () {
     it('should move to each transition state', done => {
       let count = 0;
 
-      instance.state.status.should.equal(ENTERED);
+      expect(instance.state.status).to.equal(ENTERED);
 
       instance = instance.renderWithProps({
         in: false,
 
         onExit(){
           count++;
-          instance.state.status.should.equal(ENTERED);
+          expect(instance.state.status).to.equal(ENTERED);
         },
 
         onExiting(){
           count++;
-          instance.state.status.should.equal(EXITING);
+          expect(instance.state.status).to.equal(EXITING);
         },
 
         onExited(){
-          instance.state.status.should.equal(EXITED);
-          //assert.ok(count === 2);
+          expect(instance.state.status).to.equal(EXITED);
+          expect(count).to.equal(2);
           done();
         }
       });
@@ -185,27 +185,95 @@ describe('Transition', function () {
     it('should apply classes at each transition state', done => {
       let count = 0;
 
-      instance.state.status.should.equal(ENTERED);
+      expect(instance.state.status).to.equal(ENTERED);
 
       instance = instance.renderWithProps({
         in: false,
 
         onExit(node){
           count++;
-          assert.equal(node.className, '');
+          expect(node.className).to.equal('');
         },
 
         onExiting(node){
           count++;
-          assert.equal(node.className, 'test-exiting');
+          expect(node.className).to.equal('test-exiting');
         },
 
         onExited(node){
-          assert.equal(node.className, 'test-exit');
-          assert.ok(count === 2);
+          expect(node.className).to.equal('test-exit');
+          expect(count).to.equal(2);
           done();
         }
       });
+    });
+  });
+
+  describe('unmountOnExit', () => {
+    class UnmountTransition extends React.Component {
+      constructor(props) {
+        super(props);
+
+        this.state = {in: props.initialIn};
+      }
+
+      render() {
+        return (
+          <Transition
+            ref="transition"
+            unmountOnExit
+            in={this.state.in}
+            duration={10}
+            {...this.props}
+          >
+            <div />
+          </Transition>
+        );
+      }
+
+      getStatus() {
+        return this.refs.transition.state.status;
+      }
+    }
+
+    it('should mount when entering', done => {
+      const instance = render(
+        <UnmountTransition
+          initialIn={false}
+
+          onEnter={() => {
+            expect(instance.getStatus()).to.equal(EXITED);
+            expect(React.findDOMNode(instance)).to.exist;
+
+            done();
+          }}
+        />
+      );
+
+      expect(instance.getStatus()).to.equal(UNMOUNTED);
+      expect(React.findDOMNode(instance)).to.not.exist;
+
+      instance.setState({in: true});
+    });
+
+    it('should unmount after exiting', done => {
+      const instance = render(
+        <UnmountTransition
+          initialIn={true}
+
+          onExited={() => {
+            expect(instance.getStatus()).to.equal(UNMOUNTED);
+            expect(React.findDOMNode(instance)).to.not.exist;
+
+            done();
+          }}
+        />
+      );
+
+      expect(instance.getStatus()).to.equal(ENTERED);
+      expect(React.findDOMNode(instance)).to.exist;
+
+      instance.setState({in: false});
     });
   });
 });

--- a/test/TransitionSpec.js
+++ b/test/TransitionSpec.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import ReactTestUtils from 'react/lib/ReactTestUtils';
 import { render } from './helpers';
-import Transition from '../src/Transition';
-//import classNames from 'classnames';
+import Transition, {EXITED, ENTERING, ENTERED, EXITING} from
+  '../src/Transition';
 
 describe('Transition', function () {
-
-
   it('should not transition on mount', function(){
     let instance = render(
           <Transition in onEnter={()=> { throw new Error('should not Enter'); }}>
@@ -14,8 +12,7 @@ describe('Transition', function () {
           </Transition>
         );
 
-    instance.state.in.should.equal(true);
-    assert.ok(!instance.state.transitioning);
+    instance.state.status.should.equal(ENTERED);
   });
 
   it('should transition on mount with transitionAppear', done =>{
@@ -28,8 +25,7 @@ describe('Transition', function () {
           </Transition>
         );
 
-    instance.state.in.should.equal(true);
-    instance.state.transitioning.should.equal(true);
+    instance.state.status.should.equal(EXITED);
   });
 
   describe('entering', ()=> {
@@ -51,10 +47,9 @@ describe('Transition', function () {
       let onEnter = sinon.spy();
       let onEntering = sinon.spy();
 
-      instance.state.in.should.equal(false);
+      instance.state.status.should.equal(EXITED);
 
       instance = instance.renderWithProps({
-
         in: true,
 
         onEnter,
@@ -73,27 +68,23 @@ describe('Transition', function () {
     it('should move to each transition state', done => {
       let count = 0;
 
-      instance.state.in.should.equal(false);
+      instance.state.status.should.equal(EXITED);
 
       instance = instance.renderWithProps({
-
         in: true,
 
         onEnter(){
           count++;
-          instance.state.in.should.equal(false);
-          instance.state.transitioning.should.equal(false);
+          instance.state.status.should.equal(EXITED);
         },
 
         onEntering(){
           count++;
-          instance.state.in.should.equal(true);
-          instance.state.transitioning.should.equal(true);
+          instance.state.status.should.equal(ENTERING);
         },
 
         onEntered(){
-          instance.state.in.should.equal(true);
-          instance.state.transitioning.should.equal(false);
+          instance.state.status.should.equal(ENTERED);
           assert.ok(count === 2);
           done();
         }
@@ -103,10 +94,9 @@ describe('Transition', function () {
     it('should apply classes at each transition state', done => {
       let count = 0;
 
-      instance.state.in.should.equal(false);
+      instance.state.status.should.equal(EXITED);
 
       instance = instance.renderWithProps({
-
         in: true,
 
         onEnter(node){
@@ -126,9 +116,7 @@ describe('Transition', function () {
         }
       });
     });
-
   });
-
 
   describe('exiting', ()=> {
     let instance;
@@ -150,10 +138,9 @@ describe('Transition', function () {
       let onExit = sinon.spy();
       let onExiting = sinon.spy();
 
-      instance.state.in.should.equal(true);
+      instance.state.status.should.equal(ENTERED);
 
       instance = instance.renderWithProps({
-
         in: false,
 
         onExit,
@@ -172,27 +159,23 @@ describe('Transition', function () {
     it('should move to each transition state', done => {
       let count = 0;
 
-      instance.state.in.should.equal(true);
+      instance.state.status.should.equal(ENTERED);
 
       instance = instance.renderWithProps({
-
         in: false,
 
         onExit(){
           count++;
-          instance.state.in.should.equal(true);
-          instance.state.transitioning.should.equal(false);
+          instance.state.status.should.equal(ENTERED);
         },
 
         onExiting(){
           count++;
-          instance.state.in.should.equal(false);
-          instance.state.transitioning.should.equal(true);
+          instance.state.status.should.equal(EXITING);
         },
 
         onExited(){
-          instance.state.in.should.equal(false);
-          instance.state.transitioning.should.equal(false);
+          instance.state.status.should.equal(EXITED);
           //assert.ok(count === 2);
           done();
         }
@@ -202,10 +185,9 @@ describe('Transition', function () {
     it('should apply classes at each transition state', done => {
       let count = 0;
 
-      instance.state.in.should.equal(true);
+      instance.state.status.should.equal(ENTERED);
 
       instance = instance.renderWithProps({
-
         in: false,
 
         onExit(node){
@@ -225,7 +207,5 @@ describe('Transition', function () {
         }
       });
     });
-
   });
-
 });


### PR DESCRIPTION
Fixes #1018

This restores the old behavior where we only calculate position initially (and when the target changes).

I also ended up modifying the `Transition` implementation a bit to make the state tracking a bit more explicit.