### PR TITLE
Impose airbnb linting with exceptions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": ["defaults"],
+  "extends": ["eslint-config-airbnb"],
   "env": {
     "browser": true,
     "node": true
@@ -13,19 +13,35 @@
     "babel"
   ],
   "rules": {
+    "brace-style": 0,
     "constructor-super": 2,
+    "comma-dangle": 0,
     "comma-spacing": 2,
     "comma-style": [2, "last"],
+    "default-case": 0,
+    "func-names": 0,
+    "guard-for-in": 0,
+    "indent": 0,
     "one-var": [2, { "initialized": "never" }],
+    "padded-blocks": 0,
+    "prefer-const": 0,
     "key-spacing": 0,
+    "no-eq-null": 0,
+    "no-else-return": 0,
+    "no-multiple-empty-lines": 0,
+    "no-nested-ternary": 0,
+    "no-param-reassign": 0,
     "no-this-before-super": 2,
+    "no-throw-literal": 0,
     "no-underscore-dangle": 0,
     "no-unused-vars": [2, { "vars": "all", "args": "none" }],
+    "no-use-before-define": 0,
     "no-var": 2,
     "babel/object-shorthand": 2,
     "quotes": [2, "single", "avoid-escape"],
     "react/display-name": 0,
     "react/jsx-boolean-value": [2, "never"],
+    "react/jsx-quotes": 0,
     "react/jsx-no-duplicate-props": 2,
     "react/jsx-no-undef": 2,
     "react/jsx-uses-react": 2,
@@ -35,9 +51,15 @@
     "react/prop-types": [2, { "ignore": [ "children", "className" ] }],
     "react/react-in-jsx-scope": 2,
     "react/self-closing-comp": 2,
+    "react/sort-comp": 0,
     "react/wrap-multilines": 2,
     "react/jsx-uses-vars": 2,
+    "space-after-keywords": 0,
+    "space-before-blocks": 0,
+    "space-before-function-paren": 0,
     "space-infix-ops": 2,
-    "strict": [2, "never"]
+    "spaced-comment": 0,
+    "strict": [2, "never"],
+    "vars-on-top": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "css-loader": "^0.16.0",
     "es5-shim": "^4.1.10",
     "eslint": "^1.1.0",
-    "eslint-config-defaults": "3.1.0",
+    "eslint-config-airbnb": "0.0.7",
     "eslint-plugin-babel": "^2.0.0",
     "eslint-plugin-lodash": "^0.1.3",
     "eslint-plugin-mocha": "^0.4.0",

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -52,7 +52,7 @@ const Pagination = React.createClass({
     } = this.props;
 
     if(maxButtons){
-      let hiddenPagesBefore = activePage - parseInt(maxButtons / 2);
+      let hiddenPagesBefore = activePage - parseInt(maxButtons / 2, 10);
       startPage = hiddenPagesBefore > 1 ? hiddenPagesBefore : 1;
       hasHiddenPagesAfter = startPage + maxButtons <= items;
 


### PR DESCRIPTION
just compare with https://github.com/react-bootstrap/react-bootstrap/pull/1176 
11 vs 22 exclusions :smile: 

It seems `semistandard` is way less stricter and suits more for `R-B`.