### PR TITLE
validationState prop should allow `false` on Form Components

### DIFF
--- a/docs/examples/FormBasic.js
+++ b/docs/examples/FormBasic.js
@@ -10,6 +10,7 @@ const FormExample = React.createClass({
     if (length > 10) return 'success';
     else if (length > 5) return 'warning';
     else if (length > 0) return 'error';
+    return false;
   },
 
   handleChange(e) {

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -11,7 +11,7 @@ const propTypes = {
   /**
    * Only valid if `inline` is not set.
    */
-  validationState: React.PropTypes.oneOf(['success', 'warning', 'error']),
+  validationState: React.PropTypes.oneOf(['success', 'warning', 'error', false]),
   /**
    * Attaches a ref to the `<input>` element. Only functions can be used here.
    *

--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -11,7 +11,7 @@ const propTypes = {
    * Sets `id` on `<FormControl>` and `htmlFor` on `<FormGroup.Label>`.
    */
   controlId: React.PropTypes.string,
-  validationState: React.PropTypes.oneOf(['success', 'warning', 'error']),
+  validationState: React.PropTypes.oneOf(['success', 'warning', 'error', false]),
 };
 
 const childContextTypes = {

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -11,7 +11,7 @@ const propTypes = {
   /**
    * Only valid if `inline` is not set.
    */
-  validationState: React.PropTypes.oneOf(['success', 'warning', 'error']),
+  validationState: React.PropTypes.oneOf(['success', 'warning', 'error', false]),
   /**
    * Attaches a ref to the `<input>` element. Only functions can be used here.
    *

--- a/test/FormGroupSpec.js
+++ b/test/FormGroupSpec.js
@@ -87,6 +87,31 @@ describe('<FormGroup>', () => {
     });
   });
 
+  [
+    {
+      props: { validationState: false },
+      className: 'has-success',
+    },
+    {
+      props: { validationState: false },
+      className: 'has-warning',
+    },
+    {
+      props: { validationState: false },
+      className: 'has-error',
+    },
+  ].forEach(({ props, className }) => {
+    it(`does not render ${className} class`, () => {
+      $(
+        <FormGroup {...props}>
+          <span />
+        </FormGroup>
+      )
+        .shallowRender()
+        .none(`.${className}`);
+    });
+  });
+
   describe('feedback', () => {
     it('should not have feedback without feedback component', () => {
       $(


### PR DESCRIPTION
When using validation states in Form Components, `validationState` propType only accepts `'success'` `'warning'` and `'error'`. This is inconvenient if we want the default un-styled form controls.

To avoid the following code producing warnings to our console, I want the Components to accept `false` as the propType for `validationState`.

```es6
getValidationState() {
  const length = this.state.value.length;
  if (length > 10) return false; // using 'success' is too annoying!
  else if (length > 0) return 'error';
  return false;
}

render() {
  <FormGroup validationState={this.getValidationState()}>
    <span>something</span>
  </FormGroup>
}
```