### PR TITLE
Fix Bower template

### DIFF
--- a/tools/amd/bower.json
+++ b/tools/amd/bower.json
@@ -8,7 +8,7 @@
     "react-bootstrap.js"
   ],
   "keywords": [
-    <%= _.map(pkg.keywords, function(keyword) { return '"' + keyword + '"' }).join(',\n    ')%>
+    <%= pkg.keywords.map(keyword => `"${keyword}"`).join(',\n    ') %>
   ],
   "ignore": [
     "**/.*"


### PR DESCRIPTION
I have no idea why it stopped working. It's not like `_.map` stopped existing. I guess maybe because I stopped importing Lodash as `_`? Anyway, it wasn't necessary here anyway, and now it's gone.

Going to merge this as a trivial chore update.