### PR TITLE
Use caret range for React dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "author": "Stephen J. Collings <stevoland@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=0.13"
+    "react": "^0.13"
   },
   "devDependencies": {
     "babel": "^5.8.23",


### PR DESCRIPTION
This release is not really compatible with React 0.14.

Fixes #1392 and #1393 (I guess? There's nothing wrong per se with what we have in `package.json` ¯\\\_(ツ)_/¯ , but we're not really compatible with React 0.14 on this release anyway).