### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ linter.
 
 ## Visual Changes
 
-When making a visual change, if at all feasible please provide screenshots
+When making a visual change, please provide screenshots
 and/or screencasts of the proposed change. This will help us to understand the
 desired change easier.
 


### PR DESCRIPTION
If someone is contributing visual changes, I don't think it's an undue burden to provide screenshots of the change, so I'm proposing dropping the "if at all feasible" wording. Screenshots/screencasts are vital for explaining visual changes and GitHub makes it especially easy to drag and drop images into comments.

Here's my PR as an example...

BEFORE:
![screen shot 2016-12-16 at 12 43 59 pm](https://cloud.githubusercontent.com/assets/530852/21277927/6e501d2c-c38d-11e6-8a6e-cf1ff41f7bb8.png)

AFTER:
![screen shot 2016-12-16 at 12 43 45 pm](https://cloud.githubusercontent.com/assets/530852/21277938/75a141e6-c38d-11e6-8c99-49db6c990e88.png)
