### PR TITLE
Pass event to PanelGroup onSelect handler and cancel expanding if the custom handler returns false

### DIFF
--- a/docs/examples/PanelGroupControlled.js
+++ b/docs/examples/PanelGroupControlled.js
@@ -5,7 +5,7 @@ const ControlledPanelGroup = React.createClass({
     };
   },
 
-  handleSelect(activeKey) {
+  handleSelect(e, activeKey) {
     this.setState({ activeKey });
   },
 

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -45,7 +45,9 @@ let Panel = React.createClass({
     e.selected = true;
 
     if (this.props.onSelect) {
-      this.props.onSelect(e, this.props.eventKey);
+      if (this.props.onSelect(e, this.props.eventKey) === false) {
+        e.selected = false;
+      }
     } else {
       e.preventDefault();
     }

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -75,8 +75,12 @@ const PanelGroup = React.createClass({
 
     if (this.props.onSelect) {
       this._isChanging = true;
-      this.props.onSelect(key);
+      let setActiveKey = this.props.onSelect(e, key);
       this._isChanging = false;
+
+      if (setActiveKey === false) {
+        return false;
+      }
     }
 
     if (this.state.activeKey === key) {

--- a/test/PanelGroupSpec.js
+++ b/test/PanelGroupSpec.js
@@ -51,6 +51,45 @@ describe('PanelGroup', () => {
     assert.notOk(panel.state.collapsing);
   });
 
+  it('Should obey onSelect handler', () => {
+    function handleSelect(e) {
+      if (e.target.className.indexOf('ignoreme') > -1) {
+        return false;
+      }
+    }
+
+    let header = (
+      <div>
+        <span className="clickme">Click me</span>
+        <span className="ignoreme">Ignore me</span>
+      </div>
+    );
+
+    let instance = ReactTestUtils.renderIntoDocument(
+      <PanelGroup accordion onSelect={handleSelect}>
+        <Panel eventKey="1" header={header}>
+          <div>Panel body</div>
+        </Panel>
+      </PanelGroup>
+    );
+
+    let panel = ReactTestUtils.findRenderedComponentWithType(instance, Panel);
+
+    assert.notOk(panel.state.expanded);
+
+    ReactTestUtils.Simulate.click(
+      ReactTestUtils.findRenderedDOMComponentWithClass(panel, 'ignoreme')
+    );
+
+    assert.notOk(panel.state.expanded);
+
+    ReactTestUtils.Simulate.click(
+      ReactTestUtils.findRenderedDOMComponentWithClass(panel, 'clickme')
+    );
+
+    assert.ok(panel.state.expanded);
+  });
+
   describe('Web Accessibility', () => {
     let instance, panelBodies, panelGroup, links;
 

--- a/test/PanelSpec.js
+++ b/test/PanelSpec.js
@@ -137,6 +137,32 @@ describe('Panel', () => {
     ReactTestUtils.Simulate.click(title.firstChild);
   });
 
+  it('Should obey onSelect handler', () => {
+    function handleSelect(e) {
+      if (e.target.className.indexOf('ignoreme') > -1) {
+        return false;
+      }
+    }
+    let header = (
+      <div>
+        <span className="clickme">Click me</span>
+        <span className="ignoreme">Ignore me</span>
+      </div>
+    );
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Panel collapsible={true} onSelect={handleSelect} header={header} eventKey='1'>Panel content</Panel>
+    );
+    let panel = ReactTestUtils.findRenderedComponentWithType(instance, Panel);
+    ReactTestUtils.Simulate.click(
+      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'ignoreme')
+    );
+    assert.notOk(panel.state.expanded);
+    ReactTestUtils.Simulate.click(
+      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'clickme')
+    );
+    assert.ok(panel.state.expanded);
+  });
+
   it('Should toggle when uncontrolled', () => {
     let instance = ReactTestUtils.renderIntoDocument(
       <Panel collapsible={true} defaultExpanded={false} header="Click me">Panel content</Panel>


### PR DESCRIPTION
This changes the public API for the onSelect handler from `function handleSelect(eventKey)` to `function handleSelect(event, eventKey)`.

Because the onSelect handler receives the DOM event, it can check what the target element was. Combined with the new behavior when "false" is returned from the handler, clicks on specific elements can be ignored, e.g. a button with onClick logic is included in the panel and clicking it should not toggle the panel.