### PR TITLE
Fix for #1785

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -166,7 +166,7 @@ const Modal = React.createClass({
         style={modalStyles}
         className={classNames(className, inClass)}
         dialogClassName={dialogClassName}
-        onClick={props.backdrop === true ? this.handleDialogClick : null}
+        onMouseDown={props.backdrop === true ? this.handleDialogClick : null}
       >
         { this.props.children }
       </Dialog>

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -44,7 +44,7 @@ describe('Modal', () => {
 
     let dialog = ReactDOM.findDOMNode(instance._modal);
 
-    ReactTestUtils.Simulate.click(dialog);
+    ReactTestUtils.Simulate.mouseDown(dialog);
   });
 
   it('Should not close the modal when the "static" dialog is clicked', () => {


### PR DESCRIPTION
If we drag on modal and release mouse on dialog, click event is triggered and modal is closed.
This is unexpected behaviour when modal has drag & drop or slider components.

To fix this issue, I change the modal close trigger from click to mouseDown 