### PR TITLE
Don’t set aria-describedby unless the referenced element is in the DOM

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -261,10 +261,11 @@ class OverlayTrigger extends React.Component {
 
     const child = React.Children.only(children);
     const childProps = child.props;
+    const triggerProps = {};
 
-    const triggerProps = {
-      'aria-describedby': overlay.props.id
-    };
+    if (this.state.show) {
+      triggerProps['aria-describedby'] = overlay.props.id;
+    }
 
     // FIXME: The logic here for passing through handlers on this component is
     // inconsistent. We shouldn't be passing any of these props through.

--- a/test/OverlayTriggerSpec.js
+++ b/test/OverlayTriggerSpec.js
@@ -50,6 +50,29 @@ describe('<OverlayTrigger>', () => {
     instance.state.show.should.be.true;
   });
 
+  it('Should not set aria-describedby if the state is not show', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <OverlayTrigger trigger="click" overlay={<Div>test</Div>}>
+        <button>button</button>
+      </OverlayTrigger>
+    );
+    const overlayTrigger = ReactDOM.findDOMNode(instance);
+
+    assert.equal(overlayTrigger.getAttribute('aria-describedby'), null);
+  });
+
+  it('Should set aria-describedby if the state is show', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <OverlayTrigger trigger="click" overlay={<Div id="overlayid">test</Div>}>
+        <button>button</button>
+      </OverlayTrigger>
+    );
+    const overlayTrigger = ReactDOM.findDOMNode(instance);
+    ReactTestUtils.Simulate.click(overlayTrigger);
+
+    overlayTrigger.getAttribute('aria-describedby').should.be;
+  });
+
   describe('trigger handlers', () => {
     let mountPoint;
 


### PR DESCRIPTION
Having `aria-describedby` contain a DOM ID which is not present is invalid behavior, and creates an error in e.g. Google Accessibility Audit (see [Rule AX_ARIA_04](https://github.com/GoogleChrome/accessibility-developer-tools/wiki/Audit-Rules#ax_aria_04)).

This fixes #1827.