### PR TITLE
OverlayTrigger: Remove extra comma in createChainedFunction call

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -298,7 +298,7 @@ class OverlayTrigger extends React.Component {
         childProps.onFocus, onFocus, this.handleDelayedShow
       );
       triggerProps.onBlur = createChainedFunction(
-        childProps.onBlur, onBlur, this.handleDelayedHide,
+        childProps.onBlur, onBlur, this.handleDelayedHide
       );
     }
 


### PR DESCRIPTION
Noticed this error while inspecting the code (: