### PR TITLE
Spelling error. Reuseable => Reusable.

### DIFF
--- a/docs/src/IntroductionPage.js
+++ b/docs/src/IntroductionPage.js
@@ -20,7 +20,7 @@ const IntroductionPage = React.createClass({
             <div className="col-md-9" role="main">
               <div className="bs-docs-section">
                 <p className="lead">
-                  React-Bootstrap is a library of reuseable front-end components.
+                  React-Bootstrap is a library of reusable front-end components.
                   You'll get the look-and-feel of Twitter Bootstrap,
                   but with much cleaner code, via Facebook's React.js framework.
                 </p>


### PR DESCRIPTION
On the introduction page in the first line, Reusable is misspelled as Reuseable. This is my first PR :smile: 