### PR TITLE
[fixed] title is not passed to tab pane DOM node

### DIFF
--- a/src/Tab.js
+++ b/src/Tab.js
@@ -87,6 +87,7 @@ const Tab = React.createClass({
 
     return (
       <div {...this.props}
+        title={undefined}
         role='tabpanel'
         aria-hidden={!this.props.active}
         className={classNames(this.props.className, classes)}


### PR DESCRIPTION
fixes #1238 

It effectively removes the ability to add a title to tab panes, but I don't think that is going to to be an issue...

It is a bit odd that that props doesn't do anything unless inside a `tabs` component, but nothing too weird