### PR TITLE
Fix missing glob dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "file-loader": "^0.9.0",
     "fs-extra": "^0.30.0",
     "fs-promise": "^0.5.0",
+    "glob": "^7.1.0",
     "http-proxy": "^1.14.0",
     "ip": "^1.1.3",
     "json-loader": "^0.5.4",


### PR DESCRIPTION
- glob is used in https://github.com/react-bootstrap/react-bootstrap/blob/2541d75cb30bbe21b283f8c3dd3fd7da4f51a88a/docs/generate-metadata.js
- fixes #2227