### PR TITLE
allow anchor renderer access to target page number #1866

### DIFF
--- a/src/PaginationButton.js
+++ b/src/PaginationButton.js
@@ -48,7 +48,6 @@ const PaginationButton = React.createClass({
     } = this.props;
 
     delete props.onSelect;
-    delete props.eventKey;
 
     return (
       <li

--- a/test/PaginationSpec.js
+++ b/test/PaginationSpec.js
@@ -222,7 +222,7 @@ describe('Pagination', () => {
     );
   });
 
-  it('should not fire "onSelect" event on disabled buttons', () => {
+  it('Should not fire "onSelect" event on disabled buttons', () => {
     function onSelect() {
       throw Error('this event should not happen');
     }
@@ -249,5 +249,21 @@ describe('Pagination', () => {
 
     ReactTestUtils.Simulate.click( nextButton );
     ReactTestUtils.Simulate.click( lastButton );
+  });
+
+  it('Should pass page number to buttonComponentClass', () => {
+    class DummyElement extends React.Component {
+      render() {
+        return <a href={`?page=${this.props.eventKey}`}>{this.props.eventKey}</a>;
+      }
+    }
+
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Pagination items={5} buttonComponentClass={DummyElement}/>
+    );
+
+    const pageButtons = ReactTestUtils.scryRenderedDOMComponentsWithTag(instance, 'a');
+
+    assert.equal(pageButtons[1].getAttribute('href'), '?page=2');
   });
 });


### PR DESCRIPTION
Makes it possible to provide an anchor renderer component that makes use of page number information.
Ideally `eventKey` should be renamed to something that makes more sense like `targetPage` to keep it pagination-centric.

https://github.com/react-bootstrap/react-bootstrap/issues/1866