### PR TITLE
Fixes #2209 by adding collapsed to className

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -99,6 +99,7 @@ class Panel extends React.Component {
         role={role}
         href={id && `#${id}`}
         onClick={this.handleClickTitle}
+        className={ expanded ? '' : 'collapsed' }
         aria-controls={id}
         aria-expanded={expanded}
         aria-selected={expanded}

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -94,16 +94,21 @@ class Panel extends React.Component {
   }
 
   renderAnchor(header, id, role, expanded) {
+    const props = {
+      role,
+      href: id && `#${id}`,
+      onClick: this.handleClickTitle,
+      'aria-controls': id,
+      'aria-expanded': expanded,
+      'aria-selected': expanded,
+    };
+
+    if (!expanded) {
+      props.className = 'collapsed';
+    }
+
     return (
-      <a
-        role={role}
-        href={id && `#${id}`}
-        onClick={this.handleClickTitle}
-        className={ expanded ? '' : 'collapsed' }
-        aria-controls={id}
-        aria-expanded={expanded}
-        aria-selected={expanded}
-      >
+      <a {...props}>
         {header}
       </a>
     );

--- a/test/PanelSpec.js
+++ b/test/PanelSpec.js
@@ -284,6 +284,7 @@ describe('<Panel>', () => {
       );
       const anchor = ReactDOM.findDOMNode(instance).querySelector('.panel-title a');
       assert.equal(anchor.getAttribute('aria-expanded'), 'true');
+      assert.ok(!anchor.getAttribute('class').match(/\bcollapsed\b/));
     });
 
     it('Should be aria-expanded=false', () => {
@@ -294,6 +295,7 @@ describe('<Panel>', () => {
       );
       const anchor = ReactDOM.findDOMNode(instance).querySelector('.panel-title a');
       assert.equal(anchor.getAttribute('aria-expanded'), 'false');
+      assert.ok(anchor.getAttribute('class').match(/\bcollapsed\b/));
     });
 
     it('Should add aria-controls with id', () => {

--- a/test/PanelSpec.js
+++ b/test/PanelSpec.js
@@ -284,7 +284,7 @@ describe('<Panel>', () => {
       );
       const anchor = ReactDOM.findDOMNode(instance).querySelector('.panel-title a');
       assert.equal(anchor.getAttribute('aria-expanded'), 'true');
-      assert.ok(!anchor.getAttribute('class').match(/\bcollapsed\b/));
+      assert.equal(anchor.getAttribute('class'), null);
     });
 
     it('Should be aria-expanded=false', () => {


### PR DESCRIPTION
Adds `collapsed` in the className following the example in bootstrap docs.