### PR TITLE
Enable back 'space-infix-ops' eslint rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,8 +36,7 @@
     "react/self-closing-comp": 2,
     "react/wrap-multilines": 2,
     "react/jsx-uses-vars": 2,
-    /* disable till https://github.com/eslint/eslint/issues/3016 is resolved */
-    "space-infix-ops": 0,
+    "space-infix-ops": 2,
     "strict": [2, "never"]
   }
 }


### PR DESCRIPTION
Revert of https://github.com/react-bootstrap/react-bootstrap/pull/992 is not possible
<img width="1007" alt="screen shot 2015-07-23 at 12 24 47 pm" src="https://cloud.githubusercontent.com/assets/847572/8847282/113c70e4-3136-11e5-8156-4b47e78c417c.png">