### PR TITLE
Fix Pagination ellipsis placement bug

### DIFF
--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -87,7 +87,7 @@ class Pagination extends React.Component {
 
     if (maxButtons) {
       let hiddenPagesBefore = activePage - parseInt(maxButtons / 2, 10);
-      startPage = hiddenPagesBefore > 1 ? hiddenPagesBefore : 1;
+      startPage = hiddenPagesBefore > 2 ? hiddenPagesBefore : 1;
       hasHiddenPagesAfter = startPage + maxButtons <= items;
 
       if (!hasHiddenPagesAfter) {

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -88,7 +88,7 @@ class Pagination extends React.Component {
     if (maxButtons) {
       let hiddenPagesBefore = activePage - parseInt(maxButtons / 2, 10);
       startPage = hiddenPagesBefore > 2 ? hiddenPagesBefore : 1;
-      hasHiddenPagesAfter = startPage + maxButtons <= items;
+      hasHiddenPagesAfter = startPage + maxButtons < items;
 
       if (!hasHiddenPagesAfter) {
         endPage = items;


### PR DESCRIPTION
Fixes https://github.com/react-bootstrap/react-bootstrap/issues/2159.
There's an off-by-1 bug in both `startPage` & `hasHiddenPagesAfter` calculations which cause the Pagination component to incorrectly place ellipses & group numbers excluding the first & last numbers.

This error occurs such that the first two numbers [1] ... [2] or the last two [19] ... [20] display with an ellipsis between them, when they should be connected ([1][2] & [19][20]).

It's caused by the `startPage` calculation mistakenly excluding the page `1` away from the active buttongroup when it should be included.
The same goes for `hasHiddenPagesAfter` mistakenly becoming `true` and excluding the last page button away from the button group, causing an ellipsis between the last page button & the group.

**Broken first ellipsis**
![screen shot 2016-09-01 at 9 33 04 pm](https://cloud.githubusercontent.com/assets/7256178/18192749/cac63ca8-708b-11e6-9942-2acde279434a.png)
**Broken second ellipsis**
![screen shot 2016-09-01 at 9 33 16 pm](https://cloud.githubusercontent.com/assets/7256178/18192750/cca3027c-708b-11e6-9ca6-783ce1ea0466.png)

This fix allows Pagination to display properly, with the first & last PaginationButtons included with the current active button group:

**Fixed First Group**
![screen shot 2016-09-01 at 9 16 58 pm](https://cloud.githubusercontent.com/assets/7256178/18192800/25060ea0-708c-11e6-92cc-43ad548357e8.png)
**Fixed Last Group**
![screen shot 2016-09-01 at 9 18 55 pm](https://cloud.githubusercontent.com/assets/7256178/18192805/278e667c-708c-11e6-8111-4360d73a7d0e.png)

For reference, the component used in the examples above:
```es6
          <Pagination
                  prev
                  next
                  first
                  last
                  ellipsis
                  boundaryLinks
                  items={20}
                  maxButtons={5}
                  activePage={this.state.activePage}
                  onSelect={this.handleSelect} 
          />
```
