### PR TITLE
Add missing react-prop-types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "keycode": "^2.0.0",
     "lodash-compat": "^3.10.1",
     "react-overlays": "^0.4.4",
+    "react-prop-types": "^0.3.0",
     "uncontrollable": "^3.1.1"
   },
   "release-script": {


### PR DESCRIPTION
Fixes this and similar errors bundling 0.26:

```
ERROR in ./~/react-bootstrap/lib/Col.js
Module not found: Error: Cannot resolve module 'react-prop-types/lib/elementType'
 @ ./~/react-bootstrap/lib/Col.js 23:36-79
```