### PR TITLE
Correct and improve MenuItem docs

### DIFF
--- a/docs/src/sections/MenuItemSection.js
+++ b/docs/src/sections/MenuItemSection.js
@@ -24,7 +24,7 @@ export default function MenuItemSection() {
         <li><code>eventKey</code>: passed to the callback</li>
         <li><code>onSelect</code>: a callback that is called when the user clicks the item.</li>
       </ul>
-      <p>The callback is called with the following arguments: <code>eventKey</code>, <code>href</code> and <code>target</code></p>
+      <p>The callback is called with the following arguments: <code>event</code> and <code>eventKey</code></p>
       <ReactPlayground codeText={Samples.MenuItem} />
 
       <h3><Anchor id="menu-item-props">Props</Anchor></h3>

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -76,7 +76,8 @@ MenuItem.propTypes = {
   disabled: React.PropTypes.bool,
 
   /**
-   * Make the menu item a divider.
+   * Styles the menu item as a horizontal rule, providing visual separation between
+   * groups of menu items.
    */
   divider: all(
     React.PropTypes.bool,
@@ -93,7 +94,7 @@ MenuItem.propTypes = {
   eventKey: React.PropTypes.any,
 
   /**
-   * Make the menu item a header.
+   * Styles the menu item as a header label, useful for describing a group of menu items.
    */
   header: React.PropTypes.bool,
 

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -64,8 +64,20 @@ class MenuItem extends React.Component {
 }
 
 MenuItem.propTypes = {
+
+  /**
+   * Highlight the menu item as active.
+   */
   active: React.PropTypes.bool,
+
+  /**
+   * Disable the menu item, making it unselectable.
+   */
   disabled: React.PropTypes.bool,
+
+  /**
+   * Make the menu item a divider.
+   */
   divider: all(
     React.PropTypes.bool,
     props => {
@@ -74,14 +86,51 @@ MenuItem.propTypes = {
       }
     }
   ),
+
+  /**
+   * Value passed to the `onSelect` handler, useful for identifying the selected menu item.
+   */
   eventKey: React.PropTypes.any,
+
+  /**
+   * Make the menu item a header.
+   */
   header: React.PropTypes.bool,
+
+  /**
+   * HTML `href` attribute corresponding to `a.href`.
+   */
   href: React.PropTypes.string,
+
+  /**
+   * HTML `target` attribute corresponding to `a.target`.
+   */
   target: React.PropTypes.string,
+
+  /**
+   * HTML `title` attribute corresponding to `a.title`.
+   */
   title: React.PropTypes.string,
+
+  /**
+   * Callback fired when the menu item is clicked.
+   */
   onClick: React.PropTypes.func,
+
   onKeyDown: React.PropTypes.func,
+
+  /**
+   * Callback fired when the menu item is selected.
+   *
+   * ```js
+   * function(Object event, Any eventKey)
+   * ```
+   */
   onSelect: React.PropTypes.func,
+
+  /**
+   * HTML `id` attribute.
+   */
   id: React.PropTypes.oneOfType([
     React.PropTypes.string,
     React.PropTypes.number


### PR DESCRIPTION
I just started using `react-bootstrap` and have really liked it so far. I stumbled for a little while over a mistake in the documentation, so I thought I'd take a stab at fixing it.

The section for `MenuItem` lists the wrong arguments for the `onSelect` callback (#1657). While fixing this issue, I also added blurbs for `MenuItem`'s props. Hope this is helpful.