### PR TITLE
[changed] Deprecating TabPane and TabbedArea

### DIFF
--- a/src/TabPane.js
+++ b/src/TabPane.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import TransitionEvents from './utils/TransitionEvents';
+import deprecationWarning from './utils/deprecationWarning';
 
 const TabPane = React.createClass({
   propTypes: {
@@ -76,6 +77,8 @@ const TabPane = React.createClass({
       'active': this.props.active || this.state.animateOut,
       'in': this.props.active && !this.state.animateIn
     };
+
+    deprecationWarning('TabPane', 'Tab');
 
     return (
       <div {...this.props}

--- a/src/TabbedArea.js
+++ b/src/TabbedArea.js
@@ -4,6 +4,8 @@ import BootstrapMixin from './BootstrapMixin';
 import ValidComponentChildren from './utils/ValidComponentChildren';
 import Nav from './Nav';
 import NavItem from './NavItem';
+import deprecationWarning from './utils/deprecationWarning';
+
 
 let panelId = (props, child) => child.props.id ? child.props.id : props.id && (props.id + '___panel___' + child.props.eventKey);
 let tabId = (props, child) => child.props.id ? child.props.id + '___tab' : props.id && (props.id + '___tab___' + child.props.eventKey);
@@ -89,6 +91,8 @@ const TabbedArea = React.createClass({
         {ValidComponentChildren.map(this.props.children, renderTabIfSet, this)}
       </Nav>
     );
+
+    deprecationWarning('TabbedArea', 'Tabs');
 
     return (
       <div>


### PR DESCRIPTION
TabPane and TabbedArea are now deprecated. Please use Tab and Tabs
instead.

Signed-off-by: Kenny Wang <kwang@pivotal.io>

#1091