### PR TITLE
[fixed] adds missing 'role' to .panel-collapse

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -80,7 +80,8 @@ const Panel = React.createClass({
           className={collapseClass}
           id={this.props.id}
           ref='panel'
-          aria-expanded={this.isExpanded()}>
+          aria-expanded={this.isExpanded()}
+          role='note'>
           {this.renderBody()}
 
         </div>

--- a/test/PanelSpec.js
+++ b/test/PanelSpec.js
@@ -219,5 +219,14 @@ describe('Panel', function () {
       assert.equal(anchor.getAttribute('aria-controls'), 'panel-1');
     });
 
+    it('Should add role="note"', function() {
+      let instance = ReactTestUtils.renderIntoDocument(
+        <Panel id='panel-1' collapsible expanded header="Heading">Panel content</Panel>
+      );
+
+      let collapse = React.findDOMNode(instance).querySelector('.panel-collapse');
+
+      assert.equal(collapse.getAttribute('role'), 'note');
+    });
   });
 });


### PR DESCRIPTION
To be ARIA-compliant, elements with "aria-expanded" must have a "role" set. ["note"](http://www.w3.org/TR/wai-aria/roles#note) seemed like the appropriate role.
