### PR TITLE
Updated alert to restart timer on update

### DIFF
--- a/src/Alert.js
+++ b/src/Alert.js
@@ -18,6 +18,12 @@ const Alert = React.createClass({
       closeLabel: 'Close Alert'
     };
   },
+  
+  _initDismissTimer() {
+    if (this.props.dismissAfter && this.props.onDismiss) {
+      this.dismissTimer = setTimeout(this.props.onDismiss, this.props.dismissAfter);
+    }
+  },
 
   renderDismissButton() {
     return (
@@ -44,13 +50,16 @@ const Alert = React.createClass({
       </div>
     );
   },
-
+  
   componentDidMount() {
-    if (this.props.dismissAfter && this.props.onDismiss) {
-      this.dismissTimer = setTimeout(this.props.onDismiss, this.props.dismissAfter);
-    }
+    this._initDismissTimer();
   },
-
+  
+  componentDidUpdate() {
+    clearTimeout(this.dismissTimer);
+    this._initDismissTimer();
+  },
+  
   componentWillUnmount() {
     clearTimeout(this.dismissTimer);
   }

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -18,7 +18,7 @@ const Alert = React.createClass({
       closeLabel: 'Close Alert'
     };
   },
-  
+
   _initDismissTimer() {
     if (this.props.dismissAfter && this.props.onDismiss) {
       this.dismissTimer = setTimeout(this.props.onDismiss, this.props.dismissAfter);
@@ -50,16 +50,16 @@ const Alert = React.createClass({
       </div>
     );
   },
-  
+
   componentDidMount() {
     this._initDismissTimer();
   },
-  
+
   componentDidUpdate() {
     clearTimeout(this.dismissTimer);
     this._initDismissTimer();
   },
-  
+
   componentWillUnmount() {
     clearTimeout(this.dismissTimer);
   }


### PR DESCRIPTION
After a re-render the dismissTimer did not restart, causing the new alerts to disappear before their time. Also, if a re-render has changed the dissmissAfter, it was ignored.