### PR TITLE
Overlays should stay shown when we hover over them

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -177,9 +177,13 @@ const OverlayTrigger = React.createClass({
       onEntered: this.props.onEntered
     };
 
+    let hoverOrFocus = isOneOf('focus', this.props.trigger) || isOneOf('hover', this.props.trigger);
+
     let overlay = cloneElement(this.props.overlay, {
       placement: overlayProps.placement,
-      container: overlayProps.container
+      container: overlayProps.container,
+      onMouseOver: hoverOrFocus ? this.handleDelayedShow : undefined,
+      onMouseLeave: hoverOrFocus ? this.handleDelayedHide : undefined
     });
 
     return (


### PR DESCRIPTION
HI guys, I don't expect you to accept this PR, because I know regular bootstrap forbids this behavior. I am just leaving this here as documentation for the next person.

Do you have any suggestions for how I might implement this that would not require modifying react-bootstrap?