### PR TITLE
Add 'eslint-plugin-lodash' for 'src'

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "es5-shim": "^4.1.0",
     "eslint": "0.24.1",
     "eslint-plugin-babel": "^1.0.0",
+    "eslint-plugin-lodash": "^0.1.3",
     "eslint-plugin-mocha": "^0.4.0",
     "eslint-plugin-react": "^3.0.0",
     "express": "^4.12.3",

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "lodash"
+  ],
+  "rules": {
+    "lodash/import": 2
+  }
+}


### PR DESCRIPTION
Because of that 
```js
import pick from 'lodash/object/pick';
```
https://github.com/react-bootstrap/react-bootstrap/pull/1048/files#diff-0d27b0102f68505cf339e89dfe5c6893R8

--
Readme https://github.com/eslint-plugins/eslint-plugin-lodash