### PR TITLE
Improving user experience on panels

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -192,7 +192,7 @@ let Panel = React.createClass({
     }
 
     return (
-      <div className={bootstrapUtils.prefix(this.props, 'heading')}>
+      <div className={bootstrapUtils.prefix(this.props, 'heading')} onClick={this.handleSelect}>
         {header}
       </div>
     );


### PR DESCRIPTION
Currently user has really bad experience while using `Accordion` component. He have to click directly on title to switch between tabs. He should be able to do so by clicking on header instead of anchor. 