### PR TITLE
Update eslint dev.dependency

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -15,6 +15,7 @@
   "rules": {
     "constructor-super": 2,
     "comma-dangle": 0,
+    "eqeqeq": [2, "allow-null"],
     "func-names": 0,
     "guard-for-in": 0,
     "one-var": [2, { "initialized": "never" }],

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "eslint-plugin-babel": "^2.0.0",
     "eslint-plugin-lodash": "^0.1.3",
     "eslint-plugin-mocha": "^0.5.1",
-    "eslint-plugin-react": "^3.1.0",
+    "eslint-plugin-react": "3.3.2",
     "express": "^4.13.1",
     "extract-text-webpack-plugin": "^0.8.2",
     "file-loader": "^0.8.4",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "colors": "^1.1.2",
     "css-loader": "^0.18.0",
     "es5-shim": "^4.1.10",
-    "eslint": "1.2.x",
+    "eslint": "1.4.3",
     "eslint-config-airbnb": "0.0.8",
     "eslint-plugin-babel": "^2.0.0",
     "eslint-plugin-lodash": "^0.1.3",


### PR DESCRIPTION
they have fixed those bugs.

And disable new "eqeqeq" rule. `Require === and !== (eqeqeq)`
http://eslint.org/docs/rules/eqeqeq
