### PR TITLE
Allow empty validationState on FormGroup

### DIFF
--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -11,7 +11,7 @@ const propTypes = {
    * Sets `id` on `<FormControl>` and `htmlFor` on `<FormGroup.Label>`.
    */
   controlId: React.PropTypes.string,
-  validationState: React.PropTypes.oneOf(['success', 'warning', 'error']),
+  validationState: React.PropTypes.oneOf(['success', 'warning', 'error', '']),
 };
 
 const childContextTypes = {


### PR DESCRIPTION
Sometimes it is reasonable with no validation feedback, for example before the user has entered any input.