### PR TITLE
Refactor Panel to use shouldRenderFill in renderBody function

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -149,7 +149,7 @@ class Panel extends React.Component {
 
     // Convert to array so we can re-use keys.
     React.Children.toArray(rawChildren).forEach(child => {
-      if (React.isValidElement(child) && child.props.fill) {
+      if (this.shouldRenderFill(child)) {
         maybeAddBody();
 
         // Remove the child's unknown `fill` prop.

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -62,10 +62,6 @@ class Panel extends React.Component {
     }
   }
 
-  shouldRenderFill(child) {
-    return React.isValidElement(child) && child.props.fill != null;
-  }
-
   renderHeader(collapsible, header, id, role, expanded, bsProps) {
     const titleClassName = prefix(bsProps, 'title');
 
@@ -149,7 +145,7 @@ class Panel extends React.Component {
 
     // Convert to array so we can re-use keys.
     React.Children.toArray(rawChildren).forEach(child => {
-      if (this.shouldRenderFill(child)) {
+      if (React.isValidElement(child) && child.props.fill) {
         maybeAddBody();
 
         // Remove the child's unknown `fill` prop.


### PR DESCRIPTION
In the Panel Component implementation, there is a `shouldRenderFill` function which I think was meant to be used in the `renderBody` function, but was not use. For a cleaner code base, get rid of it or put it to use. I'm putting it to use because it's a good code abstraction as it enhances code readability. 