### PR TITLE
[added] Allow overriding Dropdown CSS classes

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -92,10 +92,10 @@ class Dropdown extends React.Component {
     let className = bootstrapUtils.prefix(this.props);
 
     const rootClasses = {
-      open: this.props.open,
-      disabled: this.props.disabled,
+      [this.props.openClassName]: this.props.open,
+      [this.props.disabledClassName]: this.props.disabled,
       [className]: !this.props.dropup,
-      dropup: this.props.dropup
+      [this.props.dropupClassName]: this.props.dropup
     };
 
     return (
@@ -254,12 +254,30 @@ Dropdown.MENU_ROLE = MENU_ROLE;
 
 Dropdown.defaultProps = {
   componentClass: ButtonGroup,
-  bsClass: 'dropdown'
+  bsClass: 'dropdown',
+  openClassName: 'open',
+  disabledClassName: 'disabled',
+  dropupClassName: 'dropup'
 };
 
 Dropdown.propTypes = {
 
   bsClass: React.PropTypes.string,
+
+  /**
+   * A CSS class to apply to the dropdown when open.
+   */
+  openClassName: React.PropTypes.string.isRequired,
+
+  /**
+   * A CSS class to apply to the dropdown when disabled.
+   */
+  disabledClassName: React.PropTypes.string.isRequired,
+
+  /**
+   * A CSS class to apply to the dropdown when acting as a dropup.
+   */
+  dropupClassName: React.PropTypes.string.isRequired,
 
   /**
    * The menu will open above the dropdown button, instead of below it.

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -50,6 +50,42 @@ describe('Dropdown', () => {
     node.className.should.not.match(/\bdropup\b/);
   });
 
+  it('should allow a custom CSS class for the "open" state', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Dropdown openClassName="myOpenClass" id='test-id'>
+        {dropdownChildren}
+      </Dropdown>
+    );
+    const node = ReactDOM.findDOMNode(instance);
+    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'BUTTON');
+
+    ReactTestUtils.Simulate.click(buttonNode);
+
+    node.className.should.match(/\bmyOpenClass\b/);
+  });
+
+  it('should allow a custom CSS class for the "disabled" state', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Dropdown disabled disabledClassName="myDisabledClass" id='test-id'>
+        {dropdownChildren}
+      </Dropdown>
+    );
+    const node = ReactDOM.findDOMNode(instance);
+
+    node.className.should.match(/\bmyDisabledClass\b/);
+  });
+
+  it('should allow a custom CSS class for the "dropup" state', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Dropdown dropup dropupClassName="myDropupClass" id='test-id'>
+        {dropdownChildren}
+      </Dropdown>
+    );
+    const node = ReactDOM.findDOMNode(instance);
+
+    node.className.should.match(/\bmyDropupClass\b/);
+  });
+
   it('renders div with dropup class', () => {
     const instance = ReactTestUtils.renderIntoDocument(
       <Dropdown title='Dropup' dropup id='test-id'>


### PR DESCRIPTION
(In case it's not obvious), the intent of this is to be able to use something like CSS modules to pass custom Bootstrap class names like:

```js
import bsStyles from 'bootstrap.css'

<Dropdown openClassName={bsStyles.open} />
```

Any issues, let me know.
Cheers, Jon.