### PR TITLE
a11y: fixing the tab-index for the non-screenreader version of the Alert dismiss button

### DIFF
--- a/src/Alert.js
+++ b/src/Alert.js
@@ -23,7 +23,8 @@ let Alert = React.createClass({
         type="button"
         className="close"
         onClick={this.props.onDismiss}
-        aria-hidden="true">
+        aria-hidden="true"
+        tabIndex="-1">
         <span>&times;</span>
       </button>
     );


### PR DESCRIPTION
The version of the Alert close button that is supposed to be hidden from screen readers has `aria-hidden="true"`, as expected, but did not have `tab-index="-1"` so it may not be skipped when tabbing through the interface