### PR TITLE
Fix eslint warnings

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,7 @@
     "react/no-did-mount-set-state": 2,
     "react/no-did-update-set-state": 2,
     "react/no-multi-comp": 2,
-    "react/prop-types": [2, { "ignore": [ "children", "className" ] }],
+    "react/prop-types": [2, { "ignore": [ "children", "className", "style" ] }],
     "react/react-in-jsx-scope": 2,
     "react/self-closing-comp": 2,
     "react/wrap-multilines": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -33,7 +33,7 @@
     "react/no-did-mount-set-state": 2,
     "react/no-did-update-set-state": 2,
     "react/no-multi-comp": 2,
-    "react/prop-types": [1, { "ignore": [ "children", "className" ] }],
+    "react/prop-types": [2, { "ignore": [ "children", "className" ] }],
     "react/react-in-jsx-scope": 2,
     "react/self-closing-comp": 2,
     "react/wrap-multilines": 2,

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -248,6 +248,11 @@ Dropdown.propTypes = {
   ]),
 
   /**
+   * Whether or not component is disabled.
+   */
+  disabled: React.PropTypes.bool,
+
+  /**
    * Align the menu to the right  side of the Dropdown toggle
    */
   pullRight: React.PropTypes.bool,
@@ -258,6 +263,11 @@ Dropdown.propTypes = {
    * @controllable onToggle
    */
   open: React.PropTypes.bool,
+
+  /**
+   * A callback fired when the Dropdown closes.
+   */
+  onClose: React.PropTypes.func,
 
   /**
    * A callback fired when the Dropdown wishes to change visibility. Called with the requested

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -39,13 +39,10 @@ export default class MenuItem extends React.Component {
       disabled: this.props.disabled
     };
 
-    // we don't want to expose the `style` property
-    const style = this.props.style; // eslint-disable-line react/prop-types
-
     return (
       <li role='presentation'
         className={classnames(this.props.className, classes)}
-        style={style}
+        style={this.props.style}
       >
         <SafeAnchor
           role='menuitem'

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -39,10 +39,13 @@ export default class MenuItem extends React.Component {
       disabled: this.props.disabled
     };
 
+    // we don't want to expose the `style` property
+    const style = this.props.style; // eslint-disable-line react/prop-types
+
     return (
       <li role='presentation'
         className={classnames(this.props.className, classes)}
-        style={this.props.style}
+        style={style}
       >
         <SafeAnchor
           role='menuitem'
@@ -75,6 +78,7 @@ MenuItem.propTypes = {
   ]),
   header: React.PropTypes.bool,
   href: React.PropTypes.string,
+  target: React.PropTypes.string,
   title: React.PropTypes.string,
   onKeyDown: React.PropTypes.func,
   onSelect: React.PropTypes.func

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -305,8 +305,7 @@ const Modal = React.createClass({
       this.iosClickHack();
     }
 
-    this.setState(this._getStyles() //eslint-disable-line react/no-did-mount-set-state
-      , () => this.focusModalContent());
+    this.setState(this._getStyles(), () => this.focusModalContent());
   },
 
   onHide() {

--- a/src/NavDropdown.js
+++ b/src/NavDropdown.js
@@ -24,6 +24,7 @@ class NavDropdown extends React.Component {
 }
 
 NavDropdown.propTypes = {
+  noCaret: React.PropTypes.bool,
   title: React.PropTypes.node.isRequired,
   ...Dropdown.propTypes
 };

--- a/src/NavDropdown.js
+++ b/src/NavDropdown.js
@@ -4,13 +4,12 @@ import Dropdown from './Dropdown';
 class NavDropdown extends React.Component {
 
   render() {
-    let { children, title, noCaret, bsStyle, ...props } = this.props;
+    let { children, title, noCaret, ...props } = this.props;
 
     return (
       <Dropdown {...props} componentClass='li'>
         <Dropdown.Toggle
           useAnchor
-          bsStyle={bsStyle}
           disabled={props.disabled}
           noCaret={noCaret}
         >

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -8,7 +8,14 @@ class SplitButton extends React.Component {
 
   render() {
     let {
-      children, title, onClick, target, href, bsStyle, ...props } = this.props;
+      children,
+      title,
+      onClick,
+      target,
+      href,
+      // bsStyle is validated by 'Button' component
+      bsStyle, // eslint-disable-line
+      ...props } = this.props;
 
      let { disabled } = props;
 

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -106,7 +106,7 @@ const Tabs = React.createClass({
     let {
       id,
       className,
-      style, // eslint-disable-line react/prop-types
+      style,
       position,
       bsStyle,
       tabWidth,

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -60,8 +60,7 @@ const Tooltip = React.createClass({
     const style = {
       'left': this.props.positionLeft,
       'top': this.props.positionTop,
-      // we don't want to expose the `style` property
-      ...this.props.style // eslint-disable-line react/prop-types
+      ...this.props.style
     };
 
     const arrowStyle = {


### PR DESCRIPTION
`bsStyle` property is removed from `NavDropdown` component because it doesn't used anywhere downstream.

Remove these warnings:
<img width="750" alt="screen_shot_2015-08-21_at_10 40 50_pm" src="https://cloud.githubusercontent.com/assets/847572/9424494/1d4d623e-48f7-11e5-8397-39388f66d63b.png">

--
As promised: https://github.com/react-bootstrap/react-bootstrap/issues/646#issuecomment-122575417