### PR TITLE
Render children in FormControl.Feedback component

### DIFF
--- a/docs/src/sections/FormSection.js
+++ b/docs/src/sections/FormSection.js
@@ -12,7 +12,7 @@ export default function FormSection() {
         <Anchor id="forms">Forms</Anchor> <small>FormGroup, FormControl, ControlLabel</small>
       </h1>
 
-      <p>The <code>{'<FormControl>'}</code> component renders a form control with Bootstrap styling. The <code>{'<FormGroup>'}</code> component wraps a form control with proper spacing, along with support for a label, help text, and validation state. To ensure accessibility, set <code>controlId</code> on <code>{'<FormGroup>'}</code>, and use <code>{'<ControlLabel>'}</code> for the label.</p>
+      <p>The <code>{'<FormControl>'}</code> component renders a form control with Bootstrap styling. The <code>{'<FormGroup>'}</code> component wraps a form control with proper spacing, along with support for a label, help text, and validation state. To ensure accessibility, set <code>controlId</code> on <code>{'<FormGroup>'}</code>, and use <code>{'<ControlLabel>'}</code> for the label. To retrieve the DOM node for a <code>{'<FormControl>'}</code>, set a <code>ref</code> and use <code>getDOMNode</code> or <code>findDOMNode</code> as needed.</p>
       <ReactPlayground codeText={Samples.FormBasic} />
 
       <h3><Anchor id="forms-props">Props</Anchor></h3>

--- a/docs/src/sections/FormSection.js
+++ b/docs/src/sections/FormSection.js
@@ -12,7 +12,15 @@ export default function FormSection() {
         <Anchor id="forms">Forms</Anchor> <small>FormGroup, FormControl, ControlLabel</small>
       </h1>
 
-      <p>The <code>{'<FormControl>'}</code> component renders a form control with Bootstrap styling. The <code>{'<FormGroup>'}</code> component wraps a form control with proper spacing, along with support for a label, help text, and validation state. To ensure accessibility, set <code>controlId</code> on <code>{'<FormGroup>'}</code>, and use <code>{'<ControlLabel>'}</code> for the label. To retrieve the DOM node for a <code>{'<FormControl>'}</code>, set a <code>ref</code> and use <code>getDOMNode</code> or <code>findDOMNode</code> as needed.</p>
+      <p>
+        The <code>{'<FormControl>'}</code> component renders a form control with Bootstrap styling.
+        The <code>{'<FormGroup>'}</code> component wraps a form control with proper spacing, along with support for a label, help text, and validation state. To ensure accessibility, set <code>controlId</code> on <code>{'<FormGroup>'}</code>, and use <code>{'<ControlLabel>'}</code> for the label.
+      </p>
+      <p>
+        If you need the value of a <code>{'<FormControl>'}</code>, attach a <code>ref</code> to it.
+        Then call <code>getDOMNode</code> or <code>findDOMNode</code> to retrieve the <code>{'<FormControl>'}</code>'s node.
+      </p>
+
       <ReactPlayground codeText={Samples.FormBasic} />
 
       <h3><Anchor id="forms-props">Props</Anchor></h3>

--- a/src/FormControlFeedback.js
+++ b/src/FormControlFeedback.js
@@ -51,10 +51,11 @@ class FormControlFeedback extends React.Component {
     }
 
     const child = React.Children.only(children);
-    return React.cloneElement(child, {
-      ...props,
-      className: classNames(child.props.className, className, classes),
-    });
+    return (
+      <span {...props} className={classNames(className, classes)}>
+        {child}
+      </span>
+    );
   }
 }
 

--- a/test/FormControlFeedbackSpec.js
+++ b/test/FormControlFeedbackSpec.js
@@ -58,6 +58,6 @@ describe('<FormControl.Feedback>', () => {
       </FormControl.Feedback>
     )
       .render()
-      .single($.s`${MyComponent}.foo.form-control-feedback`);
+      .single($.s`span.form-control-feedback>${MyComponent}.foo`);
   });
 });

--- a/test/TabsSpec.js
+++ b/test/TabsSpec.js
@@ -532,7 +532,7 @@ describe('Tabs', () => {
     );
     assert.equal(ReactDOM.findDOMNode(instance).getAttribute('class'), 'my-tabs-class');
     assert.equal(ReactDOM.findDOMNode(instance).getAttribute('id'), 'my-tabs-id');
-    assert.equal(ReactDOM.findDOMNode(instance).style.opacity, 0.5);
-
+    // Decimal point string depends on locale
+    assert.equal(parseFloat(ReactDOM.findDOMNode(instance).style.opacity), 0.5);
   });
 });

--- a/test/TooltipSpec.js
+++ b/test/TooltipSpec.js
@@ -26,8 +26,10 @@ describe('Tooltip', () => {
         </Tooltip>
       );
       const tooltip = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'tooltip');
-      expect(_.pick(tooltip.style, ['opacity', 'top', 'left']))
-        .to.eql({opacity: '0.9', top: '10px', left: '20px'});
+      expect(_.pick(tooltip.style, ['top', 'left']))
+        .to.eql({top: '10px', left: '20px'});
+      // Decimal point string depends on locale
+      expect(parseFloat(tooltip.style.opacity)).to.eql(0.9);
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,7 @@
 import 'es5-shim';
 
 import { _resetWarned } from '../src/utils/deprecationWarning';
+import deprecated from 'react-prop-types/lib/deprecated';
 
 beforeEach(() => {
   sinon.stub(console, 'error', msg => {
@@ -27,6 +28,7 @@ afterEach(() => {
 
   console.error.restore();
   _resetWarned();
+  deprecated._resetWarned && deprecated._resetWarned();
 });
 
 describe('Process environment for tests', () => {


### PR DESCRIPTION
```
<FormControl.Feedback>
   <MyComponent className="oink" />
</FormControl.Feedback>
```

Will produce: `<MyComponent className="form-control-feedback oink" />`

While this is what would be produced if following the exact example from the bootstrap docs... it would be more structurally logical to render it like:

```
<span className="form-control-feedback">
  <MyComponent className="oink" />
</span>

```

Right now, trying to render a `<FormControl.Feedback />` element will work perfectly if only using bootstrap glyphicons. If you use something else like FontAwesome, it will render out like 

```
<span name="check" class="fa fa-check form-control-feedback"></span>
```

which makes everything all funky. 

### Before

| Glyphicon | Other Font Icon |
|------------------|-----------------|-----------------|
| ![Glyphicon](http://i.imgur.com/DYgQthS.png)| ![Glyphicon](http://i.imgur.com/UZXHCOZ.png) |

I imagine different types of font/vector icons would have similar problems as well.