### PR TITLE
Stop passing non-dom attributes in Glyphicon

### DIFF
--- a/src/Glyphicon.js
+++ b/src/Glyphicon.js
@@ -36,8 +36,10 @@ const Glyphicon = React.createClass({
       ['form-control-feedback']: this.props.formControlFeedback
     });
 
+	const { bsClass, glyph, formControlFeedback, ...rest } = this.props;
+
     return (
-      <span {...this.props} className={className}>
+      <span {...rest} className={className}>
         {this.props.children}
       </span>
     );


### PR DESCRIPTION
See https://github.com/react-bootstrap/react-bootstrap/issues/1994