### PR TITLE
Add missing tests for 'Row'

### DIFF
--- a/test/RowSpec.js
+++ b/test/RowSpec.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import ReactTestUtils from 'react/lib/ReactTestUtils';
+import Row from '../src/Row';
+
+describe('Row', function () {
+  it('uses "div" by default', function () {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Row />
+    );
+
+    assert.equal(React.findDOMNode(instance).nodeName, 'DIV');
+  });
+
+  it('has "row" class', function () {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Row>Row content</Row>
+    );
+    assert.equal(React.findDOMNode(instance).className, 'row');
+  });
+
+  it('Should merge additional classes passed in', function () {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Row className="bob"/>
+    );
+    assert.ok(React.findDOMNode(instance).className.match(/\bbob\b/));
+    assert.ok(React.findDOMNode(instance).className.match(/\brow\b/));
+  });
+
+  it('allows custom elements instead of "div"', function () {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Row componentClass='section' />
+    );
+
+    assert.equal(React.findDOMNode(instance).nodeName, 'SECTION');
+  });
+});


### PR DESCRIPTION
coverage: before
<img width="1086" alt="row-before" src="https://cloud.githubusercontent.com/assets/847572/8930055/1186826e-3533-11e5-80ad-50b02f610396.png">

coverage: after
<img width="1087" alt="row-after" src="https://cloud.githubusercontent.com/assets/847572/8930056/118af6e6-3533-11e5-8aa2-7a4b413c2e6c.png">