### PR TITLE
fix(ListGroupItem): Allowing for div children to be rendered.

### DIFF
--- a/docs/examples/ListGroupDefault.js
+++ b/docs/examples/ListGroupDefault.js
@@ -1,8 +1,13 @@
+let header = (<div>Header 5</div>);
+
 const listgroupInstance = (
   <ListGroup>
     <ListGroupItem>Item 1</ListGroupItem>
     <ListGroupItem>Item 2</ListGroupItem>
     <ListGroupItem>...</ListGroupItem>
+    <ListGroupItem header="Header 4"><div>Item 4</div></ListGroupItem>
+    <ListGroupItem header={header}><div>Item 5</div></ListGroupItem>
+    <ListGroupItem header="Header 6"><ul><li>Item 6</li></ul></ListGroupItem>
   </ListGroup>
 );
 

--- a/src/ListGroupItem.js
+++ b/src/ListGroupItem.js
@@ -80,6 +80,18 @@ class ListGroupItem extends React.Component {
       );
     }
 
+    /**
+     * If (this.props.children) matches an invalid descendent of the <p>, skip wrapping the children with a <p>
+     * and instead render the children as-is. See validateDOMNesting for more details.
+     */
+    let invalidPTagDescendants = {
+      ul: true,
+      div: true
+    };
+    if (this.props.children && invalidPTagDescendants[this.props.children.type]) {
+      return [header, this.props.children];
+    }
+
     let content = (
       <p key="content" className={bootstrapUtils.prefix(this.props, 'text')}>
         {this.props.children}

--- a/test/ListGroupItemSpec.js
+++ b/test/ListGroupItemSpec.js
@@ -88,4 +88,18 @@ describe('ListGroupItem', () => {
     assert.equal(node.lastChild.innerText, 'Item text');
     assert.ok(node.lastChild.className.match(/\blist-group-item-text\b/));
   });
+
+  it('Should support "div" child as a ReactComponent', () => {
+    let header = <h2>Heading</h2>;
+    let instance = ReactTestUtils.renderIntoDocument(
+      <ListGroupItem header={header}><div>Item text</div></ListGroupItem>
+    );
+
+    let node = ReactDOM.findDOMNode(instance);
+    assert.equal(node.firstChild.nodeName, 'H2');
+    assert.equal(node.firstChild.innerText, 'Heading');
+    assert.ok(node.firstChild.className.match(/\blist-group-item-heading\b/));
+    assert.equal(node.lastChild.nodeName, 'DIV');
+    assert.equal(node.lastChild.innerText, 'Item text');
+  });
 });


### PR DESCRIPTION
Attempting to fix https://github.com/react-bootstrap/react-bootstrap/issues/1271

This commit updates `ListGroupItem` to allow passing in block-level
elements (like div) by checking the `typeof` the props.children.

If its a string, then we'll wrap the content in the existing `<p>`
and render the content the same way as before.

If the children is not a string, then simply render out `props.children`
in place of where the `<p>` tag would be.

Example usage:

```javascript
let header = (<div>Header 5</div>);

const listgroupInstance = (
  <ListGroup>
    <ListGroupItem header="Header 4"><div>Item 4</div></ListGroupItem>
    <ListGroupItem header={header}><div>Item 5</div></ListGroupItem>
  </ListGroup>
);
```

will output something similar to:

```
<ul class="list-group">
  <li class="list-group-item">
    <h4 class="list-group-item-heading">Header 4</h4>
    <div>Item 4</div>
  </li>
  <li class="list-group-item">
    <div class="list-group-item-heading">Header 5</div>
    <div>Item 5</div>
  </li>
</ul>
```

<img width="881" alt="screen shot 2016-03-30 at 12 13 46 am" src="https://cloud.githubusercontent.com/assets/364028/14134727/ec32b216-f60d-11e5-9180-2c2c34de9b13.png">
