### PR TITLE
[fixed] Error on opening dropdown without focusable items

### DIFF
--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -38,6 +38,10 @@ class DropdownMenu extends React.Component {
   focusNext() {
     let { items, activeItemIndex } = this.getItemsAndActiveIndex();
 
+    if (items.length === 0) {
+      return;
+    }
+
     if (activeItemIndex === items.length - 1) {
       items[0].focus();
       return;

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -186,6 +186,21 @@ describe('Dropdown', function() {
     buttonNode.getAttribute('aria-expanded').should.equal('false');
   });
 
+  it('opens if dropdown contains no focusable menu item', function() {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Dropdown title='custom child' id='dropdown'>
+        <Dropdown.Toggle>Toggle</Dropdown.Toggle>
+        <Dropdown.Menu>
+          <li>Some custom nonfocusable content</li>
+        </Dropdown.Menu>
+      </Dropdown>
+    );
+    const node = React.findDOMNode(instance);
+    const buttonNode = React.findDOMNode(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'BUTTON'));
+    ReactTestUtils.Simulate.click(buttonNode);
+    node.className.should.match(/\bopen\b/);
+  });
+
   it('when focused and closed toggles open when the key "down" is pressed', function() {
     const instance = ReactTestUtils.renderIntoDocument(simpleDropdown);
     const node = React.findDOMNode(instance);


### PR DESCRIPTION
When dropdown without focusable items (e.g. containing only divs to display some content) is opened, exception is raised in `DropdownMenu.focusNext()` method as `items[0]` is not defined.

This commit adds additional check in `focusNext()` method, skipping focusing altogether if there are no focusable items.