### PR TITLE
Ability to add a glyphicon to a NavDropdown

### DIFF
--- a/docs/examples/NavDropdown.js
+++ b/docs/examples/NavDropdown.js
@@ -10,7 +10,7 @@ const NavDropdownExample = React.createClass({
         <NavItem eventKey={1} href="/home">NavItem 1 content</NavItem>
         <NavItem eventKey={2} title="Item">NavItem 2 content</NavItem>
         <NavItem eventKey={3} disabled>NavItem 3 content</NavItem>
-        <NavDropdown eventKey={4} title="Dropdown" id="nav-dropdown">
+        <NavDropdown eventKey={4} title="Dropdown" id="nav-dropdown" glyph="comment">
           <MenuItem eventKey="4.1">Action</MenuItem>
           <MenuItem eventKey="4.2">Another action</MenuItem>
           <MenuItem eventKey="4.3">Something else here</MenuItem>

--- a/src/NavDropdown.js
+++ b/src/NavDropdown.js
@@ -1,10 +1,15 @@
 import React from 'react';
 import Dropdown from './Dropdown';
+import Glyphicon from './Glyphicon';
 
 class NavDropdown extends React.Component {
 
   render() {
-    let { children, title, noCaret, ...props } = this.props;
+    let { children, title, noCaret, glyph, ...props } = this.props;
+
+    if (glyph !== null) {
+      title = ' ' + title;
+    }
 
     return (
       <Dropdown {...props} componentClass="li">
@@ -13,6 +18,8 @@ class NavDropdown extends React.Component {
           disabled={props.disabled}
           noCaret={noCaret}
         >
+          {glyph &&
+            <Glyphicon glyph={glyph} />}
           {title}
         </Dropdown.Toggle>
         <Dropdown.Menu>
@@ -26,6 +33,7 @@ class NavDropdown extends React.Component {
 NavDropdown.propTypes = {
   noCaret: React.PropTypes.bool,
   title: React.PropTypes.node.isRequired,
+  glyph: React.PropTypes.string,
   ...Dropdown.propTypes
 };
 

--- a/test/NavDropdownSpec.js
+++ b/test/NavDropdownSpec.js
@@ -9,7 +9,7 @@ describe('NavDropdown', () => {
 
   it('Should render li when in nav', () => {
     const instance = ReactTestUtils.renderIntoDocument(
-      <NavDropdown title="Title" className="test-class" id='nav-test'>
+      <NavDropdown title="Title" className="test-class" id='nav-test' glyph="comment">
         <MenuItem eventKey="1">MenuItem 1 content</MenuItem>
         <MenuItem eventKey="2">MenuItem 2 content</MenuItem>
       </NavDropdown>
@@ -17,12 +17,14 @@ describe('NavDropdown', () => {
 
     let li = ReactDOM.findDOMNode(instance);
     let button = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'dropdown-toggle');
+    let glyphicon = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'glyphicon');
 
     assert.equal(li.nodeName, 'LI');
     assert.ok(li.className.match(/\bdropdown\b/));
     assert.ok(li.className.match(/\btest-class\b/));
     assert.equal(button.nodeName, 'A');
     assert.equal(button.innerText.trim(), 'Title');
+    assert.ok(glyphicon.className.match(/\bglyphicon glyphicon-comment\b/));
   });
 
   it('is open with explicit prop', () => {


### PR DESCRIPTION
I needed the ability to add a glyphicon to the NavDropdown title.  This adds that ability.

![image](https://cloud.githubusercontent.com/assets/46067/16427524/879dafc0-3d22-11e6-8e62-7183e79fa0b0.png)