### PR TITLE
[added] Custom feedback icon for Input

### DIFF
--- a/src/Glyphicon.js
+++ b/src/Glyphicon.js
@@ -7,12 +7,14 @@ const Glyphicon = React.createClass({
   mixins: [BootstrapMixin],
 
   propTypes: {
-    glyph: React.PropTypes.oneOf(styleMaps.GLYPHS).isRequired
+    glyph: React.PropTypes.oneOf(styleMaps.GLYPHS).isRequired,
+    formControlFeedback: React.PropTypes.bool
   },
 
   getDefaultProps() {
     return {
-      bsClass: 'glyphicon'
+      bsClass: 'glyphicon',
+      formControlFeedback: false
     };
   },
 
@@ -20,6 +22,7 @@ const Glyphicon = React.createClass({
     let classes = this.getBsClassSet();
 
     classes['glyphicon-' + this.props.glyph] = true;
+    classes['form-control-feedback'] = this.props.formControlFeedback;
 
     return (
       <span {...this.props} className={classNames(this.props.className, classes)}>

--- a/src/InputBase.js
+++ b/src/InputBase.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import FormGroup from './FormGroup';
+import Glyphicon from './Glyphicon';
 
 class InputBase extends React.Component {
   getInputDOMNode() {
@@ -91,17 +92,20 @@ class InputBase extends React.Component {
   }
 
   renderIcon() {
-    let classes = {
-      'glyphicon': true,
-      'form-control-feedback': true,
-      'glyphicon-ok': this.props.bsStyle === 'success',
-      'glyphicon-warning-sign': this.props.bsStyle === 'warning',
-      'glyphicon-remove': this.props.bsStyle === 'error'
-    };
+    if (this.props.hasFeedback) {
+      if (this.props.feedbackIcon) {
+        return React.cloneElement(this.props.feedbackIcon, { formControlFeedback: true });
+      }
 
-    return this.props.hasFeedback ? (
-      <span className={classNames(classes)} key="icon" />
-    ) : null;
+      switch (this.props.bsStyle) {
+        case 'success': return <Glyphicon formControlFeedback glyph="ok" key="icon" />;
+        case 'warning': return <Glyphicon formControlFeedback glyph="warning-sign" key="icon" />;
+        case 'error': return <Glyphicon formControlFeedback glyph="remove" key="icon" />;
+        default: return <span className="form-control-feedback" key="icon" />;
+      }
+    } else {
+      return null;
+    }
   }
 
   renderHelp() {
@@ -214,6 +218,7 @@ InputBase.propTypes = {
   bsSize: React.PropTypes.oneOf(['small', 'medium', 'large']),
   bsStyle: React.PropTypes.oneOf(['success', 'warning', 'error']),
   hasFeedback: React.PropTypes.bool,
+  feedbackIcon: React.PropTypes.node,
   id: React.PropTypes.string,
   groupClassName: React.PropTypes.string,
   wrapperClassName: React.PropTypes.string,

--- a/test/GlyphiconSpec.js
+++ b/test/GlyphiconSpec.js
@@ -10,4 +10,22 @@ describe('Glyphicon', function () {
     assert.ok(React.findDOMNode(instance).className.match(/\bglyphicon\b/));
     assert.ok(React.findDOMNode(instance).className.match(/\bglyphicon-star\b/));
   });
+
+  it('renders without the .form-control-feedback class', function () {
+      let instance = ReactTestUtils.renderIntoDocument(
+        <Glyphicon glyph='star' />
+      );
+
+      assert.notOk(React.findDOMNode(instance).className.match(/\bform-control-feedback\b/));
+  });
+
+  context('when setting the formControlFeedback prop', function () {
+    it('should have the .form-control-feedback class set', function () {
+      let instance = ReactTestUtils.renderIntoDocument(
+        <Glyphicon formControlFeedback glyph='star' />
+      );
+
+      assert.ok(React.findDOMNode(instance).className.match(/\bform-control-feedback\b/));
+    });
+  });
 });

--- a/test/InputSpec.js
+++ b/test/InputSpec.js
@@ -4,6 +4,7 @@ import Input from '../src/Input';
 import Button from '../src/Button';
 import DropdownButton from '../src/DropdownButton';
 import MenuItem from '../src/MenuItem';
+import Glyphicon from '../src/Glyphicon';
 import {shouldWarn} from './helpers';
 
 describe('Input', function () {
@@ -278,5 +279,57 @@ describe('Input', function () {
 
     let node = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'input'));
     assert.isNotNull(node.getAttribute('disabled'));
+  });
+
+  context('when Input listens to feedback', function () {
+    it('renders success feedback as Glyphicon', function () {
+      let instance = ReactTestUtils.renderIntoDocument(
+        <Input hasFeedback={true} bsStyle="success" />
+      );
+
+      assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'glyphicon'));
+      assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'glyphicon-ok'));
+    });
+
+    it('renders warning feedback as Glyphicon', function () {
+      let instance = ReactTestUtils.renderIntoDocument(
+        <Input hasFeedback={true} bsStyle="warning" />
+      );
+
+      assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'glyphicon'));
+      assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'glyphicon-warning-sign'));
+    });
+
+    it('renders error feedback as Glyphicon', function () {
+      let instance = ReactTestUtils.renderIntoDocument(
+        <Input hasFeedback={true} bsStyle="error" />
+      );
+
+      assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'glyphicon'));
+      assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'glyphicon-remove'));
+    });
+
+    context('when using feedbackIcon', function () {
+      it('uses the feedbackIcon', function () {
+        let customIcon = <Glyphicon glyph="star" />;
+
+        let instance = ReactTestUtils.renderIntoDocument(
+            <Input feedbackIcon={customIcon} hasFeedback={true} bsStyle="success" />
+        );
+
+        assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'glyphicon'));
+        assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'glyphicon-star'));
+      });
+
+      it('adds the .form-control-feedback class for Glyphicons', function () {
+        let customIcon = <Glyphicon glyph="star" />;
+
+        let instance = ReactTestUtils.renderIntoDocument(
+            <Input feedbackIcon={customIcon} hasFeedback={true} bsStyle="success" />
+        );
+
+        assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'form-control-feedback'));
+      });
+    });
   });
 });


### PR DESCRIPTION
Reference: #502

- Added a new prop on Input named feedbackIcon
- Added tests for ensuring Glyphicons as default
- Added tests for rendering the feedbackIcon

This allows for passing custom icons that may be used instead of the default Glyphicons when an Input is having feedback.