### PR TITLE
Deprecate interpolation in <ProgressBar label>

### DIFF
--- a/docs/examples/ProgressBarScreenreaderLabel.js
+++ b/docs/examples/ProgressBarScreenreaderLabel.js
@@ -1,5 +1,7 @@
+const now = 60;
+
 const progressInstance = (
-  <ProgressBar now={60} label="%(percent)s%" srOnly />
+  <ProgressBar now={now} label={`${now}%`} srOnly />
 );
 
 ReactDOM.render(progressInstance, mountNode);

--- a/docs/examples/ProgressBarWithLabel.js
+++ b/docs/examples/ProgressBarWithLabel.js
@@ -1,5 +1,7 @@
+const now = 60;
+
 const progressInstance = (
-  <ProgressBar now={60} label="%(percent)s%" />
+  <ProgressBar now={now} label={`${now}%`} />
 );
 
 ReactDOM.render(progressInstance, mountNode);

--- a/docs/src/sections/ProgressBarSection.js
+++ b/docs/src/sections/ProgressBarSection.js
@@ -20,7 +20,6 @@ export default function ProgressBarSection() {
 
       <h2><Anchor id="progress-label">With label</Anchor></h2>
       <p>Add a <code>label</code> prop to show a visible percentage. For low percentages, consider adding a min-width to ensure the label's text is fully visible.</p>
-      <p>The following keys are interpolated with the current values: <code>%(min)s</code>, <code>%(max)s</code>, <code>%(now)s</code>, <code>%(percent)s</code>, <code>%(bsStyle)s</code></p>
       <ReactPlayground codeText={Samples.ProgressBarWithLabel} />
 
       <h2><Anchor id="progress-screenreader-label">Screenreader only label</Anchor></h2>

--- a/src/Interpolate.js
+++ b/src/Interpolate.js
@@ -82,4 +82,6 @@ const Interpolate = React.createClass({
   }
 });
 
+Object.assign(Interpolate, { REGEXP });
+
 export default Interpolate;

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -1,8 +1,10 @@
-import React, { cloneElement, PropTypes } from 'react';
-import Interpolate from './Interpolate';
-import bootstrapUtils, { bsStyles, bsClass } from './utils/bootstrapUtils';
-import { State } from './styleMaps';
 import classNames from 'classnames';
+import React, { cloneElement, PropTypes } from 'react';
+
+import Interpolate from './Interpolate';
+import { State } from './styleMaps';
+import bootstrapUtils, { bsStyles, bsClass } from './utils/bootstrapUtils';
+import deprecationWarning from './utils/deprecationWarning';
 import ValidComponentChildren from './utils/ValidComponentChildren';
 
 /**
@@ -103,23 +105,32 @@ class ProgressBar extends React.Component {
   }
 
   renderLabel(percentage) {
-    const InterpolateClass = this.props.interpolateClass || Interpolate;
+    const { interpolateClass, now, min, max, bsStyle, label } = this.props;
+    const InterpolateClass = interpolateClass || Interpolate;
+
+    const { REGEXP } = InterpolateClass;
+    if (REGEXP && REGEXP.exec(label)) {
+      deprecationWarning(
+        'String interpolation in <ProgressBar label>',
+        'ES2015 template strings or other patterns'
+      );
+    }
 
     return (
       <InterpolateClass
-        now={this.props.now}
-        min={this.props.min}
-        max={this.props.max}
+        now={now}
+        min={min}
+        max={max}
         percent={percentage}
-        bsStyle={this.props.bsStyle}>
-        {this.props.label}
+        bsStyle={bsStyle}
+      >
+        {label}
       </InterpolateClass>
     );
   }
 }
 
 ProgressBar.propTypes = {
-  ...ProgressBar.propTypes,
   min: PropTypes.number,
   now: PropTypes.number,
   max: PropTypes.number,
@@ -137,7 +148,6 @@ ProgressBar.propTypes = {
 };
 
 ProgressBar.defaultProps = {
-  ...ProgressBar.defaultProps,
   min: 0,
   max: 100,
   active: false,

--- a/test/ProgressBarSpec.js
+++ b/test/ProgressBarSpec.js
@@ -99,20 +99,30 @@ describe('ProgressBar', () => {
   it('Should have label', () => {
     let instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar min={0} max={10} now={5} bsStyle="success"
+        label="progress bar label" />
+    );
+
+    assert.equal(ReactDOM.findDOMNode(instance).innerText, 'progress bar label');
+  });
+
+  it('Should warn on deprecated label interpolation', () => {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <ProgressBar min={0} max={10} now={5} bsStyle="success"
         label="min:%(min)s, max:%(max)s, now:%(now)s, percent:%(percent)s, bsStyle:%(bsStyle)s" />
     );
 
     assert.equal(ReactDOM.findDOMNode(instance).innerText, 'min:0, max:10, now:5, percent:50, bsStyle:success');
+    shouldWarn('deprecated');
   });
 
   it('Should have screen reader only label', () => {
     let instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar min={0} max={10} now={5} srOnly bsStyle="success"
-        label="min:%(min)s, max:%(max)s, now:%(now)s, percent:%(percent)s, bsStyle:%(bsStyle)s" />
+        label="progress bar label" />
     );
     let srLabel = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'sr-only');
 
-    assert.equal(srLabel.innerText, 'min:0, max:10, now:5, percent:50, bsStyle:success');
+    assert.equal(srLabel.innerText, 'progress bar label');
   });
 
   it('Should have a label that is a React component', () => {


### PR DESCRIPTION
This is a silly feature and we shouldn't have it.