### PR TITLE
Fix Navbar Basic Example eventKeys

### DIFF
--- a/docs/examples/NavbarBasic.js
+++ b/docs/examples/NavbarBasic.js
@@ -13,7 +13,7 @@ const navbarInstance = (
         <MenuItem eventKey={3.2}>Another action</MenuItem>
         <MenuItem eventKey={3.3}>Something else here</MenuItem>
         <MenuItem divider />
-        <MenuItem eventKey={3.3}>Separated link</MenuItem>
+        <MenuItem eventKey={3.4}>Separated link</MenuItem>
       </NavDropdown>
     </Nav>
   </Navbar>


### PR DESCRIPTION
- Change the 4th MenuItem's eventKey from 3.3 to 3.4, thus making all keys unique

Resolves #2458 