### PR TITLE
Modal: added finalisation for the component when it was unbound from the tree

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -277,6 +277,12 @@ const Modal = React.createClass({
     }
   },
 
+  componentWillUnmount() {
+    if (this.props.show) {
+      this.onHide();
+    }
+  },
+
   onShow() {
     const doc = domUtils.ownerDocument(this);
     const win = domUtils.ownerWindow(this);

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -197,6 +197,22 @@ describe('Modal', function () {
       , mountPoint);
   });
 
+  it('Should unbind listeners when unmounted', function() {
+    render(
+        <div>
+          <Modal show onHide={() => null} animation={false}>
+            <strong>Foo bar</strong>
+          </Modal>
+        </div>
+    , mountPoint);
+
+    assert.include(document.body.className, 'modal-open');
+
+    render(<div />, mountPoint);
+
+    assert.notInclude(document.body.className, 'modal-open');
+  });
+
   describe('Focused state', function () {
     let focusableContainer = null;
 


### PR DESCRIPTION
Fix for #1078

The component must clean up after itself when it was unmounted