### PR TITLE
Adds prevLabel and nextLabel on carousel for screen readers

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -37,7 +37,19 @@ const propTypes = {
   defaultActiveIndex: React.PropTypes.number,
   direction: React.PropTypes.oneOf(['prev', 'next']),
   prevIcon: React.PropTypes.node,
+  /**
+   * Label shown to screen readers only, can be used to show the previous element
+   * in the carousel.
+   * Set to null to deactivate.
+   */
+  prevLabel: React.PropTypes.string,
   nextIcon: React.PropTypes.node,
+  /**
+   * Label shown to screen readers only, can be used to show the next element
+   * in the carousel.
+   * Set to null to deactivate.
+   */
+  nextLabel: React.PropTypes.string,
 };
 
 const defaultProps = {
@@ -48,7 +60,9 @@ const defaultProps = {
   indicators: true,
   controls: true,
   prevIcon: <Glyphicon glyph="chevron-left" />,
+  prevLabel: "Previous",
   nextIcon: <Glyphicon glyph="chevron-right" />,
+  nextLabel: "Next",
 };
 
 class Carousel extends React.Component {
@@ -257,9 +271,14 @@ class Carousel extends React.Component {
     );
   }
 
-  renderControls(wrap, children, activeIndex, prevIcon, nextIcon, bsProps) {
+  renderControls(properties) {
+    const { wrap, children, activeIndex, prevIcon,
+            nextIcon, bsProps, prevLabel, nextLabel } = properties;
     const controlClassName = prefix(bsProps, 'control');
     const count = ValidComponentChildren.count(children);
+
+    const prevLabelNode = prevLabel && <span className="sr-only">{prevLabel}</span>;
+    const nextLabelNode = nextLabel && <span className="sr-only">{nextLabel}</span>;
 
     return [
       (wrap || activeIndex !== 0) && (
@@ -269,6 +288,7 @@ class Carousel extends React.Component {
           onClick={this.handlePrev}
         >
           {prevIcon}
+          {prevLabelNode}
         </SafeAnchor>
       ),
 
@@ -279,6 +299,7 @@ class Carousel extends React.Component {
           onClick={this.handleNext}
         >
           {nextIcon}
+          {nextLabelNode}
         </SafeAnchor>
       ),
     ];
@@ -291,7 +312,9 @@ class Carousel extends React.Component {
       controls,
       wrap,
       prevIcon,
+      prevLabel,
       nextIcon,
+      nextLabel,
       className,
       children,
       ...props
@@ -342,9 +365,16 @@ class Carousel extends React.Component {
           })}
         </div>
 
-        {controls && this.renderControls(
-          wrap, children, activeIndex, prevIcon, nextIcon, bsProps
-        )}
+        {controls && this.renderControls({
+          wrap,
+          children,
+          activeIndex,
+          prevIcon,
+          prevLabel,
+          nextIcon,
+          nextLabel,
+          bsProps,
+        })}
       </div>
     );
   }

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -60,9 +60,9 @@ const defaultProps = {
   indicators: true,
   controls: true,
   prevIcon: <Glyphicon glyph="chevron-left" />,
-  prevLabel: "Previous",
+  prevLabel: 'Previous',
   nextIcon: <Glyphicon glyph="chevron-right" />,
-  nextLabel: "Next",
+  nextLabel: 'Next',
 };
 
 class Carousel extends React.Component {

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -277,9 +277,6 @@ class Carousel extends React.Component {
     const controlClassName = prefix(bsProps, 'control');
     const count = ValidComponentChildren.count(children);
 
-    const prevLabelNode = prevLabel && <span className="sr-only">{prevLabel}</span>;
-    const nextLabelNode = nextLabel && <span className="sr-only">{nextLabel}</span>;
-
     return [
       (wrap || activeIndex !== 0) && (
         <SafeAnchor
@@ -288,7 +285,7 @@ class Carousel extends React.Component {
           onClick={this.handlePrev}
         >
           {prevIcon}
-          {prevLabelNode}
+          {prevLabel && <span className="sr-only">{prevLabel}</span>}
         </SafeAnchor>
       ),
 
@@ -299,7 +296,7 @@ class Carousel extends React.Component {
           onClick={this.handleNext}
         >
           {nextIcon}
-          {nextLabelNode}
+          {nextLabel && <span className="sr-only">{nextLabel}</span>}
         </SafeAnchor>
       ),
     ];

--- a/test/CarouselSpec.js
+++ b/test/CarouselSpec.js
@@ -212,4 +212,43 @@ describe('<Carousel>', () => {
     assert.equal(prevButtons.length, 1);
     assert.equal(nextButtons.length, 1);
   });
+
+  it('Should allow user to specify a previous and next SR label', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Carousel
+        activeIndex={1} controls wrap={false}
+        prevLabel="Previous awesomeness"
+        nextLabel="Next awesomeness"
+      >
+        <Carousel.Item>Item 1 content</Carousel.Item>
+        <Carousel.Item>Item 2 content</Carousel.Item>
+        <Carousel.Item>Item 3 content</Carousel.Item>
+      </Carousel>
+    );
+
+    const labels = ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'sr-only');
+
+    assert.equal(labels.length, 2);
+    assert.equal(labels[0].textContent, 'Previous awesomeness');
+    assert.equal(labels[1].textContent, 'Next awesomeness');
+  });
+
+  it('Should not render labels when values are falsy', () => {
+    [null, ''].forEach(falsyValue => {
+      const instance = ReactTestUtils.renderIntoDocument(
+        <Carousel
+          activeIndex={1} controls wrap={false}
+          prevLabel={falsyValue}
+          nextLabel={falsyValue}
+        >
+          <Carousel.Item>Item 1 content</Carousel.Item>
+          <Carousel.Item>Item 2 content</Carousel.Item>
+          <Carousel.Item>Item 3 content</Carousel.Item>
+        </Carousel>
+      );
+
+      const labels = ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'sr-only');
+      assert.equal(labels.length, 0, `should not render labels for value ${falsyValue}`);
+    });
+  });
 });


### PR DESCRIPTION
Replaces #2268

Creates 2 more properties on carousel: `prevLabel` and `nextLabel`, for screen readers.