### PR TITLE
[added] restoreFocus prop to Modal

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -130,6 +130,11 @@ const Modal = React.createClass({
     enforceFocus: React.PropTypes.bool,
 
     /**
+     * When `true` The modal will automatically restore focus to the last active element when it closes.
+     */
+    restoreFocus: React.PropTypes.bool,
+
+    /**
      * Hide this from automatic props documentation generation.
      * @private
      */
@@ -150,7 +155,8 @@ const Modal = React.createClass({
       backdrop: true,
       keyboard: true,
       autoFocus: true,
-      enforceFocus: true
+      enforceFocus: true,
+      restoreFocus: true
     };
   },
 
@@ -355,7 +361,9 @@ const Modal = React.createClass({
 
     container.className = container.className.replace(/ ?modal-open/, '');
 
-    this.restoreLastFocus();
+    if (this.props.restoreFocus) {
+      this.restoreLastFocus();
+    }
   },
 
   handleHidden(...args) {

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -314,6 +314,25 @@ describe('Modal', function () {
 
       document.activeElement.should.equal(input);
     });
+
+    it('Should not focus last active element when restoreFocus is false', function () {
+      document.activeElement.should.equal(focusableContainer);
+
+      let instance = render(
+        <div>
+          <input autoFocus />
+          <Modal show restoreFocus={false} onHide={()=>{}} animation={false}>
+            <strong>Message</strong>
+          </Modal>
+        </div>
+        , focusableContainer);
+
+      instance.renderWithProps({ show: false });
+
+      let input = document.getElementsByTagName('input')[0];
+
+      document.activeElement.should.not.equal(input);
+    });
   });
 
 });


### PR DESCRIPTION
Add the ability not to automatically set focus to the last active
element, an example would be displaying a Modal on onFocus, which would
then instantly trigger opening of the same Modal everytime it's closed.

This jsfiddle demonstrates such a situation:
https://jsfiddle.net/zs3ed1ho/1/