### PR TITLE
Add 'contextMenu' trigger to OverlayTrigger

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -33,8 +33,8 @@ const OverlayTrigger = React.createClass({
      * Specify which action or actions trigger Overlay visibility
      */
     trigger: React.PropTypes.oneOfType([
-      React.PropTypes.oneOf(['click', 'hover', 'focus']),
-      React.PropTypes.arrayOf(React.PropTypes.oneOf(['click', 'hover', 'focus']))
+      React.PropTypes.oneOf(['click', 'contextmenu', 'hover', 'focus']),
+      React.PropTypes.arrayOf(React.PropTypes.oneOf(['contextmenu', 'click', 'hover', 'focus']))
     ]),
 
     /**
@@ -69,6 +69,10 @@ const OverlayTrigger = React.createClass({
      * @private
      */
     onClick: React.PropTypes.func,
+    /**
+     * @private
+     */
+    onContextMenu: React.PropTypes.func,
     /**
      * @private
      */
@@ -201,9 +205,14 @@ const OverlayTrigger = React.createClass({
     this._overlay = this.getOverlay();
 
     props.onClick = createChainedFunction(triggerProps.onClick, this.props.onClick);
+    props.onContextMenu = createChainedFunction(triggerProps.onContextMenu, this.props.onContextMenu);
 
     if (isOneOf('click', this.props.trigger)) {
       props.onClick = createChainedFunction(this.toggle, props.onClick);
+    }
+
+    if (isOneOf('contextmenu', this.props.trigger)) {
+      props.onContextMenu = createChainedFunction(this.toggle, props.onContextMenu);
     }
 
     if (isOneOf('hover', this.props.trigger)) {
@@ -292,3 +301,4 @@ const OverlayTrigger = React.createClass({
 });
 
 export default OverlayTrigger;
+

--- a/test/OverlayTriggerSpec.js
+++ b/test/OverlayTriggerSpec.js
@@ -31,6 +31,19 @@ describe('OverlayTrigger', () => {
     callback.called.should.be.true;
   });
 
+  it('Should pass OverlayTrigger onContextMenu prop to child', () => {
+    const callback = sinon.spy();
+    const instance = ReactTestUtils.renderIntoDocument(
+      <OverlayTrigger trigger='contextmenu' overlay={<div>test</div>} onContextMenu={callback}>
+        <button>button</button>
+      </OverlayTrigger>
+    );
+    const overlayTrigger = ReactDOM.findDOMNode(instance);
+    ReactTestUtils.Simulate.contextMenu(overlayTrigger);
+
+    callback.called.should.be.true;
+  });
+
   it('Should show after click trigger', () => {
     const instance = ReactTestUtils.renderIntoDocument(
       <OverlayTrigger trigger='click' overlay={<div>test</div>}>
@@ -39,6 +52,18 @@ describe('OverlayTrigger', () => {
     );
     const overlayTrigger = ReactDOM.findDOMNode(instance);
     ReactTestUtils.Simulate.click(overlayTrigger);
+
+    instance.state.isOverlayShown.should.be.true;
+  });
+
+  it('Should show after onContextMenu trigger', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <OverlayTrigger trigger='contextmenu' overlay={<div>test</div>}>
+        <button>button</button>
+      </OverlayTrigger>
+    );
+    const overlayTrigger = ReactDOM.findDOMNode(instance);
+    ReactTestUtils.Simulate.contextMenu(overlayTrigger);
 
     instance.state.isOverlayShown.should.be.true;
   });


### PR DESCRIPTION
This PR aims to allow an OverlayTrigger to accepts a 'contextmenu' trigger event and accompanying event handler. This would allow a menu/overlay to be triggered by a right-click if so desired.

I've added a couple tests so far, but haven't added any examples or anything like that in order to get feedback from the team first. 

Thanks so much for all the great work on the project! Looking forward to your thoughts.

