### PR TITLE
[added] Collapsible Panel transition hooks

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -19,7 +19,14 @@ let Panel = React.createClass({
     expanded: React.PropTypes.bool,
     eventKey: React.PropTypes.any,
     headerRole: React.PropTypes.string,
-    panelRole: React.PropTypes.string
+    panelRole: React.PropTypes.string,
+
+    onEnter: Collapse.propTypes.onEnter,
+    onEntering: Collapse.propTypes.onEntering,
+    onEntered: Collapse.propTypes.onEntered,
+    onExit: Collapse.propTypes.onExit,
+    onExiting: Collapse.propTypes.onExiting,
+    onExited: Collapse.propTypes.onExited
   },
 
   getDefaultProps() {
@@ -70,6 +77,15 @@ let Panel = React.createClass({
   },
 
   renderCollapsibleBody(panelRole) {
+    let collapseProps = {
+      onEnter: this.props.onEnter,
+      onEntering: this.props.onEntering,
+      onEntered: this.props.onEntered,
+      onExit: this.props.onExit,
+      onExiting: this.props.onExiting,
+      onExited: this.props.onExited,
+      in: this.isExpanded()
+    };
     let props = {
       className: bootstrapUtils.prefix(this.props, 'collapse'),
       id: this.props.id,
@@ -81,7 +97,7 @@ let Panel = React.createClass({
     }
 
     return (
-      <Collapse in={this.isExpanded()}>
+      <Collapse {...collapseProps}>
         <div {...props}>
           {this.renderBody()}
 

--- a/test/PanelSpec.js
+++ b/test/PanelSpec.js
@@ -187,6 +187,39 @@ describe('Panel', () => {
     assert.notOk(children[0].className.match(/\bpanel-body\b/));
   });
 
+  it('Should pass transition callbacks to Collapse', (done) => {
+    let count = 0;
+    let increment = ()=> count++;
+
+    let title;
+
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Panel
+        collapsible={true}
+        defaultExpanded={false}
+        header="Click me"
+        onExit={increment}
+        onExiting={increment}
+        onExited={()=> {
+          increment();
+          expect(count).to.equal(6);
+          done();
+        }}
+        onEnter={increment}
+        onEntering={increment}
+        onEntered={()=> {
+          increment();
+          ReactTestUtils.Simulate.click(title.firstChild);
+        }}
+      >
+        Panel content
+      </Panel>
+    );
+
+    title = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-title');
+    ReactTestUtils.Simulate.click(title.firstChild);
+  });
+
   describe('Web Accessibility', () => {
 
     it('Should be aria-expanded=true', () => {


### PR DESCRIPTION
This should fix #1540 

I found a number of different strategies for passing props to children in the codebase. Here I tried to minimize duplication of proptype definitions and their documentation.

For some reason the docs fail to build with a `TypeError: Converting circular structure to JSON` and this seems to be due to how I extended the proptypes. I don't yet understand why, any hints are appreciated.