### PR TITLE
Stop passing non-dom attributes in Breadcrumb

### DIFF
--- a/src/Breadcrumb.js
+++ b/src/Breadcrumb.js
@@ -19,7 +19,7 @@ const Breadcrumb = React.createClass({
   },
 
   render() {
-    const { className, ...props } = this.props;
+    const { className, bsClass, ...props } = this.props;
 
     return (
       <ol


### PR DESCRIPTION
See https://github.com/react-bootstrap/react-bootstrap/issues/1994