### PR TITLE
Added unmountOnExit support to Tabs

### DIFF
--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -30,7 +30,7 @@ let TabContent = React.createClass({
     ]),
 
     /**
-     * Unmounts the content (remove it from the DOM) when animation is not `false` and it is faded out
+     * Unmount the tab (remove it from the DOM) when it is no longer visible
      */
     unmountOnExit: PropTypes.bool,
   },

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -28,6 +28,11 @@ let TabContent = React.createClass({
       PropTypes.bool,
       elementType
     ]),
+
+    /**
+     * Unmounts the content (remove it from the DOM) when animation is not `false` and it is faded out
+     */
+    unmountOnExit: PropTypes.bool,
   },
 
   contextTypes: {
@@ -43,14 +48,16 @@ let TabContent = React.createClass({
       animation: animationPropType,
       activeKey: PropTypes.any,
       onExited: PropTypes.func,
-      register: PropTypes.func
+      register: PropTypes.func,
+      unmountOnExit: PropTypes.bool,
     }),
   },
 
   getDefaultProps() {
     return {
       componentClass: 'div',
-      animation: true
+      animation: true,
+      unmountOnExit: false
     };
   },
 
@@ -69,7 +76,8 @@ let TabContent = React.createClass({
         animation: this.props.animation,
         activeKey: exitingPane ? undefined : this.getActiveKey(),
         onExited: this.handlePaneExited,
-        register: this.registerPane
+        register: this.registerPane,
+        unmountOnExit: this.props.unmountOnExit
       }
     };
   },

