### PR TITLE
[added] 'onShow' property to Modal.

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -117,7 +117,12 @@ const Modal = React.createClass({
     /**
      * When `true` The modal will show itself.
      */
-    show: React.PropTypes.bool
+    show: React.PropTypes.bool,
+
+    /**
+     * When supplied this function will be called upon showing the modal.
+     */
+     onShow: React.PropTypes.func
   },
 
   getDefaultProps() {
@@ -314,6 +319,10 @@ const Modal = React.createClass({
 
     if (this.props.backdrop) {
       this.iosClickHack();
+    }
+
+    if (this.props.onShow) {
+      this.props.onShow();
     }
 
     this.setState(this._getStyles(), () => this.focusModalContent());

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -257,6 +257,13 @@ describe('Modal', () => {
     assert.notInclude(document.body.className, 'modal-open');
   });
 
+  it('Should call onShow if it is supplied as a property', () => {
+    let count = 0;
+    let onShowCallback = ()=> count++;
+    render(<Modal show onShow={onShowCallback} onHide={() => {}} animation={false}>Test</Modal>);
+    expect(count).to.equal(1);
+  });
+
   describe('Focused state', () => {
     let focusableContainer = null;
 


### PR DESCRIPTION
I'm currently building a webapp using react-bootstrap and I am using the Modal class. However, I wanted the ability to pass a callback that would be executed when the modal is shown.

Please review and let me know what you think, it's a rather simple change. Thanks!