### PR TITLE
[fixed] isRequiredForA11y check should be against undefined

### DIFF
--- a/src/utils/CustomPropTypes.js
+++ b/src/utils/CustomPropTypes.js
@@ -44,7 +44,7 @@ const CustomPropTypes = {
 
   isRequiredForA11y(propType){
     return function(props, propName, componentName){
-      if (props[propName] === null) {
+      if (props[propName] === undefined) {
         return new Error(
           'The prop `' + propName + '` is required to make ' + componentName + ' accessible ' +
             'for users using assistive technologies such as screen readers `'


### PR DESCRIPTION
We were getting silent a11y fails and found this bug. 