### PR TITLE
Update React peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "author": "Stephen J. Collings <stevoland@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=0.14.0",
-    "react-dom": ">=0.14.0"
+    "react": "^0.14.0 || ^15.0.0-0",
+    "react-dom": "^0.14.0 || ^15.0.0-0"
   },
   "devDependencies": {
     "babel": "^5.8.38",


### PR DESCRIPTION
Looking at devDepencies there doesn't seem to be a reason that >= 0.15.0 isn't accepted. (Couldn't upgrade to React 0.15 with npm2)