### PR TITLE
Allow setting carousel interval option to false

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -16,7 +16,7 @@ import ValidComponentChildren from './utils/ValidComponentChildren';
 const propTypes = {
   slide: React.PropTypes.bool,
   indicators: React.PropTypes.bool,
-  interval: React.PropTypes.number,
+  interval: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.bool]),
   controls: React.PropTypes.bool,
   pauseOnHover: React.PropTypes.bool,
   wrap: React.PropTypes.bool,

--- a/test/CarouselSpec.js
+++ b/test/CarouselSpec.js
@@ -212,4 +212,14 @@ describe('<Carousel>', () => {
     assert.equal(prevButtons.length, 1);
     assert.equal(nextButtons.length, 1);
   });
+
+  it('Should allow interval to be set to false', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Carousel activeIndex={1} controls interval={false}>
+        {items}
+      </Carousel>
+    );
+
+    assert.equal(instance.props.interval, false);
+  });
 });


### PR DESCRIPTION
According to the [docs](http://getbootstrap.com/javascript/#carousel-options), the `interval` option for Carousel can be a number or `false`. If false, "...carousel will not automatically cycle".

However, interval is currently set to `React.PropTypes.number`, preventing the user from setting interval to false.

This PR sets interval to `React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.bool])`, and adds a test confirming that interval can be set to false.