### PR TITLE
Added minWidth to progressbars as requested in #1574

### DIFF
--- a/docs/examples/ProgressBarMinimumWidth.js
+++ b/docs/examples/ProgressBarMinimumWidth.js
@@ -1,0 +1,8 @@
+const progressInstance = (
+  <div>
+    <ProgressBar now={0} label="%(percent)s%" minWidth={15} />
+    <ProgressBar now={2} label="%(percent)s%" minWidth={15} />
+  </div>
+);
+
+ReactDOM.render(progressInstance, mountNode);

--- a/docs/src/Samples.js
+++ b/docs/src/Samples.js
@@ -56,6 +56,7 @@ export default {
   ProgressBarStriped:            require('fs').readFileSync(__dirname + '/../examples/ProgressBarStriped.js', 'utf8'),
   ProgressBarAnimated:           require('fs').readFileSync(__dirname + '/../examples/ProgressBarAnimated.js', 'utf8'),
   ProgressBarStacked:            require('fs').readFileSync(__dirname + '/../examples/ProgressBarStacked.js', 'utf8'),
+  ProgressBarMinimumWidth:       require('fs').readFileSync(__dirname + '/../examples/ProgressBarMinimumWidth.js', 'utf8'),
   NavBasic:                      require('fs').readFileSync(__dirname + '/../examples/NavBasic.js', 'utf8'),
   NavDropdown:                   require('fs').readFileSync(__dirname + '/../examples/NavDropdown.js', 'utf8'),
   NavStacked:                    require('fs').readFileSync(__dirname + '/../examples/NavStacked.js', 'utf8'),

--- a/docs/src/sections/ProgressBarSection.js
+++ b/docs/src/sections/ProgressBarSection.js
@@ -23,6 +23,9 @@ export default function ProgressBarSection() {
       <p>The following keys are interpolated with the current values: <code>%(min)s</code>, <code>%(max)s</code>, <code>%(now)s</code>, <code>%(percent)s</code>, <code>%(bsStyle)s</code></p>
       <ReactPlayground codeText={Samples.ProgressBarWithLabel} />
 
+      <p>To ensure that the label text remains legible even for low percentages, consider adding a minWidth to the progress bar.</p>
+      <ReactPlayground codeText={Samples.ProgressBarMinimumWidth} />
+
       <h2><Anchor id="progress-screenreader-label">Screenreader only label</Anchor></h2>
       <p>Add a <code>srOnly</code> prop to hide the label visually.</p>
       <ReactPlayground codeText={Samples.ProgressBarScreenreaderLabel} />

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -65,7 +65,7 @@ class ProgressBar extends React.Component {
   }
 
   renderProgressBar() {
-    let { className, label, now, min, max, ...props } = this.props;
+    let { className, label, now, min, max, minWidth, ...props } = this.props;
 
     const percentage = this.getPercentage(
       now, min, max
@@ -88,12 +88,17 @@ class ProgressBar extends React.Component {
       [bootstrapUtils.prefix(this.props, 'striped')]: this.props.active || this.props.striped
     });
 
+    const inlineStyles = {
+      width: percentage + '%',
+      minWidth: this.props.minWidth
+    };
+
     return (
       <div
         {...props}
         className={classes}
         role="progressbar"
-        style={{ width: percentage + '%' }}
+        style={inlineStyles}
         aria-valuenow={this.props.now}
         aria-valuemin={this.props.min}
         aria-valuemax={this.props.max}>
@@ -124,6 +129,10 @@ ProgressBar.propTypes = {
   now: PropTypes.number,
   max: PropTypes.number,
   label: PropTypes.node,
+  /**
+   * minimum width of the progressbar in px
+   */
+  minWidth: PropTypes.number,
   srOnly: PropTypes.bool,
   striped: PropTypes.bool,
   active: PropTypes.bool,
@@ -143,7 +152,8 @@ ProgressBar.defaultProps = {
   active: false,
   isChild: false,
   srOnly: false,
-  striped: false
+  striped: false,
+  minWidth: 0
 };
 
 export default bsStyles(State.values(),

--- a/test/ProgressBarSpec.js
+++ b/test/ProgressBarSpec.js
@@ -64,6 +64,14 @@ describe('ProgressBar', () => {
     assert.equal(getProgressBarNode(instance).style.width, '0%');
   });
 
+  it('Should have min-width of 15px', () => {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <ProgressBar min={0} max={10} now={0} minWidth={15} />
+    );
+
+    assert.equal(getProgressBarNode(instance).style.minWidth, '15px');
+  });
+
   it('Should have 10% computed width', () => {
     let instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar min={0} max={10} now={1} />


### PR DESCRIPTION
Added test and updated docs
- New property of minWidth on ProgressBar (defaulted to Zero)

original issue: https://github.com/react-bootstrap/react-bootstrap/issues/1574