### PR TITLE
dialogComponent -> dialogComponentClass on <Modal>

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -10,6 +10,7 @@ import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
 import canUseDOM from 'dom-helpers/util/inDOM';
 import ownerDocument from 'dom-helpers/ownerDocument';
 import events from 'dom-helpers/events';
+import deprecated from 'react-prop-types/lib/deprecated';
 import elementType from 'react-prop-types/lib/elementType';
 
 import Fade from './Fade';
@@ -48,7 +49,12 @@ const Modal = React.createClass({
      * A Component type that provides the modal content Markup. This is a useful prop when you want to use your own
      * styles and markup to create a custom modal component.
      */
-    dialogComponent: elementType,
+    dialogComponentClass: elementType,
+
+    /**
+     * @private
+     */
+    dialogComponent: deprecated(elementType, 'Use `dialogComponentClass`.'),
 
     /**
      * When `true` The modal will automatically shift focus to itself when it opens, and replace it to the last focused element when it closes.
@@ -120,7 +126,7 @@ const Modal = React.createClass({
       ...BaseModal.defaultProps,
       bsClass: 'modal',
       animation: true,
-      dialogComponent: ModalDialog,
+      dialogComponentClass: ModalDialog,
     };
   },
 
@@ -151,7 +157,7 @@ const Modal = React.createClass({
     let { modalStyles } = this.state;
 
     let inClass = { in: props.show && !animation };
-    let Dialog = props.dialogComponent;
+    let Dialog = props.dialogComponent || props.dialogComponentClass;
 
     let parentProps = pick(props,
       Object.keys(BaseModal.propTypes).concat(

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -5,7 +5,7 @@ import ReactDOM from 'react-dom';
 
 import Modal from '../src/Modal';
 
-import { render } from './helpers';
+import { render, shouldWarn } from './helpers';
 
 describe('Modal', () => {
   let mountPoint;
@@ -134,7 +134,23 @@ describe('Modal', () => {
     assert.ok(dialog.className.match(/\btestCss\b/));
   });
 
-  it('Should use dialogComponent', () => {
+  it('Should use dialogComponentClass', () => {
+    let noOp = () => {};
+
+    class CustomDialog extends React.Component {
+      render() { return <div {...this.props}/>; }
+    }
+
+    let instance = render(
+      <Modal show dialogComponentClass={CustomDialog} onHide={noOp}>
+        <strong>Message</strong>
+      </Modal>
+    , mountPoint);
+
+    assert.ok(instance._modal instanceof CustomDialog);
+  });
+
+  it('Should use deprecated dialogComponent', () => {
     let noOp = () => {};
 
     class CustomDialog extends React.Component {
@@ -148,6 +164,7 @@ describe('Modal', () => {
     , mountPoint);
 
     assert.ok(instance._modal instanceof CustomDialog);
+    shouldWarn('deprecated');
   });
 
   it('Should pass transition callbacks to Transition', (done) => {


### PR DESCRIPTION
This makes it consistent with our use of componentClass elsewhere.