### PR TITLE
Give `props.active` precedence over children active for `NavDropdown`

### DIFF
--- a/src/NavDropdown.js
+++ b/src/NavDropdown.js
@@ -22,7 +22,9 @@ const propTypes = {
 
 class NavDropdown extends React.Component {
   isActive({ props }, activeKey, activeHref) {
-    if (
+    if (props.active != null) {
+      return props.active;
+    } else if (
       props.active ||
       activeKey != null && props.eventKey === activeKey ||
       activeHref && props.href === activeHref


### PR DESCRIPTION
The logic for determining if a `NavDropdown` component is active first checks to see if `props.active` is true.  If not, then it gets set to active if any of its children are active [[1](https://github.com/react-bootstrap/react-bootstrap/blob/master/src/NavDropdown.js#L24-L40)].  I think that setting `props.active = false` should take precendence over the children's activeness.  This will allow the programmer to explicitly set the active field to `false` regardless of the childrens' active state.

