### PR TITLE
[changed] allow PropTypes.node in valueValidation

### DIFF
--- a/src/utils/childrenValueInputValidation.js
+++ b/src/utils/childrenValueInputValidation.js
@@ -2,13 +2,13 @@ import React from 'react';
 import { singlePropFrom } from './CustomPropTypes';
 
 const propList = ['children', 'value'];
-const typeList = [React.PropTypes.number, React.PropTypes.string];
 
 export default function valueValidation(props, propName, componentName) {
   let error = singlePropFrom(propList)(props, propName, componentName);
+
   if (!error) {
-    const oneOfType = React.PropTypes.oneOfType(typeList);
-    error = oneOfType(props, propName, componentName);
+    error = React.PropTypes.node(props, propName, componentName);
   }
+
   return error;
 }

--- a/test/ButtonInputSpec.js
+++ b/test/ButtonInputSpec.js
@@ -42,8 +42,6 @@ describe('ButtonInput', () =>{
     ReactTestUtils.renderIntoDocument(
       <ButtonInput value="button" bsStyle="danger" />
     );
-
-    console.warn.called.should.be.false;
   });
 
   it('throws warning about wrong type for bsStyle=error', function () {
@@ -72,11 +70,9 @@ describe('ButtonInput', () =>{
     assert.notInstanceOf(result, Error);
   });
 
-  it('does not allow elements for children', function () {
+  it('allows elements as children', function () {
     ReactTestUtils.renderIntoDocument(
       <ButtonInput><span>blah</span></ButtonInput>
     );
-
-    shouldWarn('propType: Invalid');
   });
 });

--- a/test/FormControlsSpec.js
+++ b/test/FormControlsSpec.js
@@ -33,5 +33,11 @@ describe('Form Controls', function () {
 
       result.should.be.instanceOf(Error);
     });
+
+    it('allows elements as children', function () {
+      ReactTestUtils.renderIntoDocument(
+        <FormControls.Static><span>blah</span></FormControls.Static>
+      );
+    });
   });
 });


### PR DESCRIPTION
Remove PropTypes.number and PropTypes.string in favor of PropTypes.node.

This allows for a number, string, element, or an array of those to pass validation per #1023. Also fixes the ButtonInputSpec test and adds one to FromControlsSpec.