### PR TITLE
Require lodash-compat instead of lodash from Modal.js

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -21,7 +21,7 @@ import Footer from './ModalFooter';
 
 import BaseModal from 'react-overlays/lib/Modal';
 import isOverflowing from 'react-overlays/lib/utils/isOverflowing';
-import pick from 'lodash/object/pick';
+import pick from 'lodash-compat/object/pick';
 
 const Modal = React.createClass({
 


### PR DESCRIPTION
lodash-compat is what's listed under package.json. This matches how `pick` is imported from other source files in react-bootstrap too.