### PR TITLE
OverlayTrigger: mount overlay if mount point is defined

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -138,7 +138,9 @@ const OverlayTrigger = React.createClass({
   },
 
   componentDidUpdate(){
-    React.render(this._overlay, this._mountNode);
+    if (this._mountNode) {
+      React.render(this._overlay, this._mountNode);
+    }
   },
 
   getOverlayTarget() {


### PR DESCRIPTION
I came accross some weird React component life cycle where didUpdate was called after willUnmount. Thus, mounting overlay when there is no mount point naturally raised an error.