### PR TITLE
#2539: change condition from truthy to not nully

### DIFF
--- a/src/Nav.js
+++ b/src/Nav.js
@@ -161,7 +161,7 @@ class Nav extends React.Component {
   getNextActiveChild(offset) {
     const { children } = this.props;
     const validChildren = children.filter(child => (
-      child.props.eventKey && !child.props.disabled
+      child.props.eventKey != null && !child.props.disabled
     ));
     const { activeKey, activeHref } = this.getActiveProps();
 

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -151,7 +151,7 @@ class Nav extends React.Component {
 
     event.preventDefault();
 
-    if (onSelect && nextActiveChild && nextActiveChild.props.eventKey) {
+    if (onSelect && nextActiveChild && nextActiveChild.props.eventKey != null) {
       onSelect(nextActiveChild.props.eventKey);
     }
 

--- a/test/NavSpec.js
+++ b/test/NavSpec.js
@@ -189,6 +189,52 @@ describe('<Nav>', () => {
     });
   });
 
+  describe('event keys', () => {
+    it('should accept any number as an event key', () => {
+      let instance;
+      let selectSpy = sinon.spy(activeKey => instance.props({ activeKey }));
+      instance = tsp(
+        <Nav activeKey={-100} onSelect={selectSpy} role="tablist">
+          <NavItem eventKey={-100}>NavItem 1 content</NavItem>
+          <NavItem eventKey={0}>NavItem 2 content</NavItem>
+          <NavItem eventKey={1}>NavItem 3 content</NavItem>
+        </Nav>
+      ).render(true);
+
+      const anchors = instance.find('a').dom();
+      anchors[0].focus();
+
+      ReactTestUtils.Simulate.keyDown(anchors[0], { keyCode: keycode('right') });
+
+      expect(instance[0].props.activeKey).to.equal(0);
+      expect(document.activeElement).to.equal(anchors[1]);
+
+      instance.unmount();
+    });
+
+    it('should accept any string as an event key', () => {
+      let instance;
+      let selectSpy = sinon.spy(activeKey => instance.props({ activeKey }));
+      instance = tsp(
+        <Nav activeKey={''} onSelect={selectSpy} role="tablist">
+          <NavItem eventKey={'a'}>NavItem 1 content</NavItem>
+          <NavItem eventKey={'b'}>NavItem 2 content</NavItem>
+          <NavItem eventKey={''}>NavItem 3 content</NavItem>
+        </Nav>
+      ).render(true);
+
+      const anchors = instance.find('a').dom();
+      anchors[2].focus();
+
+      ReactTestUtils.Simulate.keyDown(anchors[2], { keyCode: keycode('right') });
+
+      expect(instance[0].props.activeKey).to.equal('a');
+      expect(document.activeElement).to.equal(anchors[0]);
+
+      instance.unmount();
+    });
+  });
+
   describe('Web Accessibility', () => {
 
     it('Should have tablist and tab roles', () => {


### PR DESCRIPTION
As described in #2539, certain falsy values such as `0` should be acceptable. The truthy condition has been changed to check whether the value is `null` or `undefined` instead.