### PR TITLE
[fixed] #1660 MenuItem divider className

### DIFF
--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -31,7 +31,10 @@ class MenuItem extends React.Component {
     let headerClass = bootstrapUtils.prefix(this.props, 'header');
 
     if (this.props.divider) {
-      return <li role="separator" className="divider" />;
+      return (
+        <li role="separator"
+          className={classnames('divider', this.props.className)} />
+      );
     }
 
     if (this.props.header) {

--- a/test/MenuItemSpec.js
+++ b/test/MenuItemSpec.js
@@ -15,6 +15,13 @@ describe('MenuItem', () => {
     node.getAttribute('role').should.equal('separator');
   });
 
+  it('renders divider className', () => {
+    const instance = ReactTestUtils.renderIntoDocument(<MenuItem divider className="foo bar" />);
+    const node = ReactDOM.findDOMNode(instance);
+
+    node.className.should.match(/\bdivider foo bar\b/);
+  });
+
   it('renders divider not children', () => {
     const instance = ReactTestUtils.renderIntoDocument(
       <MenuItem divider>


### PR DESCRIPTION
<MenuItem divider className="foo" />

rendered:

<li role="separator" class="divider" />

now renders:

<li role="separator" class="divider foo" />