### PR TITLE
Fix wrong tabs switching animation for 'Tabs' component

### DIFF
--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -59,11 +59,6 @@ const Tabs = React.createClass({
           }
         }
       });
-
-      // if the 'previousActiveKey' child does not exist anymore
-      this.setState({
-        previousActiveKey: null
-      });
     }
   },
 


### PR DESCRIPTION
With https://github.com/react-bootstrap/react-bootstrap/pull/1017 I've introduced a new subtle bug
with animation:
<img width="452" alt="screen shot 2015-08-14 at 10 03 45 pm" src="https://cloud.githubusercontent.com/assets/847572/9282020/1c558d8c-42d2-11e5-9030-e9223146748c.png">

This is the fix for it against `v0.25-rc` and new `Tabs` component.
I am sorry :sweat: 