### PR TITLE
Expose event prop from RootCloseWrapper in Dropdown

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -94,6 +94,11 @@ const propTypes = {
    * a menu button.
    */
   role: React.PropTypes.string,
+
+  /**
+   * Which event when fired outside the component will cause it to be closed
+   */
+  rootCloseEvent: React.PropTypes.oneOf(['click', 'mousedown']),
 };
 
 const defaultProps = {
@@ -241,7 +246,7 @@ class Dropdown extends React.Component {
     });
   }
 
-  renderMenu(child, { id, onClose, onSelect, ...props }) {
+  renderMenu(child, { id, onClose, onSelect, rootCloseEvent, ...props }) {
     let ref = c => { this.menu = c; };
 
     if (typeof child.ref === 'string') {
@@ -265,6 +270,7 @@ class Dropdown extends React.Component {
       onSelect: createChainedFunction(
         child.props.onSelect, onSelect, this.handleClose,
       ),
+      rootCloseEvent
     });
   }
 
@@ -281,6 +287,7 @@ class Dropdown extends React.Component {
       role,
       bsClass,
       className,
+      rootCloseEvent,
       children,
       ...props
     } = this.props;
@@ -314,7 +321,7 @@ class Dropdown extends React.Component {
               });
             case MENU_ROLE:
               return this.renderMenu(child, {
-                id, open, pullRight, bsClass, onClose, onSelect,
+                id, open, pullRight, bsClass, onClose, onSelect, rootCloseEvent,
               });
             default:
               return child;

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -17,6 +17,7 @@ const propTypes = {
     React.PropTypes.string, React.PropTypes.number,
   ]),
   onSelect: React.PropTypes.func,
+  rootCloseEvent: React.PropTypes.oneOf(['click', 'mousedown']),
 };
 
 const defaultProps = {
@@ -93,6 +94,7 @@ class DropdownMenu extends React.Component {
       labelledBy,
       onSelect,
       className,
+      rootCloseEvent,
       children,
       ...props
     } = this.props;
@@ -108,6 +110,7 @@ class DropdownMenu extends React.Component {
       <RootCloseWrapper
         disabled={!open}
         onRootClose={onClose}
+        event={rootCloseEvent}
       >
         <ul
           {...elementProps}

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -170,6 +170,52 @@ describe('<Dropdown>', () => {
     buttonNode.getAttribute('aria-expanded').should.equal('false');
   });
 
+  it('closes when clicked outside', () => {
+    const instance = ReactTestUtils.renderIntoDocument(simpleDropdown);
+    const node = ReactDOM.findDOMNode(instance);
+    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'BUTTON');
+
+    node.className.should.not.match(/\bopen\b/);
+    buttonNode.getAttribute('aria-expanded').should.equal('false');
+
+    ReactTestUtils.Simulate.click(buttonNode);
+
+    node.className.should.match(/\bopen\b/);
+    buttonNode.getAttribute('aria-expanded').should.equal('true');
+
+    // Use native events as the click doesn't have to be in the React portion
+    const event = new MouseEvent('click');
+    document.dispatchEvent(event);
+
+    node.className.should.not.match(/\bopen\b/);
+    buttonNode.getAttribute('aria-expanded').should.equal('false');
+  });
+
+  it('closes when mousedown outside if rootCloseEvent set', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Dropdown id="test-id" rootCloseEvent="mousedown">
+        {dropdownChildren}
+      </Dropdown>
+    );
+    const node = ReactDOM.findDOMNode(instance);
+    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'BUTTON');
+
+    node.className.should.not.match(/\bopen\b/);
+    buttonNode.getAttribute('aria-expanded').should.equal('false');
+
+    ReactTestUtils.Simulate.click(buttonNode);
+
+    node.className.should.match(/\bopen\b/);
+    buttonNode.getAttribute('aria-expanded').should.equal('true');
+
+    // Use native events as the click doesn't have to be in the React portion
+    const event = new MouseEvent('mousedown');
+    document.dispatchEvent(event);
+
+    node.className.should.not.match(/\bopen\b/);
+    buttonNode.getAttribute('aria-expanded').should.equal('false');
+  });
+
   it('opens if dropdown contains no focusable menu item', () => {
     const instance = ReactTestUtils.renderIntoDocument(
       <Dropdown title="custom child" id="dropdown">


### PR DESCRIPTION
This makes the prop added in https://github.com/react-bootstrap/react-overlays/pull/95 available to the dropdown component.

Please let me know if I've overlooked anything in the PR :)