### PR TITLE
Add 'customAnchor' property for 'MenuItem'

### DIFF
--- a/docs/examples/MenuItemCustomAnchor.js
+++ b/docs/examples/MenuItemCustomAnchor.js
@@ -1,0 +1,22 @@
+const MenuItems = (
+  <div className="clearfix">
+    <ul className="dropdown-menu open">
+      <MenuItem header>Header</MenuItem>
+      <MenuItem customAnchor
+        href='/song.ogg'
+        title='title for menu item'
+        className='menu-item-class'>
+        <a
+          className='custom-anchor-class'
+          style={{color: 'red'}}
+          download='filename.ogg'
+          type='audio/vorbis'
+          rel='nofollow'>
+          My custom link
+        </a>
+      </MenuItem>
+    </ul>
+  </div>
+);
+
+React.render(MenuItems, mountNode);

--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -206,6 +206,11 @@ const ComponentsPage = React.createClass({
                   </p>
                   <ReactPlayground codeText={Samples.MenuItem} />
 
+                  <h3><Anchor id='menu-item-custom-anchor'>Custom anchor child</Anchor></h3>
+                  <p>You can use your own custom component for anchor by adding <code>customAnchor</code> property.</p>
+                  <p>By using your custom component you can set any additional custom properties you need.</p>
+                  <ReactPlayground codeText={Samples.MenuItemCustomAnchor} />
+
                   <h3><Anchor id='menu-item-props'>Props</Anchor></h3>
                   <PropTable component='MenuItem'/>
                 </div>

--- a/docs/src/Samples.js
+++ b/docs/src/Samples.js
@@ -102,6 +102,7 @@ export default {
   InputHorizontal:               require('fs').readFileSync(__dirname + '/../examples/InputHorizontal.js', 'utf8'),
   InputWrapper:                  require('fs').readFileSync(__dirname + '/../examples/InputWrapper.js', 'utf8'),
   MenuItem:                      require('fs').readFileSync(__dirname + '/../examples/MenuItem.js', 'utf8'),
+  MenuItemCustomAnchor:          require('fs').readFileSync(__dirname + '/../examples/MenuItemCustomAnchor.js', 'utf8'),
 
   Overlay:                       require('fs').readFileSync(__dirname + '/../examples/Overlay.js', 'utf8'),
   OverlayCustom:                 require('fs').readFileSync(__dirname + '/../examples/OverlayCustom.js', 'utf8')

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -1,23 +1,28 @@
-import React from 'react';
+import React, { cloneElement } from 'react';
 import classNames from 'classnames';
 import SafeAnchor from './SafeAnchor';
 
 const MenuItem = React.createClass({
   propTypes: {
-    header:    React.PropTypes.bool,
-    divider:   React.PropTypes.bool,
-    href:      React.PropTypes.string,
-    title:     React.PropTypes.string,
-    target:    React.PropTypes.string,
-    onSelect:  React.PropTypes.func,
-    eventKey:  React.PropTypes.any,
-    active:    React.PropTypes.bool,
-    disabled:  React.PropTypes.bool
+    header:       React.PropTypes.bool,
+    divider:      React.PropTypes.bool,
+    href:         React.PropTypes.string,
+    title:        React.PropTypes.string,
+    target:       React.PropTypes.string,
+    onSelect:     React.PropTypes.func,
+    eventKey:     React.PropTypes.any,
+    active:       React.PropTypes.bool,
+    /**
+     * The child is used as a custom anchor element with this attribute set
+     */
+    customAnchor: React.PropTypes.bool,
+    disabled:     React.PropTypes.bool
   },
 
   getDefaultProps() {
     return {
-      active: false
+      active: false,
+      customAnchor: false
     };
   },
 
@@ -40,6 +45,20 @@ const MenuItem = React.createClass({
     );
   },
 
+  renderCustomAnchor() {
+    let child = React.Children.only(this.props.children);
+    return cloneElement(
+      child,
+      {
+        tabIndex: '-1',
+        onClick: this.handleClick,
+        href: this.props.href,
+        target: this.props.target,
+        title: this.props.title
+      }
+    );
+  },
+
   render() {
     let classes = {
         'dropdown-header': this.props.header,
@@ -48,15 +67,21 @@ const MenuItem = React.createClass({
         'disabled': this.props.disabled
       };
 
-    let children = null;
+    let children;
     if (this.props.header) {
       children = this.props.children;
-    } else if (!this.props.divider) {
+    } else if (this.props.divider) {
+      children = null;
+    } else if (this.props.customAnchor) {
+      children = this.renderCustomAnchor();
+    } else {
       children = this.renderAnchor();
     }
 
+    let {title, href, ...liProps} = this.props;
+
     return (
-      <li {...this.props} role="presentation" title={null} href={null}
+      <li {...liProps} role="presentation"
         className={classNames(this.props.className, classes)}>
         {children}
       </li>

--- a/test/MenuItemSpec.js
+++ b/test/MenuItemSpec.js
@@ -36,17 +36,6 @@ describe('MenuItem', function () {
     assert.equal(anchorNode.getAttribute('title'), 'hi mom!');
   });
 
-  it('should have an anchor', function () {
-    let instance = ReactTestUtils.renderIntoDocument(
-      <MenuItem>
-        Title
-      </MenuItem>
-    );
-
-    let anchor = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a');
-    assert.equal(React.findDOMNode(anchor).getAttribute('tabIndex'), '-1');
-  });
-
   it('should fire callback on click of link', function (done) {
     let selectOp = function (selectedKey) {
       assert.equal(selectedKey, '1');
@@ -115,5 +104,82 @@ describe('MenuItem', function () {
       </MenuItem>
     );
     assert.ok(React.findDOMNode(instance).className.match(/\bdisabled\b/));
+  });
+
+  describe('customAnchor property', function () {
+    it('renders own anchor by default', function () {
+      let instance = ReactTestUtils.renderIntoDocument(
+        <MenuItem>
+          Title
+        </MenuItem>
+      );
+
+      let anchor = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a');
+      assert.equal(React.findDOMNode(anchor).getAttribute('tabIndex'), '-1');
+    });
+
+    it('uses a child as anchor component with "customAnchor" set', function () {
+      let instance = ReactTestUtils.renderIntoDocument(
+        <MenuItem customAnchor>
+          <a className='my-custom'>
+            Title
+          </a>
+        </MenuItem>
+      );
+
+      assert.equal(ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'my-custom').length, 1);
+      assert.equal(React.findDOMNode(instance).children[0].className, 'my-custom');
+    });
+
+    it('should call `onSelect` with click on a custom child anchor', function (done) {
+      function handleSelect(key, href, target) {
+        assert.equal(href, 'link');
+        assert.equal(target, '_blank');
+        done();
+      }
+      let instance = ReactTestUtils.renderIntoDocument(
+        <MenuItem customAnchor onSelect={handleSelect} target="_blank" href="link">
+          <a>Title</a>
+        </MenuItem>
+      );
+      ReactTestUtils.Simulate.click(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a'));
+    });
+
+    it('passes anchor props onto a child anchor', function () {
+      let instance = ReactTestUtils.renderIntoDocument(
+        <MenuItem customAnchor
+          href='/song.ogg'
+          target='_blank'
+          title='title for menu item'
+          className='menu-item-class'>
+          <a
+            className='custom-anchor-class'
+            style={{color: 'red'}}
+            download='filename'
+            type='audio/vorbis'
+            rel='nofollow'>
+            Title
+          </a>
+        </MenuItem>
+      );
+
+      let node = React.findDOMNode(instance);
+      assert(node.className.match(/\bmenu-item-class\b/));
+      assert.equal(node.getAttribute('href'), null);
+      assert.equal(node.getAttribute('title'), null);
+
+      let anchorNode = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a'));
+      // custom properties
+      assert(anchorNode.className.match(/\bcustom-anchor-class\b/));
+      assert.equal(anchorNode.getAttribute('download'), 'filename');
+      assert.equal(anchorNode.getAttribute('rel'), 'nofollow');
+      assert.equal(anchorNode.getAttribute('type'), 'audio/vorbis');
+      assert.equal(anchorNode.style.color, 'red');
+      // pass through properties
+      assert.equal(anchorNode.getAttribute('tabIndex'), '-1');
+      assert.equal(anchorNode.getAttribute('href'), '/song.ogg');
+      assert.equal(anchorNode.getAttribute('target'), '_blank');
+      assert.equal(anchorNode.getAttribute('title'), 'title for menu item');
+    });
   });
 });


### PR DESCRIPTION
It allows using a child component as a custom anchor.

Closes https://github.com/react-bootstrap/react-bootstrap/issues/629

It has this API:
```js
< MenuItem customAnchor ... >
  <MyCustomAnchorElement />
</MenuItem >
```

Just to compare - how it looks alternative API: - https://github.com/react-bootstrap/react-bootstrap/pull/1072

--
First time I've done it like https://github.com/react-bootstrap/react-bootstrap/pull/1072, then I realize that I don't like that API and re-wrote all to this PR.

:cherries: 