### PR TITLE
Add support for Modal.Header closeButton without containing Modal component

### DIFF
--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -65,7 +65,7 @@ class ModalHeader extends React.Component {
             type="button"
             className="close"
             aria-label={label}
-            onClick={createChainedFunction(modal.onHide, onHide)}
+            onClick={createChainedFunction(modal && modal.onHide, onHide)}
           >
             <span aria-hidden="true">
               &times;

--- a/test/ModalHeaderSpec.js
+++ b/test/ModalHeaderSpec.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import ReactTestUtils from 'react-addons-test-utils';
+import ReactDOM from 'react-dom';
+
+import Modal from '../src/Modal';
+
+describe('Modal.Header', () => {
+  it('uses "div" by default', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Modal.Header />
+    );
+
+    assert.equal(ReactDOM.findDOMNode(instance).nodeName, 'DIV');
+  });
+
+  it('has "modal-header" class', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Modal.Header />
+    );
+
+    assert.include(ReactDOM.findDOMNode(instance).className, 'modal-header');
+  });
+
+  it('should merge additional classes passed in', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Modal.Header className="custom-class" />
+    );
+    const classes = ReactDOM.findDOMNode(instance).className;
+
+    assert.include(classes, 'modal-header');
+    assert.include(classes, 'custom-class');
+  });
+
+  it('should render children', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Modal.Header>
+        <strong>Content</strong>
+      </Modal.Header>
+    );
+
+    assert.ok(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'strong'));
+  });
+
+  it('has closeButton without a containing Modal and renders', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Modal.Header closeButton />
+    );
+
+    assert.isNotNull(ReactDOM.findDOMNode(instance));
+  });
+});

--- a/test/ModalHeaderSpec.js
+++ b/test/ModalHeaderSpec.js
@@ -48,4 +48,20 @@ describe('Modal.Header', () => {
 
     assert.isNotNull(ReactDOM.findDOMNode(instance));
   });
+
+  it('Should trigger onHide when modal is closed', () => {
+    const onHideSpy = sinon.spy();
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Modal.Header closeButton onHide={onHideSpy} />
+    );
+
+    const closeButton = ReactTestUtils.findRenderedDOMComponentWithClass(
+      instance,
+      'close',
+    );
+
+    ReactTestUtils.Simulate.click(closeButton);
+
+    expect(onHideSpy).to.have.been.called;
+  });
 });


### PR DESCRIPTION
Implements what was discussed in #2450 . Also added ModalHeaderSpec since it wasn't previously there and wrote a test to make sure the component renders with a closeButton prop now.