### PR TITLE
IE8 docs update to reflect the current status

### DIFF
--- a/docs/src/GettingStartedPage.js
+++ b/docs/src/GettingStartedPage.js
@@ -104,6 +104,8 @@ $ bower install react-bootstrap`
                 <div className="bs-docs-section">
                   <h2 className="page-header"><Anchor id="browser-support">Browser support</Anchor></h2>
                   <p>We aim to support all browsers supported by both <a href="http://facebook.github.io/react/docs/working-with-the-browser.html#browser-support-and-polyfills">React</a> and <a href="http://getbootstrap.com/getting-started/#support">Bootstrap</a>.</p>
+                  <p>Unfortunately, due to the lack of resources and the will of dedicating the efforts to modern browsers and getting closer to Bootstrap's features, we will not be testing <code>react-bootstrap</code> against IE8 anymore.
+                    <br/>We will however continue supporting IE8 as long as people submit PRs addressing compatibility issues with it.</p>
 
                   <p>React requires <a href="http://facebook.github.io/react/docs/working-with-the-browser.html#browser-support-and-polyfills">polyfills for non-ES5 capable browsers.</a></p>
 

--- a/docs/src/GettingStartedPage.js
+++ b/docs/src/GettingStartedPage.js
@@ -107,8 +107,6 @@ $ bower install react-bootstrap`
 
                   <p>React requires <a href="http://facebook.github.io/react/docs/working-with-the-browser.html#browser-support-and-polyfills">polyfills for non-ES5 capable browsers.</a></p>
 
-                  <p><a href="http://jquery.com">jQuery</a> is currently required only for IE8 support for components which require reading element positions from the DOM: <code>Popover</code> and <code>Tooltip</code> when launched with <code>OverlayTrigger</code>. We would like to remove this dependency in future versions but for now, including the following snippet in your page should have you covered:</p>
-
                   <div className="highlight">
                     <CodeExample
                       mode="htmlmixed"
@@ -123,7 +121,6 @@ $ bower install react-bootstrap`
   </script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.2/html5shiv-printshiv.min.js"></script>
-  <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/3.4.0/es5-shim.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/3.4.0/es5-sham.js"></script>
 <![endif]-->`


### PR DESCRIPTION
PR addressing the small discussion in issue https://github.com/react-bootstrap/react-bootstrap/issues/1338 and https://github.com/react-bootstrap/react-bootstrap/issues/1339

Proposal for being more specific about the current (and future) support for IE8.
I've split the changes into 2 commits, one addressing IE8 support and one addressing JQuery since I assumed (correct if I'm wrong) that there is no more plan to drop JQuery dependency for IE8