### PR TITLE
Dropdown no longer autofocuses first item on open

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -67,10 +67,6 @@ class Dropdown extends React.Component {
   componentDidUpdate(prevProps) {
     let menu = this.refs.menu;
 
-    if (this.props.open && !prevProps.open && menu.focusNext) {
-      menu.focusNext();
-    }
-
     if (!this.props.open && prevProps.open) {
       // if focus hasn't already moved from the menu lets return it
       // to the toggle


### PR DESCRIPTION
Click on a `NavDropdown` on https://react-bootstrap.github.io/components.html#navs-dropdown, and you'll get something like this:
<img width="253" alt="screen shot 2015-10-01 at 8 16 04 pm" src="https://cloud.githubusercontent.com/assets/643799/10238797/61828a50-6879-11e5-9660-8eae2955ef5b.png">

But click on a dropdown on http://getbootstrap.com/components/#nav, and you get:
<img width="239" alt="screen shot 2015-10-01 at 8 16 27 pm" src="https://cloud.githubusercontent.com/assets/643799/10238823/bc9ed48e-6879-11e5-9eb0-a2277fe142c8.png">

As you can see, `react-bootstrap` autofocuses the first menu item when you click on the button, while non-React Bootstrap does not. I am not sure if this change is intended, but it is certainly not what I want – it is unexpected and disorienting for mouse users.

I believe the code I remove here is responsible. Does this look OK?