### PR TITLE
Fix dependency security issue / Upgrade 'marked' -> v0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "less": "^2.7.1",
     "less-loader": "^2.2.3",
     "lodash": "^4.13.1",
-    "marked": "^0.3.5",
+    "marked": "^0.3.6",
     "mocha": "^2.5.3",
     "node-libs-browser": "^1.0.0",
     "nodemon": "^1.9.2",


### PR DESCRIPTION
Noticed that VersionEye was reporting a security issue with marked v0.3.5 when I opened a PR for another bug.

[VersionEye report](https://www.versioneye.com/pullrequests/57c9053112b5260012202580)

Seems like there was a significant security bug in that version, so it's worth upgrading to 0.3.6 for the fix.