### PR TITLE
Explicitly set default value for `defaultExpanded` property.

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -21,19 +21,14 @@ const Panel = React.createClass({
   getDefaultProps() {
     return {
       bsClass: 'panel',
-      bsStyle: 'default'
+      bsStyle: 'default',
+      defaultExpanded: false
     };
   },
 
   getInitialState(){
-    let defaultExpanded = this.props.defaultExpanded != null ?
-      this.props.defaultExpanded :
-        this.props.expanded != null ?
-        this.props.expanded :
-        false;
-
     return {
-      expanded: defaultExpanded
+      expanded: this.props.defaultExpanded
     };
   },
 


### PR DESCRIPTION
Part of #976

Simplify 'expanded' state code. Make it similar way to 'NavBar'.

The API behaviour has not changed.

`expanded` property has no default boolean value because of the same as https://github.com/react-bootstrap/react-bootstrap/issues/976#issuecomment-131048858
```js
isExpanded(){
  return this.props.expanded != null ? this.props.expanded : this.state.expanded;
},
```