### PR TITLE
add unstyled SplitButton to docs #btn-dropdowns-split

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# data-toggle fork
+**This fork aims on adding `data-toggle` attributes in the right places.**
+
+You can still use the bundled js in `development`, but you may drop it in `production`
+and use e.g. [bootstrap.native](https://github.com/thednp/bootstrap.native/) there.
+
 # React-Bootstrap [![Travis][build-badge]][build] [![npm][npm-badge]][npm]
 
 [Bootstrap 3][bootstrap] components built with [React][react].

--- a/docs/examples/SplitButtonBasic.js
+++ b/docs/examples/SplitButtonBasic.js
@@ -1,4 +1,4 @@
-const BUTTONS = ['Default', 'Primary', 'Success', 'Info', 'Warning', 'Danger'];
+const BUTTONS = ['Default', 'Primary', 'Success', 'Info', 'Warning', 'Danger', 'Link'];
 
 function renderDropdownButton(title, i) {
   return (

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -32,7 +32,7 @@ const propTypes = {
 class SplitButton extends React.Component {
   render() {
     const {
-      bsSize, bsStyle, title, toggleLabel, children, ...props
+      bsSize, bsStyle, title, toggleLabel, children, 'data-toggle': dataToggle, ...props
     } = this.props;
 
     const [dropdownProps, buttonProps] =
@@ -53,6 +53,7 @@ class SplitButton extends React.Component {
           {title}
         </Button>
         <SplitToggle
+          data-toggle={dataToggle || ''}
           aria-label={toggleLabel || title}
           bsSize={bsSize}
           bsStyle={bsStyle}

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -53,7 +53,7 @@ class SplitButton extends React.Component {
           {title}
         </Button>
         <SplitToggle
-          data-toggle={dataToggle || ''}
+          data-toggle={dataToggle || null}
           aria-label={toggleLabel || title}
           bsSize={bsSize}
           bsStyle={bsStyle}


### PR DESCRIPTION
I was searching for an unstyled SplitButtonDropdown and since it already seems to be supported, i think it should be reflected in the documentation.