### PR TITLE
Fix for airbnb bug about 'no-undef' rule.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,7 @@
     "no-this-before-super": 2,
     "no-throw-literal": 0,
     "no-underscore-dangle": 0,
+    "no-undef": 2,
     "no-unused-vars": [2, { "vars": "all", "args": "none" }],
     "no-use-before-define": 0,
     "no-var": 2,


### PR DESCRIPTION
https://github.com/react-bootstrap/react-bootstrap/pull/1186#issuecomment-133755557

I believe that it is just a subtle bug (https://github.com/airbnb/javascript/issues/454).

Sure we could impose additional set of rules e.g. `eslint:recommended`
or just fix it locally by adding `"no-undef", 2` rule into our `.eslintrc`.
