### PR TITLE
Add inputRef to FormControl component

### DIFF
--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -17,6 +17,14 @@ const propTypes = {
    * Uses `controlId` from `<FormGroup>` if not explicitly specified.
    */
   id: React.PropTypes.string,
+  /**
+   * Attaches a ref to the `<input>` element. Only functions can be used here.
+   *
+   * ```js
+   * <FormControl inputRef={ref => { this.input = ref; }} />
+   * ```
+   */
+  inputRef: React.PropTypes.func,
 };
 
 const defaultProps = {
@@ -36,6 +44,7 @@ class FormControl extends React.Component {
       componentClass: Component,
       type,
       id = controlId,
+      inputRef,
       className,
       ...props
     } = this.props;
@@ -58,6 +67,7 @@ class FormControl extends React.Component {
         {...elementProps}
         type={type}
         id={id}
+        ref={inputRef}
         className={classNames(className, classes)}
       />
     );

--- a/test/FormControlSpec.js
+++ b/test/FormControlSpec.js
@@ -61,4 +61,20 @@ describe('<FormControl>', () => {
       .render()
       .single('input#bar.form-control');
   });
+
+  it('should support inputRef', () => {
+    class Container extends React.Component {
+      render() {
+        return (
+          <FormGroup controlId="foo">
+            <FormControl type="text" inputRef={ref => { this.input = ref; }} />
+          </FormGroup>
+        );
+      }
+    }
+
+    const instance = $(<Container />).render().unwrap();
+    expect(instance.input.tagName).to.equal('INPUT');
+  });
+
 });


### PR DESCRIPTION
This looks like what should be here.  I was unable to get the tests to run on master, or on my branch.  Here is a gist with the console output trying to run the tests.

https://gist.github.com/sorahn/a9a4f9d4d1fd0af24faa438336ca389d

Fixes #1887 