### PR TITLE
On Accordion title hover change cursor to pointer

### DIFF
--- a/src/Panel.js
+++ b/src/Panel.js
@@ -98,6 +98,7 @@ class Panel extends React.Component {
         aria-controls={id}
         aria-expanded={expanded}
         aria-selected={expanded}
+        style={{cursor: 'pointer'}}
         className={expanded ? null : 'collapsed' }
       >
         {header}


### PR DESCRIPTION
It is quite confusing if you point at an accordion title and the cursor is a caret. It should be a pointer instead:

![image](https://cloud.githubusercontent.com/assets/2794365/20484563/fbbb0c48-aff7-11e6-80ce-c46a580c7771.png)


