### PR TITLE
Fixes https://github.com/react-bootstrap/react-bootstrap/issues/1830

### DIFF
--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -19,7 +19,7 @@ export default class DropdownToggle extends React.Component {
       <Component
         {...this.props}
         className={classNames(classes, this.props.className)}
-        type="button"
+        role="button"
         aria-haspopup
         aria-expanded={this.props.open}>
         {this.props.children || this.props.title}{caret}


### PR DESCRIPTION
Change `type="button"` to `role="button"` for DropdownToggle