### PR TITLE
Lock Babel to old version due to linting issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "react": ">=0.13"
   },
   "devDependencies": {
-    "babel": "^5.1.10",
-    "babel-core": "^5.1.10",
+    "babel": "5.6.x",
+    "babel-core": "5.6.x",
     "babel-eslint": "^3.0.1",
     "babel-loader": "^5.2.1",
     "bootstrap": "^3.3.4",


### PR DESCRIPTION
This fixes the build issues. See https://github.com/facebook/react/pull/4449.