### PR TITLE
Suggest wrapping `Collapse` contents in a `div`

### DIFF
--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -952,6 +952,20 @@ const ComponentsPage = React.createClass({
 
                   <h3><Anchor id="utilities-collapse">Collapse</Anchor></h3>
                   <p>Add a collapse toggle animation to an element or component.</p>
+                  <div className="bs-callout bs-callout-info">
+                    <h4>Smoothing animations</h4>
+                    <p>
+                      If you're noticing choppy animations,
+                      and the component that's being collapsed
+                      has non-zero margin or padding,
+                      try wrapping the contents
+                      of your <code>&lt;Collapse&gt;</code>
+                      {" "}inside a node with no margin or padding,
+                      like the <code>&lt;div&gt;</code> in the example below.
+                      This will allow the height to be computed properly,
+                      so the animation can proceed smoothly.
+                    </p>
+                  </div>
                   <ReactPlayground codeText={Samples.Collapse} />
 
                   <h4><Anchor id="utilities-collapse-props">Props</Anchor></h4>


### PR DESCRIPTION
It makes a huge difference when you have inline elements.
Compare the following two animations (sorry for poor quality).
The first is with the contents wrapped in a `<div>`;
the second has the contents not wrapped in a `<div>`.
There is no relevant lag;
the stuttering happens because the `Collapse`
can't get smaller than the line height of the alert.

![example with `div`](https://cloud.githubusercontent.com/assets/4317806/10871987/4bf4ea48-80ac-11e5-84f5-45c955a22f47.gif)
![example without `div`](https://cloud.githubusercontent.com/assets/4317806/10871988/504aee62-80ac-11e5-9232-7dc97c151fef.gif)

The example already does this, but it's far from obvious
(to ~~a newcomer~~ me, at least!)
that that's what fixes this particular issue.