### PR TITLE
[fixed] regression when clicking "static" modal backdrops

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -216,10 +216,14 @@ const Modal = React.createClass({
     let { animation, bsClass } = this.props;
     let duration = Modal.BACKDROP_TRANSITION_DURATION;
 
+    // Don't handle clicks for "static" backdrops
+    let onClick = this.props.backdrop === true ?
+      this.handleBackdropClick : null;
+
     let backdrop = (
       <div ref="backdrop"
        className={classNames(`${bsClass}-backdrop`, { in: this.props.show && !animation })}
-       onClick={this.handleBackdropClick}
+       onClick={onClick}
       />
     );
 


### PR DESCRIPTION
Not sure where this fell to the floor, but clearly we have no tests around it (will get to that)