### PR TITLE
Monitor less files by 'nodemon' with 'npm run docs' script

### DIFF
--- a/docs/dev-run
+++ b/docs/dev-run
@@ -65,9 +65,9 @@ portfinder.getPorts(2, {}, (portFinderErr, [docsPort, webpackPort]) => {
     process.exit(1);
   }
 
-  runCmd('webpack-dev-server', `nodemon --watch webpack --watch webpack.docs.js --watch node_modules --exec webpack-dev-server -- --config webpack.docs.js --color --port ${webpackPort} --debug --hot --host ${ip.address()}`);
+  runCmd('webpack-dev-server', `nodemon --watch webpack --watch webpack.docs.js --exec webpack-dev-server -- --config webpack.docs.js --color --port ${webpackPort} --debug --hot --host ${ip.address()}`);
 
-  runCmd('docs-server', 'nodemon --watch docs --watch src --watch node_modules --exec babel-node docs/server.js', {
+  runCmd('docs-server', 'nodemon --watch docs --watch src --exec babel-node docs/server.js', {
     env: {
       PORT: docsPort,
       WEBPACK_DEV_PORT: webpackPort,

--- a/nodemon.json
+++ b/nodemon.json
@@ -1,0 +1,13 @@
+{
+  "restartable": "rs",
+  "ignore": [
+    "tmp-bower-repo",
+    "tmp-docs-repo",
+    "docs-built",
+    "amd",
+    "lib",
+    "dist",
+    ".coverage",
+    "tools"
+  ]
+}


### PR DESCRIPTION
Why do we need to monitor `node_modules` in the first place ?

--
It will allow to get rid of
<img width="1064" alt="screen shot 2015-08-21 at 8 21 20 pm" src="https://cloud.githubusercontent.com/assets/847572/9414706/3363af2e-4843-11e5-8e83-70df799754c6.png">
and make less load to CPU