### PR TITLE
Pass onHide to OverlayTrigger overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **Feature:** Support `<Breadcrumb.Item>` in addition to `<BreadcrumbItem>` for breadcrumb items ([#1722])
 - **Feature:** Add `<Carousel.Caption>` for carousel captions ([#1734])
 - **Feature:** Support `<Carousel.Item>` in addition to `<CarouselItem>` for carousel items ([#1740])
+- **Feature:** Pass `onHide` callback to `<OverlayTrigger>` overlay ([#1742])
 - **Bugfix:** Properly handle `style` on nested `<ProgressBar>` ([#1719])
 - **Bugfix:** Fix CommonJS export for `<Media>` ([#1737])
 
@@ -13,6 +14,7 @@
 [#1734]: https://github.com/react-bootstrap/react-bootstrap/pull/1734
 [#1737]: https://github.com/react-bootstrap/react-bootstrap/pull/1737
 [#1740]: https://github.com/react-bootstrap/react-bootstrap/pull/1740
+[#1742]: https://github.com/react-bootstrap/react-bootstrap/pull/1742
 
 
 ## [v0.28.4]

--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -179,7 +179,8 @@ const OverlayTrigger = React.createClass({
 
     let overlay = cloneElement(this.props.overlay, {
       placement: overlayProps.placement,
-      container: overlayProps.container
+      container: overlayProps.container,
+      onHide: this.hide
     });
 
     return (

--- a/test/OverlayTriggerSpec.js
+++ b/test/OverlayTriggerSpec.js
@@ -279,4 +279,24 @@ describe('OverlayTrigger', () => {
       });
     });
   });
+
+  it('Should forward onHide to overlay', () => {
+    let props;
+    class PropsSpy extends React.Component {
+      render() {
+        props = this.props;
+        return <div>test</div>;
+      }
+    }
+
+    const instance = ReactTestUtils.renderIntoDocument(
+      <OverlayTrigger trigger="click" overlay={<PropsSpy />}>
+        <button>button</button>
+      </OverlayTrigger>
+    );
+    const overlayTrigger = ReactDOM.findDOMNode(instance);
+    ReactTestUtils.Simulate.click(overlayTrigger);
+
+    expect(props.onHide).to.equal(instance.hide);
+  });
 });


### PR DESCRIPTION
Recreated from https://github.com/react-bootstrap/react-bootstrap/pull/1288.

I thought it wasn't necessary, but it turns out that https://github.com/react-bootstrap/react-bootstrap/pull/1288#issuecomment-200866021 means it is useful to have this feature.