### PR TITLE
Add 'collapsed' class on NavbarToggle

### DIFF
--- a/src/NavbarToggle.js
+++ b/src/NavbarToggle.js
@@ -1,5 +1,8 @@
 import React, { PropTypes } from 'react';
 import tbsUtils from './utils/bootstrapUtils';
+import createChainedFunction from './utils/createChainedFunction';
+import classNames from 'classnames';
+
 
 let NavbarToggle = React.createClass({
 
@@ -15,6 +18,14 @@ let NavbarToggle = React.createClass({
     $bs_navbar_onToggle: PropTypes.func,
   },
 
+  getInitialState: function(){
+    return {collapsed: true};
+  },
+
+  handleCollapsedState: function() {
+    this.setState({collapsed: !this.state.collapsed});
+  },
+
   render() {
     let { children, ...props } = this.props;
     let {
@@ -24,8 +35,8 @@ let NavbarToggle = React.createClass({
 
     return (
       <button type="button"
-        onClick={onToggle}
-        className={tbsUtils.prefix({ bsClass }, 'toggle')}
+        onClick={createChainedFunction(this.handleCollapsedState, onToggle)}
+        className={ classNames(tbsUtils.prefix({ bsClass }, 'toggle'), {'collapsed': this.state.collapsed}) }
       >
         { children || [
           <span className="sr-only" key={0}>Toggle navigation</span>,


### PR DESCRIPTION
Added the 'collapsed' class/state to the NavbarToggle component by default. Removes and adds the 'collapsed' class according the NavbarToggle's collapse state to match the default bootstrap behavior as requested in Issue #1645 .

This is my first time trying to contribute to open source. Please let me know if I'm doing anything wrong/my style is incorrect!