### PR TITLE
Document caution required for MenuItem's onSelect

### DIFF
--- a/docs/src/sections/MenuItemSection.js
+++ b/docs/src/sections/MenuItemSection.js
@@ -22,7 +22,7 @@ export default function MenuItemSection() {
         <li><code>divider</code>: Adds an horizontal divider between sections</li>
         <li><code>disabled</code>: shows the item as disabled, and prevents the onclick</li>
         <li><code>eventKey</code>: passed to the callback</li>
-        <li><code>onSelect</code>: a callback that is called when the user clicks the item.</li>
+        <li><code>onSelect</code>: a callback that is called when the user clicks the item. <b>NOTE:</b> the containing DropdownMenu actually re-writes this property on its direct child elements. For simple (direct) uses of MenuItem, this will not affect you. However, if you wrap a MenuItem in your own component, be careful! You <em>must</em> handle the onSelect property accordingly, or the <a href="https://github.com/react-bootstrap/react-bootstrap/issues/2429">dropdown will not close</a> after a user selects a menu item!</li>
       </ul>
       <p>The callback is called with the following arguments: <code>event</code> and <code>eventKey</code></p>
       <ReactPlayground codeText={Samples.MenuItem} />


### PR DESCRIPTION
As described in more detail in https://github.com/react-bootstrap/react-bootstrap/issues/2429, there is currently a "gotcha" if one wraps a MenuItem but overrides (or fails to pass along) the monkey-patched `onSelect` property that will be unexpectedly received via the DropdownMenu internals.

I.e. logic like this will break menu closing:

```
let MyMenuItem = ({obj}) => <MenuItem
  onSelect={ () => handleSelect(obj) }
>{obj.name}</MenuItem>

let objects = [{id:123, name:"My object}, …]
let Test = () => <DropdownButton title="Test" id="naiveLogic">
  {objects.map((obj) => <MyMenuItem key={obj.id} obj={obj}/>}
</DropdownButton>
```

Instead you currently need to implement the wrapper as something like this, aware of the DropdownMenu internal behavior:

```
let MyMenuItem = ({obj, onSelect:internalOnSelectOverride}) => <MenuItem
  onSelect={ () => { handleSelect(obj); internalOnSelectOverride(); } }
>{obj.name}</MenuItem>
```

Or as something like this, passing along all received properties (even if your own calling code doesn't ever provide any extra!) and being sure to avoid using onSelect in your wrapper itself:

```
let MyMenuItem = ({obj, ...props}) => <MenuItem
  {...props}
  onClick={ () => handleSelect(obj) }
>{obj.name}</MenuItem>
```
