### PR TITLE
#1841 trigger browser reflow before starting the collapse animation

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -144,12 +144,11 @@ class Collapse extends React.Component {
   handleExit(elem) {
     const dimension = this._dimension();
     elem.style[dimension] = this.props.getDimensionValue(dimension, elem) + 'px';
+    triggerBrowserReflow(elem);
   }
 
   handleExiting(elem) {
     const dimension = this._dimension();
-
-    triggerBrowserReflow(elem);
     elem.style[dimension] = '0';
   }
 


### PR DESCRIPTION
Fixes #1841
Trigger browser reflow before the start of the collapse animation ( in onExit callback instead of onExiting)