### PR TITLE
Feature: Add closeOnSelect & onSelect to Navbar API with tests & docs

### DIFF
--- a/src/Nav.js
+++ b/src/Nav.js
@@ -93,6 +93,8 @@ const defaultProps = {
 const contextTypes = {
   $bs_navbar: React.PropTypes.shape({
     bsClass: React.PropTypes.string,
+    lazyAutoToggle: React.PropTypes.bool,
+    onToggle: React.PropTypes.func,
   }),
 
   $bs_tabContainer: React.PropTypes.shape({
@@ -319,6 +321,7 @@ class Nav extends React.Component {
           const childOnSelect = createChainedFunction(
             child.props.onSelect,
             onSelect,
+            navbar && navbar.lazyAutoToggle && navbar.onToggle || null,
             tabContainer && tabContainer.onSelect
           );
 

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -93,8 +93,6 @@ const defaultProps = {
 const contextTypes = {
   $bs_navbar: React.PropTypes.shape({
     bsClass: React.PropTypes.string,
-    toggleOnSelect: React.PropTypes.bool,
-    onToggle: React.PropTypes.func,
     onSelect: React.PropTypes.func,
   }),
 
@@ -322,7 +320,7 @@ class Nav extends React.Component {
           const childOnSelect = createChainedFunction(
             child.props.onSelect,
             onSelect,
-            navbar && (navbar.onSelect || navbar.toggleOnSelect && navbar.onToggle) || null,
+            navbar && navbar.onSelect,
             tabContainer && tabContainer.onSelect
           );
 

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -93,8 +93,9 @@ const defaultProps = {
 const contextTypes = {
   $bs_navbar: React.PropTypes.shape({
     bsClass: React.PropTypes.string,
-    lazyAutoToggle: React.PropTypes.bool,
+    toggleOnSelect: React.PropTypes.bool,
     onToggle: React.PropTypes.func,
+    onSelect: React.PropTypes.func,
   }),
 
   $bs_tabContainer: React.PropTypes.shape({
@@ -321,7 +322,7 @@ class Nav extends React.Component {
           const childOnSelect = createChainedFunction(
             child.props.onSelect,
             onSelect,
-            navbar && navbar.lazyAutoToggle && navbar.onToggle || null,
+            navbar && (navbar.onSelect || navbar.toggleOnSelect && navbar.onToggle) || null,
             tabContainer && tabContainer.onSelect
           );
 

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -57,21 +57,36 @@ const propTypes = {
    * @controllable navExpanded
    */
   onToggle: React.PropTypes.func,
-
+  /**
+   * A callback fired when a `<NavItem>` grandchild is selected inside a child
+   * `<Nav>`. Should be used to execute complex toggling or other miscellaneous
+   * actions desired after selecting a `<NavItem>`. The callback is called with
+   * an eventKey, which is a prop from the `<NavItem>`, and an event.
+   * ```js
+   * function (
+   * 	Any eventKey,
+   * 	SyntheticEvent event?
+   * )
+   * ```
+   * For basic toggling after all `<NavItem>` select events, try using
+   * toggleOnSelect. Note: When onSelect is set, toggleOnSelect will do nothing.
+   */
+  onSelect: React.PropTypes.func,
+  /**
+   * Fires the onToggle callback whenever a <NavItem> inside the child <Nav> is
+   * selected. Does nothing if an onSelect callback is provided to `<Navbar>` or
+   * if no `<Nav>` & `<NavItem>` children exist.
+   *
+   * The onSelect callback should be used instead for more complex operations
+   * desired for after `<NavItem>` select events.
+   */
+  toggleOnSelect: React.PropTypes.bool,
   /**
    * Explicitly set the visiblity of the navbar body
    *
    * @controllable onToggle
    */
   expanded: React.PropTypes.bool,
-
-  /**
-   * Sets 'lazy auto-toggling' that nondiscriminantely fires the onToggle callback
-   * after the onClick & onSelect callbacks for every item within a child <Nav>.
-   * Does nothing if no child <Nav> is present. lazyAutoToggle should not be used
-   * for complex nav menus.
-   */
-  lazyAutoToggle: React.PropTypes.bool,
 
   role: React.PropTypes.string,
 };
@@ -83,7 +98,7 @@ const defaultProps = {
   staticTop: false,
   inverse: false,
   fluid: false,
-  lazyAutoToggle: false,
+  toggleOnSelect: false,
 };
 
 const childContextTypes = {
@@ -91,7 +106,8 @@ const childContextTypes = {
     bsClass: PropTypes.string,
     expanded: PropTypes.bool,
     onToggle: PropTypes.func.isRequired,
-    lazyAutoToggle: PropTypes.bool,
+    onSelect: PropTypes.func,
+    toggleOnSelect: PropTypes.bool,
   })
 };
 
@@ -103,14 +119,15 @@ class Navbar extends React.Component {
   }
 
   getChildContext() {
-    const { bsClass, expanded, lazyAutoToggle } = this.props;
+    const { bsClass, expanded, onSelect, toggleOnSelect } = this.props;
 
     return {
       $bs_navbar: {
         bsClass,
         expanded,
         onToggle: this.handleToggle,
-        lazyAutoToggle,
+        onSelect,
+        toggleOnSelect,
       },
     };
   }
@@ -135,7 +152,7 @@ class Navbar extends React.Component {
     } = this.props;
 
     const [bsProps, elementProps] = splitBsPropsAndOmit(props, [
-      'expanded', 'onToggle', 'lazyAutoToggle'
+      'expanded', 'onToggle', 'onSelect', 'toggleOnSelect'
     ]);
 
     // will result in some false positives but that seems better

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -63,7 +63,9 @@ const propTypes = {
    * `<Nav>`. Should be used to execute complex toggling or other miscellaneous
    * actions desired after selecting a `<NavItem>`. Does nothing if no `<Nav>`
    * & `<NavItem>` children exist. The callback is called with an eventKey,
-   * which is a prop from the `<NavItem>`, and an event.
+   * which is a prop from the `<NavItem>`, and an event. If you would like
+   * onSelect to only fire when in a mobile viewport, add a condition for it to
+   * fire only when `window.innerWidth` is less than 768.
    *
    * ```js
    * function (
@@ -72,13 +74,14 @@ const propTypes = {
    * )
    * ```
    *
-   * For basic toggling after all `<NavItem>` select events, try using
-   * toggleOnSelect.
+   * For basic toggling after all `<NavItem>` select events in mobile viewports,
+   * try using toggleOnSelect.
    */
   onSelect: React.PropTypes.func,
   /**
    * Fires the onToggle callback whenever a `<NavItem>` inside the child `<Nav>` is
-   * selected. Does nothing if no `<Nav>` & `<NavItem>` children exist.
+   * selected. Does nothing if no `<Nav>` & `<NavItem>` children exist or if
+   * the window is not in a mobile-sized viewport.
    *
    * The onSelect callback should be used instead for more complex operations
    * desired for after `<NavItem>` select events.

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -128,7 +128,7 @@ class Navbar extends React.Component {
         bsClass,
         expanded,
         onToggle: this.handleToggle,
-        onSelect: createChainedFunction(onSelect, toggleOnSelect && this.handleToggle || null),
+        onSelect: createChainedFunction(onSelect, window.innerWidth < 768 && toggleOnSelect && this.handleToggle || null),
       },
     };
   }

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -65,6 +65,14 @@ const propTypes = {
    */
   expanded: React.PropTypes.bool,
 
+  /**
+   * Sets 'lazy auto-toggling' that nondiscriminantely fires the onToggle callback
+   * when an interior <Navbar.Collapse> is clicked anywhere. All subcomponent onClick
+   * events will continue to work as intended. This should not be used for complex
+   * nav menus.
+   */
+  lazyAutoToggle: React.PropTypes.bool,
+
   role: React.PropTypes.string,
 };
 
@@ -75,6 +83,7 @@ const defaultProps = {
   staticTop: false,
   inverse: false,
   fluid: false,
+  lazyAutoToggle: false,
 };
 
 const childContextTypes = {
@@ -82,6 +91,7 @@ const childContextTypes = {
     bsClass: PropTypes.string,
     expanded: PropTypes.bool,
     onToggle: PropTypes.func.isRequired,
+    lazyAutoToggle: PropTypes.bool,
   })
 };
 
@@ -93,13 +103,14 @@ class Navbar extends React.Component {
   }
 
   getChildContext() {
-    const { bsClass, expanded } = this.props;
+    const { bsClass, expanded, lazyAutoToggle } = this.props;
 
     return {
       $bs_navbar: {
         bsClass,
         expanded,
         onToggle: this.handleToggle,
+        lazyAutoToggle,
       },
     };
   }
@@ -124,7 +135,7 @@ class Navbar extends React.Component {
     } = this.props;
 
     const [bsProps, elementProps] = splitBsPropsAndOmit(props, [
-      'expanded', 'onToggle',
+      'expanded', 'onToggle', 'lazyAutoToggle'
     ]);
 
     // will result in some false positives but that seems better

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -125,13 +125,15 @@ class Navbar extends React.Component {
 
   getChildContext() {
     const { bsClass, expanded, onSelect, toggleOnSelect } = this.props;
+    const inMobileViewport = typeof(window) !== 'undefined' && window.innerWidth < 768;
+    const canToggleOnSelect = inMobileViewport && toggleOnSelect || false;
 
     return {
       $bs_navbar: {
         bsClass,
         expanded,
         onToggle: this.handleToggle,
-        onSelect: createChainedFunction(onSelect, window.innerWidth < 768 && toggleOnSelect && this.handleToggle || null),
+        onSelect: createChainedFunction(onSelect, canToggleOnSelect && this.handleToggle || null),
       },
     };
   }

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -107,7 +107,6 @@ const childContextTypes = {
     expanded: PropTypes.bool,
     onToggle: PropTypes.func.isRequired,
     onSelect: PropTypes.func,
-    toggleOnSelect: PropTypes.bool,
   })
 };
 
@@ -116,18 +115,18 @@ class Navbar extends React.Component {
     super(props, context);
 
     this.handleToggle = this.handleToggle.bind(this);
+    this.handleSelect = this.handleSelect.bind(this);
   }
 
   getChildContext() {
-    const { bsClass, expanded, onSelect, toggleOnSelect } = this.props;
+    const { bsClass, expanded } = this.props;
 
     return {
       $bs_navbar: {
         bsClass,
         expanded,
         onToggle: this.handleToggle,
-        onSelect,
-        toggleOnSelect,
+        onSelect: this.handleSelect,
       },
     };
   }
@@ -136,6 +135,16 @@ class Navbar extends React.Component {
     const { onToggle, expanded } = this.props;
 
     onToggle(!expanded);
+  }
+
+  handleSelect(eventKey, syntheticEvent) {
+    const { onSelect, toggleOnSelect } = this.props;
+
+    if (onSelect) {
+      onSelect(eventKey, syntheticEvent);
+    } else if (toggleOnSelect) {
+      this.handleToggle();
+    }
   }
 
   render() {

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -19,6 +19,7 @@ import {
   splitBsPropsAndOmit,
 } from './utils/bootstrapUtils';
 import { Style } from './utils/StyleConfig';
+import createChainedFunction from './utils/createChainedFunction';
 
 const propTypes = {
   /**
@@ -60,22 +61,24 @@ const propTypes = {
   /**
    * A callback fired when a `<NavItem>` grandchild is selected inside a child
    * `<Nav>`. Should be used to execute complex toggling or other miscellaneous
-   * actions desired after selecting a `<NavItem>`. The callback is called with
-   * an eventKey, which is a prop from the `<NavItem>`, and an event.
+   * actions desired after selecting a `<NavItem>`. Does nothing if no `<Nav>`
+   * & `<NavItem>` children exist. The callback is called with an eventKey,
+   * which is a prop from the `<NavItem>`, and an event.
+   *
    * ```js
    * function (
    * 	Any eventKey,
    * 	SyntheticEvent event?
    * )
    * ```
+   *
    * For basic toggling after all `<NavItem>` select events, try using
-   * toggleOnSelect. Note: When onSelect is set, toggleOnSelect will do nothing.
+   * toggleOnSelect.
    */
   onSelect: React.PropTypes.func,
   /**
    * Fires the onToggle callback whenever a <NavItem> inside the child <Nav> is
-   * selected. Does nothing if an onSelect callback is provided to `<Navbar>` or
-   * if no `<Nav>` & `<NavItem>` children exist.
+   * selected. Does nothing if no `<Nav>` & `<NavItem>` children exist.
    *
    * The onSelect callback should be used instead for more complex operations
    * desired for after `<NavItem>` select events.
@@ -115,18 +118,17 @@ class Navbar extends React.Component {
     super(props, context);
 
     this.handleToggle = this.handleToggle.bind(this);
-    this.handleSelect = this.handleSelect.bind(this);
   }
 
   getChildContext() {
-    const { bsClass, expanded } = this.props;
+    const { bsClass, expanded, onSelect, toggleOnSelect } = this.props;
 
     return {
       $bs_navbar: {
         bsClass,
         expanded,
         onToggle: this.handleToggle,
-        onSelect: this.handleSelect,
+        onSelect: createChainedFunction(onSelect, toggleOnSelect && this.handleToggle || null),
       },
     };
   }
@@ -135,16 +137,6 @@ class Navbar extends React.Component {
     const { onToggle, expanded } = this.props;
 
     onToggle(!expanded);
-  }
-
-  handleSelect(eventKey, syntheticEvent) {
-    const { onSelect, toggleOnSelect } = this.props;
-
-    if (onSelect) {
-      onSelect(eventKey, syntheticEvent);
-    } else if (toggleOnSelect) {
-      this.handleToggle();
-    }
   }
 
   render() {

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -59,11 +59,11 @@ const propTypes = {
    */
   onToggle: React.PropTypes.func,
   /**
-   * A callback fired when a `<NavItem>` grandchild is selected inside a child
-   * `<Nav>`. Should be used to execute complex toggling or other miscellaneous
-   * actions desired after selecting a `<NavItem>`. Does nothing if no `<Nav>`
-   * & `<NavItem>`/`<MenuItem>` children exist. The callback is called with an
-   * eventKey, which is a prop from the `<NavItem>`, and an event.
+   * A callback fired when a descendant of a child `<Nav>` is selected. Should
+   * be used to execute complex closing or other miscellaneous actions desired
+   * after selecting a descendant of `<Nav>`. Does nothing if no `<Nav>` or `<Nav>`
+   * descendants exist. The callback is called with an eventKey, which is a
+   * prop from the selected `<Nav>` descendant, and an event.
    *
    * ```js
    * function (
@@ -72,20 +72,20 @@ const propTypes = {
    * )
    * ```
    *
-   * For basic closing behavior after all `<NavItem>` onSelect events in mobile
-   * viewports, try using closeOnSelect.
+   * For basic closing behavior after all `<Nav>` descendant onSelect events in
+   * mobile viewports, try using closeOnSelect.
+   *
    * Note: If you are manually closing the navbar using this `OnSelect` prop,
    * ensure that you are setting `expanded` to false and not *toggling* between
    * true and false.
    */
   onSelect: React.PropTypes.func,
   /**
-   * Sets `expanded` to false after the onSelect event of a child of `<Nav>`
-   * (such as `<NavItem>` or `<MenuItem>`). Does nothing if no `<Nav>` or
-   * `<NavItem>`/`<MenuItem>` children exist.
+   * Sets `expanded` to `false` after the onSelect event of a descendant of a
+   * child `<Nav>`. Does nothing if no `<Nav>` or `<Nav>` descendants exist.
    *
    * The onSelect callback should be used instead for more complex operations
-   * desired for after `<NavItem>` select events.
+   * that need to be executed after the `select` event of `<Nav>` descendants.
    */
   closeOnSelect: React.PropTypes.bool,
   /**

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -125,15 +125,18 @@ class Navbar extends React.Component {
 
   getChildContext() {
     const { bsClass, expanded, onSelect, toggleOnSelect } = this.props;
-    const inMobileViewport = typeof(window) !== 'undefined' && window.innerWidth < 768;
-    const canToggleOnSelect = inMobileViewport && toggleOnSelect || false;
+    const mobileToggle = () => {
+      if (typeof(window) !== 'undefined' && window.innerWidth < 768) {
+        this.handleToggle();
+      }
+    };
 
     return {
       $bs_navbar: {
         bsClass,
         expanded,
         onToggle: this.handleToggle,
-        onSelect: createChainedFunction(onSelect, canToggleOnSelect && this.handleToggle || null),
+        onSelect: createChainedFunction(onSelect, toggleOnSelect && mobileToggle || null),
       },
     };
   }

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -67,9 +67,9 @@ const propTypes = {
 
   /**
    * Sets 'lazy auto-toggling' that nondiscriminantely fires the onToggle callback
-   * when an interior <Navbar.Collapse> is clicked anywhere. All subcomponent onClick
-   * events will continue to work as intended. This should not be used for complex
-   * nav menus.
+   * after the onClick & onSelect callbacks for every item within a child <Nav>.
+   * Does nothing if no child <Nav> is present. lazyAutoToggle should not be used
+   * for complex nav menus.
    */
   lazyAutoToggle: React.PropTypes.bool,
 

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -77,7 +77,7 @@ const propTypes = {
    */
   onSelect: React.PropTypes.func,
   /**
-   * Fires the onToggle callback whenever a <NavItem> inside the child <Nav> is
+   * Fires the onToggle callback whenever a `<NavItem>` inside the child `<Nav>` is
    * selected. Does nothing if no `<Nav>` & `<NavItem>` children exist.
    *
    * The onSelect callback should be used instead for more complex operations

--- a/src/NavbarCollapse.js
+++ b/src/NavbarCollapse.js
@@ -7,10 +7,25 @@ const contextTypes = {
   $bs_navbar: PropTypes.shape({
     bsClass: PropTypes.string,
     expanded: PropTypes.bool,
+    lazyAutoToggle: PropTypes.bool,
   }),
 };
 
+const propTypes = { lazyAutoToggle: PropTypes.bool };
+
 class NavbarCollapse extends React.Component {
+  constructor(props) {
+    super(props);
+    this.handleClick = this.handleClick.bind(this);
+  }
+
+  handleClick() {
+    const { lazyAutoToggle, onToggle } = this.context.$bs_navbar;
+    if (lazyAutoToggle && onToggle) {
+      onToggle();
+    }
+  }
+
   render() {
     const { children, ...props } = this.props;
     const navbarProps = this.context.$bs_navbar || { bsClass: 'navbar' };
@@ -19,7 +34,7 @@ class NavbarCollapse extends React.Component {
 
     return (
       <Collapse in={navbarProps.expanded} {...props}>
-        <div className={bsClassName}>
+        <div className={bsClassName} onClick={this.handleClick}>
           {children}
         </div>
       </Collapse>
@@ -28,5 +43,7 @@ class NavbarCollapse extends React.Component {
 }
 
 NavbarCollapse.contextTypes = contextTypes;
+
+NavbarCollapse.propTypes = propTypes;
 
 export default NavbarCollapse;

--- a/src/NavbarCollapse.js
+++ b/src/NavbarCollapse.js
@@ -7,25 +7,10 @@ const contextTypes = {
   $bs_navbar: PropTypes.shape({
     bsClass: PropTypes.string,
     expanded: PropTypes.bool,
-    lazyAutoToggle: PropTypes.bool,
   }),
 };
 
-const propTypes = { lazyAutoToggle: PropTypes.bool };
-
 class NavbarCollapse extends React.Component {
-  constructor(props) {
-    super(props);
-    this.handleClick = this.handleClick.bind(this);
-  }
-
-  handleClick() {
-    const { lazyAutoToggle, onToggle } = this.context.$bs_navbar;
-    if (lazyAutoToggle && onToggle) {
-      onToggle();
-    }
-  }
-
   render() {
     const { children, ...props } = this.props;
     const navbarProps = this.context.$bs_navbar || { bsClass: 'navbar' };
@@ -34,7 +19,7 @@ class NavbarCollapse extends React.Component {
 
     return (
       <Collapse in={navbarProps.expanded} {...props}>
-        <div className={bsClassName} onClick={this.handleClick}>
+        <div className={bsClassName}>
           {children}
         </div>
       </Collapse>
@@ -43,7 +28,5 @@ class NavbarCollapse extends React.Component {
 }
 
 NavbarCollapse.contextTypes = contextTypes;
-
-NavbarCollapse.propTypes = propTypes;
 
 export default NavbarCollapse;

--- a/test/NavbarSpec.js
+++ b/test/NavbarSpec.js
@@ -4,6 +4,8 @@ import ReactDOM from 'react-dom';
 
 import Nav from '../src/Nav';
 import Navbar from '../src/Navbar';
+import NavItem from '../src/NavItem';
+
 import { addStyle } from '../src/utils/bootstrapUtils';
 
 import { getOne } from './helpers';
@@ -254,28 +256,7 @@ describe('<Navbar>', () => {
     expect(toggle.className).to.not.match(/collapsed/);
   });
 
-  it('Should lazyAutoToggle to the collapse when given lazyAutoToggle prop', () => {
-    const toggleSpy = sinon.spy();
-    const instance = ReactTestUtils.renderIntoDocument(
-      <Navbar lazyAutoToggle onToggle={toggleSpy}>
-        <Navbar.Header>
-          <Navbar.Toggle />
-        </Navbar.Header>
-        <Navbar.Collapse>
-          hello
-        </Navbar.Collapse>
-      </Navbar>
-    );
-
-    const collapse = ReactTestUtils.findRenderedComponentWithType(instance, Navbar.Collapse);
-
-    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(collapse));
-
-    expect(toggleSpy).to.be.calledOnce;
-    expect(toggleSpy).to.be.calledWith(true);
-  });
-
-  it('Should lazyAutoToggle & fire subcomponent onclick', () => {
+  it('Should lazyAutoToggle & fire Nav subcomponent onSelect event', () => {
     const toggleSpy = sinon.spy();
     const navItemSpy = sinon.spy();
     const instance = ReactTestUtils.renderIntoDocument(
@@ -284,20 +265,24 @@ describe('<Navbar>', () => {
           <Navbar.Toggle />
         </Navbar.Header>
         <Navbar.Collapse>
-          <Navbar.Link onClick={navItemSpy}>
-            Hello
-          </Navbar.Link>
+          <Nav>
+            <NavItem eventKey={1} href="#" onClick={navItemSpy}>
+              <span className="link-text">
+                Option 1
+              </span>
+            </NavItem>
+          </Nav>
         </Navbar.Collapse>
       </Navbar>
     );
 
-    const link = ReactTestUtils.findRenderedComponentWithType(instance, Navbar.Link);
+    const link = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'link-text');
 
     ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link));
 
+    expect(navItemSpy).to.be.calledOnce;
     expect(toggleSpy).to.be.calledOnce;
     expect(toggleSpy).to.be.calledWith(true);
-    expect(navItemSpy).to.be.calledOnce;
   });
 
   it('Should pass `bsClass` down to sub components', () => {

--- a/test/NavbarSpec.js
+++ b/test/NavbarSpec.js
@@ -254,6 +254,52 @@ describe('<Navbar>', () => {
     expect(toggle.className).to.not.match(/collapsed/);
   });
 
+  it('Should lazyAutoToggle to the collapse when given lazyAutoToggle prop', () => {
+    const toggleSpy = sinon.spy();
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Navbar lazyAutoToggle onToggle={toggleSpy}>
+        <Navbar.Header>
+          <Navbar.Toggle />
+        </Navbar.Header>
+        <Navbar.Collapse>
+          hello
+        </Navbar.Collapse>
+      </Navbar>
+    );
+
+    const collapse = ReactTestUtils.findRenderedComponentWithType(instance, Navbar.Collapse);
+
+    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(collapse));
+
+    expect(toggleSpy).to.be.calledOnce;
+    expect(toggleSpy).to.be.calledWith(true);
+  });
+
+  it('Should lazyAutoToggle & fire subcomponent onclick', () => {
+    const toggleSpy = sinon.spy();
+    const navItemSpy = sinon.spy();
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Navbar lazyAutoToggle onToggle={toggleSpy}>
+        <Navbar.Header>
+          <Navbar.Toggle />
+        </Navbar.Header>
+        <Navbar.Collapse>
+          <Navbar.Link onClick={navItemSpy}>
+            Hello
+          </Navbar.Link>
+        </Navbar.Collapse>
+      </Navbar>
+    );
+
+    const link = ReactTestUtils.findRenderedComponentWithType(instance, Navbar.Link);
+
+    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link));
+
+    expect(toggleSpy).to.be.calledOnce;
+    expect(toggleSpy).to.be.calledWith(true);
+    expect(navItemSpy).to.be.calledOnce;
+  });
+
   it('Should pass `bsClass` down to sub components', () => {
     const instance = ReactTestUtils.renderIntoDocument(
       <Navbar bsClass="my-navbar">

--- a/test/NavbarSpec.js
+++ b/test/NavbarSpec.js
@@ -257,32 +257,38 @@ describe('<Navbar>', () => {
   });
 
   it('Should toggleOnSelect & fire Nav subcomponent onSelect event', () => {
-    const toggleSpy = sinon.spy();
-    const navItemSpy = sinon.spy();
-    const instance = ReactTestUtils.renderIntoDocument(
-      <Navbar toggleOnSelect onToggle={toggleSpy}>
-        <Navbar.Header>
-          <Navbar.Toggle />
-        </Navbar.Header>
-        <Navbar.Collapse>
-          <Nav>
-            <NavItem eventKey={1} href="#" onClick={navItemSpy}>
-              <span className="link-text">
-                Option 1
-              </span>
-            </NavItem>
-          </Nav>
-        </Navbar.Collapse>
-      </Navbar>
-    );
+    let widthBackup = window.innerWidth;
+    try {
+      window.innerWidth = 100;
+      const toggleSpy = sinon.spy();
+      const navItemSpy = sinon.spy();
+      const instance = ReactTestUtils.renderIntoDocument(
+        <Navbar toggleOnSelect onToggle={toggleSpy}>
+          <Navbar.Header>
+            <Navbar.Toggle />
+          </Navbar.Header>
+          <Navbar.Collapse>
+            <Nav>
+              <NavItem eventKey={1} href="#" onClick={navItemSpy}>
+                <span className="link-text">
+                  Option 1
+                </span>
+              </NavItem>
+            </Nav>
+          </Navbar.Collapse>
+        </Navbar>
+      );
 
-    const link = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'link-text');
+      const link = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'link-text');
 
-    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link));
+      ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link));
 
-    expect(navItemSpy).to.be.calledOnce;
-    expect(toggleSpy).to.be.calledOnce;
-    expect(toggleSpy).to.be.calledWith(true);
+      expect(navItemSpy).to.be.calledOnce;
+      expect(toggleSpy).to.be.calledOnce;
+      expect(toggleSpy).to.be.calledWith(true);
+    } finally {
+      window.innerWidth = widthBackup;
+    }
   });
 
   it('Should fire onSelect with eventKey for nav children', () => {

--- a/test/NavbarSpec.js
+++ b/test/NavbarSpec.js
@@ -314,38 +314,6 @@ describe('<Navbar>', () => {
     expect(selectSpy).to.be.calledWith(1);
   });
 
-
-  it('Should not fire onToggle for toggleOnSelect when onSelect is provided', () => {
-    const selectSpy = sinon.spy();
-    const navItemSpy = sinon.spy();
-    const toggleSpy = sinon.spy();
-    const instance = ReactTestUtils.renderIntoDocument(
-      <Navbar onSelect={selectSpy} onToggle={toggleSpy} toggleOnSelect>
-        <Navbar.Header>
-          <Navbar.Toggle />
-        </Navbar.Header>
-        <Navbar.Collapse>
-          <Nav>
-            <NavItem eventKey={1} href="#" onClick={navItemSpy}>
-              <span className="link-text">
-                Option 1
-              </span>
-            </NavItem>
-          </Nav>
-        </Navbar.Collapse>
-      </Navbar>
-    );
-
-    const link = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'link-text');
-
-    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link));
-
-    expect(navItemSpy).to.be.calledOnce;
-    expect(selectSpy).to.be.calledOnce;
-    expect(selectSpy).to.be.calledWith(1);
-    expect(toggleSpy.callCount).to.equal(0);
-  });
-
   it('Should pass `bsClass` down to sub components', () => {
     const instance = ReactTestUtils.renderIntoDocument(
       <Navbar bsClass="my-navbar">

--- a/test/NavbarSpec.js
+++ b/test/NavbarSpec.js
@@ -256,39 +256,33 @@ describe('<Navbar>', () => {
     expect(toggle.className).to.not.match(/collapsed/);
   });
 
-  it('Should toggleOnSelect & fire Nav subcomponent onSelect event', () => {
-    let widthBackup = window.innerWidth;
-    try {
-      window.innerWidth = 100;
-      const toggleSpy = sinon.spy();
-      const navItemSpy = sinon.spy();
-      const instance = ReactTestUtils.renderIntoDocument(
-        <Navbar toggleOnSelect onToggle={toggleSpy}>
-          <Navbar.Header>
-            <Navbar.Toggle />
-          </Navbar.Header>
-          <Navbar.Collapse>
-            <Nav>
-              <NavItem eventKey={1} href="#" onClick={navItemSpy}>
-                <span className="link-text">
-                  Option 1
-                </span>
-              </NavItem>
-            </Nav>
-          </Navbar.Collapse>
-        </Navbar>
-      );
+  it('Should closeOnSelect & fire Nav subcomponent onSelect event if expanded', () => {
+    const toggleSpy = sinon.spy();
+    const navItemSpy = sinon.spy();
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Navbar closeOnSelect onToggle={toggleSpy} defaultExpanded>
+        <Navbar.Header>
+          <Navbar.Toggle />
+        </Navbar.Header>
+        <Navbar.Collapse>
+          <Nav>
+            <NavItem eventKey={1} href="#" onClick={navItemSpy}>
+              <span className="link-text">
+                Option 1
+              </span>
+            </NavItem>
+          </Nav>
+        </Navbar.Collapse>
+      </Navbar>
+    );
 
-      const link = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'link-text');
+    const link = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'link-text');
 
-      ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link));
+    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link));
 
-      expect(navItemSpy).to.be.calledOnce;
-      expect(toggleSpy).to.be.calledOnce;
-      expect(toggleSpy).to.be.calledWith(true);
-    } finally {
-      window.innerWidth = widthBackup;
-    }
+    expect(navItemSpy).to.be.calledOnce;
+    expect(toggleSpy).to.be.calledOnce;
+    expect(toggleSpy).to.be.calledWith(false);
   });
 
   it('Should fire onSelect with eventKey for nav children', () => {

--- a/test/NavbarSpec.js
+++ b/test/NavbarSpec.js
@@ -256,11 +256,11 @@ describe('<Navbar>', () => {
     expect(toggle.className).to.not.match(/collapsed/);
   });
 
-  it('Should lazyAutoToggle & fire Nav subcomponent onSelect event', () => {
+  it('Should toggleOnSelect & fire Nav subcomponent onSelect event', () => {
     const toggleSpy = sinon.spy();
     const navItemSpy = sinon.spy();
     const instance = ReactTestUtils.renderIntoDocument(
-      <Navbar lazyAutoToggle onToggle={toggleSpy}>
+      <Navbar toggleOnSelect onToggle={toggleSpy}>
         <Navbar.Header>
           <Navbar.Toggle />
         </Navbar.Header>
@@ -283,6 +283,67 @@ describe('<Navbar>', () => {
     expect(navItemSpy).to.be.calledOnce;
     expect(toggleSpy).to.be.calledOnce;
     expect(toggleSpy).to.be.calledWith(true);
+  });
+
+  it('Should fire onSelect with eventKey for nav children', () => {
+    const selectSpy = sinon.spy();
+    const navItemSpy = sinon.spy();
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Navbar onSelect={selectSpy}>
+        <Navbar.Header>
+          <Navbar.Toggle />
+        </Navbar.Header>
+        <Navbar.Collapse>
+          <Nav>
+            <NavItem eventKey={1} href="#" onClick={navItemSpy}>
+              <span className="onselect-text">
+                Option 1
+              </span>
+            </NavItem>
+          </Nav>
+        </Navbar.Collapse>
+      </Navbar>
+    );
+
+    const link = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'onselect-text');
+
+    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link));
+
+    expect(navItemSpy).to.be.calledOnce;
+    expect(selectSpy).to.be.calledOnce;
+    expect(selectSpy).to.be.calledWith(1);
+  });
+
+
+  it('Should not fire onToggle for toggleOnSelect when onSelect is provided', () => {
+    const selectSpy = sinon.spy();
+    const navItemSpy = sinon.spy();
+    const toggleSpy = sinon.spy();
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Navbar onSelect={selectSpy} onToggle={toggleSpy} toggleOnSelect>
+        <Navbar.Header>
+          <Navbar.Toggle />
+        </Navbar.Header>
+        <Navbar.Collapse>
+          <Nav>
+            <NavItem eventKey={1} href="#" onClick={navItemSpy}>
+              <span className="link-text">
+                Option 1
+              </span>
+            </NavItem>
+          </Nav>
+        </Navbar.Collapse>
+      </Navbar>
+    );
+
+    const link = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'link-text');
+
+    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link));
+
+    expect(navItemSpy).to.be.calledOnce;
+    expect(selectSpy).to.be.calledOnce;
+    expect(selectSpy).to.be.calledWith(1);
+    expect(toggleSpy.callCount).to.equal(0);
   });
 
   it('Should pass `bsClass` down to sub components', () => {


### PR DESCRIPTION
**Update 10/17:**
This PR has been improved from its original implementation. To see a running demo of the current iteration, you can run this Plunker here: https://plnkr.co/edit/43i4XA

The proposal has been simplified and improved with these two new props to the `<Navbar>` API:

   > **onSelect: React.PropTypes.func**
   > A callback fired when a `<NavItem>` grandchild is selected inside a child
   > `<Nav>`. Should be used to execute complex toggling or other miscellaneous
   > actions desired after selecting a `<NavItem>`. Does nothing if no `<Nav>`
   > & `<NavItem>` children exist. The callback is called with an eventKey,
   > which is a prop from the `<NavItem>`, and an event.
   >
   > ```js
   > function (
   > 	Any eventKey,
   > 	SyntheticEvent event?
   > )
   > ```
   >
   > For basic toggling after all `<NavItem>` select events, try using
   > toggleOnSelect.

-----
   > **toggleOnSelect: React.PropTypes.bool**
   >
   > Fires the onToggle callback whenever a `<NavItem>` inside the child `<Nav>` is
   > selected. Does nothing if no `<Nav>` & `<NavItem>` children exist.
   >
   > The onSelect callback should be used instead for more complex operations
   > desired for after `<NavItem>` select events.
   >

/Update

-----
Description:
----
Auto toggling as a behavior in react-bootstrap has been discussed at length in #1301 & #1692. @jquense and @taion have made good points against implementing it into the API due to complexities of different cases. There have also been valid arguments made for a simple version of this behavior to have available for users that does not need to catch every edge case. I think there is value to having a simple implementation of this expected behavior (normal click menus) for many users.

After reading over the discussion, I'd like to propose a simple addition to the Navbar API - `lazyAutoToggle`. I thought of naming it `lazy` to make it very apparent that it goes about autotoggling in a nondiscriminant & noncomplex way on `<Navbar.Collapse>` and its subcomponents. It does not attempt to be an omni-solution for all toggling needs.

Demo:
----
I've written a demo of this functionality in the plnkr. You can run the example at the link below:
https://plnkr.co/edit/vDejOB

There you can compare the functionality of a `<Navbar>` with & without `lazyAutoToggle` on.
It uses the built version of `react-bootstrap` from this PR.

How to use:
---
Simply add `lazyAutoToggle` to a `<Navbar>` with a child `<Navbar.Collapse>`.


Changes Proposed:
----
- [x] Add `lazyAutoToggle` prop to Navbar
- [x] Add `lazyAutoToggle` to `childContext` of Navbar
- [x] Check for `lazyAutoToggle` and `onToggle` from  `this.context.$bs_navbar` in `<Navbar.Collapse>` to fire `onToggle` when both exist

This solution is fairly straightforward. It involves adding the prop value of `lazyAutoToggle` to the `childContext` of `<Navbar>` and its children - particularly for use by `<Navbar.Collapse>`.

`<Navbar.Collapse>` will then fire `onToggle` from its parent `<Navbar>` if and only if `lazyAutoToggle` && `onToggle` exist in `this.context.$bs_navbar`.

To support this new prop, I've also added:

- [x] Test for `lazyAutoToggle` on `Navbar.Collapse` clicks
- [x] Test for `lazyAutoToggle` on `Navbar.Collapse` subcomponent click + onClick events
- [x] Documentation for `lazyAutoToggle` in `Navbar` propTypes.

Not included:
----
Since this is a dead simple solution, this will not attempt to cover any complex cases where individual items might need to prevent toggling. I can foresee a roadmap towards providing an array prop of components that should be ignored by lazyAutoToggle, but that is not a part of this PR.

As a single prop solution, `lazyAutoToggle` works extremely well with regular links, buttons, etc. (normal click-related menu items).

---
cc: @jquense and @taion