--- a/src/TabPane.js
+++ b/src/TabPane.js
@@ -65,7 +65,7 @@ let TabPane = React.createClass({
     onExited: PropTypes.func,
 
     /**
-     * Unmounts the tab (remove it from the DOM) when animation is not `false` and it is faded out
+     * Unmount the tab (remove it from the DOM) when it is no longer visible
      */
     unmountOnExit: PropTypes.bool
   },
@@ -140,10 +140,10 @@ let TabPane = React.createClass({
       : context.animation;
   },
 
-  getUnmountOnExit(props = this.props, context = this.context) {
-    context = this.getContext('$bs_tabcontent', context);
-    return props.unmountOnExit != null
-      ? props.unmountOnExit
+  getUnmountOnExit() {
+    let context = this.getContext('$bs_tabcontent', this.context);
+    return this.props.unmountOnExit != null
+      ? this.props.unmountOnExit
       : context.unmountOnExit;
   },
 
@@ -158,6 +158,10 @@ let TabPane = React.createClass({
     let bsClass = this.props.bsClass || this.getContext('$bs_tabcontent').bsClass;
 
     let Transition = this.getTransition();
+
+    if (!visible && !Transition && this.getUnmountOnExit()) {
+      return null;
+    }
 
     let classes = {
       active: visible,

--- a/src/TabPane.js
+++ b/src/TabPane.js
@@ -62,12 +62,18 @@ let TabPane = React.createClass({
     /**
      * Transition onExited callback when animation is not `false`
      */
-    onExited: PropTypes.func
+    onExited: PropTypes.func,
+
+    /**
+     * Unmounts the tab (remove it from the DOM) when animation is not `false` and it is faded out
+     */
+    unmountOnExit: PropTypes.bool
   },
 
   contextTypes: {
     $bs_tabcontainer: PropTypes.shape({
-      getId: PropTypes.func
+      getId: PropTypes.func,
+      unmountOnExit: PropTypes.bool
     }),
     $bs_tabcontent: PropTypes.shape({
       bsClass: PropTypes.string,
@@ -77,7 +83,8 @@ let TabPane = React.createClass({
       ]),
       activeKey: PropTypes.any,
       onExited: PropTypes.func,
-      register: PropTypes.func
+      register: PropTypes.func,
+      unmountOnExit: PropTypes.bool
     }),
   },
 
@@ -131,6 +138,13 @@ let TabPane = React.createClass({
     return props.animation != null
       ? props.animation
       : context.animation;
+  },
+
+  getUnmountOnExit(props = this.props, context = this.context) {
+    context = this.getContext('$bs_tabcontent', context);
+    return props.unmountOnExit != null
+      ? props.unmountOnExit
+      : context.unmountOnExit;
   },
 
   isActive(props = this.props, context = this.context) {
@@ -192,6 +206,7 @@ let TabPane = React.createClass({
           onEnter={createChainedFunction(this.handleEnter, onEnter)}
           onEntering={onEntering}
           onEntered={onEntered}
+          unmountOnExit={this.getUnmountOnExit()}
         >
           { tabPane }
         </Transition>

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -65,7 +65,7 @@ const Tabs = React.createClass({
     onSelect: React.PropTypes.func,
 
     /**
-     * Unmount tabs (remove it from the DOM) when animation is not `false` and it is faded out
+     * Unmount tabs (remove it from the DOM) when it is no longer visible
      */
     unmountOnExit: React.PropTypes.bool,
 

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -65,6 +65,11 @@ const Tabs = React.createClass({
     onSelect: React.PropTypes.func,
 
     /**
+     * Unmount tabs (remove it from the DOM) when animation is not `false` and it is faded out
+     */
+    unmountOnExit: React.PropTypes.bool,
+
+    /**
      * @deprecated Use TabContainer to create differently shaped tab layouts.
      */
     position: React.PropTypes.oneOf(['top', 'left', 'right']),
@@ -107,7 +112,8 @@ const Tabs = React.createClass({
       animation: true,
       tabWidth: 2,
       position: 'top',
-      standalone: false
+      standalone: false,
+      unmountOnExit: false
     };
   },
 
@@ -145,11 +151,13 @@ const Tabs = React.createClass({
       ref: 'tabs',
       role: 'tablist'
     };
+
     const childTabs = ValidComponentChildren.map(children, this.renderTab);
 
     const panesProps = {
       ref: 'panes',
-      animation: props.animation
+      animation: props.animation,
+      unmountOnExit: props.unmountOnExit
     };
 
     const childPanes = children;

--- a/test/TabsSpec.js
+++ b/test/TabsSpec.js
@@ -155,6 +155,45 @@ describe('Tabs', () => {
     assert.equal(tabs.refs.tabs.context.$bs_tabcontainer.activeKey, 1);
   });
 
+  it('Should mount initial tab and no others when unmountOnExit is true and animation is false', () => {
+    let tab1 = <span className="tab1">Tab 1</span>;
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Tabs id='test' defaultActiveKey={1} animation={false} unmountOnExit={true}>
+        <Tab title={tab1} eventKey={1}>Tab 1 content</Tab>
+        <Tab title="Tab 2" eventKey={2}>Tab 2 content</Tab>
+        <Tab title="Tab 3" eventKey={3}>Tab 3 content</Tab>
+      </Tabs>
+    );
+
+    let panes = ReactTestUtils.scryRenderedComponentsWithType(instance, TabPane);
+
+    expect(ReactDOM.findDOMNode(panes[0])).to.exist;
+    expect(ReactDOM.findDOMNode(panes[1])).to.not.exist;
+    expect(ReactDOM.findDOMNode(panes[2])).to.not.exist;
+  });
+
+  it('Should mount the correct tab when selected and unmount the previous when unmountOnExit is true and animation is false', () => {
+    let tab1 = <span className="tab1">Tab 1</span>;
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Tabs id='test' defaultActiveKey={2} animation={false} unmountOnExit={true}>
+        <Tab title={tab1} eventKey={1}>Tab 1 content</Tab>
+        <Tab title="Tab 2" eventKey={2}>Tab 2 content</Tab>
+      </Tabs>
+    );
+
+    let tabs = instance.refs.inner;
+    let panes = ReactTestUtils.scryRenderedComponentsWithType(instance, TabPane);
+
+    ReactTestUtils.Simulate.click(
+      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'tab1')
+    );
+
+    expect(ReactDOM.findDOMNode(panes[0])).to.exist;
+    expect(ReactDOM.findDOMNode(panes[1])).to.not.exist;
+
+    assert.equal(tabs.refs.tabs.context.$bs_tabcontainer.activeKey, 1);
+  });
+
   it('Should treat active key of null as nothing selected', () => {
     const instance = ReactTestUtils.renderIntoDocument(
       <Tabs id='test' activeKey={null} onSelect={()=>{}}>


### PR DESCRIPTION
Resolves #129 

I didn't add tests for this as there weren't any existing ones for `animate` or any of the new transition ones that I could reference.