### PR TITLE
Fix documentation usage of React.findDOMNode

### DIFF
--- a/docs/examples/DropdownButtonCustomMenu.js
+++ b/docs/examples/DropdownButtonCustomMenu.js
@@ -47,7 +47,7 @@ class CustomMenu extends React.Component {
   }
 
   focusNext() {
-    let input = React.findDOMNode(this.input);
+    let input = ReactDOM.findDOMNode(this.input);
 
     if (input) {
       input.focus();

--- a/docs/examples/PopoverContained.js
+++ b/docs/examples/PopoverContained.js
@@ -15,7 +15,7 @@ class Example extends React.Component {
 
         <Overlay
           show={this.state.show}
-          target={()=> React.findDOMNode(this.state.target)}
+          target={()=> ReactDOM.findDOMNode(this.state.target)}
           placement="bottom"
           container={this}
           containerPadding={20}


### PR DESCRIPTION
Two places that slipped through the change to `ReactDOM.findDOMNode`.