### PR TITLE
Finding nested components in Modal through Refs.

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -196,9 +196,11 @@ const Modal = React.createClass({
       // TODO: use context in 0.14
       if (child && child.type && child.type.__isModalHeader) {
         return cloneElement(child, {
-          onHide: createChainedFunction(this.props.onHide, child.props.onHide)
+          onHide: createChainedFunction(this.props.onHide, child.props.onHide),
+          ref: child.ref
         });
       }
+      child = React.cloneElement(child, {ref: child.ref});
       return child;
     });
   },

--- a/src/ModalBody.js
+++ b/src/ModalBody.js
@@ -3,9 +3,12 @@ import classnames from 'classnames';
 
 class ModalBody extends React.Component {
   render() {
+    let children = React.Children.map(this.props.children, function (child) {
+      return React.cloneElement(child, {ref: child.ref});
+    });
     return (
       <div {...this.props} className={classnames(this.props.className, this.props.modalClassName)}>
-        {this.props.children}
+        {children}
       </div>
     );
   }

--- a/src/ModalFooter.js
+++ b/src/ModalFooter.js
@@ -5,9 +5,12 @@ import classnames from 'classnames';
 class ModalFooter extends React.Component {
 
   render() {
+    let children = React.Children.map(this.props.children, function (child) {
+      return React.cloneElement(child, {ref: child.ref});
+    });
     return (
       <div {...this.props} className={classnames(this.props.className, this.props.modalClassName)}>
-        {this.props.children}
+        {children}
       </div>
     );
   }

--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -5,6 +5,9 @@ import classnames from 'classnames';
 class ModalHeader extends React.Component {
 
   render() {
+    let children = React.Children.map(this.props.children, function (child) {
+      return React.cloneElement(child, {ref: child.ref});
+    });
     return (
       <div
         {...this.props}
@@ -20,7 +23,7 @@ class ModalHeader extends React.Component {
             </span>
           </button>
         }
-        { this.props.children }
+        { children }
       </div>
     );
   }

--- a/src/ModalTitle.js
+++ b/src/ModalTitle.js
@@ -4,9 +4,12 @@ import classnames from 'classnames';
 class ModalTitle extends React.Component {
 
   render() {
+    let children = React.Children.map(this.props.children, function (child) {
+      return React.cloneElement(child, {ref: child.ref});
+    });
     return (
       <h4 {...this.props} className={classnames(this.props.className, this.props.modalClassName)}>
-        { this.props.children }
+        { children }
       </h4>
     );
   }

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -148,6 +148,44 @@ describe('Modal', function () {
     assert.ok(dialog.className.match(/\bmodal-sm\b/));
   });
 
+  it('Should find nested Refs', function () {
+    let noOp = function () {};
+    let headerMsg = 'Header Message';
+    let titleMsg = 'Title Message';
+    let bodyMsg = 'Body Message';
+    let footerMsg = 'Footer Message';
+    let Xxx = React.createClass({
+      render(){
+        return (
+          <div>
+            <Modal show bsSize='small' onHide={noOp} ref='modal'>
+              <Modal.Header ref="header">
+                <Modal.Title ref="title">
+                  <strong ref='titleMsg'>{titleMsg}</strong>
+                </Modal.Title>
+                <strong ref='headerMsg'>{headerMsg}</strong>
+              </Modal.Header>
+              <Modal.Body ref='body'>
+                <strong ref='bodyMsg'>{bodyMsg}</strong>
+              </Modal.Body>
+              <Modal.Footer ref='footer'>
+                <strong ref='footerMsg'>{footerMsg}</strong>
+              </Modal.Footer>
+            </Modal>
+          </div>
+        );
+      }
+    });
+    let instance = render(
+      <Xxx/>
+    , mountPoint);
+
+    assert.ok(instance.refs.modal.refs.header.refs.headerMsg.props.children.match(headerMsg));
+    assert.ok(instance.refs.modal.refs.header.refs.title.refs.titleMsg.props.children.match(titleMsg));
+    assert.ok(instance.refs.modal.refs.body.refs.bodyMsg.props.children.match(bodyMsg));
+    assert.ok(instance.refs.modal.refs.footer.refs.footerMsg.props.children.match(footerMsg));
+  });
+
   it('Should pass dialogClassName to the dialog', function () {
     let noOp = function () {};
     let instance = render(


### PR DESCRIPTION
Hi.

At first, My English is poor. I'm sorry about that.

In current implementation, it looks like that below codes are not worked.

```
    var Xxx = React.createClass({
      render:function(){
        return (
          <div>
            <Modal show bsSize='small' onHide={noOp} ref="modal">
              <Modal.Header ref="header">
                <Modal.Title ref="title">
                  <strong ref="titleMsg">{titleMsg}</strong>
                </Modal.Title>
                <strong ref="headerMsg">{headerMsg}</strong>
              </Modal.Header>
              <Modal.Body ref="body">
                <strong ref="bodyMsg">{bodyMsg}</strong>
              </Modal.Body>
              <Modal.Footer ref="footer">
                <strong ref="footerMsg">{footerMsg}</strong>
              </Modal.Footer>
            </Modal>
          </div>
        );
      }
    });
    let instance = render(
      <Xxx/>
    , mountPoint);

    assert.ok(instance.refs.modal.refs.header.refs.headerMsg.props.children.match(headerMsg));
```

What I want to do was to click some buttons in Modal at testing, so I tried this pull request.

Review please.
