### PR TITLE
Document Button's default type attribute

### DIFF
--- a/docs/generate-metadata.js
+++ b/docs/generate-metadata.js
@@ -64,6 +64,11 @@ function applyPropDoclets(props, propName){
   if ( doclets.required) {
     prop.required = true;
   }
+
+  // Use @defaultValue to provide a prop's default value
+  if (doclets.defaultValue) {
+    prop.defaultValue = cleanDocletValue(doclets.defaultValue);
+  }
 }
 
 

--- a/src/Button.js
+++ b/src/Button.js
@@ -22,6 +22,7 @@ const Button = React.createClass({
     /**
      * Defines HTML button type Attribute
      * @type {("button"|"reset"|"submit")}
+     * @defaultValue 'button'
      */
     type: React.PropTypes.oneOf(ButtonInput.types)
   },


### PR DESCRIPTION
I just answered a [Stack Overflow question related to the default `type` of a `<Button>`](http://stackoverflow.com/questions/32074972/reactjs-onsubmit-on-form-doesnt-work) and noticed the default value wasn't documented (since it's assigned in a render method as it doesn't always apply).

This PR adds support for a new `@defaultValue` doclet and uses it to document the default for when `type` applies.

Should this also be mentioned as a prose section in the docs? Defaulting to `'button'` is IMO a nicer default than `'submit'`, but the difference in default behaviour compared to a regular HTML `<button>` is a potential gotcha.