### PR TITLE
[fixed] Badge was not shown when it had only a single child.

### DIFF
--- a/src/Badge.js
+++ b/src/Badge.js
@@ -16,7 +16,7 @@ const Badge = React.createClass({
 
   hasContent() {
     return ValidComponentChildren.hasValidComponent(this.props.children) ||
-      (React.Children.count(this.props.children) > 1) ||
+      (React.Children.count(this.props.children) > 0) ||
       (typeof this.props.children === 'string') ||
       (typeof this.props.children === 'number');
   },


### PR DESCRIPTION
Fix: Badge was not shown when it had only a single child. Now every tagtree you pass to a badge is shown.