### PR TITLE
Remove reference to factories from documentation

### DIFF
--- a/docs/src/GettingStartedPage.js
+++ b/docs/src/GettingStartedPage.js
@@ -85,18 +85,6 @@ $ bower install react-bootstrap`
                     />
                   </div>
 
-                  <h3>Without JSX</h3>
-                  <p>If you do not use JSX and just call components as functions, you must explicitly <a href="https://facebook.github.io/react/blog/2014/10/14/introducing-react-elements.html#deprecated-auto-generated-factories">create a factory before calling it</a>. React-bootstrap provides factories for you in <code>lib/factories</code>:</p>
-                  <div className="highlight">
-                    <CodeExample
-                      mode="javascript"
-                      codeText={
-`var Alert = require('react-bootstrap/lib/factories').Alert;
-// or
-var Alert = require('react-bootstrap/lib/factories/Alert');`
-                      }
-                    />
-                  </div>
                 </div>
                 <div className="bs-docs-section">
                   <h2 id="browser-support" className="page-header">Browser support</h2>


### PR DESCRIPTION
Forgot to remove this when we removed factory support.