### PR TITLE
Add support for input-sm and input-lg in FormControl

### DIFF
--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -6,6 +6,8 @@ import warning from 'warning';
 import FormControlFeedback from './FormControlFeedback';
 import FormControlStatic from './FormControlStatic';
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';
+import { SIZE_MAP } from './utils/StyleConfig';
+import { prefix } from './utils/bootstrapUtils';
 
 const propTypes = {
   componentClass: elementType,
@@ -46,6 +48,7 @@ class FormControl extends React.Component {
       id = controlId,
       inputRef,
       className,
+      bsSize,
       ...props
     } = this.props;
 
@@ -60,6 +63,13 @@ class FormControl extends React.Component {
     let classes;
     if (type !== 'file') {
       classes = getClassSet(bsProps);
+    }
+
+    // If user provides a size, make sure to append it to classes as input-
+    // e.g. if bsSize is small, it will append input-sm
+    if (bsSize) {
+      const size = SIZE_MAP[bsSize] || bsSize;
+      classes[prefix({ bsClass: 'input' }, size)] = true;
     }
 
     return (

--- a/test/FormControlSpec.js
+++ b/test/FormControlSpec.js
@@ -77,4 +77,12 @@ describe('<FormControl>', () => {
     expect(instance.input.tagName).to.equal('INPUT');
   });
 
+  it('should properly display size of FormControl', () => {
+    $(
+      <FormControl type="text" bsSize="lg" />
+    )
+      .render()
+      .single('input.form-control.input-lg');
+  });
+
 });


### PR DESCRIPTION
This is a fix that I came up with for #1889 that allows FormControl to have a bsSize prop. I know the solution probably may not be the most scalable and elegant but since this seems to be a one off case I thought it might work here.

Let me know if you think this is an acceptable fix, if not, I'm willing to try to find an alternative solution.