### PR TITLE
Update components to use external prop-types instead of React

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ propTypes: {
   /**
    * Sets the visibility of the Component
    */
-  show: React.PropTypes.bool,
+  show: PropTypes.bool,
 
   /**
    * A callback fired when the visibility changes

--- a/docs/src/Anchor.js
+++ b/docs/src/Anchor.js
@@ -1,10 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const Anchor = React.createClass({
   propTypes: {
-    id: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.number
+    id: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
     ])
   },
   render() {

--- a/docs/src/NavMain.js
+++ b/docs/src/NavMain.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import Navbar from '../../src/Navbar';
 import Nav from '../../src/Nav';
@@ -31,7 +32,7 @@ function Wrapper({ children }) {
 }
 
 const propTypes = {
-  activePage: React.PropTypes.string,
+  activePage: PropTypes.string,
 };
 
 function NavMain({ activePage }) {

--- a/docs/src/PropTable.js
+++ b/docs/src/PropTable.js
@@ -1,5 +1,6 @@
 import merge from 'lodash/merge';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Glyphicon from '../../src/Glyphicon';
 import Label from '../../src/Label';
@@ -37,7 +38,7 @@ function getPropsData(component, metadata) {
 const PropTable = React.createClass({
 
   contextTypes: {
-    metadata: React.PropTypes.object
+    metadata: PropTypes.object
   },
 
   componentWillMount() {

--- a/docs/src/ReactPlayground.js
+++ b/docs/src/ReactPlayground.js
@@ -4,6 +4,7 @@
 /* eslint-disable */
 const classNames = require('classnames');
 const React = require('react');
+const PropTypes = require('prop-types');
 const ReactDOM = require('react-dom');
 
 // Keep these in sync with src/index.js.
@@ -159,8 +160,8 @@ const ReactPlayground = React.createClass({
   mixins: [selfCleaningTimeout],
 
   propTypes: {
-    codeText: React.PropTypes.string.isRequired,
-    transformer: React.PropTypes.func
+    codeText: PropTypes.string.isRequired,
+    transformer: PropTypes.func
   },
 
   getDefaultProps() {

--- a/docs/src/Root.js
+++ b/docs/src/Root.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 const Root = React.createClass({
   statics: {
@@ -19,7 +20,7 @@ const Root = React.createClass({
   },
 
   childContextTypes: {
-    metadata: React.PropTypes.object
+    metadata: PropTypes.object
   },
 
   getChildContext() {

--- a/docs/src/SubNav.js
+++ b/docs/src/SubNav.js
@@ -1,4 +1,5 @@
 import React, { cloneElement } from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 import Nav from '../../src/Nav';
@@ -7,14 +8,14 @@ import ValidComponentChildren from '../../src/utils/ValidComponentChildren';
 import createChainedFunction from '../../src/utils/createChainedFunction';
 
 const propTypes = {
-  onSelect: React.PropTypes.func,
-  active: React.PropTypes.bool,
-  activeKey: React.PropTypes.any,
-  activeHref: React.PropTypes.string,
-  disabled: React.PropTypes.bool,
-  eventKey: React.PropTypes.any,
-  href: React.PropTypes.string,
-  text: React.PropTypes.node,
+  onSelect: PropTypes.func,
+  active: PropTypes.bool,
+  activeKey: PropTypes.any,
+  activeHref: PropTypes.string,
+  disabled: PropTypes.bool,
+  eventKey: PropTypes.any,
+  href: PropTypes.string,
+  text: PropTypes.node,
 };
 
 const defaultProps = {

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "nodemon": "^1.9.2",
     "output-file-sync": "^1.1.2",
     "portfinder": "^1.0.3",
+    "prop-types": "^15.5.6",
     "react": "^15.4.0",
     "react-addons-test-utils": "^15.4.0",
     "react-component-metadata": "^3.1.0",

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import { bsClass, bsStyles, getClassSet, prefix, splitBsProps }

--- a/src/Alert.js
+++ b/src/Alert.js
@@ -1,13 +1,15 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import { bsClass, bsStyles, getClassSet, prefix, splitBsProps }
   from './utils/bootstrapUtils';
 import { State } from './utils/StyleConfig';
 
 const propTypes = {
-  onDismiss: React.PropTypes.func,
-  closeLabel: React.PropTypes.string,
+  onDismiss: PropTypes.func,
+  closeLabel: PropTypes.string,
 };
 
 const defaultProps = {

--- a/src/Badge.js
+++ b/src/Badge.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';

--- a/src/Badge.js
+++ b/src/Badge.js
@@ -1,12 +1,14 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';
 
 // TODO: `pullRight` doesn't belong here. There's no special handling here.
 
 const propTypes = {
-  pullRight: React.PropTypes.bool,
+  pullRight: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/src/BreadcrumbItem.js
+++ b/src/BreadcrumbItem.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import SafeAnchor from './SafeAnchor';

--- a/src/BreadcrumbItem.js
+++ b/src/BreadcrumbItem.js
@@ -1,25 +1,27 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import SafeAnchor from './SafeAnchor';
 
 const propTypes = {
   /**
    * If set to true, renders `span` instead of `a`
    */
-  active: React.PropTypes.bool,
+  active: PropTypes.bool,
   /**
    * `href` attribute for the inner `a` element
    */
-  href: React.PropTypes.string,
+  href: PropTypes.string,
   /**
    * `title` attribute for the inner `a` element
    */
-  title: React.PropTypes.node,
+  title: PropTypes.node,
   /**
    * `target` attribute for the inner `a` element
    */
-  target: React.PropTypes.string,
+  target: PropTypes.string,
 };
 
 const defaultProps = {

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import elementType from 'react-prop-types/lib/elementType';
 
 import { bsClass, bsSizes, bsStyles, getClassSet, prefix, splitBsProps }
@@ -9,17 +10,17 @@ import { Size, State, Style } from './utils/StyleConfig';
 import SafeAnchor from './SafeAnchor';
 
 const propTypes = {
-  active: React.PropTypes.bool,
-  disabled: React.PropTypes.bool,
-  block: React.PropTypes.bool,
-  onClick: React.PropTypes.func,
+  active: PropTypes.bool,
+  disabled: PropTypes.bool,
+  block: PropTypes.bool,
+  onClick: PropTypes.func,
   componentClass: elementType,
-  href: React.PropTypes.string,
+  href: PropTypes.string,
   /**
    * Defines HTML button type attribute
    * @defaultValue 'button'
    */
-  type: React.PropTypes.oneOf(['button', 'reset', 'submit']),
+  type: PropTypes.oneOf(['button', 'reset', 'submit']),
 };
 
 const defaultProps = {

--- a/src/ButtonGroup.js
+++ b/src/ButtonGroup.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import all from 'react-prop-types/lib/all';
 
 import Button from './Button';
@@ -7,15 +8,15 @@ import { bsClass, getClassSet, prefix, splitBsProps }
   from './utils/bootstrapUtils';
 
 const propTypes = {
-  vertical: React.PropTypes.bool,
-  justified: React.PropTypes.bool,
+  vertical: PropTypes.bool,
+  justified: PropTypes.bool,
 
   /**
    * Display block buttons; only useful when used with the "vertical" prop.
    * @type {bool}
    */
   block: all(
-    React.PropTypes.bool,
+    PropTypes.bool,
     ({ block, vertical }) => (
       block && !vertical ?
         new Error('`block` requires `vertical` to be set to have any effect') :

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React, { cloneElement } from 'react';
-
 import PropTypes from 'prop-types';
 
 import CarouselCaption from './CarouselCaption';

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React, { cloneElement } from 'react';
 
+import PropTypes from 'prop-types';
+
 import CarouselCaption from './CarouselCaption';
 import CarouselItem from './CarouselItem';
 import Glyphicon from './Glyphicon';
@@ -14,12 +16,12 @@ import ValidComponentChildren from './utils/ValidComponentChildren';
 // TODO: Use uncontrollable.
 
 const propTypes = {
-  slide: React.PropTypes.bool,
-  indicators: React.PropTypes.bool,
-  interval: React.PropTypes.number,
-  controls: React.PropTypes.bool,
-  pauseOnHover: React.PropTypes.bool,
-  wrap: React.PropTypes.bool,
+  slide: PropTypes.bool,
+  indicators: PropTypes.bool,
+  interval: PropTypes.number,
+  controls: PropTypes.bool,
+  pauseOnHover: PropTypes.bool,
+  wrap: PropTypes.bool,
   /**
    * Callback fired when the active item changes.
    *
@@ -31,25 +33,25 @@ const propTypes = {
    * be a persisted event object with `direction` set to the direction of the
    * transition.
    */
-  onSelect: React.PropTypes.func,
-  onSlideEnd: React.PropTypes.func,
-  activeIndex: React.PropTypes.number,
-  defaultActiveIndex: React.PropTypes.number,
-  direction: React.PropTypes.oneOf(['prev', 'next']),
-  prevIcon: React.PropTypes.node,
+  onSelect: PropTypes.func,
+  onSlideEnd: PropTypes.func,
+  activeIndex: PropTypes.number,
+  defaultActiveIndex: PropTypes.number,
+  direction: PropTypes.oneOf(['prev', 'next']),
+  prevIcon: PropTypes.node,
   /**
    * Label shown to screen readers only, can be used to show the previous element
    * in the carousel.
    * Set to null to deactivate.
    */
-  prevLabel: React.PropTypes.string,
-  nextIcon: React.PropTypes.node,
+  prevLabel: PropTypes.string,
+  nextIcon: PropTypes.node,
   /**
    * Label shown to screen readers only, can be used to show the next element
    * in the carousel.
    * Set to null to deactivate.
    */
-  nextLabel: React.PropTypes.string,
+  nextLabel: PropTypes.string,
 };
 
 const defaultProps = {

--- a/src/CarouselItem.js
+++ b/src/CarouselItem.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 import TransitionEvents from './utils/TransitionEvents';
@@ -8,12 +9,12 @@ import TransitionEvents from './utils/TransitionEvents';
 // not wait until transition end to trigger continuing animations.
 
 const propTypes = {
-  direction: React.PropTypes.oneOf(['prev', 'next']),
-  onAnimateOutEnd: React.PropTypes.func,
-  active: React.PropTypes.bool,
-  animateIn: React.PropTypes.bool,
-  animateOut: React.PropTypes.bool,
-  index: React.PropTypes.number,
+  direction: PropTypes.oneOf(['prev', 'next']),
+  onAnimateOutEnd: PropTypes.func,
+  active: PropTypes.bool,
+  animateIn: PropTypes.bool,
+  animateOut: PropTypes.bool,
+  index: PropTypes.number,
 };
 
 const defaultProps = {

--- a/src/Checkbox.js
+++ b/src/Checkbox.js
@@ -1,17 +1,18 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import warning from 'warning';
 
 import { bsClass, getClassSet, prefix, splitBsProps }
   from './utils/bootstrapUtils';
 
 const propTypes = {
-  inline: React.PropTypes.bool,
-  disabled: React.PropTypes.bool,
+  inline: PropTypes.bool,
+  disabled: PropTypes.bool,
   /**
    * Only valid if `inline` is not set.
    */
-  validationState: React.PropTypes.oneOf([
+  validationState: PropTypes.oneOf([
     'success', 'warning', 'error', null,
   ]),
   /**
@@ -21,7 +22,7 @@ const propTypes = {
    * <Checkbox inputRef={ref => { this.input = ref; }} />
    * ```
    */
-  inputRef: React.PropTypes.func,
+  inputRef: PropTypes.func,
 };
 
 const defaultProps = {

--- a/src/Clearfix.js
+++ b/src/Clearfix.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import elementType from 'react-prop-types/lib/elementType';
 
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';
@@ -16,7 +17,7 @@ const propTypes = {
    *
    * adds class `visible-xs-block`
    */
-  visibleXsBlock: React.PropTypes.bool,
+  visibleXsBlock: PropTypes.bool,
   /**
    * Apply clearfix
    *
@@ -24,7 +25,7 @@ const propTypes = {
    *
    * adds class `visible-sm-block`
    */
-  visibleSmBlock: React.PropTypes.bool,
+  visibleSmBlock: PropTypes.bool,
   /**
    * Apply clearfix
    *
@@ -32,7 +33,7 @@ const propTypes = {
    *
    * adds class `visible-md-block`
    */
-  visibleMdBlock: React.PropTypes.bool,
+  visibleMdBlock: PropTypes.bool,
   /**
    * Apply clearfix
    *
@@ -40,7 +41,7 @@ const propTypes = {
    *
    * adds class `visible-lg-block`
    */
-  visibleLgBlock: React.PropTypes.bool,
+  visibleLgBlock: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/src/Col.js
+++ b/src/Col.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import elementType from 'react-prop-types/lib/elementType';
 
 import { bsClass, prefix, splitBsProps } from './utils/bootstrapUtils';
@@ -15,7 +16,7 @@ const propTypes = {
    *
    * class-prefix `col-xs-`
    */
-  xs: React.PropTypes.number,
+  xs: PropTypes.number,
   /**
    * The number of columns you wish to span
    *
@@ -23,7 +24,7 @@ const propTypes = {
    *
    * class-prefix `col-sm-`
    */
-  sm: React.PropTypes.number,
+  sm: PropTypes.number,
   /**
    * The number of columns you wish to span
    *
@@ -31,7 +32,7 @@ const propTypes = {
    *
    * class-prefix `col-md-`
    */
-  md: React.PropTypes.number,
+  md: PropTypes.number,
   /**
    * The number of columns you wish to span
    *
@@ -39,7 +40,7 @@ const propTypes = {
    *
    * class-prefix `col-lg-`
    */
-  lg: React.PropTypes.number,
+  lg: PropTypes.number,
   /**
    * Hide column
    *
@@ -47,7 +48,7 @@ const propTypes = {
    *
    * adds class `hidden-xs`
    */
-  xsHidden: React.PropTypes.bool,
+  xsHidden: PropTypes.bool,
   /**
    * Hide column
    *
@@ -55,7 +56,7 @@ const propTypes = {
    *
    * adds class `hidden-sm`
    */
-  smHidden: React.PropTypes.bool,
+  smHidden: PropTypes.bool,
   /**
    * Hide column
    *
@@ -63,7 +64,7 @@ const propTypes = {
    *
    * adds class `hidden-md`
    */
-  mdHidden: React.PropTypes.bool,
+  mdHidden: PropTypes.bool,
   /**
    * Hide column
    *
@@ -71,7 +72,7 @@ const propTypes = {
    *
    * adds class `hidden-lg`
    */
-  lgHidden: React.PropTypes.bool,
+  lgHidden: PropTypes.bool,
   /**
    * Move columns to the right
    *
@@ -79,7 +80,7 @@ const propTypes = {
    *
    * class-prefix `col-xs-offset-`
    */
-  xsOffset: React.PropTypes.number,
+  xsOffset: PropTypes.number,
   /**
    * Move columns to the right
    *
@@ -87,7 +88,7 @@ const propTypes = {
    *
    * class-prefix `col-sm-offset-`
    */
-  smOffset: React.PropTypes.number,
+  smOffset: PropTypes.number,
   /**
    * Move columns to the right
    *
@@ -95,7 +96,7 @@ const propTypes = {
    *
    * class-prefix `col-md-offset-`
    */
-  mdOffset: React.PropTypes.number,
+  mdOffset: PropTypes.number,
   /**
    * Move columns to the right
    *
@@ -103,7 +104,7 @@ const propTypes = {
    *
    * class-prefix `col-lg-offset-`
    */
-  lgOffset: React.PropTypes.number,
+  lgOffset: PropTypes.number,
   /**
    * Change the order of grid columns to the right
    *
@@ -111,7 +112,7 @@ const propTypes = {
    *
    * class-prefix `col-xs-push-`
    */
-  xsPush: React.PropTypes.number,
+  xsPush: PropTypes.number,
   /**
    * Change the order of grid columns to the right
    *
@@ -119,7 +120,7 @@ const propTypes = {
    *
    * class-prefix `col-sm-push-`
    */
-  smPush: React.PropTypes.number,
+  smPush: PropTypes.number,
   /**
    * Change the order of grid columns to the right
    *
@@ -127,7 +128,7 @@ const propTypes = {
    *
    * class-prefix `col-md-push-`
    */
-  mdPush: React.PropTypes.number,
+  mdPush: PropTypes.number,
   /**
    * Change the order of grid columns to the right
    *
@@ -135,7 +136,7 @@ const propTypes = {
    *
    * class-prefix `col-lg-push-`
    */
-  lgPush: React.PropTypes.number,
+  lgPush: PropTypes.number,
   /**
    * Change the order of grid columns to the left
    *
@@ -143,7 +144,7 @@ const propTypes = {
    *
    * class-prefix `col-xs-pull-`
    */
-  xsPull: React.PropTypes.number,
+  xsPull: PropTypes.number,
   /**
    * Change the order of grid columns to the left
    *
@@ -151,7 +152,7 @@ const propTypes = {
    *
    * class-prefix `col-sm-pull-`
    */
-  smPull: React.PropTypes.number,
+  smPull: PropTypes.number,
   /**
    * Change the order of grid columns to the left
    *
@@ -159,7 +160,7 @@ const propTypes = {
    *
    * class-prefix `col-md-pull-`
    */
-  mdPull: React.PropTypes.number,
+  mdPull: PropTypes.number,
   /**
    * Change the order of grid columns to the left
    *
@@ -167,7 +168,7 @@ const propTypes = {
    *
    * class-prefix `col-lg-pull-`
    */
-  lgPull: React.PropTypes.number,
+  lgPull: PropTypes.number,
 };
 
 const defaultProps = {

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import css from 'dom-helpers/style';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Transition from 'react-overlays/lib/Transition';
 
 import capitalize from './utils/capitalize';
@@ -31,55 +32,55 @@ const propTypes = {
   /**
    * Show the component; triggers the expand or collapse animation
    */
-  in: React.PropTypes.bool,
+  in: PropTypes.bool,
 
   /**
    * Wait until the first "enter" transition to mount the component (add it to the DOM)
    */
-  mountOnEnter: React.PropTypes.bool,
+  mountOnEnter: PropTypes.bool,
 
   /**
    * Unmount the component (remove it from the DOM) when it is collapsed
    */
-  unmountOnExit: React.PropTypes.bool,
+  unmountOnExit: PropTypes.bool,
 
   /**
    * Run the expand animation when the component mounts, if it is initially
    * shown
    */
-  transitionAppear: React.PropTypes.bool,
+  transitionAppear: PropTypes.bool,
 
   /**
    * Duration of the collapse animation in milliseconds, to ensure that
    * finishing callbacks are fired even if the original browser transition end
    * events are canceled
    */
-  timeout: React.PropTypes.number,
+  timeout: PropTypes.number,
 
   /**
    * Callback fired before the component expands
    */
-  onEnter: React.PropTypes.func,
+  onEnter: PropTypes.func,
   /**
    * Callback fired after the component starts to expand
    */
-  onEntering: React.PropTypes.func,
+  onEntering: PropTypes.func,
   /**
    * Callback fired after the component has expanded
    */
-  onEntered: React.PropTypes.func,
+  onEntered: PropTypes.func,
   /**
    * Callback fired before the component collapses
    */
-  onExit: React.PropTypes.func,
+  onExit: PropTypes.func,
   /**
    * Callback fired after the component starts to collapse
    */
-  onExiting: React.PropTypes.func,
+  onExiting: PropTypes.func,
   /**
    * Callback fired after the component has collapsed
    */
-  onExited: React.PropTypes.func,
+  onExited: PropTypes.func,
 
   /**
    * The dimension used when collapsing, or a function that returns the
@@ -88,9 +89,9 @@ const propTypes = {
    * _Note: Bootstrap only partially supports 'width'!
    * You will need to supply your own CSS animation for the `.width` CSS class._
    */
-  dimension: React.PropTypes.oneOfType([
-    React.PropTypes.oneOf(['height', 'width']),
-    React.PropTypes.func,
+  dimension: PropTypes.oneOfType([
+    PropTypes.oneOf(['height', 'width']),
+    PropTypes.func,
   ]),
 
   /**
@@ -100,12 +101,12 @@ const propTypes = {
    * should animate in its specified dimension. Called with the current
    * dimension prop value and the DOM node.
    */
-  getDimensionValue: React.PropTypes.func,
+  getDimensionValue: PropTypes.func,
 
   /**
    * ARIA role of collapsible element
    */
-  role: React.PropTypes.string,
+  role: PropTypes.string,
 };
 
 const defaultProps = {

--- a/src/ControlLabel.js
+++ b/src/ControlLabel.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import warning from 'warning';
 
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';
@@ -8,8 +9,8 @@ const propTypes = {
   /**
    * Uses `controlId` from `<FormGroup>` if not explicitly specified.
    */
-  htmlFor: React.PropTypes.string,
-  srOnly: React.PropTypes.bool,
+  htmlFor: PropTypes.string,
+  srOnly: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -17,7 +18,7 @@ const defaultProps = {
 };
 
 const contextTypes = {
-  $bs_formGroup: React.PropTypes.object,
+  $bs_formGroup: PropTypes.object,
 };
 
 class ControlLabel extends React.Component {

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -3,6 +3,7 @@ import activeElement from 'dom-helpers/activeElement';
 import contains from 'dom-helpers/query/contains';
 import keycode from 'keycode';
 import React, { cloneElement } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import all from 'react-prop-types/lib/all';
 import elementType from 'react-prop-types/lib/elementType';
@@ -25,15 +26,15 @@ const propTypes = {
   /**
    * The menu will open above the dropdown button, instead of below it.
    */
-  dropup: React.PropTypes.bool,
+  dropup: PropTypes.bool,
 
   /**
    * An html id attribute, necessary for assistive technologies, such as screen readers.
    * @type {string|number}
    * @required
    */
-  id: isRequiredForA11y(React.PropTypes.oneOfType([
-    React.PropTypes.string, React.PropTypes.number,
+  id: isRequiredForA11y(PropTypes.oneOfType([
+    PropTypes.string, PropTypes.number,
   ])),
 
   componentClass: elementType,
@@ -50,24 +51,24 @@ const propTypes = {
   /**
    * Whether or not component is disabled.
    */
-  disabled: React.PropTypes.bool,
+  disabled: PropTypes.bool,
 
   /**
    * Align the menu to the right side of the Dropdown toggle
    */
-  pullRight: React.PropTypes.bool,
+  pullRight: PropTypes.bool,
 
   /**
    * Whether or not the Dropdown is visible.
    *
    * @controllable onToggle
    */
-  open: React.PropTypes.bool,
+  open: PropTypes.bool,
 
   /**
    * A callback fired when the Dropdown closes.
    */
-  onClose: React.PropTypes.func,
+  onClose: PropTypes.func,
 
   /**
    * A callback fired when the Dropdown wishes to change visibility. Called with the requested
@@ -78,7 +79,7 @@ const propTypes = {
    * ```
    * @controllable open
    */
-  onToggle: React.PropTypes.func,
+  onToggle: PropTypes.func,
 
   /**
    * A callback fired when a menu item is selected.
@@ -87,27 +88,27 @@ const propTypes = {
    * (eventKey: any, event: Object) => any
    * ```
    */
-  onSelect: React.PropTypes.func,
+  onSelect: PropTypes.func,
 
   /**
    * If `'menuitem'`, causes the dropdown to behave like a menu item rather than
    * a menu button.
    */
-  role: React.PropTypes.string,
+  role: PropTypes.string,
 
   /**
    * Which event when fired outside the component will cause it to be closed
    */
-  rootCloseEvent: React.PropTypes.oneOf(['click', 'mousedown']),
+  rootCloseEvent: PropTypes.oneOf(['click', 'mousedown']),
 
   /**
    * @private
    */
-  onMouseEnter: React.PropTypes.func,
+  onMouseEnter: PropTypes.func,
   /**
    * @private
    */
-  onMouseLeave: React.PropTypes.func,
+  onMouseLeave: PropTypes.func,
 };
 
 const defaultProps = {

--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import Dropdown from './Dropdown';

--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import Dropdown from './Dropdown';
 import splitComponentProps from './utils/splitComponentProps';
 
@@ -7,16 +9,16 @@ const propTypes = {
   ...Dropdown.propTypes,
 
   // Toggle props.
-  bsStyle: React.PropTypes.string,
-  bsSize: React.PropTypes.string,
-  title: React.PropTypes.node.isRequired,
-  noCaret: React.PropTypes.bool,
+  bsStyle: PropTypes.string,
+  bsSize: PropTypes.string,
+  title: PropTypes.node.isRequired,
+  noCaret: PropTypes.bool,
 
   // Override generated docs from <Dropdown>.
   /**
    * @private
    */
-  children: React.PropTypes.node,
+  children: PropTypes.node,
 };
 
 class DropdownButton extends React.Component {

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import keycode from 'keycode';
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
 
@@ -10,14 +11,14 @@ import createChainedFunction from './utils/createChainedFunction';
 import ValidComponentChildren from './utils/ValidComponentChildren';
 
 const propTypes = {
-  open: React.PropTypes.bool,
-  pullRight: React.PropTypes.bool,
-  onClose: React.PropTypes.func,
-  labelledBy: React.PropTypes.oneOfType([
-    React.PropTypes.string, React.PropTypes.number,
+  open: PropTypes.bool,
+  pullRight: PropTypes.bool,
+  onClose: PropTypes.func,
+  labelledBy: PropTypes.oneOfType([
+    PropTypes.string, PropTypes.number,
   ]),
-  onSelect: React.PropTypes.func,
-  rootCloseEvent: React.PropTypes.oneOf(['click', 'mousedown']),
+  onSelect: PropTypes.func,
+  rootCloseEvent: PropTypes.oneOf(['click', 'mousedown']),
 };
 
 const defaultProps = {

--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Button from './Button';
 import SafeAnchor from './SafeAnchor';
@@ -6,10 +7,10 @@ import SafeAnchor from './SafeAnchor';
 import { bsClass as setBsClass } from './utils/bootstrapUtils';
 
 const propTypes = {
-  noCaret: React.PropTypes.bool,
-  open: React.PropTypes.bool,
-  title: React.PropTypes.string,
-  useAnchor: React.PropTypes.bool,
+  noCaret: PropTypes.bool,
+  open: PropTypes.bool,
+  title: PropTypes.string,
+  useAnchor: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -1,60 +1,61 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import Transition from 'react-overlays/lib/Transition';
 
 const propTypes = {
   /**
    * Show the component; triggers the fade in or fade out animation
    */
-  in: React.PropTypes.bool,
+  in: PropTypes.bool,
 
   /**
    * Wait until the first "enter" transition to mount the component (add it to the DOM)
    */
-  mountOnEnter: React.PropTypes.bool,
+  mountOnEnter: PropTypes.bool,
 
   /**
    * Unmount the component (remove it from the DOM) when it is faded out
    */
-  unmountOnExit: React.PropTypes.bool,
+  unmountOnExit: PropTypes.bool,
 
   /**
    * Run the fade in animation when the component mounts, if it is initially
    * shown
    */
-  transitionAppear: React.PropTypes.bool,
+  transitionAppear: PropTypes.bool,
 
   /**
    * Duration of the fade animation in milliseconds, to ensure that finishing
    * callbacks are fired even if the original browser transition end events are
    * canceled
    */
-  timeout: React.PropTypes.number,
+  timeout: PropTypes.number,
 
   /**
    * Callback fired before the component fades in
    */
-  onEnter: React.PropTypes.func,
+  onEnter: PropTypes.func,
   /**
    * Callback fired after the component starts to fade in
    */
-  onEntering: React.PropTypes.func,
+  onEntering: PropTypes.func,
   /**
    * Callback fired after the has component faded in
    */
-  onEntered: React.PropTypes.func,
+  onEntered: PropTypes.func,
   /**
    * Callback fired before the component fades out
    */
-  onExit: React.PropTypes.func,
+  onExit: PropTypes.func,
   /**
    * Callback fired after the component starts to fade out
    */
-  onExiting: React.PropTypes.func,
+  onExiting: PropTypes.func,
   /**
    * Callback fired after the component has faded out
    */
-  onExited: React.PropTypes.func,
+  onExited: PropTypes.func,
 };
 
 const defaultProps = {

--- a/src/Form.js
+++ b/src/Form.js
@@ -1,12 +1,13 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import elementType from 'react-prop-types/lib/elementType';
 
 import { bsClass, prefix, splitBsProps } from './utils/bootstrapUtils';
 
 const propTypes = {
-  horizontal: React.PropTypes.bool,
-  inline: React.PropTypes.bool,
+  horizontal: PropTypes.bool,
+  inline: PropTypes.bool,
   componentClass: elementType,
 };
 

--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import elementType from 'react-prop-types/lib/elementType';
 import warning from 'warning';
 
@@ -14,11 +15,11 @@ const propTypes = {
   /**
    * Only relevant if `componentClass` is `'input'`.
    */
-  type: React.PropTypes.string,
+  type: PropTypes.string,
   /**
    * Uses `controlId` from `<FormGroup>` if not explicitly specified.
    */
-  id: React.PropTypes.string,
+  id: PropTypes.string,
   /**
    * Attaches a ref to the `<input>` element. Only functions can be used here.
    *
@@ -26,7 +27,7 @@ const propTypes = {
    * <FormControl inputRef={ref => { this.input = ref; }} />
    * ```
    */
-  inputRef: React.PropTypes.func,
+  inputRef: PropTypes.func,
 };
 
 const defaultProps = {
@@ -34,7 +35,7 @@ const defaultProps = {
 };
 
 const contextTypes = {
-  $bs_formGroup: React.PropTypes.object,
+  $bs_formGroup: PropTypes.object,
 };
 
 class FormControl extends React.Component {

--- a/src/FormControlFeedback.js
+++ b/src/FormControlFeedback.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import Glyphicon from './Glyphicon';

--- a/src/FormControlFeedback.js
+++ b/src/FormControlFeedback.js
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import Glyphicon from './Glyphicon';
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';
 
@@ -9,7 +11,7 @@ const defaultProps = {
 };
 
 const contextTypes = {
-  $bs_formGroup: React.PropTypes.object,
+  $bs_formGroup: PropTypes.object,
 };
 
 class FormControlFeedback extends React.Component {

--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import { bsClass, bsSizes, getClassSet, splitBsPropsAndOmit }

--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import { bsClass, bsSizes, getClassSet, splitBsPropsAndOmit }
   from './utils/bootstrapUtils';
 import { Size } from './utils/StyleConfig';
@@ -10,14 +12,14 @@ const propTypes = {
   /**
    * Sets `id` on `<FormControl>` and `htmlFor` on `<FormGroup.Label>`.
    */
-  controlId: React.PropTypes.string,
-  validationState: React.PropTypes.oneOf([
+  controlId: PropTypes.string,
+  validationState: PropTypes.oneOf([
     'success', 'warning', 'error', null,
   ]),
 };
 
 const childContextTypes = {
-  $bs_formGroup: React.PropTypes.object.isRequired,
+  $bs_formGroup: PropTypes.object.isRequired,
 };
 
 class FormGroup extends React.Component {

--- a/src/Glyphicon.js
+++ b/src/Glyphicon.js
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import { bsClass, getClassSet, prefix, splitBsProps }
   from './utils/bootstrapUtils';
 
@@ -8,7 +10,7 @@ const propTypes = {
   /**
    * An icon name without "glyphicon-" prefix. See e.g. http://getbootstrap.com/components/#glyphicons
    */
-  glyph: React.PropTypes.string.isRequired,
+  glyph: PropTypes.string.isRequired,
 };
 
 class Glyphicon extends React.Component {

--- a/src/Glyphicon.js
+++ b/src/Glyphicon.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import { bsClass, getClassSet, prefix, splitBsProps }

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import elementType from 'react-prop-types/lib/elementType';
 
 import { bsClass, prefix, splitBsProps } from './utils/bootstrapUtils';
@@ -10,7 +11,7 @@ const propTypes = {
    *
    * Adds `container-fluid` class.
    */
-  fluid: React.PropTypes.bool,
+  fluid: PropTypes.bool,
   /**
    * You can use a custom element for this component
    */

--- a/src/Image.js
+++ b/src/Image.js
@@ -1,28 +1,30 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import { bsClass, prefix, splitBsProps } from './utils/bootstrapUtils';
 
 const propTypes = {
   /**
    * Sets image as responsive image
    */
-  responsive: React.PropTypes.bool,
+  responsive: PropTypes.bool,
 
   /**
    * Sets image shape as rounded
    */
-  rounded: React.PropTypes.bool,
+  rounded: PropTypes.bool,
 
   /**
    * Sets image shape as circle
    */
-  circle: React.PropTypes.bool,
+  circle: PropTypes.bool,
 
   /**
    * Sets image shape as thumbnail
    */
-  thumbnail: React.PropTypes.bool,
+  thumbnail: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/src/Image.js
+++ b/src/Image.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import { bsClass, prefix, splitBsProps } from './utils/bootstrapUtils';

--- a/src/ListGroupItem.js
+++ b/src/ListGroupItem.js
@@ -1,18 +1,20 @@
 import classNames from 'classnames';
 import React, { cloneElement } from 'react';
 
+import PropTypes from 'prop-types';
+
 import { bsClass, bsStyles, getClassSet, prefix, splitBsProps }
   from './utils/bootstrapUtils';
 import { State } from './utils/StyleConfig';
 
 const propTypes = {
-  active: React.PropTypes.any,
-  disabled: React.PropTypes.any,
-  header: React.PropTypes.node,
-  listItem: React.PropTypes.bool,
-  onClick: React.PropTypes.func,
-  href: React.PropTypes.string,
-  type: React.PropTypes.string,
+  active: PropTypes.any,
+  disabled: PropTypes.any,
+  header: PropTypes.node,
+  listItem: PropTypes.bool,
+  onClick: PropTypes.func,
+  href: PropTypes.string,
+  type: PropTypes.string,
 };
 
 const defaultProps = {

--- a/src/ListGroupItem.js
+++ b/src/ListGroupItem.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React, { cloneElement } from 'react';
-
 import PropTypes from 'prop-types';
 
 import { bsClass, bsStyles, getClassSet, prefix, splitBsProps }

--- a/src/MediaLeft.js
+++ b/src/MediaLeft.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import Media from './Media';

--- a/src/MediaLeft.js
+++ b/src/MediaLeft.js
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import Media from './Media';
 import { bsClass, getClassSet, prefix, splitBsProps }
   from './utils/bootstrapUtils';
@@ -9,7 +11,7 @@ const propTypes = {
   /**
    * Align the media to the top, middle, or bottom of the media object.
    */
-  align: React.PropTypes.oneOf(['top', 'middle', 'bottom']),
+  align: PropTypes.oneOf(['top', 'middle', 'bottom']),
 };
 
 class MediaLeft extends React.Component {

--- a/src/MediaRight.js
+++ b/src/MediaRight.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import Media from './Media';

--- a/src/MediaRight.js
+++ b/src/MediaRight.js
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import Media from './Media';
 import { bsClass, getClassSet, prefix, splitBsProps }
   from './utils/bootstrapUtils';
@@ -9,7 +11,7 @@ const propTypes = {
   /**
    * Align the media to the top, middle, or bottom of the media object.
    */
-  align: React.PropTypes.oneOf(['top', 'middle', 'bottom']),
+  align: PropTypes.oneOf(['top', 'middle', 'bottom']),
 };
 
 class MediaRight extends React.Component {

--- a/src/MenuItem.js
+++ b/src/MenuItem.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import all from 'react-prop-types/lib/all';
 
 import SafeAnchor from './SafeAnchor';
@@ -10,19 +11,19 @@ const propTypes = {
   /**
    * Highlight the menu item as active.
    */
-  active: React.PropTypes.bool,
+  active: PropTypes.bool,
 
   /**
    * Disable the menu item, making it unselectable.
    */
-  disabled: React.PropTypes.bool,
+  disabled: PropTypes.bool,
 
   /**
    * Styles the menu item as a horizontal rule, providing visual separation between
    * groups of menu items.
    */
   divider: all(
-    React.PropTypes.bool,
+    PropTypes.bool,
     ({ divider, children }) => (
       divider && children ?
         new Error('Children will not be rendered for dividers') :
@@ -33,22 +34,22 @@ const propTypes = {
   /**
    * Value passed to the `onSelect` handler, useful for identifying the selected menu item.
    */
-  eventKey: React.PropTypes.any,
+  eventKey: PropTypes.any,
 
   /**
    * Styles the menu item as a header label, useful for describing a group of menu items.
    */
-  header: React.PropTypes.bool,
+  header: PropTypes.bool,
 
   /**
    * HTML `href` attribute corresponding to `a.href`.
    */
-  href: React.PropTypes.string,
+  href: PropTypes.string,
 
   /**
    * Callback fired when the menu item is clicked.
    */
-  onClick: React.PropTypes.func,
+  onClick: PropTypes.func,
 
   /**
    * Callback fired when the menu item is selected.
@@ -57,7 +58,7 @@ const propTypes = {
    * (eventKey: any, event: Object) => any
    * ```
    */
-  onSelect: React.PropTypes.func,
+  onSelect: PropTypes.func,
 };
 
 const defaultProps = {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -4,6 +4,7 @@ import ownerDocument from 'dom-helpers/ownerDocument';
 import canUseDOM from 'dom-helpers/util/inDOM';
 import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import BaseModal from 'react-overlays/lib/Modal';
 import isOverflowing from 'react-overlays/lib/utils/isOverflowing';
@@ -28,17 +29,17 @@ const propTypes = {
    * Include a backdrop component. Specify 'static' for a backdrop that doesn't
    * trigger an "onHide" when clicked.
    */
-  backdrop: React.PropTypes.oneOf(['static', true, false]),
+  backdrop: PropTypes.oneOf(['static', true, false]),
 
   /**
    * Close the modal when escape key is pressed
    */
-  keyboard: React.PropTypes.bool,
+  keyboard: PropTypes.bool,
 
   /**
    * Open and close the Modal with a slide and fade animation.
    */
-  animation: React.PropTypes.bool,
+  animation: PropTypes.bool,
 
   /**
    * A Component type that provides the modal content Markup. This is a useful
@@ -53,61 +54,61 @@ const propTypes = {
    * Generally this should never be set to false as it makes the Modal less
    * accessible to assistive technologies, like screen-readers.
    */
-  autoFocus: React.PropTypes.bool,
+  autoFocus: PropTypes.bool,
 
   /**
    * When `true` The modal will prevent focus from leaving the Modal while
    * open. Consider leaving the default value here, as it is necessary to make
    * the Modal work well with assistive technologies, such as screen readers.
    */
-  enforceFocus: React.PropTypes.bool,
+  enforceFocus: PropTypes.bool,
 
   /**
    * When `true` The modal will restore focus to previously focused element once
    * modal is hidden
    */
-  restoreFocus: React.PropTypes.bool,
+  restoreFocus: PropTypes.bool,
 
   /**
    * When `true` The modal will show itself.
    */
-  show: React.PropTypes.bool,
+  show: PropTypes.bool,
 
   /**
    * A callback fired when the header closeButton or non-static backdrop is
    * clicked. Required if either are specified.
    */
-  onHide: React.PropTypes.func,
+  onHide: PropTypes.func,
 
   /**
    * Callback fired before the Modal transitions in
    */
-  onEnter: React.PropTypes.func,
+  onEnter: PropTypes.func,
 
   /**
    * Callback fired as the Modal begins to transition in
    */
-  onEntering: React.PropTypes.func,
+  onEntering: PropTypes.func,
 
   /**
    * Callback fired after the Modal finishes transitioning in
    */
-  onEntered: React.PropTypes.func,
+  onEntered: PropTypes.func,
 
   /**
    * Callback fired right before the Modal transitions out
    */
-  onExit: React.PropTypes.func,
+  onExit: PropTypes.func,
 
   /**
    * Callback fired as the Modal begins to transition out
    */
-  onExiting: React.PropTypes.func,
+  onExiting: PropTypes.func,
 
   /**
    * Callback fired after the Modal finishes transitioning out
    */
-  onExited: React.PropTypes.func,
+  onExited: PropTypes.func,
 
   /**
    * @private
@@ -122,8 +123,8 @@ const defaultProps = {
 };
 
 const childContextTypes = {
-  $bs_modal: React.PropTypes.shape({
-    onHide: React.PropTypes.func,
+  $bs_modal: PropTypes.shape({
+    onHide: PropTypes.func,
   }),
 };
 

--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import { bsClass, bsSizes, getClassSet, prefix, splitBsProps }
   from './utils/bootstrapUtils';
 import { Size } from './utils/StyleConfig';
@@ -9,7 +11,7 @@ const propTypes = {
   /**
    * A css class to apply to the Modal dialog DOM node.
    */
-  dialogClassName: React.PropTypes.string,
+  dialogClassName: PropTypes.string,
 };
 
 class ModalDialog extends React.Component {

--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import { bsClass, bsSizes, getClassSet, prefix, splitBsProps }

--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';

--- a/src/ModalHeader.js
+++ b/src/ModalHeader.js
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';
 import createChainedFunction from './utils/createChainedFunction';
 
@@ -12,19 +14,19 @@ const propTypes = {
    * button. It is used for Assistive Technology when the label text is not
    * readable.
    */
-  'aria-label': React.PropTypes.string,
+  'aria-label': PropTypes.string,
 
   /**
    * Specify whether the Component should contain a close button
    */
-  closeButton: React.PropTypes.bool,
+  closeButton: PropTypes.bool,
 
   /**
    * A Callback fired when the close button is clicked. If used directly inside
    * a Modal component, the onHide will automatically be propagated up to the
    * parent Modal `onHide`.
    */
-  onHide: React.PropTypes.func,
+  onHide: PropTypes.func,
 };
 
 const defaultProps = {
@@ -33,8 +35,8 @@ const defaultProps = {
 };
 
 const contextTypes = {
-  $bs_modal: React.PropTypes.shape({
-    onHide: React.PropTypes.func,
+  $bs_modal: PropTypes.shape({
+    onHide: PropTypes.func,
   }),
 };
 

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import keycode from 'keycode';
 import React, { cloneElement } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import all from 'react-prop-types/lib/all';
 import warning from 'warning';
@@ -22,20 +23,20 @@ const propTypes = {
    * Marks the NavItem with a matching `eventKey` as active. Has a
    * higher precedence over `activeHref`.
    */
-  activeKey: React.PropTypes.any,
+  activeKey: PropTypes.any,
 
   /**
    * Marks the child NavItem with a matching `href` prop as active.
    */
-  activeHref: React.PropTypes.string,
+  activeHref: PropTypes.string,
 
   /**
    * NavItems are be positioned vertically.
    */
-  stacked: React.PropTypes.bool,
+  stacked: PropTypes.bool,
 
   justified: all(
-    React.PropTypes.bool,
+    PropTypes.bool,
     ({ justified, navbar }) => (
       justified && navbar ?
         Error('justified navbar `Nav`s are not supported') : null
@@ -52,7 +53,7 @@ const propTypes = {
    * )
    * ```
    */
-  onSelect: React.PropTypes.func,
+  onSelect: PropTypes.func,
 
   /**
    * ARIA role for the Nav, in the context of a TabContainer, the default will
@@ -62,25 +63,25 @@ const propTypes = {
    * the ARIA authoring practices for tabs:
    * https://www.w3.org/TR/2013/WD-wai-aria-practices-20130307/#tabpanel
    */
-  role: React.PropTypes.string,
+  role: PropTypes.string,
 
   /**
    * Apply styling an alignment for use in a Navbar. This prop will be set
    * automatically when the Nav is used inside a Navbar.
    */
-  navbar: React.PropTypes.bool,
+  navbar: PropTypes.bool,
 
   /**
    * Float the Nav to the right. When `navbar` is `true` the appropriate
    * contextual classes are added as well.
    */
-  pullRight: React.PropTypes.bool,
+  pullRight: PropTypes.bool,
 
   /**
    * Float the Nav to the left. When `navbar` is `true` the appropriate
    * contextual classes are added as well.
    */
-  pullLeft: React.PropTypes.bool,
+  pullLeft: PropTypes.bool,
 };
 
 const defaultProps = {
@@ -91,16 +92,16 @@ const defaultProps = {
 };
 
 const contextTypes = {
-  $bs_navbar: React.PropTypes.shape({
-    bsClass: React.PropTypes.string,
-    onSelect: React.PropTypes.func,
+  $bs_navbar: PropTypes.shape({
+    bsClass: PropTypes.string,
+    onSelect: PropTypes.func,
   }),
 
-  $bs_tabContainer: React.PropTypes.shape({
-    activeKey: React.PropTypes.any,
-    onSelect: React.PropTypes.func.isRequired,
-    getTabId: React.PropTypes.func.isRequired,
-    getPaneId: React.PropTypes.func.isRequired,
+  $bs_tabContainer: PropTypes.shape({
+    activeKey: PropTypes.any,
+    onSelect: PropTypes.func.isRequired,
+    getTabId: PropTypes.func.isRequired,
+    getPaneId: PropTypes.func.isRequired,
   }),
 };
 

--- a/src/NavDropdown.js
+++ b/src/NavDropdown.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 
 import Dropdown from './Dropdown';
 import splitComponentProps from './utils/splitComponentProps';
@@ -9,15 +10,15 @@ const propTypes = {
   ...Dropdown.propTypes,
 
   // Toggle props.
-  title: React.PropTypes.node.isRequired,
-  noCaret: React.PropTypes.bool,
-  active: React.PropTypes.bool,
+  title: PropTypes.node.isRequired,
+  noCaret: PropTypes.bool,
+  active: PropTypes.bool,
 
   // Override generated docs from <Dropdown>.
   /**
    * @private
    */
-  children: React.PropTypes.node,
+  children: PropTypes.node,
 };
 
 class NavDropdown extends React.Component {

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import SafeAnchor from './SafeAnchor';

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -1,17 +1,19 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import SafeAnchor from './SafeAnchor';
 import createChainedFunction from './utils/createChainedFunction';
 
 const propTypes = {
-  active: React.PropTypes.bool,
-  disabled: React.PropTypes.bool,
-  role: React.PropTypes.string,
-  href: React.PropTypes.string,
-  onClick: React.PropTypes.func,
-  onSelect: React.PropTypes.func,
-  eventKey: React.PropTypes.any,
+  active: PropTypes.bool,
+  disabled: PropTypes.bool,
+  role: PropTypes.string,
+  href: PropTypes.string,
+  onClick: PropTypes.func,
+  onSelect: PropTypes.func,
+  eventKey: PropTypes.any,
 };
 
 const defaultProps = {

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -2,7 +2,8 @@
 /* eslint-disable react/no-multi-comp */
 
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import elementType from 'react-prop-types/lib/elementType';
 import uncontrollable from 'uncontrollable';
 
@@ -26,25 +27,25 @@ const propTypes = {
    * Create a fixed navbar along the top of the screen, that scrolls with the
    * page
    */
-  fixedTop: React.PropTypes.bool,
+  fixedTop: PropTypes.bool,
   /**
    * Create a fixed navbar along the bottom of the screen, that scrolls with
    * the page
    */
-  fixedBottom: React.PropTypes.bool,
+  fixedBottom: PropTypes.bool,
   /**
    * Create a full-width navbar that scrolls away with the page
    */
-  staticTop: React.PropTypes.bool,
+  staticTop: PropTypes.bool,
   /**
    * An alternative dark visual style for the Navbar
    */
-  inverse: React.PropTypes.bool,
+  inverse: PropTypes.bool,
   /**
    * Allow the Navbar to fluidly adjust to the page or container width, instead
    * of at the predefined screen breakpoints
    */
-  fluid: React.PropTypes.bool,
+  fluid: PropTypes.bool,
 
   /**
    * Set a custom element for this component.
@@ -57,7 +58,7 @@ const propTypes = {
    *
    * @controllable navExpanded
    */
-  onToggle: React.PropTypes.func,
+  onToggle: PropTypes.func,
   /**
    * A callback fired when a descendant of a child `<Nav>` is selected. Should
    * be used to execute complex closing or other miscellaneous actions desired
@@ -79,7 +80,7 @@ const propTypes = {
    * ensure that you are setting `expanded` to false and not *toggling* between
    * true and false.
    */
-  onSelect: React.PropTypes.func,
+  onSelect: PropTypes.func,
   /**
    * Sets `expanded` to `false` after the onSelect event of a descendant of a
    * child `<Nav>`. Does nothing if no `<Nav>` or `<Nav>` descendants exist.
@@ -87,15 +88,15 @@ const propTypes = {
    * The onSelect callback should be used instead for more complex operations
    * that need to be executed after the `select` event of `<Nav>` descendants.
    */
-  collapseOnSelect: React.PropTypes.bool,
+  collapseOnSelect: PropTypes.bool,
   /**
    * Explicitly set the visiblity of the navbar body
    *
    * @controllable onToggle
    */
-  expanded: React.PropTypes.bool,
+  expanded: PropTypes.bool,
 
-  role: React.PropTypes.string,
+  role: PropTypes.string,
 };
 
 const defaultProps = {
@@ -230,8 +231,8 @@ function createSimpleWrapper(tag, suffix, displayName) {
 
   Wrapper.propTypes = {
     componentClass: elementType,
-    pullRight: React.PropTypes.bool,
-    pullLeft: React.PropTypes.bool,
+    pullRight: PropTypes.bool,
+    pullLeft: PropTypes.bool,
   };
 
   Wrapper.defaultProps = {

--- a/src/NavbarBrand.js
+++ b/src/NavbarBrand.js
@@ -1,11 +1,13 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import { prefix } from './utils/bootstrapUtils';
 
 const contextTypes = {
-  $bs_navbar: React.PropTypes.shape({
-    bsClass: React.PropTypes.string,
+  $bs_navbar: PropTypes.shape({
+    bsClass: PropTypes.string,
   }),
 };
 

--- a/src/NavbarBrand.js
+++ b/src/NavbarBrand.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import { prefix } from './utils/bootstrapUtils';

--- a/src/NavbarCollapse.js
+++ b/src/NavbarCollapse.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import Collapse from './Collapse';

--- a/src/NavbarCollapse.js
+++ b/src/NavbarCollapse.js
@@ -1,4 +1,6 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+
+import PropTypes from 'prop-types';
 
 import Collapse from './Collapse';
 import { prefix } from './utils/bootstrapUtils';

--- a/src/NavbarHeader.js
+++ b/src/NavbarHeader.js
@@ -1,11 +1,13 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import { prefix } from './utils/bootstrapUtils';
 
 const contextTypes = {
-  $bs_navbar: React.PropTypes.shape({
-    bsClass: React.PropTypes.string,
+  $bs_navbar: PropTypes.shape({
+    bsClass: PropTypes.string,
   }),
 };
 

--- a/src/NavbarHeader.js
+++ b/src/NavbarHeader.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import { prefix } from './utils/bootstrapUtils';

--- a/src/NavbarToggle.js
+++ b/src/NavbarToggle.js
@@ -1,5 +1,7 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+
+import PropTypes from 'prop-types';
 
 import { prefix } from './utils/bootstrapUtils';
 import createChainedFunction from './utils/createChainedFunction';

--- a/src/NavbarToggle.js
+++ b/src/NavbarToggle.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import { prefix } from './utils/bootstrapUtils';

--- a/src/Overlay.js
+++ b/src/Overlay.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React, { cloneElement } from 'react';
+import PropTypes from 'prop-types';
 import BaseOverlay from 'react-overlays/lib/Overlay';
 import elementType from 'react-prop-types/lib/elementType';
 
@@ -11,58 +12,58 @@ const propTypes = {
   /**
    * Set the visibility of the Overlay
    */
-  show: React.PropTypes.bool,
+  show: PropTypes.bool,
   /**
    * Specify whether the overlay should trigger onHide when the user clicks outside the overlay
    */
-  rootClose: React.PropTypes.bool,
+  rootClose: PropTypes.bool,
   /**
    * A callback invoked by the overlay when it wishes to be hidden. Required if
    * `rootClose` is specified.
    */
-  onHide: React.PropTypes.func,
+  onHide: PropTypes.func,
 
   /**
    * Use animation
    */
-  animation: React.PropTypes.oneOfType([
-    React.PropTypes.bool, elementType,
+  animation: PropTypes.oneOfType([
+    PropTypes.bool, elementType,
   ]),
 
   /**
    * Callback fired before the Overlay transitions in
    */
-  onEnter: React.PropTypes.func,
+  onEnter: PropTypes.func,
 
   /**
    * Callback fired as the Overlay begins to transition in
    */
-  onEntering: React.PropTypes.func,
+  onEntering: PropTypes.func,
 
   /**
    * Callback fired after the Overlay finishes transitioning in
    */
-  onEntered: React.PropTypes.func,
+  onEntered: PropTypes.func,
 
   /**
    * Callback fired right before the Overlay transitions out
    */
-  onExit: React.PropTypes.func,
+  onExit: PropTypes.func,
 
   /**
    * Callback fired as the Overlay begins to transition out
    */
-  onExiting: React.PropTypes.func,
+  onExiting: PropTypes.func,
 
   /**
    * Callback fired after the Overlay finishes transitioning out
    */
-  onExited: React.PropTypes.func,
+  onExited: PropTypes.func,
 
   /**
    * Sets the direction of the Overlay.
    */
-  placement: React.PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+  placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 };
 
 const defaultProps = {

--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -1,5 +1,6 @@
 import contains from 'dom-helpers/query/contains';
 import React, { cloneElement } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import warning from 'warning';
 
@@ -21,7 +22,7 @@ function isOneOf(one, of) {
   return one === of;
 }
 
-const triggerType = React.PropTypes.oneOf(['click', 'hover', 'focus']);
+const triggerType = PropTypes.oneOf(['click', 'hover', 'focus']);
 
 const propTypes = {
   ...Overlay.propTypes,
@@ -29,69 +30,69 @@ const propTypes = {
    /**
    * Specify which action or actions trigger Overlay visibility
    */
-  trigger: React.PropTypes.oneOfType([
-    triggerType, React.PropTypes.arrayOf(triggerType),
+  trigger: PropTypes.oneOfType([
+    triggerType, PropTypes.arrayOf(triggerType),
   ]),
 
   /**
    * A millisecond delay amount to show and hide the Overlay once triggered
    */
-  delay: React.PropTypes.number,
+  delay: PropTypes.number,
   /**
    * A millisecond delay amount before showing the Overlay once triggered.
    */
-  delayShow: React.PropTypes.number,
+  delayShow: PropTypes.number,
   /**
    * A millisecond delay amount before hiding the Overlay once triggered.
    */
-  delayHide: React.PropTypes.number,
+  delayHide: PropTypes.number,
 
   // FIXME: This should be `defaultShow`.
   /**
    * The initial visibility state of the Overlay. For more nuanced visibility
    * control, consider using the Overlay component directly.
    */
-  defaultOverlayShown: React.PropTypes.bool,
+  defaultOverlayShown: PropTypes.bool,
 
   /**
    * An element or text to overlay next to the target.
    */
-  overlay: React.PropTypes.node.isRequired,
+  overlay: PropTypes.node.isRequired,
 
   /**
    * @private
    */
-  onBlur: React.PropTypes.func,
+  onBlur: PropTypes.func,
   /**
    * @private
    */
-  onClick: React.PropTypes.func,
+  onClick: PropTypes.func,
   /**
    * @private
    */
-  onFocus: React.PropTypes.func,
+  onFocus: PropTypes.func,
   /**
    * @private
    */
-  onMouseOut: React.PropTypes.func,
+  onMouseOut: PropTypes.func,
   /**
    * @private
    */
-  onMouseOver: React.PropTypes.func,
+  onMouseOver: PropTypes.func,
 
   // Overridden props from `<Overlay>`.
   /**
    * @private
    */
-  target: React.PropTypes.oneOf([null]),
+  target: PropTypes.oneOf([null]),
    /**
    * @private
    */
-  onHide: React.PropTypes.oneOf([null]),
+  onHide: PropTypes.oneOf([null]),
   /**
    * @private
    */
-  show: React.PropTypes.oneOf([null]),
+  show: PropTypes.oneOf([null]),
 };
 
 const defaultProps = {

--- a/src/Pager.js
+++ b/src/Pager.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React, { cloneElement } from 'react';
-
 import PropTypes from 'prop-types';
 
 import PagerItem from './PagerItem';

--- a/src/Pager.js
+++ b/src/Pager.js
@@ -1,13 +1,15 @@
 import classNames from 'classnames';
 import React, { cloneElement } from 'react';
 
+import PropTypes from 'prop-types';
+
 import PagerItem from './PagerItem';
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';
 import createChainedFunction from './utils/createChainedFunction';
 import ValidComponentChildren from './utils/ValidComponentChildren';
 
 const propTypes = {
-  onSelect: React.PropTypes.func,
+  onSelect: PropTypes.func,
 };
 
 class Pager extends React.Component {

--- a/src/PagerItem.js
+++ b/src/PagerItem.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import SafeAnchor from './SafeAnchor';

--- a/src/PagerItem.js
+++ b/src/PagerItem.js
@@ -1,16 +1,18 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import SafeAnchor from './SafeAnchor';
 import createChainedFunction from './utils/createChainedFunction';
 
 const propTypes = {
-  disabled: React.PropTypes.bool,
-  previous: React.PropTypes.bool,
-  next: React.PropTypes.bool,
-  onClick: React.PropTypes.func,
-  onSelect: React.PropTypes.func,
-  eventKey: React.PropTypes.any,
+  disabled: PropTypes.bool,
+  previous: PropTypes.bool,
+  next: PropTypes.bool,
+  onClick: PropTypes.func,
+  onSelect: PropTypes.func,
+  eventKey: PropTypes.any,
 };
 
 const defaultProps = {

--- a/src/Pagination.js
+++ b/src/Pagination.js
@@ -1,62 +1,63 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import elementType from 'react-prop-types/lib/elementType';
 
 import PaginationButton from './PaginationButton';
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';
 
 const propTypes = {
-  activePage: React.PropTypes.number,
-  items: React.PropTypes.number,
-  maxButtons: React.PropTypes.number,
+  activePage: PropTypes.number,
+  items: PropTypes.number,
+  maxButtons: PropTypes.number,
 
   /**
    * When `true`, will display the first and the last button page when
    * displaying ellipsis.
    */
-  boundaryLinks: React.PropTypes.bool,
+  boundaryLinks: PropTypes.bool,
 
   /**
    * When `true`, will display the default node value ('&hellip;').
    * Otherwise, will display provided node (when specified).
    */
-  ellipsis: React.PropTypes.oneOfType([
-    React.PropTypes.bool, React.PropTypes.node,
+  ellipsis: PropTypes.oneOfType([
+    PropTypes.bool, PropTypes.node,
   ]),
 
   /**
    * When `true`, will display the default node value ('&laquo;').
    * Otherwise, will display provided node (when specified).
    */
-  first: React.PropTypes.oneOfType([
-    React.PropTypes.bool, React.PropTypes.node,
+  first: PropTypes.oneOfType([
+    PropTypes.bool, PropTypes.node,
   ]),
 
   /**
    * When `true`, will display the default node value ('&raquo;').
    * Otherwise, will display provided node (when specified).
    */
-  last: React.PropTypes.oneOfType([
-    React.PropTypes.bool, React.PropTypes.node,
+  last: PropTypes.oneOfType([
+    PropTypes.bool, PropTypes.node,
   ]),
 
   /**
    * When `true`, will display the default node value ('&lsaquo;').
    * Otherwise, will display provided node (when specified).
    */
-  prev: React.PropTypes.oneOfType([
-    React.PropTypes.bool, React.PropTypes.node,
+  prev: PropTypes.oneOfType([
+    PropTypes.bool, PropTypes.node,
   ]),
 
   /**
    * When `true`, will display the default node value ('&rsaquo;').
    * Otherwise, will display provided node (when specified).
    */
-  next: React.PropTypes.oneOfType([
-    React.PropTypes.bool, React.PropTypes.node,
+  next: PropTypes.oneOfType([
+    PropTypes.bool, PropTypes.node,
   ]),
 
-  onSelect: React.PropTypes.func,
+  onSelect: PropTypes.func,
 
   /**
    * You can use a custom element for the buttons

--- a/src/PaginationButton.js
+++ b/src/PaginationButton.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import elementType from 'react-prop-types/lib/elementType';
 
 import SafeAnchor from './SafeAnchor';
@@ -11,12 +12,12 @@ import createChainedFunction from './utils/createChainedFunction';
 
 const propTypes = {
   componentClass: elementType,
-  className: React.PropTypes.string,
-  eventKey: React.PropTypes.any,
-  onSelect: React.PropTypes.func,
-  disabled: React.PropTypes.bool,
-  active: React.PropTypes.bool,
-  onClick: React.PropTypes.func,
+  className: PropTypes.string,
+  eventKey: PropTypes.any,
+  onSelect: PropTypes.func,
+  disabled: PropTypes.bool,
+  active: PropTypes.bool,
+  onClick: PropTypes.func,
 };
 
 const defaultProps = {

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -1,6 +1,8 @@
 import classNames from 'classnames';
 import React, { cloneElement } from 'react';
 
+import PropTypes from 'prop-types';
+
 import Collapse from './Collapse';
 import { bsStyles, bsClass, getClassSet, prefix, splitBsPropsAndOmit }
   from './utils/bootstrapUtils';
@@ -9,26 +11,26 @@ import { State, Style } from './utils/StyleConfig';
 // TODO: Use uncontrollable.
 
 const propTypes = {
-  collapsible: React.PropTypes.bool,
-  onSelect: React.PropTypes.func,
-  header: React.PropTypes.node,
-  id: React.PropTypes.oneOfType([
-    React.PropTypes.string, React.PropTypes.number,
+  collapsible: PropTypes.bool,
+  onSelect: PropTypes.func,
+  header: PropTypes.node,
+  id: PropTypes.oneOfType([
+    PropTypes.string, PropTypes.number,
   ]),
-  footer: React.PropTypes.node,
-  defaultExpanded: React.PropTypes.bool,
-  expanded: React.PropTypes.bool,
-  eventKey: React.PropTypes.any,
-  headerRole: React.PropTypes.string,
-  panelRole: React.PropTypes.string,
+  footer: PropTypes.node,
+  defaultExpanded: PropTypes.bool,
+  expanded: PropTypes.bool,
+  eventKey: PropTypes.any,
+  headerRole: PropTypes.string,
+  panelRole: PropTypes.string,
 
   // From Collapse.
-  onEnter: React.PropTypes.func,
-  onEntering: React.PropTypes.func,
-  onEntered: React.PropTypes.func,
-  onExit: React.PropTypes.func,
-  onExiting: React.PropTypes.func,
-  onExited: React.PropTypes.func,
+  onEnter: PropTypes.func,
+  onEntering: PropTypes.func,
+  onEntered: PropTypes.func,
+  onExit: PropTypes.func,
+  onExiting: PropTypes.func,
+  onExited: PropTypes.func,
 };
 
 const defaultProps = {

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React, { cloneElement } from 'react';
-
 import PropTypes from 'prop-types';
 
 import Collapse from './Collapse';

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -1,17 +1,19 @@
 import classNames from 'classnames';
 import React, { cloneElement } from 'react';
 
+import PropTypes from 'prop-types';
+
 import { bsClass, getClassSet, splitBsPropsAndOmit }
   from './utils/bootstrapUtils';
 import createChainedFunction from './utils/createChainedFunction';
 import ValidComponentChildren from './utils/ValidComponentChildren';
 
 const propTypes = {
-  accordion: React.PropTypes.bool,
-  activeKey: React.PropTypes.any,
-  defaultActiveKey: React.PropTypes.any,
-  onSelect: React.PropTypes.func,
-  role: React.PropTypes.string,
+  accordion: PropTypes.bool,
+  activeKey: PropTypes.any,
+  defaultActiveKey: PropTypes.any,
+  onSelect: PropTypes.func,
+  role: PropTypes.string,
 };
 
 const defaultProps = {

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React, { cloneElement } from 'react';
-
 import PropTypes from 'prop-types';
 
 import { bsClass, getClassSet, splitBsPropsAndOmit }

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import isRequiredForA11y from 'react-prop-types/lib/isRequiredForA11y';
 
 import { bsClass, getClassSet, prefix, splitBsProps }
@@ -11,45 +12,45 @@ const propTypes = {
    * @type {string}
    * @required
    */
-  id: isRequiredForA11y(React.PropTypes.oneOfType([
-    React.PropTypes.string, React.PropTypes.number,
+  id: isRequiredForA11y(PropTypes.oneOfType([
+    PropTypes.string, PropTypes.number,
   ])),
 
   /**
    * Sets the direction the Popover is positioned towards.
    */
-  placement: React.PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+  placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 
   /**
    * The "top" position value for the Popover.
    */
-  positionTop: React.PropTypes.oneOfType([
-    React.PropTypes.number, React.PropTypes.string,
+  positionTop: PropTypes.oneOfType([
+    PropTypes.number, PropTypes.string,
   ]),
   /**
    * The "left" position value for the Popover.
    */
-  positionLeft: React.PropTypes.oneOfType([
-    React.PropTypes.number, React.PropTypes.string,
+  positionLeft: PropTypes.oneOfType([
+    PropTypes.number, PropTypes.string,
   ]),
 
   /**
    * The "top" position value for the Popover arrow.
    */
-  arrowOffsetTop: React.PropTypes.oneOfType([
-    React.PropTypes.number, React.PropTypes.string,
+  arrowOffsetTop: PropTypes.oneOfType([
+    PropTypes.number, PropTypes.string,
   ]),
   /**
    * The "left" position value for the Popover arrow.
    */
-  arrowOffsetLeft: React.PropTypes.oneOfType([
-    React.PropTypes.number, React.PropTypes.string,
+  arrowOffsetLeft: PropTypes.oneOfType([
+    PropTypes.number, PropTypes.string,
   ]),
 
   /**
    * Title content
    */
-  title: React.PropTypes.node,
+  title: PropTypes.node,
 };
 
 const defaultProps = {

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { cloneElement, PropTypes } from 'react';
+import React, { cloneElement } from 'react';
+import PropTypes from 'prop-types';
 
 import { bsClass as setBsClass, bsStyles, getClassSet, prefix, splitBsProps }
   from './utils/bootstrapUtils';

--- a/src/Radio.js
+++ b/src/Radio.js
@@ -1,17 +1,18 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import warning from 'warning';
 
 import { bsClass, getClassSet, prefix, splitBsProps }
   from './utils/bootstrapUtils';
 
 const propTypes = {
-  inline: React.PropTypes.bool,
-  disabled: React.PropTypes.bool,
+  inline: PropTypes.bool,
+  disabled: PropTypes.bool,
   /**
    * Only valid if `inline` is not set.
    */
-  validationState: React.PropTypes.oneOf([
+  validationState: PropTypes.oneOf([
     'success', 'warning', 'error', null,
   ]),
   /**
@@ -21,7 +22,7 @@ const propTypes = {
    * <Radio inputRef={ref => { this.input = ref; }} />
    * ```
    */
-  inputRef: React.PropTypes.func,
+  inputRef: PropTypes.func,
 };
 
 const defaultProps = {

--- a/src/ResponsiveEmbed.js
+++ b/src/ResponsiveEmbed.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { cloneElement, PropTypes } from 'react';
+import React, { cloneElement } from 'react';
+import PropTypes from 'prop-types';
 import warning from 'warning';
 
 import { bsClass, getClassSet, prefix, splitBsProps }

--- a/src/SafeAnchor.js
+++ b/src/SafeAnchor.js
@@ -1,13 +1,14 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import elementType from 'react-prop-types/lib/elementType';
 
 const propTypes = {
-  href: React.PropTypes.string,
-  onClick: React.PropTypes.func,
-  disabled: React.PropTypes.bool,
-  role: React.PropTypes.string,
-  tabIndex: React.PropTypes.oneOfType([
-    React.PropTypes.number, React.PropTypes.string,
+  href: PropTypes.string,
+  onClick: PropTypes.func,
+  disabled: PropTypes.bool,
+  role: PropTypes.string,
+  tabIndex: PropTypes.oneOfType([
+    PropTypes.number, PropTypes.string,
   ]),
   /**
    * this is sort of silly but needed for Button

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import Button from './Button';
 import Dropdown from './Dropdown';
 import SplitToggle from './SplitToggle';
@@ -9,24 +11,24 @@ const propTypes = {
   ...Dropdown.propTypes,
 
   // Toggle props.
-  bsStyle: React.PropTypes.string,
-  bsSize: React.PropTypes.string,
-  href: React.PropTypes.string,
-  onClick: React.PropTypes.func,
+  bsStyle: PropTypes.string,
+  bsSize: PropTypes.string,
+  href: PropTypes.string,
+  onClick: PropTypes.func,
   /**
    * The content of the split button.
    */
-  title: React.PropTypes.node.isRequired,
+  title: PropTypes.node.isRequired,
   /**
    * Accessible label for the toggle; the value of `title` if not specified.
    */
-  toggleLabel: React.PropTypes.string,
+  toggleLabel: PropTypes.string,
 
   // Override generated docs from <Dropdown>.
   /**
    * @private
    */
-  children: React.PropTypes.node,
+  children: PropTypes.node,
 };
 
 class SplitButton extends React.Component {

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import Button from './Button';

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import TabContainer from './TabContainer';
 import TabContent from './TabContent';
 import TabPane from './TabPane';
@@ -7,14 +9,14 @@ import TabPane from './TabPane';
 const propTypes = {
   ...TabPane.propTypes,
 
-  disabled: React.PropTypes.bool,
+  disabled: PropTypes.bool,
 
-  title: React.PropTypes.node,
+  title: PropTypes.node,
 
   /**
    * tabClassName is used as className for the associated NavItem
    */
-  tabClassName: React.PropTypes.string
+  tabClassName: PropTypes.string
 };
 
 class Tab extends React.Component {

--- a/src/Tab.js
+++ b/src/Tab.js
@@ -1,5 +1,4 @@
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import TabContainer from './TabContainer';

--- a/src/TabContainer.js
+++ b/src/TabContainer.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import uncontrollable from 'uncontrollable';
 
 const TAB = 'tab';
@@ -60,7 +61,7 @@ const propTypes = {
 };
 
 const childContextTypes = {
-  $bs_tabContainer: React.PropTypes.shape({
+  $bs_tabContainer: PropTypes.shape({
     activeKey: PropTypes.any,
     onSelect: PropTypes.func.isRequired,
     getTabId: PropTypes.func.isRequired,

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import elementType from 'react-prop-types/lib/elementType';
 
 import { bsClass as setBsClass, prefix, splitBsPropsAndOmit }
@@ -20,7 +21,7 @@ const propTypes = {
   /**
    * Wait until the first "enter" transition to mount tabs (add them to the DOM)
    */
-  mountOnEnter: React.PropTypes.bool,
+  mountOnEnter: PropTypes.bool,
 
   /**
    * Unmount tabs (remove it from the DOM) when they are no longer visible

--- a/src/TabPane.js
+++ b/src/TabPane.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import elementType from 'react-prop-types/lib/elementType';
 import warning from 'warning';
 
@@ -33,7 +34,7 @@ const propTypes = {
    * `<TabContent>`, the `bsClass` of the `<TabContent>` suffixed by `-pane`.
    * If otherwise not explicitly specified, `tab-pane`.
    */
-  bsClass: React.PropTypes.string,
+  bsClass: PropTypes.string,
 
   /**
    * Transition onEnter callback when animation is not `false`
@@ -68,7 +69,7 @@ const propTypes = {
   /**
    * Wait until the first "enter" transition to mount the tab (add it to the DOM)
    */
-  mountOnEnter: React.PropTypes.bool,
+  mountOnEnter: PropTypes.bool,
 
   /**
    * Unmount the tab (remove it from the DOM) when it is no longer visible

--- a/src/Table.js
+++ b/src/Table.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import { bsClass, getClassSet, prefix, splitBsProps }

--- a/src/Table.js
+++ b/src/Table.js
@@ -1,15 +1,17 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import { bsClass, getClassSet, prefix, splitBsProps }
   from './utils/bootstrapUtils';
 
 const propTypes = {
-  striped: React.PropTypes.bool,
-  bordered: React.PropTypes.bool,
-  condensed: React.PropTypes.bool,
-  hover: React.PropTypes.bool,
-  responsive: React.PropTypes.bool,
+  striped: PropTypes.bool,
+  bordered: PropTypes.bool,
+  condensed: PropTypes.bool,
+  hover: PropTypes.bool,
+  responsive: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import requiredForA11y from 'react-prop-types/lib/isRequiredForA11y';
 import uncontrollable from 'uncontrollable';
 
@@ -17,17 +18,17 @@ const propTypes = {
    *
    * @controllable onSelect
    */
-  activeKey: React.PropTypes.any,
+  activeKey: PropTypes.any,
 
   /**
    * Navigation style
    */
-  bsStyle: React.PropTypes.oneOf(['tabs', 'pills']),
+  bsStyle: PropTypes.oneOf(['tabs', 'pills']),
 
-  animation: React.PropTypes.bool,
+  animation: PropTypes.bool,
 
-  id: requiredForA11y(React.PropTypes.oneOfType([
-    React.PropTypes.string, React.PropTypes.number,
+  id: requiredForA11y(PropTypes.oneOfType([
+    PropTypes.string, PropTypes.number,
   ])),
 
   /**
@@ -42,17 +43,17 @@ const propTypes = {
    *
    * @controllable activeKey
    */
-  onSelect: React.PropTypes.func,
+  onSelect: PropTypes.func,
 
   /**
    * Wait until the first "enter" transition to mount tabs (add them to the DOM)
    */
-  mountOnEnter: React.PropTypes.bool,
+  mountOnEnter: PropTypes.bool,
 
   /**
    * Unmount tabs (remove it from the DOM) when it is no longer visible
    */
-  unmountOnExit: React.PropTypes.bool,
+  unmountOnExit: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/src/Thumbnail.js
+++ b/src/Thumbnail.js
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import React from 'react';
-
 import PropTypes from 'prop-types';
 
 import SafeAnchor from './SafeAnchor';

--- a/src/Thumbnail.js
+++ b/src/Thumbnail.js
@@ -1,13 +1,15 @@
 import classNames from 'classnames';
 import React from 'react';
 
+import PropTypes from 'prop-types';
+
 import SafeAnchor from './SafeAnchor';
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';
 
 const propTypes = {
-  src: React.PropTypes.string,
-  alt: React.PropTypes.string,
-  href: React.PropTypes.string,
+  src: PropTypes.string,
+  alt: PropTypes.string,
+  href: PropTypes.string,
 };
 
 class Thumbnail extends React.Component {

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,5 +1,6 @@
 import classNames from 'classnames';
 import React from 'react';
+import PropTypes from 'prop-types';
 import isRequiredForA11y from 'react-prop-types/lib/isRequiredForA11y';
 
 import { bsClass, getClassSet, prefix, splitBsProps }
@@ -11,39 +12,39 @@ const propTypes = {
    * @type {string|number}
    * @required
    */
-  id: isRequiredForA11y(React.PropTypes.oneOfType([
-    React.PropTypes.string, React.PropTypes.number,
+  id: isRequiredForA11y(PropTypes.oneOfType([
+    PropTypes.string, PropTypes.number,
   ])),
 
   /**
    * Sets the direction the Tooltip is positioned towards.
    */
-  placement: React.PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
+  placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 
   /**
    * The "top" position value for the Tooltip.
    */
-  positionTop: React.PropTypes.oneOfType([
-    React.PropTypes.number, React.PropTypes.string,
+  positionTop: PropTypes.oneOfType([
+    PropTypes.number, PropTypes.string,
   ]),
   /**
    * The "left" position value for the Tooltip.
    */
-  positionLeft: React.PropTypes.oneOfType([
-    React.PropTypes.number, React.PropTypes.string,
+  positionLeft: PropTypes.oneOfType([
+    PropTypes.number, PropTypes.string,
   ]),
 
   /**
    * The "top" position value for the Tooltip arrow.
    */
-  arrowOffsetTop: React.PropTypes.oneOfType([
-    React.PropTypes.number, React.PropTypes.string,
+  arrowOffsetTop: PropTypes.oneOfType([
+    PropTypes.number, PropTypes.string,
   ]),
   /**
    * The "left" position value for the Tooltip arrow.
    */
-  arrowOffsetLeft: React.PropTypes.oneOfType([
-    React.PropTypes.number, React.PropTypes.string,
+  arrowOffsetLeft: PropTypes.oneOfType([
+    PropTypes.number, PropTypes.string,
   ]),
 };
 

--- a/src/utils/bootstrapUtils.js
+++ b/src/utils/bootstrapUtils.js
@@ -1,7 +1,7 @@
 // TODO: The publicly exposed parts of this should be in lib/BootstrapUtils.
 
 import invariant from 'invariant';
-import { PropTypes } from 'react';
+import 'react';
 
 import { SIZE_MAP } from './StyleConfig';
 

--- a/src/utils/bootstrapUtils.js
+++ b/src/utils/bootstrapUtils.js
@@ -1,7 +1,7 @@
 // TODO: The publicly exposed parts of this should be in lib/BootstrapUtils.
 
 import invariant from 'invariant';
-import 'react';
+import PropTypes from 'prop-types';
 
 import { SIZE_MAP } from './StyleConfig';
 

--- a/test/OverlayTriggerSpec.js
+++ b/test/OverlayTriggerSpec.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import ReactTestUtils from 'react-addons-test-utils';
 import ReactDOM from 'react-dom';
 
@@ -149,7 +150,7 @@ describe('<OverlayTrigger>', () => {
 
   it('Should forward requested context', () => {
     const contextTypes = {
-      key: React.PropTypes.string,
+      key: PropTypes.string,
     };
 
     const contextSpy = sinon.spy();


### PR DESCRIPTION
Fixes #2547 

I upgraded all the components with the official [`react-codemod`](https://github.com/reactjs/react-codemod#react-proptypes-to-prop-types).  After that I went through and cleaned up all the files that it couldn't automatically do. 

When I tried to run the tests I got a bunch of errors that looked like this
```
    Error: Warning: Shallow renderer has been moved to react-test-renderer/shallow. Update references to remove this warning.
        at Object.<anonymous> (webpack:///test/index.js:22:0 <- test/index.js:78:12)
        at Function.invoke (node_modules/sinon/pkg/sinon.js:2651:59)
        at Object.proxy [as error] (eval at createProxy (node_modules/sinon/pkg/sinon.js:2556:17), <anonymous>:1:35)
        at printWarning (webpack:///~/fbjs/lib/warning.js:36:0 <- test/index.js:3605:18)
        at warning (webpack:///~/fbjs/lib/warning.js:60:0 <- test/index.js:3629:23)
        at Object.createRendererWithWarning [as createRenderer] (webpack:///~/react-dom/lib/ReactTestUtils.js:42:0 <- test/index.js:88693:12)
        at QueryCollection.shallowRender (webpack:///~/teaspoon/element.js:124:0 <- test/index.js:90718:55)
        at Context.<anonymous> (webpack:///test/FormGroupSpec.js:71:0 <- test/index.js:99015:11)
```
I'm not sure what's up with that but it happens in the master branch too.