### PR TITLE
[changed] tab keyboard navigation to be more inline with ARIA spec

### DIFF
--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -36,6 +36,7 @@ const NavItem = React.createClass({
         title,
         target,
         children,
+        tabIndex, //eslint-disable-line
         'aria-controls': ariaControls,
         ...props } = this.props;
     let classes = {
@@ -47,6 +48,7 @@ const NavItem = React.createClass({
       href,
       title,
       target,
+      tabIndex,
       id: linkId,
       onClick: this.handleClick
     };

--- a/src/utils/ValidComponentChildren.js
+++ b/src/utils/ValidComponentChildren.js
@@ -82,9 +82,22 @@ function hasValidComponent(children) {
   return hasValid;
 }
 
+function find(children, finder) {
+  let child;
+
+  forEachValidComponents(children, (c, idx)=> {
+    if (!child && finder(c, idx, children)) {
+      child = c;
+    }
+  });
+
+  return child;
+}
+
 export default {
   map: mapValidComponents,
   forEach: forEachValidComponents,
   numberOf: numberOfValidComponents,
+  find,
   hasValidComponent
 };

--- a/test/NavItemSpec.js
+++ b/test/NavItemSpec.js
@@ -43,6 +43,20 @@ describe('NavItem', function () {
     assert.ok(!React.findDOMNode(instance).hasAttribute('title'));
   });
 
+  it('Should pass tabIndex to the anchor', () => {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <NavItem href='/hi' tabIndex='3' title='boom!'>
+        Item content
+      </NavItem>
+    );
+
+    let node = React.findDOMNode(instance);
+
+    expect(node.hasAttribute('tabindex')).to.equal(false);
+    expect(node.firstChild.getAttribute('tabindex')).to.equal('3');
+
+  });
+
   it('Should call `onSelect` when item is selected', function (done) {
     function handleSelect(key) {
       assert.equal(key, '2');

--- a/test/TabsSpec.js
+++ b/test/TabsSpec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactTestUtils from 'react/lib/ReactTestUtils';
+import keycode from 'keycode';
 
 import Col from '../src/Col';
 import Nav from '../src/Nav';
@@ -430,6 +431,63 @@ describe('Tabs', function () {
 
     checkTabRemovingWithAnimation(true);
     checkTabRemovingWithAnimation(false);
+  });
+
+  describe('keyboard navigation', function() {
+    let instance;
+
+    beforeEach(function() {
+      instance = render(
+        <Tabs defaultActiveKey={1} id='tabs'>
+          <Tab id='pane-1' title="Tab 1" eventKey={1}>Tab 1 content</Tab>
+          <Tab id='pane-2' title="Tab 2" eventKey={2} disabled>Tab 2 content</Tab>
+          <Tab id='pane-2' title="Tab 3" eventKey={3}>Tab 3 content</Tab>
+        </Tabs>
+      , document.body);
+    });
+
+    afterEach(function() {
+      instance = React.unmountComponentAtNode(document.body);
+    });
+
+    it('only the active tab should be focusable', () => {
+      let tabs = ReactTestUtils.scryRenderedComponentsWithType(instance, NavItem);
+
+      expect(React.findDOMNode(tabs[0]).firstChild.getAttribute('tabindex')).to.equal('0');
+
+      expect(React.findDOMNode(tabs[1]).firstChild.getAttribute('tabindex')).to.equal('-1');
+      expect(React.findDOMNode(tabs[2]).firstChild.getAttribute('tabindex')).to.equal('-1');
+    });
+
+    it('should focus the next tab on arrow key', () => {
+      let tabs = ReactTestUtils.scryRenderedComponentsWithType(instance, NavItem);
+
+      let firstAnchor = React.findDOMNode(tabs[0]).firstChild;
+      let lastAnchor = React.findDOMNode(tabs[2]).firstChild; // skip disabled
+
+      firstAnchor.focus();
+
+      ReactTestUtils.Simulate.keyDown(firstAnchor, { keyCode: keycode('right') });
+
+      expect(instance.getActiveKey() === 2);
+      expect(document.activeElement).to.equal(lastAnchor);
+    });
+
+    it('should focus the previous tab on arrow key', () => {
+      instance.setState({ activeKey: 3 });
+
+      let tabs = ReactTestUtils.scryRenderedComponentsWithType(instance, NavItem);
+
+      let firstAnchor = React.findDOMNode(tabs[0]).firstChild;
+      let lastAnchor = React.findDOMNode(tabs[2]).firstChild;
+
+      lastAnchor.focus();
+
+      ReactTestUtils.Simulate.keyDown(lastAnchor, { keyCode: keycode('left') });
+
+      expect(instance.getActiveKey() === 2);
+      expect(document.activeElement).to.equal(firstAnchor);
+    });
   });
 
   describe('Web Accessibility', function() {


### PR DESCRIPTION
http://www.w3.org/TR/wai-aria-practices/#tabpanel

Only the active tab is focus-able, and rather then hitting tab to change the active tab you use the arrow keys. 

I didn't do the ctrl page up stuff b/c that sounds bit more undecided from reading through. It also seems like it would conflict with anything inside the panel that used that key combo...