### PR TITLE
Fix #2532

### DIFF
--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -38,13 +38,14 @@ class DropdownMenu extends React.Component {
   }
 
   handleKeyDown(event) {
+    const targetElement = event.target;
     switch (event.keyCode) {
       case keycode.codes.down:
-        this.focusNext();
+        this.focusNext(targetElement);
         event.preventDefault();
         break;
       case keycode.codes.up:
-        this.focusPrevious();
+        this.focusPrevious(targetElement);
         event.preventDefault();
         break;
       case keycode.codes.esc:
@@ -55,9 +56,9 @@ class DropdownMenu extends React.Component {
     }
   }
 
-  getItemsAndActiveIndex() {
+  getItemsAndActiveIndex(targetElement) {
     const items = this.getFocusableMenuItems();
-    const activeIndex = items.indexOf(document.activeElement);
+    const activeIndex = items.indexOf(targetElement);
 
     return { items, activeIndex };
   }
@@ -71,8 +72,8 @@ class DropdownMenu extends React.Component {
     return Array.from(node.querySelectorAll('[tabIndex="-1"]'));
   }
 
-  focusNext() {
-    const { items, activeIndex } = this.getItemsAndActiveIndex();
+  focusNext(targetElement) {
+    const { items, activeIndex } = this.getItemsAndActiveIndex(targetElement);
     if (items.length === 0) {
       return;
     }
@@ -81,8 +82,8 @@ class DropdownMenu extends React.Component {
     items[nextIndex].focus();
   }
 
-  focusPrevious() {
-    const { items, activeIndex } = this.getItemsAndActiveIndex();
+  focusPrevious(targetElement) {
+    const { items, activeIndex } = this.getItemsAndActiveIndex(targetElement);
     if (items.length === 0) {
       return;
     }


### PR DESCRIPTION
The issue right now is the use of `document.activeElement`. 

When the user press the *down button* the browser moves the *focus to the next element*(document.activeElement gets changed) and then our logic for focusing the next element is hit; which mean it will always focus the next to next element. 

The fix is to use the `event.target` instead of `document.activeElement`;

Fixes #2532