### PR TITLE
bsStyle custom style documentation

### DIFF
--- a/docs/examples/.eslintrc
+++ b/docs/examples/.eslintrc
@@ -8,6 +8,7 @@
     "React",
     "ReactDOM",
     "classNames",
+    "bootstrapUtils",
     "Accordion",
     "Alert",
     "Badge",

--- a/docs/examples/CustomButtonStyle.js
+++ b/docs/examples/CustomButtonStyle.js
@@ -1,0 +1,15 @@
+bootstrapUtils.addStyle(Button, ['custom']);
+
+const customButtonStyle = (
+  <div>
+    <style type="text/css">{"\
+    .btn-custom {\
+        background-color: purple;\
+        color: white;\
+    }\
+    "}</style>
+    <Button bsStyle="custom">Custom</Button>
+  </div>
+);
+
+ReactDOM.render(customButtonStyle, mountNode);

--- a/docs/src/ComponentsPage.js
+++ b/docs/src/ComponentsPage.js
@@ -16,6 +16,7 @@ import BreadcrumbSection from './sections/BreadcrumbSection';
 import ButtonGroupSection from './sections/ButtonGroupSection';
 import ButtonSection from './sections/ButtonSection';
 import CarouselSection from './sections/CarouselSection';
+import CustomStylesSection from './sections/CustomStylesSection';
 import DropdownSection from './sections/DropdownSection';
 import FormSection from './sections/FormSection';
 import GlyphiconSection from './sections/GlyphiconSection';
@@ -86,6 +87,7 @@ const sections = {
     progress: '#progress',
   utilities: '#utilities',
     transitions: '#transitions',
+    customStyles: '#custom-styles',
   missing: '#missing',
     affix: '#affix',
     scrollspy: '#scrollspy'
@@ -320,6 +322,9 @@ const ComponentsPage = React.createClass({
                 {this.renderScrollSpy(sections.transitions)}
                 <TransitionSection />
 
+                {this.renderScrollSpy(sections.customStyles)}
+                <CustomStylesSection />
+
                 {this.renderScrollSpy(sections.missing)}
                 <div className="bs-docs-section">
                   <h1 className="page-header">
@@ -421,6 +426,7 @@ const ComponentsPage = React.createClass({
 
                       <SubNav href={sections.utilities} text="Utilities">
                         <NavItem href={sections.transitions}>Transitions</NavItem>
+                        <NavItem href={sections.customStyles}>Custom Styles</NavItem>
                       </SubNav>
 
                       <SubNav href={sections.missing} text="Missing components">

--- a/docs/src/ReactPlayground.js
+++ b/docs/src/ReactPlayground.js
@@ -6,6 +6,8 @@ const classNames = require('classnames');
 const React = require('react');
 const ReactDOM = require('react-dom');
 
+const bootstrapUtils = require('../../src/utils/bootstrapUtils.js').default;
+
 const Accordion = require('../../src/Accordion');
 const Alert = require('../../src/Alert');
 const Badge = require('../../src/Badge');

--- a/docs/src/Samples.js
+++ b/docs/src/Samples.js
@@ -19,6 +19,7 @@ export default {
   ButtonGroupVertical:           require('fs').readFileSync(__dirname + '/../examples/ButtonGroupVertical.js', 'utf8'),
   ButtonGroupJustified:          require('fs').readFileSync(__dirname + '/../examples/ButtonGroupJustified.js', 'utf8'),
   ButtonGroupBlock:              require('fs').readFileSync(__dirname + '/../examples/ButtonGroupBlock.js', 'utf8'),
+  CustomButtonStyle:             require('fs').readFileSync(__dirname + '/../examples/CustomButtonStyle.js', 'utf8'),
   DropdownButtonBasic:           require('fs').readFileSync(__dirname + '/../examples/DropdownButtonBasic.js', 'utf8'),
   DropdownButtonCustom:          require('fs').readFileSync(__dirname + '/../examples/DropdownButtonCustom.js', 'utf8'),
   DropdownButtonCustomMenu:      require('fs').readFileSync(__dirname + '/../examples/DropdownButtonCustomMenu.js', 'utf8'),

--- a/docs/src/sections/CustomStylesSection.js
+++ b/docs/src/sections/CustomStylesSection.js
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import Anchor from '../Anchor';
+import ReactPlayground from '../ReactPlayground';
+import Samples from '../Samples';
+
+export default function CustomStylesSection() {
+  return (
+    <div className="bs-docs-section">
+      <h2 className="page-header">
+        <Anchor id="custom-styles">Custom Styles</Anchor>
+      </h2>
+
+      <p>The <code>bsStyle</code> prop, available in many components in React-Bootstrap, is used to map to a Bootstrap class for styling; for example, the Bootstrap class used for <code>Button</code> is <code>`btn-${'{'}bsStyle{'}'}`</code>. Use <code>bootstrapUtils</code> to create a custom class that is used in lieu of the classes provided by Bootstrap:</p>
+
+      <ReactPlayground codeText={Samples.CustomButtonStyle} />
+    </div>
+  );
+}


### PR DESCRIPTION
Documentation per request in #1721 

* The `require` statement in `ReactPlayground.js` for `bootstrapUtils` needed `.default`; that area of JavaScript is still unfamiliar to me- advice on a better approach is welcome.
* I am not providing an import hint for `bootstrapUtils` per #1728 comment by @taion. I suspect this will be difficult for new users to figure out since the location of bootstrapUtils looks to require a path (e.g. ```import bootstrapUtils from 'react-bootstrap/lib/utils/bootstrapUtils';```). Feedback/suggestions welcome.