### PR TITLE
WIP: bootstrap mixin removal

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,6 @@
 {
   "stage": 1,
   "optional": ["runtime"],
-  "loose": ["all"]
+  "loose": ["all"],
+  "plugins": ["object-assign"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -46,7 +46,15 @@
     "react/no-did-mount-set-state": 2,
     "react/no-did-update-set-state": 2,
     "react/no-multi-comp": 2,
-    "react/prop-types": [2, { "ignore": [ "children", "className", "style" ] }],
+    "react/prop-types": [2, { "ignore": [
+        "children",
+        "className",
+        "style",
+        "bsStyle",
+        "bsClass",
+        "bsSize"
+        ]
+    }],
     "react/react-in-jsx-scope": 2,
     "react/self-closing-comp": 2,
     "react/sort-comp": 0,

--- a/docs/generate-metadata.js
+++ b/docs/generate-metadata.js
@@ -3,6 +3,7 @@ import glob from 'glob';
 import fsp from 'fs-promise';
 import promisify from '../tools/promisify';
 import marked from 'marked';
+import defaultDescriptions from './src/defaultPropDescriptions';
 
 marked.setOptions({
   xhtml: true
@@ -18,6 +19,7 @@ let cleanDoclets = desc => {
 
 let cleanDocletValue = str => str.trim().replace(/^\{/, '').replace(/\}$/, '');
 
+let quote = str => str && `'${str}'`;
 
 let isLiteral = str => (/^('|")/).test(str.trim());
 
@@ -26,10 +28,11 @@ let isLiteral = str => (/^('|")/).test(str.trim());
  *
  * @param  {ComponentMetadata|PropMetadata} obj
  */
-function parseDoclets(obj){
-  obj.doclets = metadata.parseDoclets(obj.desc || '') || {};
-  obj.desc = cleanDoclets(obj.desc || '');
-  obj.descHtml = marked(obj.desc || '');
+function parseDoclets(obj, propName){
+  let desc = obj.desc || defaultDescriptions[propName] || ''
+  obj.doclets = metadata.parseDoclets(desc) || {};
+  obj.desc = cleanDoclets(desc);
+  obj.descHtml = marked(desc);
 }
 
 /**
@@ -61,7 +64,7 @@ function applyPropDoclets(props, propName){
 
   // Use @required to mark a prop as required
   // useful for custom propTypes where there isn't a `.isRequired` addon
-  if ( doclets.required) {
+  if (doclets.required) {
     prop.required = true;
   }
 
@@ -71,6 +74,39 @@ function applyPropDoclets(props, propName){
   }
 }
 
+function addBootstrapPropTypes(Component, componentData){
+  let propTypes = Component.propTypes || {};
+  let defaultProps = Component.defaultProps || {};
+
+  function bsPropInfo(propName) {
+    let props = componentData.props;
+    let prop = propTypes[propName];
+
+    if (prop && !props[propName]) {
+      let values = prop._values || [];
+
+      props[propName] = {
+        desc: '',
+        defaultValue: quote(defaultProps[propName]),
+        type: {
+          name: 'enum',
+          value: values.map( v => `"${v}"`),
+        }
+      };
+    }
+  }
+
+  bsPropInfo('bsStyle');
+  bsPropInfo('bsSize');
+
+  if (propTypes.bsClass) {
+    componentData.props.bsClass = {
+      desc: '',
+      defaultValue: quote(defaultProps.bsClass),
+      type: { name: 'string' }
+    };
+  }
+}
 
 export default function generate(destination, options = { mixins: true, inferComponent: true }){
 
@@ -78,7 +114,7 @@ export default function generate(destination, options = { mixins: true, inferCom
     .then( files => {
 
       let results = files.map(
-        filename => fsp.readFile(filename).then(content => metadata(content, options)) );
+        filename => fsp.readFile(filename).then(content => metadata(content, options)));
 
       return Promise.all(results)
         .then( data => {
@@ -86,14 +122,25 @@ export default function generate(destination, options = { mixins: true, inferCom
 
           data.forEach(components => {
             Object.keys(components).forEach(key => {
+              let Component;
+
+              try {
+                //require the actual component to inspect props we can only get a runtime
+                Component = require('../src/' + key);
+              } catch (e) {} //eslint-disable-line
+
               const component = components[key];
+
+              if (Component) {
+                addBootstrapPropTypes(Component, component);
+              }
 
               parseDoclets(component);
 
               Object.keys(component.props).forEach( propName => {
                 const prop = component.props[propName];
 
-                parseDoclets(prop);
+                parseDoclets(prop, propName);
                 applyPropDoclets(component.props, propName);
               });
             });

--- a/docs/src/PropTable.js
+++ b/docs/src/PropTable.js
@@ -46,7 +46,7 @@ const PropTable = React.createClass({
   render(){
     let propsData = this.propsData;
 
-    if ( !Object.keys(propsData).length){
+    if (!Object.keys(propsData).length){
       return <span/>;
     }
 

--- a/docs/src/defaultPropDescriptions.js
+++ b/docs/src/defaultPropDescriptions.js
@@ -1,0 +1,7 @@
+
+export default {
+  bsClass: 'Base css class name and prefix for the Component. Generally one should only change `bsClass` ' +
+    'if they are providing new, non bootstrap, css styles for a component.',
+  bsStyle: 'Component visual or contextual style variants.',
+  bsSize: 'Component size variations.'
+};

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "babel-core": "^5.8.19",
     "babel-eslint": "^4.0.5",
     "babel-loader": "^5.3.2",
+    "babel-plugin-object-assign": "^1.2.1",
     "bootstrap": "^3.3.5",
     "brfs": "^1.4.0",
     "chai": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "phantomjs": "^1.9.17",
     "portfinder": "^0.4.0",
     "react": "^0.13.3",
-    "react-component-metadata": "^1.3.0",
+    "react-component-metadata": "^1.3.1",
     "react-hot-loader": "^1.2.8",
     "react-prop-types": "^0.2.2",
     "react-router": "^0.13.3",

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 
 const Alert = React.createClass({
-  mixins: [BootstrapMixin],
+
 
   propTypes: {
+    ...bootstrapUtils.propTypes,
     onDismiss: React.PropTypes.func,
     dismissAfter: React.PropTypes.number,
     closeLabel: React.PropTypes.string
@@ -32,7 +33,7 @@ const Alert = React.createClass({
   },
 
   render() {
-    let classes = this.getBsClassSet();
+    let classes = bootstrapUtils.getClassSet(this.props);
     let isDismissable = !!this.props.onDismiss;
 
     classes['alert-dismissable'] = isDismissable;

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -36,7 +36,7 @@ const Alert = React.createClass({
     let classes = bootstrapUtils.getClassSet(this.props);
     let isDismissable = !!this.props.onDismiss;
 
-    classes['alert-dismissable'] = isDismissable;
+    classes[bootstrapUtils.prefix(this.props, 'dismissable')] = isDismissable;
 
     return (
       <div {...this.props} role='alert' className={classNames(this.props.className, classes)}>

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -1,12 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
-import bootstrapUtils from './utils/bootstrapUtils';
+import bootstrapUtils, { bsStyles, bsClass } from './utils/bootstrapUtils';
+import { State } from './styleMaps';
 
-const Alert = React.createClass({
-
+let Alert = React.createClass({
 
   propTypes: {
-    ...bootstrapUtils.propTypes,
     onDismiss: React.PropTypes.func,
     dismissAfter: React.PropTypes.number,
     closeLabel: React.PropTypes.string
@@ -14,8 +13,6 @@ const Alert = React.createClass({
 
   getDefaultProps() {
     return {
-      bsClass: 'alert',
-      bsStyle: 'info',
       closeLabel: 'Close Alert'
     };
   },
@@ -57,4 +54,7 @@ const Alert = React.createClass({
   }
 });
 
-export default Alert;
+
+export default bsStyles(State.values(), State.INFO,
+  bsClass('alert', Alert)
+);

--- a/src/Badge.js
+++ b/src/Badge.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ValidComponentChildren from './utils/ValidComponentChildren';
 import classNames from 'classnames';
-
+import tbsUtils from './utils/bootstrapUtils';
 
 const Badge = React.createClass({
   propTypes: {
@@ -10,7 +10,8 @@ const Badge = React.createClass({
 
   getDefaultProps() {
     return {
-      pullRight: false
+      pullRight: false,
+      bsClass: 'badge'
     };
   },
 
@@ -24,7 +25,7 @@ const Badge = React.createClass({
   render() {
     let classes = {
       'pull-right': this.props.pullRight,
-      'badge': this.hasContent()
+      [tbsUtils.prefix(this.props)]: this.hasContent()
     };
     return (
       <span

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import classNames from 'classnames';
-import bootstrapUtils from './utils/bootstrapUtils';
 import elementType from 'react-prop-types/lib/elementType';
 import ButtonInput from './ButtonInput';
+import bootstrapUtils, { bsStyles, bsSizes } from './utils/bootstrapUtils';
+import { Sizes, State, DEFAULT, PRIMARY, LINK } from './styleMaps';
 
-const Button = React.createClass({
+const ButtonStyles = State.values().concat(DEFAULT, PRIMARY, LINK);
 
+let Button = React.createClass({
 
   propTypes: {
-    ...bootstrapUtils.propTypes,
     active: React.PropTypes.bool,
     disabled: React.PropTypes.bool,
     block: React.PropTypes.bool,
@@ -33,7 +34,6 @@ const Button = React.createClass({
       active: false,
       block: false,
       bsClass: 'btn',
-      bsStyle: 'default',
       disabled: false,
       navItem: false,
       navDropdown: false
@@ -104,5 +104,8 @@ const Button = React.createClass({
     );
   }
 });
+
+Button = bsStyles(ButtonStyles, DEFAULT, Button);
+Button = bsSizes([Sizes.LARGE, Sizes.SMALL, Sizes.XSMALL], Button);
 
 export default Button;

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import classNames from 'classnames';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 import elementType from 'react-prop-types/lib/elementType';
 import ButtonInput from './ButtonInput';
 
 const Button = React.createClass({
-  mixins: [BootstrapMixin],
+
 
   propTypes: {
+    ...bootstrapUtils.propTypes,
     active: React.PropTypes.bool,
     disabled: React.PropTypes.bool,
     block: React.PropTypes.bool,
@@ -40,7 +41,7 @@ const Button = React.createClass({
   },
 
   render() {
-    let classes = this.props.navDropdown ? {} : this.getBsClassSet();
+    let classes = this.props.navDropdown ? {} : bootstrapUtils.getClassSet(this.props);
     let renderFuncName;
 
     classes = {

--- a/src/Button.js
+++ b/src/Button.js
@@ -32,7 +32,7 @@ const Button = React.createClass({
     return {
       active: false,
       block: false,
-      bsClass: 'button',
+      bsClass: 'btn',
       bsStyle: 'default',
       disabled: false,
       navItem: false,
@@ -44,9 +44,11 @@ const Button = React.createClass({
     let classes = this.props.navDropdown ? {} : bootstrapUtils.getClassSet(this.props);
     let renderFuncName;
 
+    let blockClass = bootstrapUtils.prefix(this.props, 'block');
+
     classes = {
       active: this.props.active,
-      'btn-block': this.props.block,
+      [blockClass]: this.props.block,
       ...classes
     };
 

--- a/src/ButtonGroup.js
+++ b/src/ButtonGroup.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 import all from 'react-prop-types/lib/all';
 
 const ButtonGroup = React.createClass({
-  mixins: [BootstrapMixin],
 
   propTypes: {
+    ...bootstrapUtils.propTypes,
     vertical:  React.PropTypes.bool,
     justified: React.PropTypes.bool,
     /**
@@ -33,7 +33,7 @@ const ButtonGroup = React.createClass({
   },
 
   render() {
-    let classes = this.getBsClassSet();
+    let classes = bootstrapUtils.getClassSet(this.props);
     classes['btn-group'] = !this.props.vertical;
     classes['btn-group-vertical'] = this.props.vertical;
     classes['btn-group-justified'] = this.props.justified;

--- a/src/ButtonGroup.js
+++ b/src/ButtonGroup.js
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import bootstrapUtils from './utils/bootstrapUtils';
 import all from 'react-prop-types/lib/all';
+import Button from './Button';
 
 const ButtonGroup = React.createClass({
 
@@ -26,7 +27,7 @@ const ButtonGroup = React.createClass({
   getDefaultProps() {
     return {
       block: false,
-      bsClass: 'button-group',
+      bsClass: 'btn-group',
       justified: false,
       vertical: false
     };
@@ -34,10 +35,13 @@ const ButtonGroup = React.createClass({
 
   render() {
     let classes = bootstrapUtils.getClassSet(this.props);
-    classes['btn-group'] = !this.props.vertical;
-    classes['btn-group-vertical'] = this.props.vertical;
-    classes['btn-group-justified'] = this.props.justified;
-    classes['btn-block'] = this.props.block;
+
+    classes[bootstrapUtils.prefix(this.props)] = !this.props.vertical;
+    classes[bootstrapUtils.prefix(this.props, 'vertical')] = this.props.vertical;
+    classes[bootstrapUtils.prefix(this.props, 'justified')] = this.props.justified;
+
+    //this is annoying, since the class is `btn-block` not `btn-group-block`
+    classes[bootstrapUtils.prefix(Button.defaultProps, 'block')] = this.props.block;
 
     return (
       <div

--- a/src/ButtonToolbar.js
+++ b/src/ButtonToolbar.js
@@ -1,11 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
 import bootstrapUtils from './utils/bootstrapUtils';
+import Button from './Button';
 
 const ButtonToolbar = React.createClass({
 
   propTypes: {
-    ...bootstrapUtils.propTypes
+    bsSize: Button.propTypes.bsSize
   },
 
   getDefaultProps() {

--- a/src/ButtonToolbar.js
+++ b/src/ButtonToolbar.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 
 const ButtonToolbar = React.createClass({
-  mixins: [BootstrapMixin],
+
+  propTypes: {
+    ...bootstrapUtils.propTypes
+  },
 
   getDefaultProps() {
     return {
@@ -12,7 +15,7 @@ const ButtonToolbar = React.createClass({
   },
 
   render() {
-    let classes = this.getBsClassSet();
+    let classes = bootstrapUtils.getClassSet(this.props);
 
     return (
       <div

--- a/src/ButtonToolbar.js
+++ b/src/ButtonToolbar.js
@@ -10,7 +10,7 @@ const ButtonToolbar = React.createClass({
 
   getDefaultProps() {
     return {
-      bsClass: 'button-toolbar'
+      bsClass: 'btn-toolbar'
     };
   },
 

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -1,11 +1,9 @@
 import React, { cloneElement } from 'react';
 import classNames from 'classnames';
-import BootstrapMixin from './BootstrapMixin';
 import ValidComponentChildren from './utils/ValidComponentChildren';
 import Glyphicon from './Glyphicon';
 
 const Carousel = React.createClass({
-  mixins: [BootstrapMixin],
 
   propTypes: {
     slide: React.PropTypes.bool,

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -2,6 +2,7 @@ import React, { cloneElement } from 'react';
 import classNames from 'classnames';
 import ValidComponentChildren from './utils/ValidComponentChildren';
 import Glyphicon from './Glyphicon';
+import tbsUtils from './utils/bootstrapUtils';
 
 const Carousel = React.createClass({
 
@@ -23,6 +24,7 @@ const Carousel = React.createClass({
 
   getDefaultProps() {
     return {
+      bsClass: 'carousel',
       slide: true,
       interval: 5000,
       pauseOnHover: true,
@@ -138,10 +140,12 @@ const Carousel = React.createClass({
   },
 
   render() {
+
     let classes = {
-      carousel: true,
+      [tbsUtils.prefix(this.props)]: true,
       slide: this.props.slide
     };
+
 
     return (
       <div
@@ -149,8 +153,13 @@ const Carousel = React.createClass({
         className={classNames(this.props.className, classes)}
         onMouseOver={this.handleMouseOver}
         onMouseOut={this.handleMouseOut}>
-        {this.props.indicators ? this.renderIndicators() : null}
-        <div className="carousel-inner" ref="inner">
+        {
+          this.props.indicators ? this.renderIndicators() : null
+        }
+        <div
+          ref="inner"
+          className={tbsUtils.prefix(this.props, 'inner')}
+        >
           {ValidComponentChildren.map(this.props.children, this.renderItem)}
         </div>
         {this.props.controls ? this.renderControls() : null}
@@ -159,16 +168,20 @@ const Carousel = React.createClass({
   },
 
   renderPrev() {
+    let classes = 'left ' + tbsUtils.prefix(this.props, 'control');
+
     return (
-      <a className="left carousel-control" href="#prev" key={0} onClick={this.prev}>
+      <a className={classes} href="#prev" key={0} onClick={this.prev}>
         {this.props.prevIcon}
       </a>
     );
   },
 
   renderNext() {
+    let classes = 'right ' + tbsUtils.prefix(this.props, 'control');
+
     return (
-      <a className="right carousel-control" href="#next" key={1} onClick={this.next}>
+      <a className={classes} href="#next" key={1} onClick={this.next}>
         {this.props.nextIcon}
       </a>
     );
@@ -217,7 +230,7 @@ const Carousel = React.createClass({
       }, this);
 
     return (
-      <ol className="carousel-indicators">
+      <ol className={tbsUtils.prefix(this.props, 'indicators')}>
         {indicators}
       </ol>
     );

--- a/src/CarouselItem.js
+++ b/src/CarouselItem.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import TransitionEvents from './utils/TransitionEvents';
+import tbsUtils from './utils/bootstrapUtils';
 
 const CarouselItem = React.createClass({
   propTypes: {
@@ -21,6 +22,7 @@ const CarouselItem = React.createClass({
 
   getDefaultProps() {
     return {
+      bsStyle: 'carousel',
       active: false,
       animateIn: false,
       animateOut: false
@@ -86,8 +88,10 @@ const CarouselItem = React.createClass({
   },
 
   renderCaption() {
+    let classes = tbsUtils.prefix(this.props, 'caption');
+
     return (
-      <div className="carousel-caption">
+      <div className={classes}>
         {this.props.caption}
       </div>
     );

--- a/src/CollapsibleNav.js
+++ b/src/CollapsibleNav.js
@@ -1,5 +1,4 @@
 import React, { cloneElement } from 'react';
-import BootstrapMixin from './BootstrapMixin';
 import Collapse from './Collapse';
 import classNames from 'classnames';
 
@@ -7,7 +6,6 @@ import ValidComponentChildren from './utils/ValidComponentChildren';
 import createChainedFunction from './utils/createChainedFunction';
 
 const CollapsibleNav = React.createClass({
-  mixins: [BootstrapMixin],
 
   propTypes: {
     onSelect: React.PropTypes.func,

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -2,6 +2,7 @@ import React, { cloneElement } from 'react';
 import keycode from 'keycode';
 import classNames from 'classnames';
 import uncontrollable from 'uncontrollable';
+import bootstrapUtils from './utils/bootstrapUtils';
 import ButtonGroup from './ButtonGroup';
 import DropdownToggle from './DropdownToggle';
 import DropdownMenu from './DropdownMenu';
@@ -66,11 +67,12 @@ class Dropdown extends React.Component {
     let children = this.extractChildren();
     let Component = this.props.componentClass;
 
-    let props = omit(this.props, ['id']);
+    let props = omit(this.props, ['id', 'bsClass']);
+    let className = bootstrapUtils.prefix(this.props);
 
     const rootClasses = {
       open: this.props.open,
-      dropdown: !this.props.dropup,
+      [className]: !this.props.dropup,
       dropup: this.props.dropup
     };
 
@@ -173,7 +175,8 @@ class Dropdown extends React.Component {
       ref: 'menu',
       open,
       labelledBy: this.props.id,
-      pullRight: this.props.pullRight
+      pullRight: this.props.pullRight,
+      bsClass: this.props.bsClass
     };
 
     menuProps.onClose = createChainedFunction(
@@ -217,10 +220,14 @@ Dropdown.Toggle = DropdownToggle;
 Dropdown.TOGGLE_REF = TOGGLE_REF;
 
 Dropdown.defaultProps = {
-  componentClass: ButtonGroup
+  componentClass: ButtonGroup,
+  bsClass: 'dropdown'
 };
 
 Dropdown.propTypes = {
+
+  bsClass: React.PropTypes.string,
+
   /**
    * The menu will open above the dropdown button, instead of below it.
    */

--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -5,12 +5,9 @@ import NavDropdown from './NavDropdown';
 import all from 'react-prop-types/lib/all';
 import deprecationWarning from './utils/deprecationWarning';
 import omit from 'lodash/object/omit';
+import Button from './Button';
 
 class DropdownButton extends React.Component {
-
-  constructor(props) {
-    super(props);
-  }
 
   render() {
     let { title, navItem, ...props } = this.props;
@@ -35,6 +32,11 @@ class DropdownButton extends React.Component {
 }
 
 DropdownButton.propTypes = {
+  ...Dropdown.propTypes,
+
+  bsStyle: Button.propTypes.bsStyle,
+  bsSize: Button.propTypes.bsSize,
+
   /**
    * When used with the `title` prop, the noCaret option will not render a caret icon, in the toggle element.
    */
@@ -54,9 +56,7 @@ DropdownButton.propTypes = {
       }
     }
   ]),
-  title: React.PropTypes.node.isRequired,
-  ...Dropdown.propTypes,
-  ...bootstrapUtils.propTypes
+  title: React.PropTypes.node.isRequired
 };
 
 DropdownButton.defaultProps = {

--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 import Dropdown from './Dropdown';
 import NavDropdown from './NavDropdown';
 import all from 'react-prop-types/lib/all';
@@ -56,7 +56,7 @@ DropdownButton.propTypes = {
   ]),
   title: React.PropTypes.node.isRequired,
   ...Dropdown.propTypes,
-  ...BootstrapMixin.propTypes
+  ...bootstrapUtils.propTypes
 };
 
 DropdownButton.defaultProps = {

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import keycode from 'keycode';
 import classNames from 'classnames';
+import bootstrapUtils from './utils/bootstrapUtils';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 import ValidComponentChildren from './utils/ValidComponentChildren';
 import createChainedFunction from './utils/createChainedFunction';
@@ -81,18 +82,20 @@ class DropdownMenu extends React.Component {
       let {
         children,
         onKeyDown,
-        onSelect
+        onSelect,
+        bsClass
       } = child.props || {};
 
       return React.cloneElement(child, {
+        bsClass: bsClass || this.props.bsClass,
         onKeyDown: createChainedFunction(onKeyDown, this.handleKeyDown),
         onSelect: createChainedFunction(onSelect, this.props.onSelect)
       }, children);
     });
 
     const classes = {
-      'dropdown-menu': true,
-      'dropdown-menu-right': this.props.pullRight
+      [bootstrapUtils.prefix(this.props, 'menu')]: true,
+      [bootstrapUtils.prefix(this.props, 'menu-right')]: this.props.pullRight
     };
 
     let list = (
@@ -119,6 +122,7 @@ class DropdownMenu extends React.Component {
 
 DropdownMenu.defaultProps = {
   bsRole: 'menu',
+  bsClass: 'dropdown',
   pullRight: false
 };
 

--- a/src/Label.js
+++ b/src/Label.js
@@ -1,19 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
-import bootstrapUtils from './utils/bootstrapUtils';
+import bootstrapUtils, { bsStyles, bsClass } from './utils/bootstrapUtils';
+import { State, DEFAULT, PRIMARY } from './styleMaps';
 
-const Label = React.createClass({
-
-  propTypes: {
-    ...bootstrapUtils.propTypes
-  },
-
-  getDefaultProps() {
-    return {
-      bsClass: 'label',
-      bsStyle: 'default'
-    };
-  },
+@bsClass('label')
+@bsStyles(State.values().concat(DEFAULT, PRIMARY), DEFAULT)
+class Label extends React.Component {
 
   render() {
     let classes = bootstrapUtils.getClassSet(this.props);
@@ -24,6 +16,6 @@ const Label = React.createClass({
       </span>
     );
   }
-});
+}
 
 export default Label;

--- a/src/Label.js
+++ b/src/Label.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 
 const Label = React.createClass({
-  mixins: [BootstrapMixin],
+
+  propTypes: {
+    ...bootstrapUtils.propTypes
+  },
 
   getDefaultProps() {
     return {
@@ -13,7 +16,7 @@ const Label = React.createClass({
   },
 
   render() {
-    let classes = this.getBsClassSet();
+    let classes = bootstrapUtils.getClassSet(this.props);
 
     return (
       <span {...this.props} className={classNames(this.props.className, classes)}>

--- a/src/ListGroupItem.js
+++ b/src/ListGroupItem.js
@@ -1,30 +1,11 @@
 import React, { cloneElement } from 'react';
-import bootstrapUtils from './utils/bootstrapUtils';
+import bootstrapUtils, { bsStyles, bsClass } from './utils/bootstrapUtils';
+import { State } from './styleMaps';
 import classNames from 'classnames';
 
-const ListGroupItem = React.createClass({
-
-  propTypes: {
-    ...bootstrapUtils.propTypes,
-
-    bsStyle: React.PropTypes.oneOf(['danger', 'info', 'success', 'warning']),
-    className: React.PropTypes.string,
-    active: React.PropTypes.any,
-    disabled: React.PropTypes.any,
-    header: React.PropTypes.node,
-    listItem: React.PropTypes.bool,
-    onClick: React.PropTypes.func,
-    eventKey: React.PropTypes.any,
-    href: React.PropTypes.string,
-    target: React.PropTypes.string
-  },
-
-  getDefaultProps() {
-    return {
-      bsClass: 'list-group-item',
-      listItem: false
-    };
-  },
+@bsClass('list-group-item')
+@bsStyles(State.values())
+class ListGroupItem extends React.Component {
 
   render() {
     let classes = bootstrapUtils.getClassSet(this.props);
@@ -41,7 +22,7 @@ const ListGroupItem = React.createClass({
     } else {
       return this.renderSpan(classes);
     }
-  },
+  }
 
   renderLi(classes) {
     return (
@@ -50,7 +31,7 @@ const ListGroupItem = React.createClass({
         {this.props.header ? this.renderStructuredContent() : this.props.children}
       </li>
     );
-  },
+  }
 
   renderAnchor(classes) {
     return (
@@ -61,7 +42,7 @@ const ListGroupItem = React.createClass({
         {this.props.header ? this.renderStructuredContent() : this.props.children}
       </a>
     );
-  },
+  }
 
   renderButton(classes) {
     return (
@@ -72,7 +53,7 @@ const ListGroupItem = React.createClass({
         {this.props.children}
       </button>
     );
-  },
+  }
 
   renderSpan(classes) {
     return (
@@ -81,7 +62,7 @@ const ListGroupItem = React.createClass({
         {this.props.header ? this.renderStructuredContent() : this.props.children}
       </span>
     );
-  },
+  }
 
   renderStructuredContent() {
     let header;
@@ -108,6 +89,24 @@ const ListGroupItem = React.createClass({
 
     return [header, content];
   }
-});
+}
+
+ListGroupItem.propTypes = {
+  ...ListGroupItem.propTypes,
+  className: React.PropTypes.string,
+  active: React.PropTypes.any,
+  disabled: React.PropTypes.any,
+  header: React.PropTypes.node,
+  listItem: React.PropTypes.bool,
+  onClick: React.PropTypes.func,
+  eventKey: React.PropTypes.any,
+  href: React.PropTypes.string,
+  target: React.PropTypes.string
+};
+
+ListGroupItem.defaultTypes = {
+  ...ListGroupItem.defaultTypes,
+  listItem: false
+};
 
 export default ListGroupItem;

--- a/src/ListGroupItem.js
+++ b/src/ListGroupItem.js
@@ -85,21 +85,23 @@ const ListGroupItem = React.createClass({
 
   renderStructuredContent() {
     let header;
+    let headingClass = bootstrapUtils.prefix(this.props, 'heading');
+
     if (React.isValidElement(this.props.header)) {
       header = cloneElement(this.props.header, {
         key: 'header',
-        className: classNames(this.props.header.props.className, 'list-group-item-heading')
+        className: classNames(this.props.header.props.className, headingClass)
       });
     } else {
       header = (
-        <h4 key='header' className="list-group-item-heading">
+        <h4 key='header' className={headingClass}>
           {this.props.header}
         </h4>
       );
     }
 
     let content = (
-      <p key='content' className="list-group-item-text">
+      <p key='content' className={bootstrapUtils.prefix(this.props, 'text')}>
         {this.props.children}
       </p>
     );

--- a/src/ListGroupItem.js
+++ b/src/ListGroupItem.js
@@ -1,11 +1,12 @@
 import React, { cloneElement } from 'react';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 import classNames from 'classnames';
 
 const ListGroupItem = React.createClass({
-  mixins: [BootstrapMixin],
 
   propTypes: {
+    ...bootstrapUtils.propTypes,
+
     bsStyle: React.PropTypes.oneOf(['danger', 'info', 'success', 'warning']),
     className: React.PropTypes.string,
     active: React.PropTypes.any,
@@ -26,7 +27,7 @@ const ListGroupItem = React.createClass({
   },
 
   render() {
-    let classes = this.getBsClassSet();
+    let classes = bootstrapUtils.getClassSet(this.props);
 
     classes.active = this.props.active;
     classes.disabled = this.props.disabled;

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import classnames from 'classnames';
+import bootstrapUtils from './utils/bootstrapUtils';
 import all from 'react-prop-types/lib/all';
 import SafeAnchor from './SafeAnchor';
 
@@ -25,13 +26,15 @@ export default class MenuItem extends React.Component {
   }
 
   render() {
+    let headerClass = bootstrapUtils.prefix(this.props, 'header');
+
     if (this.props.divider) {
       return <li role='separator' className='divider' />;
     }
 
     if (this.props.header) {
       return (
-        <li role='heading' className='dropdown-header'>{this.props.children}</li>
+        <li role='heading' className={headerClass}>{this.props.children}</li>
       );
     }
 
@@ -61,6 +64,8 @@ export default class MenuItem extends React.Component {
 }
 
 MenuItem.propTypes = {
+  bsClass: React.PropTypes.string,
+
   disabled: React.PropTypes.bool,
   divider: all([
     React.PropTypes.bool,
@@ -89,5 +94,6 @@ MenuItem.propTypes = {
 MenuItem.defaultProps = {
   divider: false,
   disabled: false,
-  header: false
+  header: false,
+  bsClass: 'dropdown'
 };

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -2,6 +2,7 @@
 import React, { cloneElement } from 'react';
 import classNames from 'classnames';
 import domUtils from './utils/domUtils';
+import bootstrapUtils from './utils/bootstrapUtils';
 import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
 import EventListener from './utils/EventListener';
 import createChainedFunction from './utils/createChainedFunction';
@@ -203,8 +204,9 @@ const Modal = React.createClass({
   },
 
   renderBackdrop(modal) {
-    let { animation, bsClass } = this.props;
+    let { animation } = this.props;
     let duration = Modal.BACKDROP_TRANSITION_DURATION;
+    let prefix = bootstrapUtils.prefix(this.props);
 
     // Don't handle clicks for "static" backdrops
     let onClick = this.props.backdrop === true ?
@@ -213,7 +215,7 @@ const Modal = React.createClass({
     let backdrop = (
       <div
         ref="backdrop"
-        className={classNames(`${bsClass}-backdrop`, { in: this.props.show && !animation })}
+        className={classNames(`${prefix}-backdrop`, { in: this.props.show && !animation })}
         onClick={onClick}/>
     );
 

--- a/src/ModalBody.js
+++ b/src/ModalBody.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import classNames from 'classnames';
+import tbsUtils from './utils/bootstrapUtils';
 
 class ModalBody extends React.Component {
   render() {
     return (
       <div
         {...this.props}
-        className={classNames(this.props.className, this.props.modalClassName)}>
+        className={classNames(this.props.className, tbsUtils.prefix(this.props, 'body'))}>
         {this.props.children}
       </div>
     );
@@ -17,11 +18,11 @@ ModalBody.propTypes = {
   /**
    * A css class applied to the Component
    */
-  modalClassName: React.PropTypes.string
+  bsClass: React.PropTypes.string
 };
 
 ModalBody.defaultProps = {
-  modalClassName: 'modal-body'
+  bsClass: 'modal'
 };
 
 

--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -1,12 +1,12 @@
 /*eslint-disable react/prop-types */
 import React from 'react';
 import classNames from 'classnames';
-import bootstrapUtils from './utils/bootstrapUtils';
+import bootstrapUtils, { bsSizes } from './utils/bootstrapUtils';
+import { Sizes } from './styleMaps';
 
 const ModalDialog = React.createClass({
 
   propTypes: {
-    ...bootstrapUtils.propTypes,
     /**
      * A Callback fired when the header closeButton or non-static backdrop is clicked.
      * @type {function}
@@ -57,4 +57,4 @@ const ModalDialog = React.createClass({
   }
 });
 
-export default ModalDialog;
+export default bsSizes([Sizes.LARGE, Sizes.SMALL], ModalDialog);

--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -33,11 +33,11 @@ const ModalDialog = React.createClass({
       display: 'block',
       ...this.props.style
     };
-    let bsClass = this.props.bsClass;
+    let prefix = bootstrapUtils.prefix(this.props);
     let dialogClasses = bootstrapUtils.getClassSet(this.props);
 
     delete dialogClasses.modal;
-    dialogClasses[`${bsClass}-dialog`] = true;
+    dialogClasses[`${prefix}-dialog`] = true;
 
     return (
       <div
@@ -46,9 +46,9 @@ const ModalDialog = React.createClass({
         tabIndex="-1"
         role="dialog"
         style={modalStyle}
-        className={classNames(this.props.className, bsClass)}>
+        className={classNames(this.props.className, prefix)}>
         <div className={classNames(this.props.dialogClassName, dialogClasses)}>
-          <div className={`${bsClass}-content`} role='document'>
+          <div className={`${prefix}-content`} role='document'>
             { this.props.children }
           </div>
         </div>

--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -1,12 +1,12 @@
 /*eslint-disable react/prop-types */
 import React from 'react';
 import classNames from 'classnames';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 
 const ModalDialog = React.createClass({
-  mixins: [BootstrapMixin],
 
   propTypes: {
+    ...bootstrapUtils.propTypes,
     /**
      * A Callback fired when the header closeButton or non-static backdrop is clicked.
      * @type {function}
@@ -34,7 +34,7 @@ const ModalDialog = React.createClass({
       ...this.props.style
     };
     let bsClass = this.props.bsClass;
-    let dialogClasses = this.getBsClassSet();
+    let dialogClasses = bootstrapUtils.getClassSet(this.props);
 
     delete dialogClasses.modal;
     dialogClasses[`${bsClass}-dialog`] = true;

--- a/src/ModalFooter.js
+++ b/src/ModalFooter.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import classNames from 'classnames';
+import tbsUtils from './utils/bootstrapUtils';
 
 class ModalFooter extends React.Component {
   render() {
     return (
       <div
         {...this.props}
-        className={classNames(this.props.className, this.props.modalClassName)}>
+        className={classNames(this.props.className, tbsUtils.prefix(this.props, 'footer'))}>
         {this.props.children}
       </div>
     );
@@ -17,11 +18,11 @@ ModalFooter.propTypes = {
   /**
    * A css class applied to the Component
    */
-  modalClassName: React.PropTypes.string
+  bsClass: React.PropTypes.string
 };
 
 ModalFooter.defaultProps = {
-  modalClassName: 'modal-footer'
+  bsClass: 'modal'
 };
 
 export default ModalFooter;

--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import classNames from 'classnames';
+import tbsUtils from './utils/bootstrapUtils';
 
 class ModalHeader extends React.Component {
   render() {
     return (
       <div
         {...this.props}
-        className={classNames(this.props.className, this.props.modalClassName)}>
+        className={classNames(this.props.className, tbsUtils.prefix(this.props, 'header'))}>
         { this.props.closeButton &&
           <button
             className='close'
@@ -32,10 +33,7 @@ ModalHeader.propTypes = {
    */
   'aria-label': React.PropTypes.string,
 
-  /**
-   * A css class applied to the Component
-   */
-  modalClassName: React.PropTypes.string,
+  bsClass: React.PropTypes.string,
 
   /**
    * Specify whether the Component should contain a close button
@@ -51,7 +49,7 @@ ModalHeader.propTypes = {
 
 ModalHeader.defaultProps = {
   'aria-label': 'Close',
-  modalClassName: 'modal-header',
+  bsClass: 'modal',
   closeButton: false
 };
 

--- a/src/ModalTitle.js
+++ b/src/ModalTitle.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import classNames from 'classnames';
+import tbsUtils from './utils/bootstrapUtils';
 
 class ModalTitle extends React.Component {
   render() {
     return (
       <h4
         {...this.props}
-        className={classNames(this.props.className, this.props.modalClassName)}>
+        className={classNames(this.props.className, tbsUtils.prefix(this.props, 'title'))}>
         { this.props.children }
       </h4>
     );
@@ -14,14 +15,11 @@ class ModalTitle extends React.Component {
 }
 
 ModalTitle.propTypes = {
-  /**
-   * A css class applied to the Component
-   */
-  modalClassName: React.PropTypes.string
+  bsClass: React.PropTypes.string
 };
 
 ModalTitle.defaultProps = {
-  modalClassName: 'modal-title'
+  bsClass: 'modal'
 };
 
 export default ModalTitle;

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -1,60 +1,14 @@
 import React, { cloneElement } from 'react';
-import tbsUtils from './utils/bootstrapUtils';
+import tbsUtils, { bsStyles, bsClass } from './utils/bootstrapUtils';
 import Collapse from './Collapse';
 import classNames from 'classnames';
 
 import ValidComponentChildren from './utils/ValidComponentChildren';
 import createChainedFunction from './utils/createChainedFunction';
 
-const Nav = React.createClass({
-
-  propTypes: {
-    ...tbsUtils.propTypes,
-    activeHref: React.PropTypes.string,
-    activeKey: React.PropTypes.any,
-    bsStyle: React.PropTypes.oneOf(['tabs', 'pills']),
-    stacked: React.PropTypes.bool,
-    justified: React.PropTypes.bool,
-    onSelect: React.PropTypes.func,
-    collapsible: React.PropTypes.bool,
-    /**
-     * CSS classes for the wrapper `nav` element
-     */
-    className: React.PropTypes.string,
-    /**
-     * HTML id for the wrapper `nav` element
-     */
-    id: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number
-    ]),
-    /**
-     * CSS classes for the inner `ul` element
-     */
-    ulClassName: React.PropTypes.string,
-    /**
-     * HTML id for the inner `ul` element
-     */
-    ulId: React.PropTypes.string,
-    expanded: React.PropTypes.bool,
-    navbar: React.PropTypes.bool,
-    eventKey: React.PropTypes.any,
-    pullRight: React.PropTypes.bool,
-    right: React.PropTypes.bool
-  },
-
-  getDefaultProps() {
-    return {
-      bsClass: 'nav',
-      collapsible: false,
-      expanded: true,
-      justified: false,
-      navbar: false,
-      pullRight: false,
-      right: false,
-      stacked: false
-    };
-  },
+@bsClass('nav')
+@bsStyles(['tabs', 'pills'])
+class Nav extends React.Component {
 
   render() {
     const classes = this.props.collapsible ? 'navbar-collapse' : null;
@@ -70,7 +24,7 @@ const Nav = React.createClass({
         </nav>
       </Collapse>
     );
-  },
+  }
 
   renderUl() {
     const classes = tbsUtils.getClassSet(this.props);
@@ -89,10 +43,10 @@ const Nav = React.createClass({
         id={this.props.ulId}
         ref="ul"
       >
-        {ValidComponentChildren.map(this.props.children, this.renderNavItem)}
+        {ValidComponentChildren.map(this.props.children, this.renderNavItem, this)}
       </ul>
     );
-  },
+  }
 
   getChildActiveProp(child) {
     if (child.props.active) {
@@ -110,7 +64,7 @@ const Nav = React.createClass({
     }
 
     return child.props.active;
-  },
+  }
 
   renderNavItem(child, index) {
     return cloneElement(
@@ -126,6 +80,52 @@ const Nav = React.createClass({
       }
     );
   }
-});
+}
+
+Nav.propTypes = {
+  ...Nav.propTypes,
+  activeHref: React.PropTypes.string,
+  activeKey: React.PropTypes.any,
+
+  stacked: React.PropTypes.bool,
+  justified: React.PropTypes.bool,
+  onSelect: React.PropTypes.func,
+  collapsible: React.PropTypes.bool,
+  /**
+   * CSS classes for the wrapper `nav` element
+   */
+  className: React.PropTypes.string,
+  /**
+   * HTML id for the wrapper `nav` element
+   */
+  id: React.PropTypes.oneOfType([
+    React.PropTypes.string,
+    React.PropTypes.number
+  ]),
+  /**
+   * CSS classes for the inner `ul` element
+   */
+  ulClassName: React.PropTypes.string,
+  /**
+   * HTML id for the inner `ul` element
+   */
+  ulId: React.PropTypes.string,
+  expanded: React.PropTypes.bool,
+  navbar: React.PropTypes.bool,
+  eventKey: React.PropTypes.any,
+  pullRight: React.PropTypes.bool,
+  right: React.PropTypes.bool
+};
+
+Nav.defaultProps = {
+  ...Nav.defaultProps,
+  collapsible: false,
+  expanded: true,
+  justified: false,
+  navbar: false,
+  pullRight: false,
+  right: false,
+  stacked: false
+};
 
 export default Nav;

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -1,5 +1,5 @@
 import React, { cloneElement } from 'react';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 import Collapse from './Collapse';
 import classNames from 'classnames';
 
@@ -7,9 +7,10 @@ import ValidComponentChildren from './utils/ValidComponentChildren';
 import createChainedFunction from './utils/createChainedFunction';
 
 const Nav = React.createClass({
-  mixins: [BootstrapMixin],
+
 
   propTypes: {
+    ...bootstrapUtils.propTypes,
     activeHref: React.PropTypes.string,
     activeKey: React.PropTypes.any,
     bsStyle: React.PropTypes.oneOf(['tabs', 'pills']),
@@ -73,7 +74,7 @@ const Nav = React.createClass({
   },
 
   renderUl() {
-    const classes = this.getBsClassSet();
+    const classes = bootstrapUtils.getClassSet(this.props);
 
     classes['nav-stacked'] = this.props.stacked;
     classes['nav-justified'] = this.props.justified;

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -1,5 +1,5 @@
 import React, { cloneElement } from 'react';
-import bootstrapUtils from './utils/bootstrapUtils';
+import tbsUtils from './utils/bootstrapUtils';
 import Collapse from './Collapse';
 import classNames from 'classnames';
 
@@ -8,9 +8,8 @@ import createChainedFunction from './utils/createChainedFunction';
 
 const Nav = React.createClass({
 
-
   propTypes: {
-    ...bootstrapUtils.propTypes,
+    ...tbsUtils.propTypes,
     activeHref: React.PropTypes.string,
     activeKey: React.PropTypes.any,
     bsStyle: React.PropTypes.oneOf(['tabs', 'pills']),
@@ -74,10 +73,11 @@ const Nav = React.createClass({
   },
 
   renderUl() {
-    const classes = bootstrapUtils.getClassSet(this.props);
+    const classes = tbsUtils.getClassSet(this.props);
 
-    classes['nav-stacked'] = this.props.stacked;
-    classes['nav-justified'] = this.props.justified;
+    //TODO: need to pass navbar bsClass down...
+    classes[tbsUtils.prefix(this.props, 'stacked')] = this.props.stacked;
+    classes[tbsUtils.prefix(this.props, 'justified')] = this.props.justified;
     classes['navbar-nav'] = this.props.navbar;
     classes['pull-right'] = this.props.pullRight;
     classes['navbar-right'] = this.props.right;

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -1,10 +1,8 @@
 import React from 'react';
 import classNames from 'classnames';
-import BootstrapMixin from './BootstrapMixin';
 import SafeAnchor from './SafeAnchor';
 
 const NavItem = React.createClass({
-  mixins: [BootstrapMixin],
 
   propTypes: {
     linkId: React.PropTypes.string,

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -34,7 +34,6 @@ const Navbar = React.createClass({
   getDefaultProps() {
     return {
       bsClass: 'navbar',
-      bsStyle: 'default',
       role: 'navigation',
       componentClass: 'nav',
       fixedTop: false,

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -1,5 +1,5 @@
 import React, { cloneElement } from 'react';
-import bootstrapUtils from './utils/bootstrapUtils';
+import tbsUtils from './utils/bootstrapUtils';
 import classNames from 'classnames';
 
 import ValidComponentChildren from './utils/ValidComponentChildren';
@@ -9,7 +9,7 @@ import elementType from 'react-prop-types/lib/elementType';
 const Navbar = React.createClass({
 
   propTypes: {
-    ...bootstrapUtils.propTypes,
+    ...tbsUtils.propTypes,
     fixedTop: React.PropTypes.bool,
     fixedBottom: React.PropTypes.bool,
     staticTop: React.PropTypes.bool,
@@ -74,13 +74,13 @@ const Navbar = React.createClass({
   },
 
   render() {
-    let classes = bootstrapUtils.getClassSet(this.props);
+    let classes = tbsUtils.getClassSet(this.props);
     let ComponentClass = this.props.componentClass;
 
-    classes['navbar-fixed-top'] = this.props.fixedTop;
-    classes['navbar-fixed-bottom'] = this.props.fixedBottom;
-    classes['navbar-static-top'] = this.props.staticTop;
-    classes['navbar-inverse'] = this.props.inverse;
+    classes[tbsUtils.prefix(this.props, 'fixed-top')] = this.props.fixedTop;
+    classes[tbsUtils.prefix(this.props, 'fixed-bottom')] = this.props.fixedBottom;
+    classes[tbsUtils.prefix(this.props, 'static-top')] = this.props.staticTop;
+    classes[tbsUtils.prefix(this.props, 'inverse')] = this.props.inverse;
 
     return (
       <ComponentClass {...this.props} className={classNames(this.props.className, classes)}>
@@ -103,19 +103,21 @@ const Navbar = React.createClass({
 
   renderHeader() {
     let brand;
+    let headerClass = tbsUtils.prefix(this.props, 'header');
+    let brandClass = tbsUtils.prefix(this.props, 'brand');
 
     if (this.props.brand) {
       if (React.isValidElement(this.props.brand)) {
         brand = cloneElement(this.props.brand, {
-          className: classNames(this.props.brand.props.className, 'navbar-brand')
+          className: classNames(this.props.brand.props.className, brandClass)
         });
       } else {
-        brand = <span className="navbar-brand">{this.props.brand}</span>;
+        brand = <span className={brandClass}>{this.props.brand}</span>;
       }
     }
 
     return (
-      <div className="navbar-header">
+      <div className={headerClass}>
         {brand}
         {(this.props.toggleButton || this.props.toggleNavKey != null) ? this.renderToggleButton() : null}
       </div>
@@ -124,11 +126,12 @@ const Navbar = React.createClass({
 
   renderToggleButton() {
     let children;
+    let toggleClass =  tbsUtils.prefix(this.props, 'toggle');
 
     if (React.isValidElement(this.props.toggleButton)) {
 
       return cloneElement(this.props.toggleButton, {
-        className: classNames(this.props.toggleButton.props.className, 'navbar-toggle'),
+        className: classNames(this.props.toggleButton.props.className, toggleClass),
         onClick: createChainedFunction(this.handleToggle, this.props.toggleButton.props.onClick)
       });
     }
@@ -142,7 +145,7 @@ const Navbar = React.createClass({
       ];
 
     return (
-      <button className="navbar-toggle" type="button" onClick={this.handleToggle}>
+      <button className={toggleClass} type="button" onClick={this.handleToggle}>
         {children}
       </button>
     );

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -1,5 +1,5 @@
 import React, { cloneElement } from 'react';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 import classNames from 'classnames';
 
 import ValidComponentChildren from './utils/ValidComponentChildren';
@@ -7,9 +7,9 @@ import createChainedFunction from './utils/createChainedFunction';
 import elementType from 'react-prop-types/lib/elementType';
 
 const Navbar = React.createClass({
-  mixins: [BootstrapMixin],
 
   propTypes: {
+    ...bootstrapUtils.propTypes,
     fixedTop: React.PropTypes.bool,
     fixedBottom: React.PropTypes.bool,
     staticTop: React.PropTypes.bool,
@@ -74,7 +74,7 @@ const Navbar = React.createClass({
   },
 
   render() {
-    let classes = this.getBsClassSet();
+    let classes = bootstrapUtils.getClassSet(this.props);
     let ComponentClass = this.props.componentClass;
 
     classes['navbar-fixed-top'] = this.props.fixedTop;

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import classNames from 'classnames';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 import PaginationButton from './PaginationButton';
 import elementType from 'react-prop-types/lib/elementType';
 import SafeAnchor from './SafeAnchor';
 
 const Pagination = React.createClass({
-  mixins: [BootstrapMixin],
 
   propTypes: {
+    ...bootstrapUtils.propTypes,
     activePage: React.PropTypes.number,
     items: React.PropTypes.number,
     maxButtons: React.PropTypes.number,
@@ -169,7 +169,7 @@ const Pagination = React.createClass({
     return (
       <ul
         {...this.props}
-        className={classNames(this.props.className, this.getBsClassSet())}>
+        className={classNames(this.props.className, bootstrapUtils.getClassSet(this.props))}>
         {this.renderFirst()}
         {this.renderPrev()}
         {this.renderPageButtons()}

--- a/src/PaginationButton.js
+++ b/src/PaginationButton.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import classNames from 'classnames';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 import createSelectedEvent from './utils/createSelectedEvent';
 import elementType from 'react-prop-types/lib/elementType';
 
 const PaginationButton = React.createClass({
-  mixins: [BootstrapMixin],
 
   propTypes: {
+    ...bootstrapUtils.propTypes,
     className: React.PropTypes.string,
     eventKey: React.PropTypes.oneOfType([
       React.PropTypes.string,
@@ -44,7 +44,7 @@ const PaginationButton = React.createClass({
     let classes = {
       active: this.props.active,
       disabled: this.props.disabled,
-      ...this.getBsClassSet()
+      ...bootstrapUtils.getClassSet(this.props)
     };
 
     let {

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -1,13 +1,13 @@
 import React, { cloneElement } from 'react';
 import classNames from 'classnames';
 
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 import Collapse from './Collapse';
 
 const Panel = React.createClass({
-  mixins: [BootstrapMixin],
 
   propTypes: {
+    ...bootstrapUtils.propTypes,
     collapsible: React.PropTypes.bool,
     onSelect: React.PropTypes.func,
     header: React.PropTypes.node,
@@ -63,7 +63,7 @@ const Panel = React.createClass({
     let {headerRole, panelRole, ...props} = this.props;
     return (
       <div {...props}
-        className={classNames(this.props.className, this.getBsClassSet())}
+        className={classNames(this.props.className, bootstrapUtils.getClassSet(this.props))}
         id={this.props.collapsible ? null : this.props.id} onSelect={null}>
         {this.renderHeading(headerRole)}
         {this.props.collapsible ? this.renderCollapsibleBody(panelRole) : this.renderBody()}
@@ -74,7 +74,7 @@ const Panel = React.createClass({
 
   renderCollapsibleBody(panelRole) {
     let props = {
-      className: this.prefixClass('collapse'),
+      className: bootstrapUtils.prefix(this.props, 'collapse'),
       id: this.props.id,
       ref: 'panel',
       'aria-hidden': !this.isExpanded()
@@ -97,7 +97,7 @@ const Panel = React.createClass({
     let allChildren = this.props.children;
     let bodyElements = [];
     let panelBodyChildren = [];
-    let bodyClass = this.prefixClass('body');
+    let bodyClass = bootstrapUtils.prefix(this.props, 'body');
 
     function getProps() {
       return {key: bodyElements.length};
@@ -166,7 +166,7 @@ const Panel = React.createClass({
         this.renderCollapsibleTitle(header, headerRole) : header;
     } else {
       const className = classNames(
-        this.prefixClass('title'), header.props.className
+        bootstrapUtils.prefix(this.props, 'title'), header.props.className
       );
 
       if (this.props.collapsible) {
@@ -180,7 +180,7 @@ const Panel = React.createClass({
     }
 
     return (
-      <div className={this.prefixClass('heading')}>
+      <div className={bootstrapUtils.prefix(this.props, 'heading')}>
         {header}
       </div>
     );
@@ -203,7 +203,7 @@ const Panel = React.createClass({
 
   renderCollapsibleTitle(header, headerRole) {
     return (
-      <h4 className={this.prefixClass('title')} role="presentation">
+      <h4 className={bootstrapUtils.prefix(this.props, 'title')} role="presentation">
         {this.renderAnchor(header, headerRole)}
       </h4>
     );
@@ -215,7 +215,7 @@ const Panel = React.createClass({
     }
 
     return (
-      <div className={this.prefixClass('footer')}>
+      <div className={bootstrapUtils.prefix(this.props, 'footer')}>
         {this.props.footer}
       </div>
     );

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -1,10 +1,10 @@
 import React, { cloneElement } from 'react';
 import classNames from 'classnames';
-
-import bootstrapUtils from './utils/bootstrapUtils';
+import bootstrapUtils, { bsStyles } from './utils/bootstrapUtils';
+import { State, PRIMARY, DEFAULT } from './styleMaps';
 import Collapse from './Collapse';
 
-const Panel = React.createClass({
+let Panel = React.createClass({
 
   propTypes: {
     ...bootstrapUtils.propTypes,
@@ -26,7 +26,6 @@ const Panel = React.createClass({
   getDefaultProps() {
     return {
       bsClass: 'panel',
-      bsStyle: 'default',
       defaultExpanded: false
     };
   },
@@ -221,5 +220,7 @@ const Panel = React.createClass({
     );
   }
 });
+
+Panel = bsStyles(State.values().concat(DEFAULT, PRIMARY), DEFAULT, Panel);
 
 export default Panel;

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -4,13 +4,14 @@
 import React, { cloneElement } from 'react';
 import classNames from 'classnames';
 
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 import ValidComponentChildren from './utils/ValidComponentChildren';
 
 const PanelGroup = React.createClass({
-  mixins: [BootstrapMixin],
+
 
   propTypes: {
+    ...bootstrapUtils.propTypes,
     accordion: React.PropTypes.bool,
     activeKey: React.PropTypes.any,
     className: React.PropTypes.string,
@@ -35,7 +36,7 @@ const PanelGroup = React.createClass({
   },
 
   render() {
-    let classes = this.getBsClassSet();
+    let classes = bootstrapUtils.getClassSet(this.props);
     let {className, ...props} = this.props;
     if (this.props.accordion) { props.role = 'tablist'; }
     return (

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -1,13 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
-import BootstrapMixin from './BootstrapMixin';
 import isRequiredForA11y from 'react-prop-types/lib/isRequiredForA11y';
 
 const Popover = React.createClass({
 
-  mixins: [ BootstrapMixin ],
-
   propTypes: {
+
     /**
      * An html id attribute, necessary for accessibility
      * @type {string}

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
+import tbsUtils from './utils/bootstrapUtils';
 import isRequiredForA11y from 'react-prop-types/lib/isRequiredForA11y';
 
 const Popover = React.createClass({
@@ -51,13 +52,14 @@ const Popover = React.createClass({
 
   getDefaultProps() {
     return {
-      placement: 'right'
+      placement: 'right',
+      bsClass: 'popover'
     };
   },
 
   render() {
     const classes = {
-      'popover': true,
+      [tbsUtils.prefix(this.props)]: true,
       [this.props.placement]: true
     };
 
@@ -78,7 +80,7 @@ const Popover = React.createClass({
       <div role='tooltip' {...this.props} className={classNames(this.props.className, classes)} style={style} title={null}>
         <div className="arrow" style={arrowStyle} />
         {this.props.title ? this.renderTitle() : null}
-        <div className="popover-content">
+        <div className={tbsUtils.prefix(this.props, 'content')}>
           {this.props.children}
         </div>
       </div>
@@ -87,7 +89,9 @@ const Popover = React.createClass({
 
   renderTitle() {
     return (
-      <h3 className="popover-title">{this.props.title}</h3>
+      <h3 className={tbsUtils.prefix(this.props, 'title')}>
+        {this.props.title}
+      </h3>
     );
   }
 });

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -3,13 +3,15 @@
 
 import React, { cloneElement, PropTypes } from 'react';
 import Interpolate from './Interpolate';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 import classNames from 'classnames';
 
 import ValidComponentChildren from './utils/ValidComponentChildren';
 
 const ProgressBar = React.createClass({
+
   propTypes: {
+    ...bootstrapUtils.propTypes,
     min: PropTypes.number,
     now: PropTypes.number,
     max: PropTypes.number,
@@ -25,8 +27,6 @@ const ProgressBar = React.createClass({
      */
     isChild: PropTypes.bool
   },
-
-  mixins: [BootstrapMixin],
 
   getDefaultProps() {
     return {
@@ -98,7 +98,7 @@ const ProgressBar = React.createClass({
       );
     }
 
-    const classes = classNames(className, this.getBsClassSet(), {
+    const classes = classNames(className, bootstrapUtils.getClassSet(this.props), {
       active: this.props.active,
       'progress-bar-striped': this.props.active || this.props.striped
     });

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -1,49 +1,38 @@
 /* eslint react/prop-types: [2, {ignore: "bsStyle"}] */
 /* BootstrapMixin contains `bsStyle` type validation */
-
 import React, { cloneElement, PropTypes } from 'react';
 import Interpolate from './Interpolate';
-import bootstrapUtils from './utils/bootstrapUtils';
+import bootstrapUtils, { bsStyles, bsClass } from './utils/bootstrapUtils';
+import { State } from './styleMaps';
 import classNames from 'classnames';
-
 import ValidComponentChildren from './utils/ValidComponentChildren';
 
-const ProgressBar = React.createClass({
+/**
+ * Custom propTypes checker
+ */
+function onlyProgressBar(props, propName, componentName) {
+  if (props[propName]) {
+    let error, childIdentifier;
 
-  propTypes: {
-    ...bootstrapUtils.propTypes,
-    min: PropTypes.number,
-    now: PropTypes.number,
-    max: PropTypes.number,
-    label: PropTypes.node,
-    srOnly: PropTypes.bool,
-    striped: PropTypes.bool,
-    active: PropTypes.bool,
-    children: onlyProgressBar,
-    className: React.PropTypes.string,
-    interpolateClass: PropTypes.node,
-    /**
-     * @private
-     */
-    isChild: PropTypes.bool
-  },
+    React.Children.forEach(props[propName], (child) => {
+      if (child.type !== ProgressBar) {
+        childIdentifier = (child.type.displayName ? child.type.displayName : child.type);
+        error = new Error(`Children of ${componentName} can contain only ProgressBar components. Found ${childIdentifier}`);
+      }
+    });
 
-  getDefaultProps() {
-    return {
-      bsClass: 'progress-bar',
-      min: 0,
-      max: 100,
-      active: false,
-      isChild: false,
-      srOnly: false,
-      striped: false
-    };
-  },
+    return error;
+  }
+}
+
+@bsClass('progress-bar')
+@bsStyles(State.values())
+class ProgressBar extends React.Component {
 
   getPercentage(now, min, max) {
     const roundPrecision = 1000;
     return Math.round(((now - min) / (max - min) * 100) * roundPrecision) / roundPrecision;
-  },
+  }
 
   render() {
     if (this.props.isChild) {
@@ -70,14 +59,14 @@ const ProgressBar = React.createClass({
         {content}
       </div>
     );
-  },
+  }
 
   renderChildBar(child, index) {
     return cloneElement(child, {
       isChild: true,
       key: child.key ? child.key : index
     });
-  },
+  }
 
   renderProgressBar() {
     let { className, label, now, min, max, ...props } = this.props;
@@ -115,7 +104,7 @@ const ProgressBar = React.createClass({
         {label}
       </div>
     );
-  },
+  }
 
   renderLabel(percentage) {
     const InterpolateClass = this.props.interpolateClass || Interpolate;
@@ -131,24 +120,34 @@ const ProgressBar = React.createClass({
       </InterpolateClass>
     );
   }
-});
-
-/**
- * Custom propTypes checker
- */
-function onlyProgressBar(props, propName, componentName) {
-  if (props[propName]) {
-    let error, childIdentifier;
-
-    React.Children.forEach(props[propName], (child) => {
-      if (child.type !== ProgressBar) {
-        childIdentifier = (child.type.displayName ? child.type.displayName : child.type);
-        error = new Error(`Children of ${componentName} can contain only ProgressBar components. Found ${childIdentifier}`);
-      }
-    });
-
-    return error;
-  }
 }
+
+ProgressBar.propTypes = {
+  ...ProgressBar.propTypes,
+  min: PropTypes.number,
+  now: PropTypes.number,
+  max: PropTypes.number,
+  label: PropTypes.node,
+  srOnly: PropTypes.bool,
+  striped: PropTypes.bool,
+  active: PropTypes.bool,
+  children: onlyProgressBar,
+  className: React.PropTypes.string,
+  interpolateClass: PropTypes.node,
+  /**
+   * @private
+   */
+  isChild: PropTypes.bool
+};
+
+ProgressBar.defaultProps = {
+  ...ProgressBar.defaultProps,
+  min: 0,
+  max: 100,
+  active: false,
+  isChild: false,
+  srOnly: false,
+  striped: false
+};
 
 export default ProgressBar;

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -100,7 +100,7 @@ const ProgressBar = React.createClass({
 
     const classes = classNames(className, bootstrapUtils.getClassSet(this.props), {
       active: this.props.active,
-      'progress-bar-striped': this.props.active || this.props.striped
+      [bootstrapUtils.prefix(this.props, 'striped')]: this.props.active || this.props.striped
     });
 
     return (

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 import Button from './Button';
 import Dropdown from './Dropdown';
 import SplitToggle from './SplitToggle';
@@ -51,7 +51,7 @@ class SplitButton extends React.Component {
 SplitButton.propTypes = {
   //dropup: React.PropTypes.bool,
   ...Dropdown.propTypes,
-  ...BootstrapMixin.propTypes,
+  ...bootstrapUtils.propTypes,
 
   /**
    * @private

--- a/src/SubNav.js
+++ b/src/SubNav.js
@@ -3,11 +3,10 @@ import classNames from 'classnames';
 
 import ValidComponentChildren from './utils/ValidComponentChildren';
 import createChainedFunction from './utils/createChainedFunction';
-import BootstrapMixin from './BootstrapMixin';
 import SafeAnchor from './SafeAnchor';
 
 const SubNav = React.createClass({
-  mixins: [BootstrapMixin],
+
 
   propTypes: {
     onSelect: React.PropTypes.func,

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
+import tbsUtils from './utils/bootstrapUtils';
 import TransitionEvents from './utils/TransitionEvents';
 
 const Tab = React.createClass({
@@ -20,6 +21,7 @@ const Tab = React.createClass({
 
   getDefaultProps() {
     return {
+      bsClass: 'tab',
       animation: true
     };
   },
@@ -79,7 +81,7 @@ const Tab = React.createClass({
 
   render() {
     let classes = {
-      'tab-pane': true,
+      [tbsUtils.prefix(this.props, 'pane')]: true,
       'fade': true,
       'active': this.props.active || this.state.animateOut,
       'in': this.props.active && !this.state.animateIn

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -6,7 +6,7 @@ import Nav from './Nav';
 import NavItem from './NavItem';
 import Row from './Row';
 import styleMaps from './styleMaps';
-
+import tbsUtils from './utils/bootstrapUtils';
 import ValidComponentChildren from './utils/ValidComponentChildren';
 
 let paneId = (props, child) => child.props.id ? child.props.id : props.id && (props.id + '___pane___' + child.props.eventKey);
@@ -66,6 +66,7 @@ const Tabs = React.createClass({
 
   getDefaultProps() {
     return {
+      bsClass: 'tab',
       animation: true,
       tabWidth: 2,
       position: 'top'
@@ -129,6 +130,7 @@ const Tabs = React.createClass({
     const tabsProps = {
       ...props,
       bsStyle,
+      bsClass: undefined,
       stacked: isHorizontal,
       activeKey: this.getActiveKey(),
       onSelect: this.handleSelect,
@@ -138,7 +140,7 @@ const Tabs = React.createClass({
     const childTabs = ValidComponentChildren.map(children, this.renderTab);
 
     const panesProps = {
-      className: 'tab-content',
+      className: tbsUtils.prefix(this.props, 'content'),
       ref: 'panes'
     };
     const childPanes = ValidComponentChildren.map(children, this.renderPane);

--- a/src/Thumbnail.js
+++ b/src/Thumbnail.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import classSet from 'classnames';
-import BootstrapMixin from './BootstrapMixin';
 import SafeAnchor from './SafeAnchor';
+import bootstrapUtils from './utils/bootstrapUtils';
 
 const Thumbnail = React.createClass({
-  mixins: [BootstrapMixin],
+
 
   propTypes: {
+    ...bootstrapUtils.propTypes,
     alt: React.PropTypes.string,
     href: React.PropTypes.string,
     src: React.PropTypes.string
@@ -19,7 +20,7 @@ const Thumbnail = React.createClass({
   },
 
   render() {
-    let classes = this.getBsClassSet();
+    let classes = bootstrapUtils.getClassSet(this.props);
 
     if(this.props.href) {
       return (

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
+import tbsUtils from './utils/bootstrapUtils';
 import isRequiredForA11y from 'react-prop-types/lib/isRequiredForA11y';
 
 const Tooltip = React.createClass({
@@ -51,13 +52,14 @@ const Tooltip = React.createClass({
 
   getDefaultProps() {
     return {
+      bsClass: 'tooltip',
       placement: 'right'
     };
   },
 
   render() {
     const classes = {
-      'tooltip': true,
+      [tbsUtils.prefix(this.props)]: true,
       [this.props.placement]: true
     };
 
@@ -74,8 +76,8 @@ const Tooltip = React.createClass({
 
     return (
         <div role='tooltip' {...this.props} className={classNames(this.props.className, classes)} style={style}>
-          <div className="tooltip-arrow" style={arrowStyle} />
-          <div className="tooltip-inner">
+          <div className={tbsUtils.prefix(this.props, 'arrow')} style={arrowStyle} />
+          <div className={tbsUtils.prefix(this.props, 'inner')}>
             {this.props.children}
           </div>
         </div>

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,10 +1,9 @@
 import React from 'react';
 import classNames from 'classnames';
-import BootstrapMixin from './BootstrapMixin';
 import isRequiredForA11y from 'react-prop-types/lib/isRequiredForA11y';
 
 const Tooltip = React.createClass({
-  mixins: [BootstrapMixin],
+
 
   propTypes: {
     /**

--- a/src/Well.js
+++ b/src/Well.js
@@ -1,19 +1,11 @@
 import React from 'react';
 import classNames from 'classnames';
-import bootstrapUtils from './utils/bootstrapUtils';
+import bootstrapUtils, { bsSizes, bsClass } from './utils/bootstrapUtils';
+import { Sizes } from './styleMaps';
 
-const Well = React.createClass({
-
-  propTypes: {
-    ...bootstrapUtils.propTypes
-  },
-
-  getDefaultProps() {
-    return {
-      bsClass: 'well'
-    };
-  },
-
+@bsClass('well')
+@bsSizes([Sizes.LARGE, Sizes.SMALL])
+class Well extends React.Component {
   render() {
     let classes = bootstrapUtils.getClassSet(this.props);
 
@@ -23,6 +15,6 @@ const Well = React.createClass({
       </div>
     );
   }
-});
+}
 
 export default Well;

--- a/src/Well.js
+++ b/src/Well.js
@@ -1,9 +1,12 @@
 import React from 'react';
 import classNames from 'classnames';
-import BootstrapMixin from './BootstrapMixin';
+import bootstrapUtils from './utils/bootstrapUtils';
 
 const Well = React.createClass({
-  mixins: [BootstrapMixin],
+
+  propTypes: {
+    ...bootstrapUtils.propTypes
+  },
 
   getDefaultProps() {
     return {
@@ -12,7 +15,7 @@ const Well = React.createClass({
   },
 
   render() {
-    let classes = this.getBsClassSet();
+    let classes = bootstrapUtils.getClassSet(this.props);
 
     return (
       <div {...this.props} className={classNames(this.props.className, classes)}>

--- a/src/styleMaps.js
+++ b/src/styleMaps.js
@@ -1,20 +1,16 @@
+
+let constant = obj => {
+  return Object.assign(
+    Object.create({
+      values(){
+        return Object.keys(this).map(k => this[k]);
+      }
+    }), obj);
+};
+
 const styleMaps = {
 
-  STYLES: [
-    'default',
-    'primary',
-    'success',
-    'info',
-    'warning',
-    'danger',
-    'link',
-    'inline',
-    'tabs',
-    'pills'
-  ],
-  addStyle(name) {
-    styleMaps.STYLES.push(name);
-  },
+
   SIZES: {
     'large': 'lg',
     'medium': 'md',
@@ -27,5 +23,31 @@ const styleMaps = {
   },
   GRID_COLUMNS: 12
 };
+
+export function addStyle(Component, names) {
+  names = names == null ? [].concat(names) : [];
+
+  if (Component.Styles) {
+    Component.STYLES.push(...names);
+  }
+}
+
+export const Sizes = constant({
+  LARGE: 'large',
+  MEDIUM: 'medium',
+  SMALL: 'small',
+  XSMALL: 'xsmall'
+});
+
+export const State = constant({
+  SUCCESS: 'success',
+  WARNING: 'warning',
+  DANGER: 'danger',
+  INFO: 'info'
+});
+
+export const DEFAULT = 'default';
+export const PRIMARY = 'primary';
+export const LINK = 'link';
 
 export default styleMaps;

--- a/src/styleMaps.js
+++ b/src/styleMaps.js
@@ -1,26 +1,5 @@
 const styleMaps = {
-  CLASSES: {
-    'alert': 'alert',
-    'button': 'btn',
-    'button-group': 'btn-group',
-    'button-toolbar': 'btn-toolbar',
-    'column': 'col',
-    'input-group': 'input-group',
-    'form': 'form',
-    'glyphicon': 'glyphicon',
-    'label': 'label',
-    'thumbnail': 'thumbnail',
-    'list-group-item': 'list-group-item',
-    'panel': 'panel',
-    'panel-group': 'panel-group',
-    'pagination': 'pagination',
-    'progress-bar': 'progress-bar',
-    'nav': 'nav',
-    'navbar': 'navbar',
-    'modal': 'modal',
-    'row': 'row',
-    'well': 'well'
-  },
+
   STYLES: [
     'default',
     'primary',

--- a/src/utils/bootstrapUtils.js
+++ b/src/utils/bootstrapUtils.js
@@ -1,7 +1,16 @@
 import { PropTypes } from 'react';
 import styleMaps from '../styleMaps';
-import keyOf from 'react-prop-types/lib/keyOf';
 import invariant from 'react/lib/invariant';
+
+function curry(fn){
+  return (...args) => {
+    let last = args[args.length - 1];
+    if (typeof last === 'function'){
+      return fn(...args);
+    }
+    return Component => fn(...args, Component);
+  };
+}
 
 function prefix(props = {}, variant) {
   invariant((props.bsClass || '').trim(), 'Must provide a bsClass for components');
@@ -11,22 +20,7 @@ function prefix(props = {}, variant) {
 export default {
 
   propTypes: {
-    /**
-     * bootstrap className
-     * @private
-     */
-    bsClass: keyOf(styleMaps.CLASSES),
-    /**
-     * Style variants
-     * @type {("default"|"primary"|"success"|"info"|"warning"|"danger"|"link")}
-     */
-    bsStyle: PropTypes.oneOf(styleMaps.STYLES),
-
-    /**
-     * Size variants
-     * @type {("xsmall"|"small"|"medium"|"large"|"xs"|"sm"|"md"|"lg")}
-     */
-    bsSize: keyOf(styleMaps.SIZES)
+    bsClass: PropTypes.string,
   },
 
   prefix,
@@ -36,9 +30,13 @@ export default {
     let bsClass = (props.bsClass || '').trim();
 
     if (bsClass) {
+      let bsSize;
+
       classes[bsClass] = true;
 
-      let bsSize = props.bsSize && styleMaps.SIZES[props.bsSize];
+      if (props.bsSize) {
+        bsSize = styleMaps.SIZES[props.bsSize] || bsSize;
+      }
 
       if (bsSize) {
         classes[prefix(props, bsSize)] = true;
@@ -52,3 +50,90 @@ export default {
     return classes;
   }
 };
+
+export let bsClass = curry((defaultClass, Component) => {
+  let propTypes = Component.propTypes || (Component.propTypes = {});
+  let defaultProps = Component.defaultProps || (Component.defaultProps = {});
+
+  propTypes.bsClass = PropTypes.string;
+  defaultProps.bsClass = defaultClass;
+
+  return Component;
+});
+
+export let bsStyles = curry((styles, defaultStyle, Component) => {
+  if (typeof defaultStyle !== 'string') {
+    Component = defaultStyle;
+    defaultStyle = undefined;
+  }
+
+  let existing = Component.STYLES || [];
+  let propTypes = Component.propTypes || {};
+
+  styles.forEach(style => {
+    if (existing.indexOf(style) === -1) {
+      existing.push(style);
+    }
+  });
+
+  let propType = PropTypes.oneOf(existing);
+
+  // expose the values on the propType function for documentation
+  Component.STYLES = propType._values = existing;
+
+  Component.propTypes = {
+    ...propTypes,
+    bsStyle: propType
+  };
+
+  if (defaultStyle !== undefined) {
+    let defaultProps = Component.defaultProps || (Component.defaultProps = {});
+    defaultProps.bsStyle = defaultStyle;
+  }
+
+  return Component;
+});
+
+
+export let bsSizes = curry((sizes, defaultSize, Component) => {
+  if (typeof defaultSize !== 'string') {
+    Component = defaultSize;
+    defaultSize = undefined;
+  }
+
+  let existing = Component.SIZES || [];
+  let propTypes = Component.propTypes || {};
+
+  sizes.forEach(size => {
+    if (existing.indexOf(size) === -1) {
+      existing.push(size);
+    }
+  });
+
+  let values = existing.reduce((result, size) => {
+    if (styleMaps.SIZES[size] && styleMaps.SIZES[size] !== size){
+      result.push(styleMaps.SIZES[size]);
+    }
+    return result.concat(size);
+  }, []);
+
+  let propType = PropTypes.oneOf(values);
+
+  propType._values = values;
+  // expose the values on the propType function for documentation
+  Component.SIZES = existing;
+
+  Component.propTypes = {
+    ...propTypes,
+    bsSize: propType
+  };
+
+  if (defaultSize !== undefined) {
+    let defaultProps = Component.defaultProps || (Component.defaultProps = {});
+    defaultProps.bsSize = defaultSize;
+  }
+
+  return Component;
+});
+
+export let _curry = curry;

--- a/src/utils/bootstrapUtils.js
+++ b/src/utils/bootstrapUtils.js
@@ -1,0 +1,60 @@
+import { PropTypes } from 'react';
+import styleMaps from '../styleMaps';
+import keyOf from 'react-prop-types/lib/keyOf';
+
+export default {
+
+  propTypes: {
+    /**
+     * bootstrap className
+     * @private
+     */
+    bsClass: keyOf(styleMaps.CLASSES),
+    /**
+     * Style variants
+     * @type {("default"|"primary"|"success"|"info"|"warning"|"danger"|"link")}
+     */
+    bsStyle: PropTypes.oneOf(styleMaps.STYLES),
+
+    /**
+     * Size variants
+     * @type {("xsmall"|"small"|"medium"|"large"|"xs"|"sm"|"md"|"lg")}
+     */
+    bsSize: keyOf(styleMaps.SIZES)
+  },
+
+  getClassSet(props) {
+    let classes = {};
+    let bsClass;
+
+    if (props.bsClass && styleMaps.CLASSES[props.bsClass]) {
+      bsClass = styleMaps.CLASSES[props.bsClass];
+    }
+
+    if (bsClass) {
+      classes[bsClass] = true;
+
+      let prefix = bsClass + '-';
+
+      let bsSize = props.bsSize && styleMaps.SIZES[props.bsSize];
+
+      if (bsSize) {
+        classes[prefix + bsSize] = true;
+      }
+
+      if (props.bsStyle) {
+        if (styleMaps.STYLES.indexOf(props.bsStyle) >= 0) {
+          classes[prefix + props.bsStyle] = true;
+        } else {
+          classes[props.bsStyle] = true;
+        }
+      }
+    }
+
+    return classes;
+  },
+
+  prefix(props, variant) {
+    return styleMaps.CLASSES[props.bsClass] + '-' + variant;
+  }
+};

--- a/src/utils/bootstrapUtils.js
+++ b/src/utils/bootstrapUtils.js
@@ -1,6 +1,12 @@
 import { PropTypes } from 'react';
 import styleMaps from '../styleMaps';
 import keyOf from 'react-prop-types/lib/keyOf';
+import invariant from 'react/lib/invariant';
+
+function prefix(props = {}, variant) {
+  invariant((props.bsClass || '').trim(), 'Must provide a bsClass for components');
+  return props.bsClass + (variant ? '-' + variant : '');
+}
 
 export default {
 
@@ -23,38 +29,26 @@ export default {
     bsSize: keyOf(styleMaps.SIZES)
   },
 
+  prefix,
+
   getClassSet(props) {
     let classes = {};
-    let bsClass;
-
-    if (props.bsClass && styleMaps.CLASSES[props.bsClass]) {
-      bsClass = styleMaps.CLASSES[props.bsClass];
-    }
+    let bsClass = (props.bsClass || '').trim();
 
     if (bsClass) {
       classes[bsClass] = true;
 
-      let prefix = bsClass + '-';
-
       let bsSize = props.bsSize && styleMaps.SIZES[props.bsSize];
 
       if (bsSize) {
-        classes[prefix + bsSize] = true;
+        classes[prefix(props, bsSize)] = true;
       }
 
       if (props.bsStyle) {
-        if (styleMaps.STYLES.indexOf(props.bsStyle) >= 0) {
-          classes[prefix + props.bsStyle] = true;
-        } else {
-          classes[props.bsStyle] = true;
-        }
+        classes[prefix(props, props.bsStyle)] = true;
       }
     }
 
     return classes;
-  },
-
-  prefix(props, variant) {
-    return styleMaps.CLASSES[props.bsClass] + '-' + variant;
   }
 };

--- a/test/utils/bootstrapUtilsSpec.js
+++ b/test/utils/bootstrapUtilsSpec.js
@@ -1,0 +1,209 @@
+import React from 'react';
+import tbsUtils, { bsStyles, bsSizes, _curry } from '../../src/utils/bootstrapUtils';
+import { render, shouldWarn } from '../helpers';
+
+describe.only('bootstrapUtils', function() {
+
+  function validatePropType(propTypes, prop, value, match){
+    let result = propTypes[prop]({ [prop]: value }, prop, 'Component');
+
+    if (match) {
+      expect(result.message).to.match(match);
+    } else {
+      expect(result).to.not.exist;
+    }
+  }
+
+  it('should prefix with bsClass', function() {
+    expect(tbsUtils.prefix({ bsClass: 'yolo'}, 'pie')).to.equal('yolo-pie');
+  });
+
+  it('should return bsClass when there is no suffix', function() {
+    expect(tbsUtils.prefix({ bsClass: 'yolo'})).to.equal('yolo');
+    expect(tbsUtils.prefix({ bsClass: 'yolo'}, '')).to.equal('yolo');
+    expect(tbsUtils.prefix({ bsClass: 'yolo'}, null)).to.equal('yolo');
+  });
+
+  it('returns a classSet of bsClass', function() {
+    expect(tbsUtils.getClassSet({ bsClass: 'btn' })).to.eql({'btn': true });
+  });
+
+  it('returns a classSet of bsClass and style', function() {
+    expect(
+      tbsUtils.getClassSet({ bsClass: 'btn', bsStyle: 'primary' })
+    )
+    .to.eql({'btn': true, 'btn-primary': true });
+  });
+
+  it('returns a classSet of bsClass and size', function() {
+    expect(tbsUtils
+      .getClassSet({ bsClass: 'btn', bsSize: 'large' }))
+        .to.eql({'btn': true, 'btn-lg': true });
+
+    expect(tbsUtils
+      .getClassSet({ bsClass: 'btn', bsSize: 'lg' }))
+        .to.eql({'btn': true, 'btn-lg': true });
+  });
+
+  it('returns a classSet of bsClass, style and size', function() {
+    expect(tbsUtils
+      .getClassSet({ bsClass: 'btn', bsSize: 'lg', bsStyle: 'primary' }))
+        .to.eql({'btn': true, 'btn-lg': true, 'btn-primary': true });
+  });
+
+  describe('decorators', ()=>{
+    it('should apply immediately if a component is supplied', ()=> {
+      let spy = sinon.spy();
+      let component = function(){};
+
+      _curry(spy)(true, 'hi', component);
+
+      expect(spy).to.have.been.calledOnce;
+      expect(spy).to.have.been.calledWith(true, 'hi', component);
+    });
+
+    it('should curry the method as a decorator', ()=> {
+      let spy = sinon.spy();
+      let component = function(){};
+      let decorator = _curry(spy)(true, 'hi');
+
+      expect(spy).to.have.not.been.calledOnce;
+
+      decorator(component);
+
+      expect(spy).to.have.been.calledOnce;
+      expect(spy).to.have.been.calledWith(true, 'hi', component);
+    });
+  });
+
+  describe('bsStyles', ()=> {
+
+    it('should add style to allowed propTypes', function(){
+      let Component = {};
+
+      bsStyles(['minimal', 'boss', 'plaid'])(Component);
+
+      expect(Component.propTypes).to.exist;
+
+      validatePropType(Component.propTypes, 'bsStyle', 'plaid');
+
+      validatePropType(Component.propTypes, 'bsStyle', 'not-plaid',
+        /expected one of \["minimal","boss","plaid"\]/);
+    });
+
+    it('should not override other propTypes', function(){
+      let Component = { propTypes: { other(){} } };
+
+      bsStyles(['minimal', 'boss', 'plaid'])(Component);
+
+      expect(Component.propTypes).to.exist;
+      expect(Component.propTypes.other).to.exist;
+    });
+
+    it('should set a default if provided', function(){
+      let Component = { propTypes: { other(){} } };
+
+      bsStyles(['minimal', 'boss', 'plaid'], 'plaid')(Component);
+
+      expect(Component.defaultProps).to.exist;
+      expect(Component.defaultProps.bsStyle).to.equal('plaid');
+    });
+
+    it('should work with es6 classes', function(){
+      @bsStyles(['minimal', 'boss', 'plaid'], 'plaid')
+      class Component {
+        render(){ return <span/>; }
+      }
+
+      let instance = render(<Component />);
+
+      expect(instance.props.bsStyle).to.equal('plaid');
+
+      render(<Component bsStyle='not-plaid'/>);
+
+      shouldWarn(/expected one of \["minimal","boss","plaid"\]/);
+    });
+
+    it('should work with createClass', function(){
+      let Component = bsStyles(['minimal', 'boss', 'plaid'], 'plaid')(
+        React.createClass({
+          render(){ return <span/>; }
+        })
+      );
+
+      let instance = render(<Component />);
+
+      expect(instance.props.bsStyle).to.equal('plaid');
+
+      render(<Component bsStyle='not-plaid'/>);
+
+      shouldWarn(/expected one of \["minimal","boss","plaid"\]/);
+    });
+  });
+
+  describe('bsSizes', ()=> {
+
+    it('should add size to allowed propTypes', function(){
+      let Component = {};
+
+      bsSizes(['large', 'small'])(Component);
+
+      expect(Component.propTypes).to.exist;
+
+      validatePropType(Component.propTypes, 'bsSize', 'small');
+      validatePropType(Component.propTypes, 'bsSize', 'sm');
+
+      validatePropType(Component.propTypes, 'bsSize', 'superSmall',
+        /expected one of \["lg","large","sm","small"\]/);
+    });
+
+    it('should not override other propTypes', function(){
+      let Component = { propTypes: { other(){} } };
+
+      bsSizes(['smallish', 'micro', 'planet'])(Component);
+
+      expect(Component.propTypes).to.exist;
+      expect(Component.propTypes.other).to.exist;
+    });
+
+    it('should set a default if provided', function(){
+      let Component = { propTypes: { other(){} } };
+
+      bsSizes(['smallish', 'micro', 'planet'], 'smallish')(Component);
+
+      expect(Component.defaultProps).to.exist;
+      expect(Component.defaultProps.bsSize).to.equal('smallish');
+    });
+
+    it('should work with es6 classes', function(){
+      @bsSizes(['smallish', 'micro', 'planet'], 'smallish')
+      class Component {
+        render(){ return <span/>; }
+      }
+
+      let instance = render(<Component />);
+
+      expect(instance.props.bsSize).to.equal('smallish');
+
+      render(<Component bsSize='not-smallish'/>);
+
+      shouldWarn(/expected one of \["smallish","micro","planet"\]/);
+    });
+
+    it('should work with createClass', function(){
+      let Component = bsSizes(['smallish', 'micro', 'planet'], 'smallish')(
+        React.createClass({
+          render(){ return <span/>; }
+        })
+      );
+
+      let instance = render(<Component />);
+
+      expect(instance.props.bsSize).to.equal('smallish');
+
+      render(<Component bsSize='not-smallish'/>);
+
+      shouldWarn(/expected one of \["smallish","micro","planet"\]/);
+    });
+  });
+});


### PR DESCRIPTION
DO NOT MERGE: not ready yet.

- [x] remove component dependence on Mixin
- [x] change propType validation (either remove it, or make it actually work)
- [ ] first class api for changing `bsClass` result prefix: `btn` -> `mybtn`, `btn-primary` -> `mybtn-primary`
- [ ] Api for adding custom styles to components
- [x] Allow custom "styles" to work with bsClass prefix
- [x] make sure `bsClass` prefixes are not [hard coded](https://github.com/react-bootstrap/react-bootstrap/blob/63d8e066e4e4578fe234d63d0adc038d719cea3e/src/Button.js#L48)
- [x] documentation strategy for allowed styles and sizes

Am I missing anything else @AlexKVal?