### PR TITLE
Add 'active' prop to NavDropdown component

### DIFF
--- a/src/NavDropdown.js
+++ b/src/NavDropdown.js
@@ -1,13 +1,15 @@
 import React from 'react';
+import classNames from 'classnames';
 import Dropdown from './Dropdown';
 
 class NavDropdown extends React.Component {
 
   render() {
-    let { children, title, noCaret, ...props } = this.props;
+    let { children, title, noCaret, active, className, ...props } = this.props;
+    const classes = classNames(className, { active });
 
     return (
-      <Dropdown {...props} componentClass="li">
+      <Dropdown className={classes} {...props} componentClass="li">
         <Dropdown.Toggle
           useAnchor
           disabled={props.disabled}
@@ -26,6 +28,7 @@ class NavDropdown extends React.Component {
 NavDropdown.propTypes = {
   noCaret: React.PropTypes.bool,
   title: React.PropTypes.node.isRequired,
+  active: React.PropTypes.bool,
   ...Dropdown.propTypes
 };
 

--- a/test/NavDropdownSpec.js
+++ b/test/NavDropdownSpec.js
@@ -21,8 +21,24 @@ describe('NavDropdown', () => {
     assert.equal(li.nodeName, 'LI');
     assert.ok(li.className.match(/\bdropdown\b/));
     assert.ok(li.className.match(/\btest-class\b/));
+    assert.ok(li.className.should.not.match(/\bactive\b/));
     assert.equal(button.nodeName, 'A');
     assert.equal(button.innerText.trim(), 'Title');
+  });
+
+  it('renders div with active class', () => {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <NavDropdown active title="Title" className="test-class" id='nav-test'>
+        <MenuItem eventKey="1">MenuItem 1 content</MenuItem>
+        <MenuItem eventKey="2">MenuItem 2 content</MenuItem>
+      </NavDropdown>
+    );
+
+    let li = ReactDOM.findDOMNode(instance);
+
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'active'));
+    assert.ok(li.className.match(/\btest-class\b/)); // it still has the given className
+    assert.ok(li.className.match(/\bactive\b/)); // plus the active class
   });
 
   it('is open with explicit prop', () => {


### PR DESCRIPTION
This commit adds the 'active' prop to the NavDropdown component, which
when true adds the 'active' class to the component.

Note that this does not automatically fix https://github.com/react-bootstrap/react-router-bootstrap/issues/167, because the `LinkContainer` does not wrap the entire NavDropdown, but only the individual items. 
Personally I fixed this by using a wrapper component wrapping the NavDropdown which checks in the render() if the path of any of its children currently is active (the same check the LinkContainer performs) like so:

```js
  isAnyChildActive() {
    let anyChildActive = false;
    React.Children.forEach(this.props.menuItems, (child) => {
      if (!anyChildActive)
        anyChildActive = this.context.router.isActive(child.props.path, false);
    });
    return anyChildActive;
  }
```
(in the above code `this.props.menuItems` is a list of MenuItem wrappers which have the `path` prop which is passed to the LinkContainer as the `to` prop)