### PR TITLE
Fix "Unknown props" warnings with Navbar Form, Text & Link

### DIFF
--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -168,7 +168,7 @@ const UncontrollableNavbar = uncontrollable(Navbar, { expanded: 'onToggle' });
 
 function createSimpleWrapper(tag, suffix, displayName) {
   const Wrapper = (
-    { componentClass: Component, className, pullRight, pullLeft, ...props },
+    { active, activeKey, activeHref, componentClass: Component, className, pullRight, pullLeft, ...props },
     { $bs_navbar: navbarProps = { bsClass: 'navbar' } }
   ) => (
     <Component


### PR DESCRIPTION
I see `Unknown props 'active', 'activeKey', 'activeHref' on <div> tag.` warnings when using Navbar.Form

I'm not certain this is the best way of fixing this, or whether this will have any fallout, I'd appreciate any advise here.