### PR TITLE
Add 'deprecated' wrapper for property deprecation warning

### DIFF
--- a/src/utils/CustomPropTypes.js
+++ b/src/utils/CustomPropTypes.js
@@ -1,8 +1,19 @@
 import React from 'react';
+import warning from 'react/lib/warning';
 
 const ANONYMOUS = '<<anonymous>>';
 
 const CustomPropTypes = {
+
+  deprecated(propType, explanation){
+    return function(props, propName, componentName){
+      if (props[propName] != null) {
+        warning(false, `"${propName}" property of "${componentName}" has been deprecated.\n${explanation}`);
+      }
+
+      return propType(props, propName, componentName);
+    };
+  },
 
   isRequiredForA11y(propType){
     return function(props, propName, componentName){

--- a/test/utils/CustomPropTypesSpec.js
+++ b/test/utils/CustomPropTypesSpec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactTestUtils from 'react/lib/ReactTestUtils';
 import CustomPropTypes from '../../src/utils/CustomPropTypes';
+import {shouldWarn} from '../helpers';
 
 function isChainableAndUndefinedOK(validatorUnderTest) {
   it('Should validate OK with undefined or null values', function() {
@@ -182,6 +183,25 @@ describe('CustomPropTypes', function() {
       let err = validate(null);
       assert.instanceOf(err, Error);
       assert.include(err.message, 'accessible for users using assistive technologies such as screen readers');
+    });
+  });
+
+  describe('deprecated', function () {
+    function validate(prop) {
+      return CustomPropTypes.deprecated(React.PropTypes.string, 'Read more at link')({pName: prop}, 'pName', 'ComponentName');
+    }
+
+    it('Should warn about deprecation and validate OK', function() {
+      let err = validate('value');
+      shouldWarn('"pName" property of "ComponentName" has been deprecated.\nRead more at link');
+      assert.notInstanceOf(err, Error);
+    });
+
+    it('Should warn about deprecation and throw validation error when property value is not OK', function() {
+      let err = validate({});
+      shouldWarn('"pName" property of "ComponentName" has been deprecated.\nRead more at link');
+      assert.instanceOf(err, Error);
+      assert.include(err.message, 'Invalid undefined `pName` of type `object` supplied to `ComponentName`');
     });
   });
 });


### PR DESCRIPTION
```js
propTypes: {
  collapsable: deprecated(React.PropTypes.bool, 'Use "collapsible" instead.')
```

Beginning: https://github.com/react-bootstrap/react-bootstrap/pull/1184#issuecomment-132801266