### PR TITLE
Cancel slide when passing in an activeIndex prop

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -57,7 +57,7 @@ const Carousel = React.createClass({
   componentWillReceiveProps(nextProps) {
     let activeIndex = this.getActiveIndex();
 
-    if (nextProps.activeIndex != null && nextProps.activeIndex !== activeIndex) {
+    if (nextProps.activeIndex != null && nextProps.activeIndex !== this.props.activeIndex) {
       clearTimeout(this.timeout);
       this.setState({
         previousActiveIndex: activeIndex,


### PR DESCRIPTION
Previous code used getActiveIndex to compare to nextProps, but getActiveIndex falls back to looking at state when props.activeIndex is null.  state always has an activeIndex.  But we want to cancel the slide timeout when we're moving from a prop of activeIndex null to a prop of activeIndex that is not null (container specifying an active index).

The symptom of this bug is that you get one more slide after you've passed in an active index.