### PR TITLE
Add Modal propTypes for transition callbacks so it will be documented.

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -78,7 +78,37 @@ const Modal = React.createClass({
      * A callback fired when the header closeButton or non-static backdrop is
      * clicked. Required if either are specified.
      */
-    onHide: React.PropTypes.func
+    onHide: React.PropTypes.func,
+
+    /**
+     * Callback fired before the Modal transitions in
+     */
+    onEnter: React.PropTypes.func,
+
+    /**
+     * Callback fired as the Modal begins to transition in
+     */
+    onEntering: React.PropTypes.func,
+
+    /**
+     * Callback fired after the Modal finishes transitioning in
+     */
+    onEntered: React.PropTypes.func,
+
+    /**
+     * Callback fired right before the Modal transitions out
+     */
+    onExit: React.PropTypes.func,
+
+    /**
+     * Callback fired as the Modal begins to transition out
+     */
+    onExiting: React.PropTypes.func,
+
+    /**
+     * Callback fired after the Modal finishes transitioning out
+     */
+    onExited: React.PropTypes.func
   },
 
   childContextTypes: {


### PR DESCRIPTION
Currently these props are not documented. This is causing confusion. See this SO thread for reference: http://stackoverflow.com/questions/31836812/trigger-modal-shown-for-react-bootstrap/34901027#34901027