### PR TITLE
Fix deprecation warning message for 'Input type=static' component

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -6,7 +6,7 @@ import deprecationWarning from './utils/deprecationWarning';
 class Input extends InputBase {
   render() {
     if (this.props.type === 'static') {
-      deprecationWarning('Input type=static', 'StaticText');
+      deprecationWarning('Input type=static', 'FormControls.Static');
       return <FormControls.Static {...this.props} />;
     }
 


### PR DESCRIPTION
https://reactiflux.slack.com/archives/react-bootstrap/p1443209265000177
<img width="798" alt="screen shot 2015-09-26 at 11 24 29 pm" src="https://cloud.githubusercontent.com/assets/847572/10119709/c50c0272-64a5-11e5-9609-131b2e3a6aa7.png">
