### PR TITLE
Remove cross import between Button & ButtonInput

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -2,7 +2,8 @@ import React from 'react';
 import classNames from 'classnames';
 import BootstrapMixin from './BootstrapMixin';
 import elementType from 'react-prop-types/lib/elementType';
-import ButtonInput from './ButtonInput';
+
+const types = ['button', 'reset', 'submit'];
 
 const Button = React.createClass({
   mixins: [BootstrapMixin],
@@ -24,7 +25,7 @@ const Button = React.createClass({
      * @type {("button"|"reset"|"submit")}
      * @defaultValue 'button'
      */
-    type: React.PropTypes.oneOf(ButtonInput.types)
+    type: React.PropTypes.oneOf(types)
   },
 
   getDefaultProps() {
@@ -100,5 +101,7 @@ const Button = React.createClass({
     );
   }
 });
+
+Button.types = types;
 
 export default Button;

--- a/src/ButtonInput.js
+++ b/src/ButtonInput.js
@@ -17,7 +17,7 @@ class ButtonInput extends InputBase {
   }
 }
 
-ButtonInput.types = ['button', 'reset', 'submit'];
+ButtonInput.types = Button.types;
 
 ButtonInput.defaultProps = {
   type: 'button'


### PR DESCRIPTION
Hi,

This is an attempt to fix #1428 which is where I'm having trouble using `ButtonInput` in a server side React render. I believe this is due to cross imports between `ButtonInput` and `Button` which might not be an issue when using a client bundle?

The details are in the commit message.

There might be a better way to solve the issue but I hope this helps if it is the preferred route.

Cheers,
Michael