### PR TITLE
Announce about 'React-0.14' branch and 'react-pre' tag.

### DIFF
--- a/docs/src/HomePage.js
+++ b/docs/src/HomePage.js
@@ -33,6 +33,10 @@ export default class HomePage extends React.Component{
             <p><Glyphicon glyph="warning-sign" /> The project is under active development, and APIs will change. </p>
             <p><Glyphicon glyph="bullhorn" /> Prior to the 1.0.0 release, breaking changes should result in a Minor version bump.</p>
           </Alert>
+          <Alert bsStyle="info">
+            <p><Glyphicon glyph="bullhorn" /> If you want to try / play with <b>React-0.14</b> betas, we cut releases from the <b>react-14</b> branch. They're on the <b>react-pre</b> tag.</p>
+            <p><kbd>$ npm install react-bootstrap@react-pre</kbd></p>
+          </Alert>
         </Grid>
 
         <PageFooter />


### PR DESCRIPTION
https://github.com/react-bootstrap/react-bootstrap/pull/1261#issuecomment-137342050

It looks like:
<img width="839" alt="screen shot 2015-09-03 at 2 04 25 pm" src="https://cloud.githubusercontent.com/assets/847572/9656915/fb73ee7e-5244-11e5-8930-137d3d275569.png">
