### PR TITLE
[fixed] Dropdown focus behavior on click

### DIFF
--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -416,7 +416,7 @@ describe('Dropdown', () => {
     // I am fairly confident that the failure is due to a test specific conflict and not an actual bug.
     it('when open and the key "esc" is pressed the menu is closed and focus is returned to the button', () => {
       const instance = React.render(
-        <Dropdown defaultOpen id='test-id'>
+        <Dropdown defaultOpen alwaysFocusNextOnOpen id='test-id'>
           {dropdownChildren}
         </Dropdown>
       , focusableContainer);


### PR DESCRIPTION
By default, only focus the first dropdown menu item after keydown.

Fixes #1233.