### PR TITLE
Pass onHide to OverlayTrigger overlay

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -168,7 +168,8 @@ const OverlayTrigger = React.createClass({
 
     let overlay = cloneElement(this.props.overlay, {
       placement: overlayProps.placement,
-      container: overlayProps.container
+      container: overlayProps.container,
+      onHide: this.hide
     });
 
     return (

--- a/test/OverlayTriggerSpec.js
+++ b/test/OverlayTriggerSpec.js
@@ -266,4 +266,24 @@ describe('OverlayTrigger', function() {
       });
     });
   });
+
+  it('Should forward onHide to overlay', function() {
+    let props;
+    class PropsSpy extends React.Component {
+      render() {
+        props = this.props;
+        return <div>test</div>;
+      }
+    }
+
+    const instance = ReactTestUtils.renderIntoDocument(
+      <OverlayTrigger trigger="click" overlay={<PropsSpy />}>
+        <button>button</button>
+      </OverlayTrigger>
+    );
+    const overlayTrigger = React.findDOMNode(instance);
+    ReactTestUtils.Simulate.click(overlayTrigger);
+
+    expect(props.onHide).to.equal(instance.hide);
+  });
 });


### PR DESCRIPTION
`OverlayTrigger` used to pass `onRequestHide` as a prop to the overlay child. At some point during the overlay refactor this behavior got dropped.

Is this reasonable? Maybe we don't want to bring back this feature and I should actually just manage my own overlay state explicitly. I feel a lot less confident that this is the right thing now that I'm submitting this PR.