### PR TITLE
[fixed] Modal uses provided className again

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -163,7 +163,7 @@ const Modal = React.createClass({
     let modal = (
       <Dialog {...props}
         ref={this._setDialogRef}
-        className={classNames({ in: show && !animation })}
+        className={classNames(this.props.className, { in: show && !animation })}
         onClick={backdrop === true ? this.handleBackdropClick : null}
       >
         { this.renderContent() }

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -130,6 +130,19 @@ describe('Modal', function () {
     ReactTestUtils.Simulate.click(button);
   });
 
+  it('Should pass className to the dialog', function () {
+    let noOp = function () {};
+    let instance = render(
+      <Modal show className='mymodal' onHide={noOp}>
+        <strong>Message</strong>
+      </Modal>
+    , mountPoint);
+
+    let dialog = React.findDOMNode(instance.refs.dialog);
+
+    assert.ok(dialog.className.match(/\bmymodal\b/));
+  });
+
   it('Should use bsClass on the dialog', function () {
     let noOp = function () {};
     let instance = render(


### PR DESCRIPTION
Somewhere along the way in 0.24 Modal lost the ability to use a provided className.

In other words, you can now do this again:
```
<Modal className="my-modal-class" ... />
```

I had some code do this and figured it was useful enough to re-add.