### PR TITLE
Fix ComponentsPage ScrollSpy - last section active

### DIFF
--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -139,12 +139,13 @@ const ComponentsPage = React.createClass({
 
     for (const href of Object.keys(this.afterSections)) {
       if (!this.afterSections[href]) {
-        this.setState({ activeNavItemHref });
-        return;
+        break;
       }
 
       activeNavItemHref = href;
     }
+
+    this.setState({ activeNavItemHref });
   },
 
   renderScrollSpy(href) {


### PR DESCRIPTION
Fix for minor bug on ComponentsPage with the ScrollSpy.  It was unable to set the last section/Anchor as active.

## Steps to reproduce

1. Navigate to: [Components Page](http://react-bootstrap.github.io/components.html)
1. Resize browser so that the **ScrollSpy** section should be marked as active in the side nav.
![image](https://cloud.githubusercontent.com/assets/12118344/14037117/e22a68f6-f205-11e5-9480-e9401c9f85f4.png)

### Expected
**ScrollSpy** section to be active.

### Actual
**Affix** section is active.

## Fix Details
The `setActiveNavItem` function loops through the sections until it finds the first `afterSection` that is false.  In the case where all sections are true it did nothing.  This change breaks out of the for loop if/when a false value is encountered and then sets the state of the `activeNavItemHref`.