### PR TITLE
Add eventType to onToggle and source for handleClose

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "dom-helpers": "^3.2.0",
     "invariant": "^2.2.1",
     "keycode": "^2.1.2",
-    "react-overlays": "^0.6.10",
+    "react-overlays": "^0.6.11",
     "react-prop-types": "^0.4.0",
     "uncontrollable": "^4.0.1",
     "warning": "^3.0.0"

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -71,10 +71,10 @@ const propTypes = {
 
   /**
    * A callback fired when the Dropdown wishes to change visibility. Called with the requested
-   * `open` value.
+   * `open` value, the DOM event, and the source that fired it: `'click'`,`'keydown'`,`'close'`, or `'select'`.
    *
    * ```js
-   * function(Boolean isOpen) {}
+   * function(Boolean isOpen, Object event, { String source }) {}
    * ```
    * @controllable open
    */
@@ -156,12 +156,12 @@ class Dropdown extends React.Component {
     }
   }
 
-  handleClick() {
+  handleClick(event) {
     if (this.props.disabled) {
       return;
     }
 
-    this.toggleOpen('click');
+    this.toggleOpen(event, 'click');
   }
 
   handleKeyDown(event) {
@@ -172,7 +172,7 @@ class Dropdown extends React.Component {
     switch (event.keyCode) {
       case keycode.codes.down:
         if (!this.props.open) {
-          this.toggleOpen('keydown');
+          this.toggleOpen(event, 'keydown');
         } else if (this.menu.focusNext) {
           this.menu.focusNext();
         }
@@ -180,30 +180,30 @@ class Dropdown extends React.Component {
         break;
       case keycode.codes.esc:
       case keycode.codes.tab:
-        this.handleClose(event);
+        this.handleClose(event, 'keydown');
         break;
       default:
     }
   }
 
-  toggleOpen(eventType) {
+  toggleOpen(event, source) {
     let open = !this.props.open;
 
     if (open) {
-      this.lastOpenEventType = eventType;
+      this.lastOpenEventType = source;
     }
 
     if (this.props.onToggle) {
-      this.props.onToggle(open);
+      this.props.onToggle(open, event, { source });
     }
   }
 
-  handleClose() {
+  handleClose(event, source) {
     if (!this.props.open) {
       return;
     }
 
-    this.toggleOpen(null);
+    this.toggleOpen(event, source);
   }
 
   focusNextOnOpen() {
@@ -274,10 +274,10 @@ class Dropdown extends React.Component {
       labelledBy: id,
       bsClass: prefix(props, 'menu'),
       onClose: createChainedFunction(
-        child.props.onClose, onClose, this.handleClose,
+        child.props.onClose, onClose, (event) => this.handleClose(event, 'close'),
       ),
       onSelect: createChainedFunction(
-        child.props.onSelect, onSelect, this.handleClose,
+        child.props.onSelect, onSelect, (key, event) => this.handleClose(event, 'select'),
       ),
       rootCloseEvent
     });

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -161,7 +161,7 @@ class Dropdown extends React.Component {
       return;
     }
 
-    this.toggleOpen(event, 'click');
+    this.toggleOpen(event, { source: 'click' });
   }
 
   handleKeyDown(event) {
@@ -172,7 +172,7 @@ class Dropdown extends React.Component {
     switch (event.keyCode) {
       case keycode.codes.down:
         if (!this.props.open) {
-          this.toggleOpen(event, 'keydown');
+          this.toggleOpen(event, { source: 'keydown' });
         } else if (this.menu.focusNext) {
           this.menu.focusNext();
         }
@@ -180,7 +180,7 @@ class Dropdown extends React.Component {
         break;
       case keycode.codes.esc:
       case keycode.codes.tab:
-        this.handleClose(event, 'keydown');
+        this.handleClose(event, { source: 'keydown' });
         break;
       default:
     }
@@ -194,7 +194,7 @@ class Dropdown extends React.Component {
     }
 
     if (this.props.onToggle) {
-      this.props.onToggle(open, event, { source });
+      this.props.onToggle(open, event, source);
     }
   }
 
@@ -274,10 +274,10 @@ class Dropdown extends React.Component {
       labelledBy: id,
       bsClass: prefix(props, 'menu'),
       onClose: createChainedFunction(
-        child.props.onClose, onClose, (event) => this.handleClose(event, 'close'),
+        child.props.onClose, onClose, this.handleClose,
       ),
       onSelect: createChainedFunction(
-        child.props.onSelect, onSelect, (key, event) => this.handleClose(event, 'select'),
+        child.props.onSelect, onSelect, (key, event) => this.handleClose(event, { source: 'select' }),
       ),
       rootCloseEvent
     });

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -71,7 +71,7 @@ const propTypes = {
 
   /**
    * A callback fired when the Dropdown wishes to change visibility. Called with the requested
-   * `open` value, the DOM event, and the source that fired it: `'click'`,`'keydown'`,`'close'`, or `'select'`.
+   * `open` value, the DOM event, and the source that fired it: `'click'`,`'keydown'`,`'rootClose'`, or `'select'`.
    *
    * ```js
    * function(Boolean isOpen, Object event, { String source }) {}
@@ -186,24 +186,24 @@ class Dropdown extends React.Component {
     }
   }
 
-  toggleOpen(event, source) {
+  toggleOpen(event, eventDetails) {
     let open = !this.props.open;
 
     if (open) {
-      this.lastOpenEventType = source;
+      this.lastOpenEventType = eventDetails.source;
     }
 
     if (this.props.onToggle) {
-      this.props.onToggle(open, event, source);
+      this.props.onToggle(open, event, eventDetails);
     }
   }
 
-  handleClose(event, source) {
+  handleClose(event, eventDetails) {
     if (!this.props.open) {
       return;
     }
 
-    this.toggleOpen(event, source);
+    this.toggleOpen(event, eventDetails);
   }
 
   focusNextOnOpen() {
@@ -274,10 +274,14 @@ class Dropdown extends React.Component {
       labelledBy: id,
       bsClass: prefix(props, 'menu'),
       onClose: createChainedFunction(
-        child.props.onClose, onClose, this.handleClose,
+        child.props.onClose,
+        onClose,
+        this.handleClose,
       ),
       onSelect: createChainedFunction(
-        child.props.onSelect, onSelect, (key, event) => this.handleClose(event, { source: 'select' }),
+        child.props.onSelect,
+        onSelect,
+        (key, event) => this.handleClose(event, { source: 'select' }),
       ),
       rootCloseEvent
     });

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -44,7 +44,7 @@ class DropdownMenu extends React.Component {
         break;
       case keycode.codes.esc:
       case keycode.codes.tab:
-        this.props.onClose(event);
+        this.props.onClose(event, { source: 'keydown' });
         break;
       default:
     }
@@ -109,7 +109,7 @@ class DropdownMenu extends React.Component {
     return (
       <RootCloseWrapper
         disabled={!open}
-        onRootClose={onClose}
+        onRootClose={(e) => onClose(e, { source: 'rootClose' })}
         event={rootCloseEvent}
       >
         <ul

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -4,7 +4,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 
-import { bsClass, getClassSet, prefix, splitBsProps }
+import { bsClass, getClassSet, prefix, splitBsPropsAndOmit }
   from './utils/bootstrapUtils';
 import createChainedFunction from './utils/createChainedFunction';
 import ValidComponentChildren from './utils/ValidComponentChildren';
@@ -29,7 +29,12 @@ class DropdownMenu extends React.Component {
   constructor(props) {
     super(props);
 
+    this.handleRootClose = this.handleRootClose.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
+  }
+
+  handleRootClose(event) {
+    this.props.onClose(event, { source: 'rootClose' });
   }
 
   handleKeyDown(event) {
@@ -90,7 +95,6 @@ class DropdownMenu extends React.Component {
     const {
       open,
       pullRight,
-      onClose,
       labelledBy,
       onSelect,
       className,
@@ -99,7 +103,7 @@ class DropdownMenu extends React.Component {
       ...props
     } = this.props;
 
-    const [bsProps, elementProps] = splitBsProps(props);
+    const [bsProps, elementProps] = splitBsPropsAndOmit(props, ['onClose']);
 
     const classes = {
       ...getClassSet(bsProps),
@@ -109,7 +113,7 @@ class DropdownMenu extends React.Component {
     return (
       <RootCloseWrapper
         disabled={!open}
-        onRootClose={(e) => onClose(e, { source: 'rootClose' })}
+        onRootClose={this.handleRootClose}
         event={rootCloseEvent}
       >
         <ul
@@ -121,9 +125,11 @@ class DropdownMenu extends React.Component {
           {ValidComponentChildren.map(children, child => (
             React.cloneElement(child, {
               onKeyDown: createChainedFunction(
-                child.props.onKeyDown, this.handleKeyDown
+                child.props.onKeyDown, this.handleKeyDown,
               ),
-              onSelect: createChainedFunction(child.props.onSelect, onSelect),
+              onSelect: createChainedFunction(
+                child.props.onSelect, onSelect,
+              ),
             })
           ))}
         </ul>

--- a/test/DropdownMenuSpec.js
+++ b/test/DropdownMenuSpec.js
@@ -125,7 +125,7 @@ describe('<Dropdown.Menu>', () => {
       button.click();
 
       requestClose.should.have.been.calledOnce;
-      requestClose.getCall(0).args.length.should.equal(0);
+      requestClose.getCall(0).args.length.should.equal(1);
     });
 
     describe('Keyboard Navigation', () => {

--- a/test/DropdownMenuSpec.js
+++ b/test/DropdownMenuSpec.js
@@ -125,7 +125,7 @@ describe('<Dropdown.Menu>', () => {
       button.click();
 
       requestClose.should.have.been.calledOnce;
-      requestClose.getCall(0).args.length.should.equal(1);
+      requestClose.getCall(0).args.length.should.equal(2);
     });
 
     describe('Keyboard Navigation', () => {

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -9,7 +9,7 @@ import DropdownMenu from '../src/DropdownMenu';
 import Grid from '../src/Grid';
 import MenuItem from '../src/MenuItem';
 
-import { shouldWarn } from './helpers';
+import { shouldWarn, getOne } from './helpers';
 
 class CustomMenu extends React.Component {
   render() {
@@ -523,6 +523,133 @@ describe('<Dropdown>', () => {
       // simulating a tab event doesn't actually shift focus.
       // at least that seems to be the case according to SO.
       // hence no assert on the input having focus.
+    });
+  });
+
+  describe('DOM event and source passed to onToggle', () => {
+    let focusableContainer;
+
+    beforeEach(() => {
+      focusableContainer = document.createElement('div');
+      document.body.appendChild(focusableContainer);
+    });
+
+    afterEach(() => {
+      ReactDOM.unmountComponentAtNode(focusableContainer);
+      document.body.removeChild(focusableContainer);
+    });
+
+    it('passes open, event, and source correctly when opened with click', () => {
+      const spy = sinon.spy();
+      const instance = ReactTestUtils.renderIntoDocument(
+        <Dropdown id="test-id" onToggle={spy}>
+          {dropdownChildren}
+        </Dropdown>
+      );
+      const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'BUTTON');
+
+      expect(spy).to.not.have.been.called;
+
+      ReactTestUtils.Simulate.click(buttonNode);
+
+      expect(spy).to.have.been.calledOnce;
+      expect(spy.getCall(0).args.length).to.equal(3);
+      expect(spy.getCall(0).args[0]).to.equal(true);
+      expect(spy.getCall(0).args[1]).to.be.an('object');
+      assert.deepEqual(spy.getCall(0).args[2], { source: 'click' });
+    });
+
+    it('passes open, event, and source correctly when closed with click', () => {
+      const spy = sinon.spy();
+      const instance = ReactTestUtils.renderIntoDocument(
+        <Dropdown id="test-id" onToggle={spy}>
+          {dropdownChildren}
+        </Dropdown>
+      );
+      const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'BUTTON');
+
+      expect(spy).to.not.have.been.called;
+      ReactTestUtils.Simulate.click(buttonNode);
+      expect(spy).to.have.been.calledOnce;
+      ReactTestUtils.Simulate.click(buttonNode);
+
+      expect(spy).to.have.been.calledTwice;
+      expect(spy.getCall(1).args.length).to.equal(3);
+      expect(spy.getCall(1).args[0]).to.equal(false);
+      expect(spy.getCall(1).args[1]).to.be.an('object');
+      assert.deepEqual(spy.getCall(1).args[2], { source: 'click' });
+    });
+
+    it('passes open, event, and source correctly when child selected', () => {
+      const spy = sinon.spy();
+      const instance = ReactTestUtils.renderIntoDocument(
+        <Dropdown id="test-id" onToggle={spy}>
+          <Dropdown.Toggle key="toggle">
+            Child Title
+          </Dropdown.Toggle>
+          <Dropdown.Menu key="menu">
+            <MenuItem eventKey={1}>Item 1</MenuItem>
+          </Dropdown.Menu>
+        </Dropdown>
+      );
+      const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'BUTTON');
+      const childNode = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'A');
+
+      expect(spy).to.not.have.been.called;
+      ReactTestUtils.Simulate.click(buttonNode);
+      expect(spy).to.have.been.calledOnce;
+
+      ReactTestUtils.Simulate.click(childNode);
+
+      expect(spy).to.have.been.calledTwice;
+      expect(spy.getCall(1).args.length).to.equal(3);
+      expect(spy.getCall(1).args[0]).to.equal(false);
+      expect(spy.getCall(1).args[1]).to.be.an('object');
+      assert.deepEqual(spy.getCall(1).args[2], { source: 'select' });
+    });
+
+    it('passes open, event, and source correctly when opened with keydown', () => {
+      const spy = sinon.spy();
+      const instance = ReactTestUtils.renderIntoDocument(
+        <Dropdown id="test-id" onToggle={spy}>
+          {dropdownChildren}
+        </Dropdown>
+      );
+      const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'BUTTON');
+
+      ReactTestUtils.Simulate.keyDown(buttonNode, { key: 'Down Arrow', keyCode: 40, which: 40 });
+
+      expect(spy).to.have.been.calledOnce;
+      expect(spy.getCall(0).args.length).to.equal(3);
+      expect(spy.getCall(0).args[0]).to.equal(true);
+      expect(spy.getCall(0).args[1]).to.be.an('object');
+      assert.deepEqual(spy.getCall(0).args[2], { source: 'keydown' });
+    });
+
+    it('passes open, event, and source correctly when closed from RootClose', () => {
+      const onToggleSpy = sinon.spy();
+
+      function onToggle(...args) {
+        onToggleSpy(...args);
+
+        expect(onToggleSpy).to.have.been.calledOnce;
+        expect(onToggleSpy.getCall(0).args.length).to.equal(3);
+        expect(onToggleSpy.getCall(0).args[0]).to.equal(false);
+        expect(onToggleSpy.getCall(0).args[1]).to.be.an('object');
+        assert.deepEqual(onToggleSpy.getCall(0).args[2], { source: 'close' });
+      }
+
+      const instance = ReactDOM.render(
+        <div>
+          <button>Something to click</button>
+          <Dropdown id="test" onToggle={onToggle}>
+            <Dropdown.Menu open>
+              <MenuItem>Item</MenuItem>
+            </Dropdown.Menu>
+          </Dropdown>
+        </div>, focusableContainer);
+      const button = getOne(instance.getElementsByTagName('button'));
+      button.click();
     });
   });
 

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -9,7 +9,7 @@ import DropdownMenu from '../src/DropdownMenu';
 import Grid from '../src/Grid';
 import MenuItem from '../src/MenuItem';
 
-import { shouldWarn, getOne } from './helpers';
+import { shouldWarn } from './helpers';
 
 class CustomMenu extends React.Component {
   render() {
@@ -624,32 +624,6 @@ describe('<Dropdown>', () => {
       expect(spy.getCall(0).args[0]).to.equal(true);
       expect(spy.getCall(0).args[1]).to.be.an('object');
       assert.deepEqual(spy.getCall(0).args[2], { source: 'keydown' });
-    });
-
-    it('passes open, event, and source correctly when closed from RootClose', () => {
-      const onToggleSpy = sinon.spy();
-
-      function onToggle(...args) {
-        onToggleSpy(...args);
-
-        expect(onToggleSpy).to.have.been.calledOnce;
-        expect(onToggleSpy.getCall(0).args.length).to.equal(3);
-        expect(onToggleSpy.getCall(0).args[0]).to.equal(false);
-        expect(onToggleSpy.getCall(0).args[1]).to.be.an('object');
-        assert.deepEqual(onToggleSpy.getCall(0).args[2], { source: 'close' });
-      }
-
-      const instance = ReactDOM.render(
-        <div>
-          <button>Something to click</button>
-          <Dropdown id="test" onToggle={onToggle}>
-            <Dropdown.Menu open>
-              <MenuItem>Item</MenuItem>
-            </Dropdown.Menu>
-          </Dropdown>
-        </div>, focusableContainer);
-      const button = getOne(instance.getElementsByTagName('button'));
-      button.click();
     });
   });
 


### PR DESCRIPTION
This PR attempts to resolve #1490. The main things that I changed are:
1) Added a parameter (eventType) to onToggle so that every time onToggle is fired you know exactly what event fired it ('click' if from handleClick, 'keydown' if from handleKeyDown, 'close' if from onClose, 'select' if from onSelect).
2) Added a parameter (source) to handleClose which is the source function that fired the handleClose.

I tried it out locally in my own app and I was able to override the default closing of the dropdown by creating my own state that I called `dropdownOpen` that I passed in as the `open` prop to the Dropdown component. I created a `handleToggle` function that I pass in as the `onToggle` prop which only closes when `open` is `false` and the event that closed it is `close`. Here's what my handleToggle looks like:
```
handleToggle(open, eventType) {
    // If open is false and type of event is 'close'
    if (!open && eventType === 'close') {
      this.setState({
        dropdownOpen: false,
      });
    }
    else {
      this.setState({
        dropdownOpen: true,
      });
    }
  } 
```

Here's what you get when you console.log the inputs to onToggle:
![onToggle Screenshot](https://i.gyazo.com/855929ad1755a1526ab80b552731ef75.png)

I didn't know how to write a test for this so if you could advise me on how I could then I'll add it to this PR, thanks!