### PR TITLE
Changed default href in SafeAnchor to '#' to make IE happy

### DIFF
--- a/src/SafeAnchor.js
+++ b/src/SafeAnchor.js
@@ -61,7 +61,7 @@ class SafeAnchor extends React.Component {
       props.role = props.role || 'button';
       // we want to make sure there is a href attribute on the node
       // otherwise, the cursor incorrectly styled (except with role='button')
-      props.href = props.href || '';
+      props.href = props.href || '#';
     }
 
     if (disabled) {

--- a/test/PaginationSpec.js
+++ b/test/PaginationSpec.js
@@ -181,8 +181,8 @@ describe('<Pagination>', () => {
     assert.equal(pageButtons[0].children[0].tagName, 'A');
     assert.equal(pageButtons[1].children[0].tagName, 'A');
 
-    assert.equal(pageButtons[0].children[0].getAttribute('href'), '');
-    assert.equal(pageButtons[1].children[0].getAttribute('href'), '');
+    assert.equal(pageButtons[0].children[0].getAttribute('href'), '#');
+    assert.equal(pageButtons[1].children[0].getAttribute('href'), '#');
   });
 
   it('should wrap each button in a buttonComponentClass when it is present', () => {


### PR DESCRIPTION
This PR makes the default href of an anchor `#` instead of an empty string to make IE happy.

Discussion: https://github.com/react-bootstrap/react-bootstrap/issues/2065