### PR TITLE
Don't require duplicate shouldWarn declarations

### DIFF
--- a/test/ButtonInputSpec.js
+++ b/test/ButtonInputSpec.js
@@ -34,7 +34,6 @@ describe('ButtonInput', () => {
 
   it('throws warning about unsupported type', () => {
     shouldWarn('propType: Invalid');
-    shouldWarn('propType: Invalid');
     shouldWarn('Failed form propType');
 
     ReactTestUtils.renderIntoDocument(

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -136,7 +136,7 @@ describe('Dropdown', () => {
   });
 
   it('only renders one menu', () => {
-    shouldWarn(/Duplicate children.*bsRole: menu/);
+    shouldWarn('Duplicate children');
 
     const instance = ReactTestUtils.renderIntoDocument(
       <Dropdown title='Single child' id='test-id'>

--- a/test/NavbarSpec.js
+++ b/test/NavbarSpec.js
@@ -296,8 +296,6 @@ describe('Navbar', () => {
   describe('deprecations', ()=> {
     it('Should add header with brand', () => {
       shouldWarn('deprecated');
-      shouldWarn('deprecated');
-      shouldWarn('has been renamed');
       shouldWarn('has been renamed');
 
       let instance = ReactTestUtils.renderIntoDocument(
@@ -316,7 +314,6 @@ describe('Navbar', () => {
     });
 
     it('Should add header when toggleNavKey is 0', () => {
-      shouldWarn('deprecated');
       shouldWarn('deprecated');
 
       let instance = ReactTestUtils.renderIntoDocument(

--- a/test/index.js
+++ b/test/index.js
@@ -4,25 +4,24 @@ import { _resetWarned } from '../src/utils/deprecationWarning';
 
 beforeEach(() => {
   sinon.stub(console, 'error', msg => {
-    const nextExpected = console.error.expected.shift();
-    if (nextExpected) {
-      if (nextExpected instanceof RegExp) {
-        expect(msg).to.match(nextExpected);
-      } else {
-        expect(msg).to.contain(nextExpected);
+    for (const about of console.error.expected) {
+      if (msg.indexOf(about) !== -1) {
+        console.error.warned[about] = true;
+        return;
       }
-
-      return;
     }
 
     throw new Error(msg);
   });
 
   console.error.expected = [];
+  console.error.warned = Object.create(null);
 });
 
 afterEach(() => {
-  expect(console.error.expected).to.be.empty;
+  if (console.error.expected.length) {
+    expect(console.error.warned).to.have.keys(console.error.expected);
+  }
 
   console.error.restore();
   _resetWarned();

--- a/test/utils/bootstrapUtilsSpec.js
+++ b/test/utils/bootstrapUtilsSpec.js
@@ -110,7 +110,7 @@ describe('bootstrapUtils', ()=> {
     });
 
     it('should work with es6 classes', ()=> {
-      shouldWarn(/expected one of \["minimal","boss","plaid"\]/);
+      shouldWarn('expected one of ["minimal","boss","plaid"]');
 
       @bsStyles(['minimal', 'boss', 'plaid'], 'plaid')
       class Component extends React.Component {
@@ -125,7 +125,7 @@ describe('bootstrapUtils', ()=> {
     });
 
     it('should work with createClass', ()=> {
-      shouldWarn(/expected one of \["minimal","boss","plaid"\]/);
+      shouldWarn('expected one of ["minimal","boss","plaid"]');
 
       let Component = bsStyles(['minimal', 'boss', 'plaid'], 'plaid')(
         React.createClass({
@@ -176,7 +176,7 @@ describe('bootstrapUtils', ()=> {
     });
 
     it('should work with es6 classes', ()=> {
-      shouldWarn(/expected one of \["smallish","micro","planet"\]/);
+      shouldWarn('expected one of ["smallish","micro","planet"]');
 
       @bsSizes(['smallish', 'micro', 'planet'], 'smallish')
       class Component extends React.Component {
@@ -191,7 +191,7 @@ describe('bootstrapUtils', ()=> {
     });
 
     it('should work with createClass', ()=> {
-      shouldWarn(/expected one of \["smallish","micro","planet"\]/);
+      shouldWarn('expected one of ["smallish","micro","planet"]');
 
       let Component = bsSizes(['smallish', 'micro', 'planet'], 'smallish')(
         React.createClass({


### PR DESCRIPTION
I thought this was more explicit but actually it's just dumb.