### PR TITLE
Add missing type="button" in modal header

### DIFF
--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -9,6 +9,7 @@ class ModalHeader extends React.Component {
         className={classNames(this.props.className, this.props.modalClassName)}>
         { this.props.closeButton &&
           <button
+            type="button"
             className="close"
             onClick={this.props.onHide}>
             <span aria-hidden="true">


### PR DESCRIPTION
If we have a form in the modal, it triggers the onClick..