### PR TITLE
[do not merge] Add 'anchorComponentClass' property to 'MenuItem'

### DIFF
--- a/docs/examples/MenuItemCustomAnchor.js
+++ b/docs/examples/MenuItemCustomAnchor.js
@@ -1,0 +1,29 @@
+class CustomAnchor extends React.Component {
+  render() {
+    return (
+      <a {...this.props}
+        className='custom-anchor-class'
+        style={{color: 'red'}}
+        download='filename.ogg'
+        type='audio/vorbis'
+        rel='nofollow' />
+    );
+  }
+}
+
+const MenuItems = (
+  <div className="clearfix">
+    <ul className="dropdown-menu open">
+      <MenuItem header>Header</MenuItem>
+      <MenuItem
+        anchorComponentClass={CustomAnchor}
+        href='/song.ogg'
+        title='title for menu item'
+        className='menu-item-class'>
+        my custom link
+      </MenuItem>
+    </ul>
+  </div>
+);
+
+React.render(MenuItems, mountNode);

--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -206,6 +206,11 @@ const ComponentsPage = React.createClass({
                   </p>
                   <ReactPlayground codeText={Samples.MenuItem} />
 
+                  <h3><Anchor id='menu-item-custom-anchor'>Custom anchor</Anchor></h3>
+                  <p>You can use your own custom component for inner anchor via <code>anchorComponentClass</code> property.</p>
+                  <p>By using your custom component you can set any additional custom property you need.</p>
+                  <ReactPlayground codeText={Samples.MenuItemCustomAnchor} />
+
                   <h3><Anchor id='menu-item-props'>Props</Anchor></h3>
                   <PropTable component='MenuItem'/>
                 </div>

--- a/docs/src/Samples.js
+++ b/docs/src/Samples.js
@@ -102,6 +102,7 @@ export default {
   InputHorizontal:               require('fs').readFileSync(__dirname + '/../examples/InputHorizontal.js', 'utf8'),
   InputWrapper:                  require('fs').readFileSync(__dirname + '/../examples/InputWrapper.js', 'utf8'),
   MenuItem:                      require('fs').readFileSync(__dirname + '/../examples/MenuItem.js', 'utf8'),
+  MenuItemCustomAnchor:          require('fs').readFileSync(__dirname + '/../examples/MenuItemCustomAnchor.js', 'utf8'),
 
   Overlay:                       require('fs').readFileSync(__dirname + '/../examples/Overlay.js', 'utf8'),
   OverlayCustom:                 require('fs').readFileSync(__dirname + '/../examples/OverlayCustom.js', 'utf8')

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import SafeAnchor from './SafeAnchor';
+import CustomPropTypes from './utils/CustomPropTypes';
 
 const MenuItem = React.createClass({
   propTypes: {
@@ -12,12 +13,17 @@ const MenuItem = React.createClass({
     onSelect:  React.PropTypes.func,
     eventKey:  React.PropTypes.any,
     active:    React.PropTypes.bool,
-    disabled:  React.PropTypes.bool
+    disabled:  React.PropTypes.bool,
+    /**
+     * You can use a custom element for inner anchor component
+     */
+    anchorComponentClass: CustomPropTypes.elementType
   },
 
   getDefaultProps() {
     return {
-      active: false
+      active: false,
+      anchorComponentClass: SafeAnchor
     };
   },
 
@@ -33,10 +39,11 @@ const MenuItem = React.createClass({
   },
 
   renderAnchor() {
+    let AnchorComponentClass = this.props.anchorComponentClass;
     return (
-      <SafeAnchor onClick={this.handleClick} href={this.props.href} target={this.props.target} title={this.props.title} tabIndex="-1">
+      <AnchorComponentClass onClick={this.handleClick} href={this.props.href} target={this.props.target} title={this.props.title} tabIndex="-1">
         {this.props.children}
-      </SafeAnchor>
+      </AnchorComponentClass>
     );
   },
 

--- a/test/MenuItemSpec.js
+++ b/test/MenuItemSpec.js
@@ -36,17 +36,6 @@ describe('MenuItem', function () {
     assert.equal(anchorNode.getAttribute('title'), 'hi mom!');
   });
 
-  it('should have an anchor', function () {
-    let instance = ReactTestUtils.renderIntoDocument(
-      <MenuItem>
-        Title
-      </MenuItem>
-    );
-
-    let anchor = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a');
-    assert.equal(React.findDOMNode(anchor).getAttribute('tabIndex'), '-1');
-  });
-
   it('should fire callback on click of link', function (done) {
     let selectOp = function (selectedKey) {
       assert.equal(selectedKey, '1');
@@ -115,5 +104,74 @@ describe('MenuItem', function () {
       </MenuItem>
     );
     assert.ok(React.findDOMNode(instance).className.match(/\bdisabled\b/));
+  });
+
+  describe('anchorComponentClass', function () {
+    it('uses SafeAnchor by default', function () {
+      let instance = ReactTestUtils.renderIntoDocument(
+        <MenuItem>
+          Title
+        </MenuItem>
+      );
+
+      let anchor = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a');
+      assert.equal(React.findDOMNode(anchor).getAttribute('tabIndex'), '-1');
+    });
+
+    it('should use a custom anchor component provided via anchorComponentClass', function () {
+      class CustomAnchor extends React.Component {
+        render() {
+          return <a {...this.props} className='my-custom'/>;
+        }
+      }
+
+      let instance = ReactTestUtils.renderIntoDocument(
+        <MenuItem anchorComponentClass={CustomAnchor}>
+          Title
+        </MenuItem>
+      );
+
+      assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'my-custom'));
+    });
+
+    it('should allow custom props and pass through existing ones', function () {
+      class CustomAnchor extends React.Component {
+        render() {
+          return (
+            <a {...this.props}
+              className='custom-anchor-class'
+              style={{color: 'red'}}
+              download='filename'
+              type='audio/vorbis'
+              rel='nofollow' />
+          );
+        }
+      }
+
+      let instance = ReactTestUtils.renderIntoDocument(
+        <MenuItem
+          anchorComponentClass={CustomAnchor}
+          href='/song.ogg'
+          title='title for menu item'
+          className='menu-item-class'>
+          Title
+        </MenuItem>
+      );
+
+      let node = React.findDOMNode(instance);
+      assert(node.className.match(/\bmenu-item-class\b/));
+      assert.equal(node.getAttribute('href'), null);
+      assert.equal(node.getAttribute('title'), null);
+
+      let anchorNode = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a'));
+      // custom properties
+      assert(anchorNode.className.match(/\bcustom-anchor-class\b/));
+      assert.equal(anchorNode.getAttribute('download'), 'filename');
+      assert.equal(anchorNode.getAttribute('rel'), 'nofollow');
+      assert.equal(anchorNode.style.color, 'red');
+      // pass through properties
+      assert.equal(anchorNode.getAttribute('href'), '/song.ogg');
+      assert.equal(anchorNode.getAttribute('title'), 'title for menu item');
+    });
   });
 });


### PR DESCRIPTION
allows to set custom anchor component with custom additional properties.

--
#### This is only for demonstration purposes.
--

Just as alternative to https://github.com/react-bootstrap/react-bootstrap/pull/1071 to compare APIs

--
This PR's API:

```js
class CustomAnchor extends React.Component {
  render() {
    return (
      <a {...this.props}
        className='custom-anchor-class'
        style={{color: 'red'}}
        download='filename.ogg'
        type='audio/vorbis'
        rel='nofollow' />
    );
  }
}

<MenuItem anchorComponentClass={CustomAnchor} ...
</MenuItem>
```

--
And example looks like:
<img width="685" alt="custom-anchor" src="https://cloud.githubusercontent.com/assets/847572/8905423/d254f1bc-346e-11e5-9286-403424f5784f.png">
