### PR TITLE
Clarify 'Glyphicon' 'glyph' property

### DIFF
--- a/src/Glyphicon.js
+++ b/src/Glyphicon.js
@@ -9,7 +9,7 @@ const Glyphicon = React.createClass({
      */
     bsClass: React.PropTypes.string,
     /**
-     * An icon name
+     * An icon name. See e.g. http://getbootstrap.com/components/#glyphicons
      */
     glyph: React.PropTypes.string.isRequired,
     /**


### PR DESCRIPTION
per: https://github.com/react-bootstrap/react-bootstrap/pull/1122#issuecomment-129731182

Something like that ?
<img width="728" alt="screen shot 2015-08-11 at 6 12 06 pm" src="https://cloud.githubusercontent.com/assets/847572/9201267/bfe7ab2c-4054-11e5-8729-222e9cb42ea5.png">
