### PR TITLE
Fixes #2256 by adding SR controls by default

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -36,14 +36,8 @@ const propTypes = {
   activeIndex: React.PropTypes.number,
   defaultActiveIndex: React.PropTypes.number,
   direction: React.PropTypes.oneOf(['prev', 'next']),
-  prevIcon: React.PropTypes.oneOfType([
-    React.PropTypes.node,
-    React.PropTypes.arrayOf(React.PropTypes.node),
-  ]),
-  nextIcon: React.PropTypes.oneOfType([
-    React.PropTypes.node,
-    React.PropTypes.arrayOf(React.PropTypes.node),
-  ]),
+  prevIcon: React.PropTypes.node,
+  nextIcon: React.PropTypes.node,
 };
 
 const defaultProps = {

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -36,8 +36,14 @@ const propTypes = {
   activeIndex: React.PropTypes.number,
   defaultActiveIndex: React.PropTypes.number,
   direction: React.PropTypes.oneOf(['prev', 'next']),
-  prevIcon: React.PropTypes.node,
-  nextIcon: React.PropTypes.node,
+  prevIcon: React.PropTypes.oneOfType([
+    React.PropTypes.node,
+    React.PropTypes.arrayOf(React.PropTypes.node),
+  ]),
+  nextIcon: React.PropTypes.oneOfType([
+    React.PropTypes.node,
+    React.PropTypes.arrayOf(React.PropTypes.node),
+  ]),
 };
 
 const defaultProps = {
@@ -47,8 +53,14 @@ const defaultProps = {
   wrap: true,
   indicators: true,
   controls: true,
-  prevIcon: <Glyphicon glyph="chevron-left" />,
-  nextIcon: <Glyphicon glyph="chevron-right" />,
+  prevIcon: [
+    <Glyphicon glyph="chevron-left" key="icon" />,
+    <span className="sr-only" key="sr">Previous</span>,
+  ],
+  nextIcon: [
+    <Glyphicon glyph="chevron-right" key="icon" />,
+    <span className="sr-only" key="sr">Next</span>,
+  ],
 };
 
 class Carousel extends React.Component {

--- a/test/CarouselSpec.js
+++ b/test/CarouselSpec.js
@@ -212,4 +212,34 @@ describe('<Carousel>', () => {
     assert.equal(prevButtons.length, 1);
     assert.equal(nextButtons.length, 1);
   });
+
+  it('Should allow user to specify an array of elements as icons', () => {
+    const prevIcon = [
+      <span className="previous" key="first"></span>,
+      <span className="previous" key="second"></span>,
+    ];
+
+    const nextIcon = [
+      <span className="next" key="first"></span>,
+      <span className="next" key="second"></span>,
+    ];
+
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Carousel
+        activeIndex={1} controls wrap={false}
+        prevIcon={prevIcon}
+        nextIcon={nextIcon}
+      >
+        <Carousel.Item>Item 1 content</Carousel.Item>
+        <Carousel.Item>Item 2 content</Carousel.Item>
+        <Carousel.Item>Item 3 content</Carousel.Item>
+      </Carousel>
+    );
+
+    const prevButtons = ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'previous');
+    const nextButtons = ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'next');
+
+    assert.equal(prevButtons.length, 2);
+    assert.equal(nextButtons.length, 2);
+  });
 });

--- a/test/CarouselSpec.js
+++ b/test/CarouselSpec.js
@@ -212,34 +212,4 @@ describe('<Carousel>', () => {
     assert.equal(prevButtons.length, 1);
     assert.equal(nextButtons.length, 1);
   });
-
-  it('Should allow user to specify an array of elements as icons', () => {
-    const prevIcon = [
-      <span className="previous" key="first"></span>,
-      <span className="previous" key="second"></span>,
-    ];
-
-    const nextIcon = [
-      <span className="next" key="first"></span>,
-      <span className="next" key="second"></span>,
-    ];
-
-    const instance = ReactTestUtils.renderIntoDocument(
-      <Carousel
-        activeIndex={1} controls wrap={false}
-        prevIcon={prevIcon}
-        nextIcon={nextIcon}
-      >
-        <Carousel.Item>Item 1 content</Carousel.Item>
-        <Carousel.Item>Item 2 content</Carousel.Item>
-        <Carousel.Item>Item 3 content</Carousel.Item>
-      </Carousel>
-    );
-
-    const prevButtons = ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'previous');
-    const nextButtons = ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'next');
-
-    assert.equal(prevButtons.length, 2);
-    assert.equal(nextButtons.length, 2);
-  });
 });


### PR DESCRIPTION
Adds SR controls by default, following the example on the bootstrap documentation:

https://getbootstrap.com/javascript/#carousel

I changed the API of the component, allowing to pass either a single node, or an array of nodes.

This way, it will not change the DOM tree in websites already using this component, but still allow to customize SR labels.