### PR TITLE
Fixes #2209 by adding collapsed in anchor className

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -102,6 +102,7 @@ class Panel extends React.Component {
         aria-controls={id}
         aria-expanded={expanded}
         aria-selected={expanded}
+        className={expanded ? null : 'collapsed' }
       >
         {header}
       </a>

--- a/test/PanelSpec.js
+++ b/test/PanelSpec.js
@@ -144,7 +144,10 @@ describe('<Panel>', () => {
       </Panel>
     );
     const collapse = ReactDOM.findDOMNode(instance).querySelector('.panel-collapse');
+    const anchor = ReactDOM.findDOMNode(instance).querySelector('.panel-title a');
+
     assert.notOk(collapse.className.match(/\bin\b/));
+    assert.ok(anchor.className.match(/\bcollapsed\b/), 'The anchor should have collapsed in its class name');
   });
 
   it('Should call onSelect handler', (done) => {


### PR DESCRIPTION
Replaces #2269

Adds `collapsed` in panel anchor's className, to follow bootstrap examples.

`className` is set to null if there is no need to add `collapsed`