### PR TITLE
Clarify ES6 imports

### DIFF
--- a/docs/src/GettingStartedPage.js
+++ b/docs/src/GettingStartedPage.js
@@ -4,6 +4,7 @@ import CodeExample from './CodeExample';
 import NavMain from './NavMain';
 import PageHeader from './PageHeader';
 import PageFooter from './PageFooter';
+import Anchor from './Anchor';
 
 export default class Page extends React.Component {
   render() {
@@ -19,7 +20,7 @@ export default class Page extends React.Component {
             <div className="row">
               <div className="col-md-9" role="main">
                 <div className="bs-docs-section">
-                  <h2 id="setup" className="page-header">Setup</h2>
+                  <h2 className='page-header'><Anchor id='setup'>Setup</Anchor></h2>
                   <p className="lead">You can import the lib as AMD modules, CommonJS modules, or as a global JS script.</p>
 
                   <p>First add the Bootstrap CSS to your project; check <a href="http://getbootstrap.com/getting-started/" name="Bootstrap Docs">here</a> if you have not already done that. Note that:</p>
@@ -29,7 +30,7 @@ export default class Page extends React.Component {
                   </ul>
                   <p>Then:</p>
 
-                  <h3>CommonJS</h3>
+                  <h3><Anchor id='commonjs'>CommonJS</Anchor></h3>
                   <div className="highlight">
                     <CodeExample
                       codeText={
@@ -43,17 +44,31 @@ $ npm install react-bootstrap`
                       codeText={
 `var Alert = require('react-bootstrap/lib/Alert');
 // or
-var Alert = require('react-bootstrap').Alert;
-
-// with ES6 modules
-import Alert from 'react-bootstrap/lib/Alert';
-// or
-import {Alert} from 'react-bootstrap';`
+var Alert = require('react-bootstrap').Alert;`
                       }
                     />
                   </div>
 
-                  <h3>AMD</h3>
+                  <h3><Anchor id='es6'>ES6</Anchor></h3>
+                  <div className="highlight">
+                    <CodeExample
+                      codeText={
+`$ npm install react
+$ npm install react-bootstrap`
+                      }
+                    />
+                    <br />
+                    <CodeExample
+                      mode="javascript"
+                      codeText={
+`import Button from 'react-bootstrap/lib/Button';
+// or
+import { Button } from 'react-bootstrap';`
+                      }
+                    />
+                  </div>
+
+                  <h3><Anchor id='amd'>AMD</Anchor></h3>
                   <div className="highlight">
                     <CodeExample
                       codeText={
@@ -70,7 +85,7 @@ $ bower install react-bootstrap`
                     />
                   </div>
 
-                  <h3>Browser globals</h3>
+                  <h3 className='page-header'><Anchor id='browser-globals'>Browser globals</Anchor></h3>
                   <p>The bower repo contains <code>react-bootstrap.js</code> and <code>react-bootstrap.min.js</code> with all components exported in the <code>window.ReactBootstrap</code> object.</p>
                   <div className="highlight">
                     <CodeExample
@@ -87,7 +102,7 @@ $ bower install react-bootstrap`
 
                 </div>
                 <div className="bs-docs-section">
-                  <h2 id="browser-support" className="page-header">Browser support</h2>
+                  <h2 className='page-header'><Anchor id='browser-support'>Browser support</Anchor></h2>
                   <p>We aim to support all browsers supported by both <a href="http://facebook.github.io/react/docs/working-with-the-browser.html#browser-support-and-polyfills">React</a> and <a href="http://getbootstrap.com/getting-started/#support">Bootstrap</a>.</p>
 
                   <p>React requires <a href="http://facebook.github.io/react/docs/working-with-the-browser.html#browser-support-and-polyfills">polyfills for non-ES5 capable browsers.</a></p>


### PR DESCRIPTION
Closes #1115

It looks like (and uses `Anchor` now)
<img width="705" alt="screen shot 2015-08-11 at 5 56 06 pm" src="https://cloud.githubusercontent.com/assets/847572/9200835/798e2bda-4052-11e5-8bf5-4901908d2b1c.png">
