### PR TITLE
Modal: add restoreFocus option

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "dom-helpers": "^3.2.0",
     "invariant": "^2.2.1",
     "keycode": "^2.1.2",
-    "react-overlays": "^0.6.10",
+    "react-overlays": "^0.6.12",
     "react-prop-types": "^0.4.0",
     "uncontrollable": "^4.0.1",
     "warning": "^3.0.0"

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -61,6 +61,12 @@ const propTypes = {
    * the Modal work well with assistive technologies, such as screen readers.
    */
   enforceFocus: React.PropTypes.bool,
+  
+  /**
+   * When `true` The modal will restore focus to previously focused element once
+   * modal is hidden
+   */
+  restoreFocus: React.PropTypes.bool,
 
   /**
    * When `true` The modal will show itself.

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -61,7 +61,7 @@ const propTypes = {
    * the Modal work well with assistive technologies, such as screen readers.
    */
   enforceFocus: React.PropTypes.bool,
-  
+
   /**
    * When `true` The modal will restore focus to previously focused element once
    * modal is hidden


### PR DESCRIPTION
Allow to specify if last focus should be restored after hiding modal. Requires https://github.com/react-bootstrap/react-overlays/pull/145 to be merged.