### PR TITLE
Clarify naming expectation for glyph prop

### DIFF
--- a/src/Glyphicon.js
+++ b/src/Glyphicon.js
@@ -6,7 +6,7 @@ import { bsClass, getClassSet, prefix, splitBsProps }
 
 const propTypes = {
   /**
-   * An icon name. See e.g. http://getbootstrap.com/components/#glyphicons
+   * An icon name without "glyphicon-" prefix. See e.g. http://getbootstrap.com/components/#glyphicons
    */
   glyph: React.PropTypes.string.isRequired,
 };


### PR DESCRIPTION
It was not immediately obvious to remove the prefix since we specify using the icon name with a link to bootstrap which does use the prefix. It was only after looking at the sample and my written code that I noticed the difference.

While its nothing major I feel that this just adds a bit of clarity to the naming convention.