### PR TITLE
[changed] Make Panel expansion cancelable

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -38,9 +38,7 @@ let Panel = React.createClass({
     e.selected = true;
 
     if (this.props.onSelect) {
-      if (this.props.onSelect(this.props.eventKey, e) === false) {
-        e.selected = false;
-      }
+      this.props.onSelect(this.props.eventKey, e);
     } else {
       e.preventDefault();
     }

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -38,7 +38,9 @@ let Panel = React.createClass({
     e.selected = true;
 
     if (this.props.onSelect) {
-      this.props.onSelect(e, this.props.eventKey);
+      if (this.props.onSelect(this.props.eventKey, e) === false) {
+        e.selected = false;
+      }
     } else {
       e.preventDefault();
     }

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -70,13 +70,17 @@ const PanelGroup = React.createClass({
     return !this._isChanging;
   },
 
-  handleSelect(e, key) {
+  handleSelect(key, e) {
     e.preventDefault();
 
     if (this.props.onSelect) {
       this._isChanging = true;
-      this.props.onSelect(key);
+      let setActiveKey = this.props.onSelect(key, e);
       this._isChanging = false;
+
+      if (setActiveKey === false) {
+        return false;
+      }
     }
 
     if (this.state.activeKey === key) {

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -75,12 +75,8 @@ const PanelGroup = React.createClass({
 
     if (this.props.onSelect) {
       this._isChanging = true;
-      let setActiveKey = this.props.onSelect(key, e);
+      this.props.onSelect(key, e);
       this._isChanging = false;
-
-      if (setActiveKey === false) {
-        return false;
-      }
     }
 
     if (this.state.activeKey === key) {

--- a/test/PanelGroupSpec.js
+++ b/test/PanelGroupSpec.js
@@ -51,6 +51,45 @@ describe('PanelGroup', () => {
     assert.notOk(panel.state.collapsing);
   });
 
+  it('Should obey onSelect handler', () => {
+    function handleSelect(eventKey, e) {
+      if (e.target.className.indexOf('ignoreme') > -1) {
+        return false;
+      }
+    }
+
+    let header = (
+      <div>
+        <span className="clickme">Click me</span>
+        <span className="ignoreme">Ignore me</span>
+      </div>
+    );
+
+    let instance = ReactTestUtils.renderIntoDocument(
+      <PanelGroup accordion onSelect={handleSelect}>
+        <Panel eventKey="1" header={header}>
+          <div>Panel body</div>
+        </Panel>
+      </PanelGroup>
+    );
+
+    let panel = ReactTestUtils.findRenderedComponentWithType(instance, Panel);
+
+    assert.notOk(panel.state.expanded);
+
+    ReactTestUtils.Simulate.click(
+      ReactTestUtils.findRenderedDOMComponentWithClass(panel, 'ignoreme')
+    );
+
+    assert.notOk(panel.state.expanded);
+
+    ReactTestUtils.Simulate.click(
+      ReactTestUtils.findRenderedDOMComponentWithClass(panel, 'clickme')
+    );
+
+    assert.ok(panel.state.expanded);
+  });
+
   describe('Web Accessibility', () => {
     let instance, panelBodies, panelGroup, links;
 

--- a/test/PanelGroupSpec.js
+++ b/test/PanelGroupSpec.js
@@ -54,7 +54,7 @@ describe('PanelGroup', () => {
   it('Should obey onSelect handler', () => {
     function handleSelect(eventKey, e) {
       if (e.target.className.indexOf('ignoreme') > -1) {
-        return false;
+        e.selected = false;
       }
     }
 

--- a/test/PanelSpec.js
+++ b/test/PanelSpec.js
@@ -140,7 +140,7 @@ describe('Panel', () => {
   it('Should obey onSelect handler', () => {
     function handleSelect(key, e) {
       if (e.target.className.indexOf('ignoreme') > -1) {
-        return false;
+        e.selected = false;
       }
     }
     let header = (

--- a/test/PanelSpec.js
+++ b/test/PanelSpec.js
@@ -126,7 +126,7 @@ describe('Panel', () => {
   });
 
   it('Should call onSelect handler', (done) => {
-    function handleSelect(e, key) {
+    function handleSelect(key) {
       assert.equal(key, '1');
       done();
     }
@@ -135,6 +135,32 @@ describe('Panel', () => {
     );
     let title = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-title');
     ReactTestUtils.Simulate.click(title.firstChild);
+  });
+
+  it('Should obey onSelect handler', () => {
+    function handleSelect(key, e) {
+      if (e.target.className.indexOf('ignoreme') > -1) {
+        return false;
+      }
+    }
+    let header = (
+      <div>
+        <span className="clickme">Click me</span>
+        <span className="ignoreme">Ignore me</span>
+      </div>
+    );
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Panel collapsible={true} onSelect={handleSelect} header={header} eventKey='1'>Panel content</Panel>
+    );
+    let panel = ReactTestUtils.findRenderedComponentWithType(instance, Panel);
+    ReactTestUtils.Simulate.click(
+      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'ignoreme')
+    );
+    assert.notOk(panel.state.expanded);
+    ReactTestUtils.Simulate.click(
+      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'clickme')
+    );
+    assert.ok(panel.state.expanded);
   });
 
   it('Should toggle when uncontrolled', () => {


### PR DESCRIPTION
Pass event to PanelGroup onSelect handler and cancel expanding if the custom handler returns false

This changes the public API for the onSelect handler from `function handleSelect(eventKey)` to `function handleSelect(eventKey, event)`.

Because the onSelect handler receives the DOM event, it can check what the target element was. Combined with the new behavior when "false" is returned from the handler, clicks on specific elements can be ignored, e.g. a button with onClick logic is included in the panel and clicking it should not toggle the panel.