### PR TITLE
ListGroup shouldRenderDiv issue

### DIFF
--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -14,7 +14,7 @@ class ListGroup extends React.Component {
     if (!this.props.children) {
       shouldRenderDiv = true;
     } else {
-      React.Children.forEach(this.props.children, (child) => {
+      ValidComponentChildren.forEach(this.props.children, (child) => {
         if (this.isAnchorOrButton(child.props)) {
           shouldRenderDiv = true;
         }


### PR DESCRIPTION
ListGroup shouldRenderDiv check is not using ValidComponentChildren, causing errors if the child is a falsey value.