### PR TITLE
Deprecate 'utils/CustomPropTypes' exporting in v0.25

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -67,4 +67,17 @@ export Collapse from './Collapse';
 export Fade from './Collapse';
 
 export * as FormControls from './FormControls';
-export * as utils from './utils';
+
+import childrenValueInputValidation from './utils/childrenValueInputValidation';
+import createChainedFunction from './utils/createChainedFunction';
+import domUtils from './utils/domUtils';
+import ValidComponentChildren from './utils/ValidComponentChildren';
+import CustomPropTypes from './utils/CustomPropTypes';
+
+export const utils = {
+  childrenValueInputValidation,
+  createChainedFunction,
+  domUtils,
+  ValidComponentChildren,
+  CustomPropTypes
+};

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,5 +1,10 @@
+import deprecationWarning from './deprecationWarning';
+
 export childrenValueInputValidation from './childrenValueInputValidation';
 export createChainedFunction from './createChainedFunction';
-export CustomPropTypes from './CustomPropTypes';
 export domUtils from './domUtils';
 export ValidComponentChildren from './ValidComponentChildren';
+
+deprecationWarning('utils/CustomPropTypes', 'npm install react-prop-types',
+  'https://github.com/react-bootstrap/react-bootstrap/issues/937');
+export CustomPropTypes from './CustomPropTypes';


### PR DESCRIPTION
I have to change `src/index.js` because otherwise it warns about deprecation
even when users don't import 'utils/CustomPropTypes'.

But if users import `CustomPropTypes` as
```js
import CustomPropTypes from 'react-bootstrap/lib/utils/CustomPropTypes'
```
there is no warning.

And the deprecation warning cannot be added straight to `utils/CustomPropTypes.js`
because in this case there are a lot of deprecations in console.

--
First part of #937