### PR TITLE
Add table headers

### DIFF
--- a/src/Table.js
+++ b/src/Table.js
@@ -7,7 +7,8 @@ const Table = React.createClass({
     bordered: React.PropTypes.bool,
     condensed: React.PropTypes.bool,
     hover: React.PropTypes.bool,
-    responsive: React.PropTypes.bool
+    responsive: React.PropTypes.bool,
+    headers: React.PropTypes.arrayOf(React.PropTypes.string)
   },
 
   getDefaultProps() {
@@ -16,7 +17,8 @@ const Table = React.createClass({
       condensed: false,
       hover: false,
       responsive: false,
-      striped: false
+      striped: false,
+      headers: []
     };
   },
 
@@ -28,11 +30,31 @@ const Table = React.createClass({
       'table-condensed': this.props.condensed,
       'table-hover': this.props.hover
     };
-    let table = (
-      <table {...this.props} className={classNames(this.props.className, classes)}>
-        {this.props.children}
-      </table>
-    );
+
+    let table;
+
+    if (this.props.headers) {
+      const headerCols = this.props.headers.map((header, index) => <th key={index}>{header}</th>);
+      table = (
+        <table {...this.props} className={classNames(this.props.className, classes)}>
+          <thead>
+            <tr>
+              {headerCols}
+            </tr>
+          </thead>
+          <tbody>
+            {this.props.children}
+          </tbody>
+        </table>
+      );
+    } else {
+      table = (
+        <table {...this.props} className={classNames(this.props.className, classes)}>
+          {this.props.children}
+        </table>
+      );
+    }
+
 
     return this.props.responsive ? (
       <div className="table-responsive">

--- a/test/TableSpec.js
+++ b/test/TableSpec.js
@@ -68,7 +68,7 @@ describe('Table', () => {
     });
 
     it('Should have row in table head', () => {
-     const tr = ReactDOM.findDOMNode(instance).firstChild.firstChild;
+      const tr = ReactDOM.findDOMNode(instance).firstChild.firstChild;
       assert.equal(tr.nodeName, 'TR');
     });
 

--- a/test/TableSpec.js
+++ b/test/TableSpec.js
@@ -48,4 +48,48 @@ describe('Table', () => {
     assert.ok(ReactDOM.findDOMNode(instance).className.match(/\btable-responsive\b/));
     assert.ok(ReactDOM.findDOMNode(instance).firstChild.className.match(/\btable\b/));
   });
+
+  describe('When column headers are given', () => {
+    let instance;
+    let headers = ['Col 1', 'Col 2', 'Col 3'];
+
+    beforeEach(() => {
+      instance = ReactTestUtils.renderIntoDocument(
+        <Table headers={headers}>
+          <tr className="test"></tr>
+        </Table>
+      );
+    });
+
+
+    it('Should have table head', () => {
+      const theadNode = ReactDOM.findDOMNode(instance).firstChild;
+      assert.equal(theadNode.nodeName, 'THEAD');
+    });
+
+    it('Should have row in table head', () => {
+     const tr = ReactDOM.findDOMNode(instance).firstChild.firstChild;
+      assert.equal(tr.nodeName, 'TR');
+    });
+
+    it('Should have column headers in table head row', () => {
+      const tds = ReactDOM.findDOMNode(instance).firstChild.firstChild.childNodes;
+
+      assert.equal(tds.length, headers.length);
+
+      for (let i = 0; i < tds.length; i++) {
+        assert.equal(tds[i].nodeName, 'TH');
+        assert.equal(tds[i].textContent, headers[i]);
+      }
+    });
+
+    it('Should have table body with contents', () => {
+      const tbody = ReactDOM.findDOMNode(instance).childNodes[1];
+
+      assert.equal(tbody.nodeName, 'TBODY');
+      assert.equal(tbody.childNodes.length, 1);
+      assert.equal(tbody.childNodes[0].nodeName, 'TR');
+      assert.equal(tbody.childNodes[0].className, 'test');
+    });
+  });
 });


### PR DESCRIPTION
This PR adds a `headers` prop to `Table`. `headers` is an array of strings that generates the column headers in <thead>, as well as an empty <tbody>. It removes a fair bit of boilerplate.