### PR TITLE
pin eslint version because of bug in 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "colors": "^1.1.2",
     "css-loader": "^0.16.0",
     "es5-shim": "^4.1.10",
-    "eslint": "^1.1.0",
+    "eslint": "1.2.x",
     "eslint-config-airbnb": "0.0.8",
     "eslint-plugin-babel": "^2.0.0",
     "eslint-plugin-lodash": "^0.1.3",


### PR DESCRIPTION
is there any good reason not to just always pin deps like this to patch versions? That we have to spend any bandwidth on these sorts of breakages is annoying. We rarely need new eslint features, but deal with breakages due to upgrades fairly often it seems