### PR TITLE
Unfix 'babel' back.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,9 +43,9 @@
     "react": ">=0.13"
   },
   "devDependencies": {
-    "babel": "5.6.x",
-    "babel-core": "5.6.x",
-    "babel-eslint": "^3.0.1",
+    "babel": "^5.8.3",
+    "babel-core": "^5.8.3",
+    "babel-eslint": "^3.1.26",
     "babel-loader": "^5.2.1",
     "bootstrap": "^3.3.4",
     "brfs": "^1.4.0",


### PR DESCRIPTION
It has been fixed.
https://github.com/facebook/react/pull/4449#issuecomment-123484276

`[changed]` tag in the commit is because 'babel' affects output code.