### PR TITLE
Delegate the control over a collapsible panel to elements other than anchor

### DIFF
--- a/docs/examples/PanelCollapseControl.js
+++ b/docs/examples/PanelCollapseControl.js
@@ -1,0 +1,9 @@
+const collapseControlInstance = (
+  <PanelGroup accordion>
+    <Panel header="Clickable header" collapseControl="heading" eventKey="1">Panel 1 content</Panel>
+    <Panel header={<Button>Clickable button</Button>} collapseControl="element" eventKey="2">Panel 2 content</Panel>
+    <Panel header="Clickable anchor" eventKey="3">Panel 3 content</Panel>
+  </PanelGroup>
+);
+
+ReactDOM.render(collapseControlInstance, mountNode);

--- a/docs/src/Samples.js
+++ b/docs/src/Samples.js
@@ -83,6 +83,7 @@ export default {
   PanelGroupAccordion:           require('fs').readFileSync(__dirname + '/../examples/PanelGroupAccordion.js', 'utf8'),
   PanelGroupControlled:          require('fs').readFileSync(__dirname + '/../examples/PanelGroupControlled.js', 'utf8'),
   PanelGroupUncontrolled:        require('fs').readFileSync(__dirname + '/../examples/PanelGroupUncontrolled.js', 'utf8'),
+  PanelCollapseControl:          require('fs').readFileSync(__dirname + '/../examples/PanelCollapseControl.js', 'utf8'),
   PanelListGroupFill:            require('fs').readFileSync(__dirname + '/../examples/PanelListGroupFill.js', 'utf8'),
   PanelWithFooter:               require('fs').readFileSync(__dirname + '/../examples/PanelWithFooter.js', 'utf8'),
   PanelWithHeading:              require('fs').readFileSync(__dirname + '/../examples/PanelWithHeading.js', 'utf8'),

--- a/docs/src/sections/PanelSection.js
+++ b/docs/src/sections/PanelSection.js
@@ -44,6 +44,10 @@ export default function PanelSection() {
       <p><code>PanelGroup</code>s can also be uncontrolled where they manage their own state. The <code>defaultActiveKey</code> prop dictates which panel is open when initially.</p>
       <ReactPlayground codeText={Samples.PanelGroupUncontrolled} />
 
+      <h3><Anchor id="panels-collapse-control">Collapse control</Anchor></h3>
+      <p>The control over a collapsible panel can be delegated to an <code>anchor</code>, an <code>element</code> or the entire <code>heading</code>. The <code>collapseControl</code> prop dictates the behaviour, as well as structure of the header HTML code. Notice how <code>element</code> and <code>heading</code> values omit the unnecessary anchor tag. You can define individual <code>collapseControl</code> props for each panel, however it will always prioritize the value passed to <code>PanelGroup</code>.</p>
+      <ReactPlayground codeText={Samples.PanelCollapseControl} />
+
       <h3><Anchor id="panels-accordion">Accordions</Anchor></h3>
       <p><code>&lt;Accordion /&gt;</code> aliases <code>&lt;PanelGroup accordion /&gt;</code>.</p>
       <ReactPlayground codeText={Samples.PanelGroupAccordion} />

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -12,6 +12,7 @@ const propTypes = {
   defaultActiveKey: React.PropTypes.any,
   onSelect: React.PropTypes.func,
   role: React.PropTypes.string,
+  collapseControl: React.PropTypes.oneOf([undefined, 'heading', 'element', 'anchor']),
 };
 
 const defaultProps = {
@@ -51,11 +52,12 @@ class PanelGroup extends React.Component {
       activeKey: propsActiveKey,
       className,
       children,
+      collapseControl,
       ...props
     } = this.props;
 
     const [bsProps, elementProps] = splitBsPropsAndOmit(props, [
-      'defaultActiveKey', 'onSelect',
+      'defaultActiveKey', 'onSelect', 'collapseControl',
     ]);
 
     let activeKey;
@@ -82,6 +84,7 @@ class PanelGroup extends React.Component {
               headerRole: 'tab',
               panelRole: 'tabpanel',
               collapsible: true,
+              collapseControl: collapseControl || child.props.collapseControl,
               expanded: child.props.eventKey === activeKey,
               onSelect: createChainedFunction(
                 this.handleSelect, child.props.onSelect

--- a/test/PanelGroupSpec.js
+++ b/test/PanelGroupSpec.js
@@ -31,6 +31,28 @@ describe('<PanelGroup>', () => {
     assert.equal(panel.props.bsStyle, 'primary');
   });
 
+  it('Should pass collapseControl prop to children', () => {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <PanelGroup collapseControl="heading" accordion>
+        <Panel>Panel 1</Panel>
+      </PanelGroup>
+    );
+
+    let panel = ReactTestUtils.findRenderedComponentWithType(instance, Panel);
+    assert.equal(panel.props.collapseControl, 'heading');
+  });
+
+  it('Should prioritize container collapseControl value', () => {
+    let instance = ReactTestUtils.renderIntoDocument(
+      <PanelGroup collapseControl="anchor" accordion>
+        <Panel collapseControl="heading">Panel 1</Panel>
+      </PanelGroup>
+    );
+
+    let panel = ReactTestUtils.findRenderedComponentWithType(instance, Panel);
+    assert.equal(panel.props.collapseControl, 'anchor');
+  });
+
   it('Should not collapse panel by bubbling onSelect callback', () => {
     let instance = ReactTestUtils.renderIntoDocument(
       <PanelGroup accordion>

--- a/test/PanelSpec.js
+++ b/test/PanelSpec.js
@@ -69,6 +69,47 @@ describe('<Panel>', () => {
     assert.equal(header.firstChild.firstChild.textContent, 'Heading');
   });
 
+  it('Should have custom component header without anchor', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Panel header={<h3>Heading</h3>} collapseControl="heading" collapsible>
+        Panel content
+      </Panel>
+    );
+    const header = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-heading');
+    assert.equal(header.firstChild.nodeName, 'H3');
+    assert.ok(header.firstChild.className.match(/\bpanel-title\b/));
+    assert.notEqual(header.firstChild.firstChild.nodeName, 'A');
+    assert.equal(header.firstChild.firstChild.textContent, 'Heading');
+  });
+
+  it('Should give collapse control to header', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Panel header="Heading" collapseControl="heading" collapsible>
+        Panel content
+      </Panel>
+    );
+    const header = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-heading');
+    assert.ok(header.className.match(/\bcollapsed\b/));
+    assert.equal(header.getAttribute('aria-expanded'), 'false');
+    ReactTestUtils.Simulate.click(header);
+    assert.notOk(header.className.match(/\bcollapsed\b/));
+    assert.equal(header.getAttribute('aria-expanded'), 'true');
+  });
+
+  it('Should give collapse control to element', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Panel header={<div>Heading</div>} collapseControl="element" collapsible>
+        Panel content
+      </Panel>
+    );
+    const header = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'panel-heading');
+    assert.ok(header.firstChild.className.match(/\bcollapsed\b/));
+    assert.equal(header.firstChild.getAttribute('aria-expanded'), 'false');
+    ReactTestUtils.Simulate.click(header.firstChild);
+    assert.notOk(header.firstChild.className.match(/\bcollapsed\b/));
+    assert.equal(header.firstChild.getAttribute('aria-expanded'), 'true');
+  });
+
   it('Should have custom component header with custom class', () => {
     const instance = ReactTestUtils.renderIntoDocument(
       <Panel


### PR DESCRIPTION
Hello, this PR implements a change to collapsible panels with header - allowing nested elements or the entire heading to be toggles for collapsible panel, which is a must-have feature we needed at work. This is easily done with Bootstrap by simply reordering the elements or moving the control attributes up in the tree, but not so simple with react-bootstrap as far as I'm concerned. Up to this point, it was only possible for the text inside a header to be an anchor controlling the collapsible, and there was no elegant solution for making the entire header or nested elements toggles for collapsible panels. Here's how this works:

![react-bootstrap-collapse-control](https://cloud.githubusercontent.com/assets/12484983/23822961/fccc7390-0657-11e7-86dc-c8fe015deca7.gif)

This change introduces a new prop for `PanelGroup` and `Panel` components: `collapseControl`, that takes one of three values: `heading`, `element` or `anchor`, with `anchor` being the default. Those should be self-explanatory. You can specify different `collapseControl` values for each `Panel` component, or have a "global" behaviour for a group of Panels by passing it to a `PanelGroup`. Note that this will always be prioritized, as in `PanelGroup` prop value will override any `Panel` prop values.

Notice how `heading` makes the entire header clickable, and removes the underline text decoration from the text. Same applies to `element` - before, passing a JSX component (eg. <Button>) as `header` resulted in the text inside the element being underlined on hover.

This is a non-breaking change, the default behaviour for this component should stay the same since the `collapseControl` prop is `anchor` by default. Please verify this statement though.

Docs and tests included, Travis build passes.