### PR TITLE
Stick to eslint-config-defaults@3.1.0 version

### DIFF
--- a/docs/examples/ListGroupLinked.js
+++ b/docs/examples/ListGroupLinked.js
@@ -1,5 +1,5 @@
 function alertClicked () {
-  alert('You clicked the third ListGroupItem'); 
+  alert('You clicked the third ListGroupItem');
 }
 
 const listgroupInstance = (

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "css-loader": "^0.16.0",
     "es5-shim": "^4.1.10",
     "eslint": "^1.1.0",
-    "eslint-config-defaults": "^4.0.1",
+    "eslint-config-defaults": "3.1.0",
     "eslint-plugin-babel": "^2.0.0",
     "eslint-plugin-lodash": "^0.1.3",
     "eslint-plugin-mocha": "^0.4.0",

--- a/src/ListGroupItem.js
+++ b/src/ListGroupItem.js
@@ -64,7 +64,7 @@ const ListGroupItem = React.createClass({
 
   renderButton(classes) {
     return (
-      <button 
+      <button
         type='button'
         {...this.props}
         className={classNames(this.props.className, classes)}>

--- a/tools/buildBabel.js
+++ b/tools/buildBabel.js
@@ -4,13 +4,13 @@ import fs from 'fs';
 import path from 'path';
 import outputFileSync from 'output-file-sync';
 
-export function buildContent(content, filename, destination, babelOptions={}) {
+export function buildContent(content, filename, destination, babelOptions = {}) {
   babelOptions.filename = filename;
   const result = transform(content, babelOptions);
   outputFileSync(destination, result.code, {encoding: 'utf8'});
 }
 
-export function buildFile(filename, destination, babelOptions={}) {
+export function buildFile(filename, destination, babelOptions = {}) {
   const content = fs.readFileSync(filename, {encoding: 'utf8'});
   // We only have .js files that we need to build
   if(path.extname(filename) === '.js') {
@@ -20,7 +20,7 @@ export function buildFile(filename, destination, babelOptions={}) {
   }
 }
 
-export function buildFolder(folderPath, destination, babelOptions={}, firstFolder=true) {
+export function buildFolder(folderPath, destination, babelOptions = {}, firstFolder = true) {
   let stats = fs.statSync(folderPath);
 
   if(stats.isFile()) {
@@ -32,11 +32,10 @@ export function buildFolder(folderPath, destination, babelOptions={}, firstFolde
   }
 }
 
-export function buildGlob(filesGlob, destination, babelOptions={}) {
+export function buildGlob(filesGlob, destination, babelOptions = {}) {
   let files = glob.sync(filesGlob);
   if (!files.length) {
     files = [filesGlob];
   }
   files.forEach(filename => buildFolder(filename, destination, babelOptions, true));
 }
-

--- a/tools/generateFactories.js
+++ b/tools/generateFactories.js
@@ -5,7 +5,7 @@ import { srcRoot } from './constants';
 import components from './public-components';
 import { buildContent } from './buildBabel';
 
-export default function generateFactories(destination, babelOptions={}) {
+export default function generateFactories(destination, babelOptions = {}) {
 
   function generateCompiledFile(file, content) {
     const outpath = path.join(destination, 'factories', `${file}.js`);


### PR DESCRIPTION
This is the last version working as `eslint@0.24` defaults

Fixes this https://github.com/react-bootstrap/react-bootstrap/pull/1184#issuecomment-132470865

--
There are first signs that `eslint-config-defaults` `defaults` are not working for us.
This two wasn't catched by `eslint-config-defaults@^4.0.1` version,
but `3.1.0` does:
<img width="556" alt="screen shot 2015-08-19 at 10 12 17 am" src="https://cloud.githubusercontent.com/assets/847572/9350697/81e9016a-465b-11e5-82ad-0c7ba95185bb.png">

--
I propose https://github.com/react-bootstrap/react-bootstrap/pull/1176