### PR TITLE
Rename closeOnSelect to collapseOnSelect

### DIFF
--- a/docs/examples/NavbarCollapsible.js
+++ b/docs/examples/NavbarCollapsible.js
@@ -1,5 +1,5 @@
 const navbarInstance = (
-  <Navbar inverse>
+  <Navbar inverse collapseOnSelect>
     <Navbar.Header>
       <Navbar.Brand>
         <a href="#">React-Bootstrap</a>

--- a/docs/src/sections/NavbarSection.js
+++ b/docs/src/sections/NavbarSection.js
@@ -46,9 +46,7 @@ export default function NavbarSection() {
         the toggle and collapse together!
       </p>
       <p>
-        By setting the prop <code>defaultExpanded</code> the Navbar will start
-        expanded by default. You can also finely control the collapsing behavior by using
-        the <code>expanded</code> and <code>onToggle</code> props.
+        Set the <code>defaultExpanded</code> prop to make the Navbar start expanded. Set <code>collapseOnSelect</code> to make the Navbar collapse automatically when the user selects an item. You can also finely control the collapsing behavior by using the <code>expanded</code> and <code>onToggle</code> props.
       </p>
 
       <ReactPlayground codeText={Samples.NavbarCollapsible} />

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -73,7 +73,7 @@ const propTypes = {
    * ```
    *
    * For basic closing behavior after all `<Nav>` descendant onSelect events in
-   * mobile viewports, try using closeOnSelect.
+   * mobile viewports, try using collapseOnSelect.
    *
    * Note: If you are manually closing the navbar using this `OnSelect` prop,
    * ensure that you are setting `expanded` to false and not *toggling* between
@@ -87,7 +87,7 @@ const propTypes = {
    * The onSelect callback should be used instead for more complex operations
    * that need to be executed after the `select` event of `<Nav>` descendants.
    */
-  closeOnSelect: React.PropTypes.bool,
+  collapseOnSelect: React.PropTypes.bool,
   /**
    * Explicitly set the visiblity of the navbar body
    *
@@ -105,7 +105,7 @@ const defaultProps = {
   staticTop: false,
   inverse: false,
   fluid: false,
-  closeOnSelect: false,
+  collapseOnSelect: false,
 };
 
 const childContextTypes = {
@@ -122,23 +122,25 @@ class Navbar extends React.Component {
     super(props, context);
 
     this.handleToggle = this.handleToggle.bind(this);
-    this.handleClose = this.handleClose.bind(this);
+    this.handleCollapse = this.handleCollapse.bind(this);
   }
 
   getChildContext() {
-    const { bsClass, expanded, onSelect, closeOnSelect } = this.props;
+    const { bsClass, expanded, onSelect, collapseOnSelect } = this.props;
 
     return {
       $bs_navbar: {
         bsClass,
         expanded,
         onToggle: this.handleToggle,
-        onSelect: createChainedFunction(onSelect, closeOnSelect && this.handleClose || null),
+        onSelect: createChainedFunction(
+          onSelect, collapseOnSelect ? this.handleCollapse : null,
+        ),
       },
     };
   }
 
-  handleClose() {
+  handleCollapse() {
     const { onToggle, expanded } = this.props;
 
     if (expanded) {
@@ -166,7 +168,7 @@ class Navbar extends React.Component {
     } = this.props;
 
     const [bsProps, elementProps] = splitBsPropsAndOmit(props, [
-      'expanded', 'onToggle', 'onSelect', 'closeOnSelect'
+      'expanded', 'onToggle', 'onSelect', 'collapseOnSelect',
     ]);
 
     // will result in some false positives but that seems better

--- a/test/NavbarSpec.js
+++ b/test/NavbarSpec.js
@@ -256,11 +256,11 @@ describe('<Navbar>', () => {
     expect(toggle.className).to.not.match(/collapsed/);
   });
 
-  it('Should closeOnSelect & fire Nav subcomponent onSelect event if expanded', () => {
+  it('Should collapseOnSelect & fire Nav subcomponent onSelect event if expanded', () => {
     const toggleSpy = sinon.spy();
     const navItemSpy = sinon.spy();
     const instance = ReactTestUtils.renderIntoDocument(
-      <Navbar closeOnSelect onToggle={toggleSpy} defaultExpanded>
+      <Navbar collapseOnSelect onToggle={toggleSpy} defaultExpanded>
         <Navbar.Header>
           <Navbar.Toggle />
         </Navbar.Header>


### PR DESCRIPTION
I think this naming is a bit more consistent; the prop is `expanded`, not `open`.

Also, update the relevant docs section.

cc @kevinzwhuang