### PR TITLE
Explicitly set default values for boolean properties

### DIFF
--- a/src/Tab.js
+++ b/src/Tab.js
@@ -4,6 +4,9 @@ import TransitionEvents from './utils/TransitionEvents';
 
 const Tab = React.createClass({
   propTypes: {
+    /**
+     * @private
+     */
     active:          React.PropTypes.bool,
     animation:       React.PropTypes.bool,
     onAnimateOutEnd: React.PropTypes.func,


### PR DESCRIPTION
for the sake of clarity in documentation.

The part of #976