### PR TITLE
[added] closeOnSelect prop for Dropdown

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -218,7 +218,7 @@ class Dropdown extends React.Component {
     menuProps.onSelect = createChainedFunction(
       menu.props.onSelect,
       this.props.onSelect,
-      this.props.closeOnSelect && this.handleClose
+      this.props.closeOnSelect ? this.handleClose : undefined
     );
 
     return cloneElement(menu, menuProps, menu.props.children);

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -331,9 +331,9 @@ Dropdown.propTypes = {
    * ```
    */
   onSelect: React.PropTypes.func,
-  
+
   /**
-   * If true, the dropdown will close automatically on select
+   * If false, the dropdown will not close automatically on select
    */
   closeOnSelect: React.PropTypes.bool,
 

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -218,7 +218,7 @@ class Dropdown extends React.Component {
     menuProps.onSelect = createChainedFunction(
       menu.props.onSelect,
       this.props.onSelect,
-      this.handleClose
+      this.props.closeOnSelect && this.handleClose
     );
 
     return cloneElement(menu, menuProps, menu.props.children);
@@ -254,7 +254,8 @@ Dropdown.MENU_ROLE = MENU_ROLE;
 
 Dropdown.defaultProps = {
   componentClass: ButtonGroup,
-  bsClass: 'dropdown'
+  bsClass: 'dropdown',
+  closeOnSelect: true
 };
 
 Dropdown.propTypes = {
@@ -330,6 +331,11 @@ Dropdown.propTypes = {
    * ```
    */
   onSelect: React.PropTypes.func,
+  
+  /**
+   * If true, the dropdown will close automatically on select
+   */
+  closeOnSelect: React.PropTypes.bool,
 
   /**
    * If `'menuitem'`, causes the dropdown to behave like a menu item rather than

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -240,6 +240,24 @@ describe('Dropdown', () => {
     node.className.should.not.match(/\bopen\b/);
   });
 
+  it('does not close when closeOnSelect is false', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Dropdown id='test-id' closeOnSelect={false}>
+        {dropdownChildren}
+      </Dropdown>
+    );
+
+    const node = ReactDOM.findDOMNode(instance);
+
+    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'BUTTON');
+    ReactTestUtils.Simulate.click(buttonNode);
+    node.className.should.match(/\bopen\b/);
+
+    const menuItem = ReactTestUtils.scryRenderedDOMComponentsWithTag(instance, 'A')[0];
+    ReactTestUtils.Simulate.click(menuItem);
+    node.className.should.match(/\bopen\b/);
+  });
+
   it('does not close when onToggle is controlled', () => {
     const handleSelect = () => {};
 


### PR DESCRIPTION
Allow making dropdown menus that persist clicks, e.g. for dropdown lists of toggle switches, for issue #1490 