### PR TITLE
Add 'collapsed' class on NavbarToggle

### DIFF
--- a/src/NavbarToggle.js
+++ b/src/NavbarToggle.js
@@ -1,6 +1,5 @@
 import React, { PropTypes } from 'react';
 import tbsUtils from './utils/bootstrapUtils';
-import createChainedFunction from './utils/createChainedFunction';
 import classNames from 'classnames';
 
 
@@ -29,7 +28,7 @@ let NavbarToggle = React.createClass({
 
     return (
       <button type="button"
-        onClick={createChainedFunction(this.handleCollapsedState, onToggle)}
+        onClick={onToggle}
         className={ classNames(tbsUtils.prefix({ bsClass }, 'toggle'), {'collapsed': !expanded}) }
       >
         { children || [

--- a/src/NavbarToggle.js
+++ b/src/NavbarToggle.js
@@ -19,25 +19,18 @@ let NavbarToggle = React.createClass({
     $bs_navbar_expanded: PropTypes.bool
   },
 
-  getInitialState() {
-    return {collapsed: true};
-  },
-
-  handleCollapsedState() {
-    this.setState({collapsed: !this.state.collapsed});
-  },
-
   render() {
     let { children, ...props } = this.props;
     let {
       $bs_navbar_bsClass: bsClass = 'navbar',
-      $bs_navbar_onToggle: onToggle
+      $bs_navbar_onToggle: onToggle,
+      $bs_navbar_expanded: expanded
     } = this.context;
 
     return (
       <button type="button"
         onClick={createChainedFunction(this.handleCollapsedState, onToggle)}
-        className={ classNames(tbsUtils.prefix({ bsClass }, 'toggle'), {'collapsed': this.state.collapsed}) }
+        className={ classNames(tbsUtils.prefix({ bsClass }, 'toggle'), {'collapsed': !expanded}) }
       >
         { children || [
           <span className="sr-only" key={0}>Toggle navigation</span>,

--- a/src/NavbarToggle.js
+++ b/src/NavbarToggle.js
@@ -16,6 +16,7 @@ let NavbarToggle = React.createClass({
   contextTypes: {
     $bs_navbar_bsClass: PropTypes.string,
     $bs_navbar_onToggle: PropTypes.func,
+    $bs_navbar_expanded: PropTypes.bool
   },
 
   getInitialState() {

--- a/src/NavbarToggle.js
+++ b/src/NavbarToggle.js
@@ -1,5 +1,8 @@
 import React, { PropTypes } from 'react';
 import tbsUtils from './utils/bootstrapUtils';
+import createChainedFunction from './utils/createChainedFunction';
+import classNames from 'classnames';
+
 
 let NavbarToggle = React.createClass({
 
@@ -15,6 +18,14 @@ let NavbarToggle = React.createClass({
     $bs_navbar_onToggle: PropTypes.func,
   },
 
+  getInitialState: function(){
+    return {collapsed: true};
+  },
+
+  handleCollapsedState: function() {
+    this.setState({collapsed: !this.state.collapsed});
+  },
+
   render() {
     let { children, ...props } = this.props;
     let {
@@ -24,8 +35,8 @@ let NavbarToggle = React.createClass({
 
     return (
       <button type="button"
-        onClick={onToggle}
-        className={tbsUtils.prefix({ bsClass }, 'toggle')}
+        onClick={createChainedFunction(this.handleCollapsedState, onToggle)}
+        className={ classNames(tbsUtils.prefix({ bsClass }, 'toggle'), {'collapsed': this.state.collapsed}) }
       >
         { children || [
           <span className="sr-only" key={0}>Toggle navigation</span>,

--- a/src/NavbarToggle.js
+++ b/src/NavbarToggle.js
@@ -18,11 +18,11 @@ let NavbarToggle = React.createClass({
     $bs_navbar_onToggle: PropTypes.func,
   },
 
-  getInitialState: function(){
+  getInitialState() {
     return {collapsed: true};
   },
 
-  handleCollapsedState: function() {
+  handleCollapsedState() {
     this.setState({collapsed: !this.state.collapsed});
   },
 


### PR DESCRIPTION
Added the 'collapsed' class/state to the NavbarToggle component by default. Removes and adds the 'collapsed' class according the NavbarToggle's collapse state to match the default bootstrap behavior as requested in Issue #1645 .

This is my first time trying to contribute to open source. Please let me know if I'm doing anything wrong/my style is incorrect!