### PR TITLE
Update contributing and maintaining guidelines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ before_install:
 branches:
   only:
     - master
+    - next

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,35 +3,22 @@
 We welcome community support with both pull requests and reporting bugs. Please
 don't hesitate to jump in.
 
-## Review others work
+## Review others' work
 
 Check out the list of outstanding pull requests if there is something you might
 be interested in. Maybe somebody is trying to fix that stupid bug that bothers
 you. Review the PR. Do you have any better ideas how to fix this problem? Let us
-know...
+know.
 
 ## Issues
 
 The issue tracker is the preferred channel for bug reports, features requests
 and submitting pull requests, but please respect the following restrictions:
 
-- Please do not use the issue tracker for personal support requests. Stack
-  Overflow ([react-bootstrap](http://stackoverflow.com/questions/tagged/react-bootstrap)
-  tag), [Slack](http://www.reactiflux.com/),
-  [gitter](https://gitter.im/react-bootstrap/react-bootstrap), or
-  [Thinkful](http://start.thinkful.com/react/?utm_source=github&utm_medium=badge&utm_campaign=react-bootstrap)
-  are better places to get help.
-- Please do not open issues or pull requests regarding the code in React or
-  Bootstrap (open them in their respective repositories).
+- Please do not use the issue tracker for personal support requests. Stack Overflow ([react-bootstrap](http://stackoverflow.com/questions/tagged/react-bootstrap) tag), [Discord](https://discord.gg/0ZcbPKXt5bXLs9XK), or [Thinkful](http://start.thinkful.com/react/?utm_source=github&utm_medium=badge&utm_campaign=react-bootstrap) are better places to get help.
+- Please do not open issues or pull requests regarding the code in React or Bootstrap (open them in their respective repositories).
 
-_Note: Occasionally issues are opened that are unclear, or we cannot verify them. When
-the issue author has not responded to our questions for verification within 7
-days then we will close the issue._
-
-[![HuBoard][huboard-badge]][huboard] We use HuBoard to triage issues and
-prioritize the backlog for the core dev team. Feel free to tackle any currently
-open [issue][issues]. The issues tagged with "help wanted" and especially those
-high in the backlog are fair game.
+_Note: Occasionally issues are opened that are unclear, or we cannot verify them. When the issue author has not responded to our questions for verification within 7 days then we will close the issue._
 
 ## Tests
 
@@ -65,17 +52,17 @@ or change in a Component.
 
 ```js
 propTypes: {
-    /**
-     * Sets the visibility of the Component
-     */
-    show: React.PropTypes.bool,
+  /**
+   * Sets the visibility of the Component
+   */
+  show: React.PropTypes.bool,
 
-    /**
-     * A callback fired when the visibility changes
-     * @type {func}
-     * @required
-     */
-    onHide: myCustomPropType
+  /**
+   * A callback fired when the visibility changes
+   * @type {func}
+   * @required
+   */
+  onHide: myCustomPropType
 }
 ```
 
@@ -98,13 +85,7 @@ therefore this project is the wrong place to implement them.
 
 ## Breaking changes
 
-Breaking changes should be accompanied with deprecations of removed
-functionality. Prior to the 1.0.0 release, we aim to follow React's example of
-taking two Minor releases to break old functionality. As such, changes that
-intend to remove or change public APIs should be be submitted against the
-`vX-rc` branch, and should be accompanied with deprecation warnings on the old
-APIs. The deprecated APIs themselves should not be removed until the Minor
-release after that.
+Breaking changes should be accompanied with deprecations of removed functionality. Prior to the 1.0.0 release, we aim to follow React's example of taking two minor releases to break old functionality. As such, changes that intend to remove or change public APIs should be be submitted against the `next` branch, and should be accompanied with deprecation warnings on the old APIs. The deprecated APIs themselves should not be removed until the minor release after that.
 
 ## Notes for lodash functions usage in the code
 

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -101,14 +101,7 @@ then be re-applied and released with the proper version bump.
 
 ### Release Candidates
 
-In an effort to reduce the frequency with which we introduce breaking changes we
-should do our best to first push deprecation warnings in a Minor release. Also,
-Pull Requests with breaking changes should be submitted against the `vX-rc`
-branch, where X is the next Major version. Which we will in turn release as an
-`alpha` release of the next Major version. When we are ready to release the next
-Major version bump we will merge the `vX-rc` branch into the `master` branch and
-cut a `beta` release.  Once bugs have been addressed with the `beta` release
-then we will release the Major version bump.
+In an effort to reduce the frequency with which we introduce breaking changes we should do our best to first push deprecation warnings in a minor release. Additionally, Pull Requests with breaking changes should be submitted against the `next` branch, which we will release as an `alpha` release of the next major version. When we are ready to release the next major version bump we will merge the `next` branch into the `master` branch and cut a release.
 
 ### Live releasing the documentation
 


### PR DESCRIPTION
This mostly removes cruft. It'll also be easier to keep around a `next` branch than to keep rolling rc branches.