### PR TITLE
Fix logging from afterEach hook in tests

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -4,7 +4,7 @@ beforeEach(() => {
   sinon.stub(console, 'error');
 });
 
-afterEach(() => {
+afterEach(function checkNoUnexpectedWarnings() {
   if (typeof console.error.restore === 'function') {
     assert(!console.error.called, () => {
       return `${console.error.getCall(0).args[0]} \nIn '${this.currentTest.fullTitle()}'`;


### PR DESCRIPTION
Logging was previously messed up because this function tried to use `this.currentTest`.