### PR TITLE
when overlay animation is false the transition prop passed to base ov…

### DIFF
--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -19,6 +19,10 @@ class Overlay extends React.Component {
       transition = Fade;
     }
 
+    if (transition === false) {
+      transition = null;
+    }
+
     if (!transition) {
       child = cloneElement(child, {
         className: classNames('in', child.props.className)


### PR DESCRIPTION
when overlay animation is false the transition prop passed to base overlay should be undefined so that it does not trigger a React PropTypes warning

fixes #1435 