### PR TITLE
Update NavbarSection.js

### DIFF
--- a/docs/src/sections/NavbarSection.js
+++ b/docs/src/sections/NavbarSection.js
@@ -33,7 +33,7 @@ export default function NavbarSection() {
         <h4>Additional Import Options</h4>
         <p>
           The Navbar Header, Toggle, Brand, and Collapse components are available as static properties
-          the <code>{"<Navbar/>"}</code> component but you can also import them directly from
+          like the <code>{"<Navbar/>"}</code> component but you can also import them directly from
           the <code>/lib</code> directory
           like: <code>{'require("react-bootstrap/lib/NavbarHeader")'}</code>.
         </p>


### PR DESCRIPTION
Fixed typo in the Navbar docs section.

Took me a while to understand this one, realised it was missing the word `like` 😄 