### PR TITLE
[changed] use `lodash-compat` in src/ for IE8 compatibility

### DIFF
--- a/docs/src/PropTable.js
+++ b/docs/src/PropTable.js
@@ -1,4 +1,4 @@
-import merge from 'lodash/object/merge';
+import merge from 'lodash-compat/object/merge';
 import React from 'react';
 import Glyphicon from '../../src/Glyphicon';
 import Label from '../../src/Label';

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "karma-webpack": "^1.7.0",
     "less": "^2.5.1",
     "less-loader": "^2.2.0",
+    "lodash": "^3.10.1",
     "marked": "^0.3.5",
     "mocha": "^2.2.5",
     "mt-changelog": "^0.6.1",
@@ -113,7 +114,7 @@
     "classnames": "^2.1.3",
     "dom-helpers": "^2.2.4",
     "keycode": "^2.0.0",
-    "lodash": "^3.10.0",
+    "lodash-compat": "^3.10.1",
     "react-overlays": "^0.4.4",
     "uncontrollable": "^3.1.1"
   },

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -8,8 +8,8 @@ import DropdownMenu from './DropdownMenu';
 import CustomPropTypes from './utils/CustomPropTypes';
 import ValidComponentChildren from './utils/ValidComponentChildren';
 import createChainedFunction from './utils/createChainedFunction';
-import find from 'lodash/collection/find';
-import omit from 'lodash/object/omit';
+import find from 'lodash-compat/collection/find';
+import omit from 'lodash-compat/object/omit';
 
 import activeElement from 'dom-helpers/activeElement';
 import contains from 'dom-helpers/query/contains';

--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -4,7 +4,7 @@ import Dropdown from './Dropdown';
 import NavDropdown from './NavDropdown';
 import CustomPropTypes from './utils/CustomPropTypes';
 import deprecationWarning from './utils/deprecationWarning';
-import omit from 'lodash/object/omit';
+import omit from 'lodash-compat/object/omit';
 
 class DropdownButton extends React.Component {
 

--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -5,7 +5,7 @@ import createChainedFunction from './utils/createChainedFunction';
 import createContextWrapper from './utils/createContextWrapper';
 import Overlay from './Overlay';
 import warning from 'react/lib/warning';
-import pick from 'lodash/object/pick';
+import pick from 'lodash-compat/object/pick';
 /**
  * Check if value one is inside or equal to the of value
  *


### PR DESCRIPTION
`lodash` needs to be customised in order to be IE8 compatible.
Luckily, the owner is providing a package already customised for that purpose, and that package is `lodash-compat` and this is what this PR is about.

I've replaced every call to `lodash` **in the source code** to `lodash-compat`, while leaving the development part untouched (src, tooling, webpack cfg).

What do you think?