### PR TITLE
Added title for close button

### DIFF
--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -10,6 +10,7 @@ class ModalHeader extends React.Component {
         { this.props.closeButton &&
           <button
             className="close"
+            title={this.props['aria-label']}
             onClick={this.props.onHide}>
             <span aria-hidden="true">
               &times;


### PR DESCRIPTION
Our QA team requested titles for Close buttons. So, I decided it would be good to patch react-bootstrap instead of creating custom ModalHeader...