### PR TITLE
Allow using `.value` property

### DIFF
--- a/src/FormControls/Static.js
+++ b/src/FormControls/Static.js
@@ -11,6 +11,10 @@ class Static extends InputBase {
     const {children, value} = this.props;
     return children ? children : value;
   }
+  
+  get value() {
+    return this.getValue();
+  }
 
   renderInput() {
     const {componentClass: ComponentClass, ...props} = this.props;


### PR DESCRIPTION
This more closely mimics the behavior of inputs in the DOM.