### PR TITLE
Add support for styling pagination buttons (first, prev, next, & last)

### DIFF
--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -205,6 +205,7 @@ class Pagination extends React.Component {
         {first && (
           <PaginationButton
             {...buttonProps}
+            className="btn-first"
             eventKey={1}
             disabled={activePage === 1}
           >
@@ -216,6 +217,7 @@ class Pagination extends React.Component {
         {prev && (
           <PaginationButton
             {...buttonProps}
+            className="btn-prev"
             eventKey={activePage - 1}
             disabled={activePage === 1}
           >
@@ -232,6 +234,7 @@ class Pagination extends React.Component {
         {next && (
           <PaginationButton
             {...buttonProps}
+            className="btn-next"
             eventKey={activePage + 1}
             disabled={activePage >= items}
           >
@@ -243,6 +246,7 @@ class Pagination extends React.Component {
         {last && (
           <PaginationButton
             {...buttonProps}
+            className="btn-last"
             eventKey={items}
             disabled={activePage >= items}
           >


### PR DESCRIPTION
There is currently no non-hacky way to custom style the for first, prev, next, and last icon buttons.  The enterprise software development entity I contract with currently has a style requirement for showing and hiding these buttons based on the active page (ie if it's the first or last) and also custom styling.  All of this can be easily manged if there are some base classes on these buttons.  I admit it's a little bit of an edge case and so I'm already doing this on my fork but would like to propose it may benefit others to forward this option as well.