### PR TITLE
Fix wrong tabs switching animation for 'TabbedArea' component

### DIFF
--- a/src/TabbedArea.js
+++ b/src/TabbedArea.js
@@ -63,11 +63,6 @@ const TabbedArea = React.createClass({
           }
         }
       });
-
-      // if the 'previousActiveKey' child does not exist anymore
-      this.setState({
-        previousActiveKey: null
-      });
     }
   },
 


### PR DESCRIPTION
With https://github.com/react-bootstrap/react-bootstrap/pull/1017 I've introduced a new subtle bug
with animation:
<img width="452" alt="screen shot 2015-08-14 at 10 03 45 pm" src="https://cloud.githubusercontent.com/assets/847572/9282020/1c558d8c-42d2-11e5-9030-e9223146748c.png">

This is the fix for it.
I am sorry :sweat: 