### PR TITLE
Update react-overlays

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,8 +38,8 @@
   "author": "Stephen J. Collings <stevoland@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "react": ">=0.14.0",
-    "react-dom": ">=0.14.0"
+    "react": "^0.14.9 || >=15.3.0",
+    "react-dom": "^0.14.9 || >=15.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
@@ -124,7 +124,7 @@
     "dom-helpers": "^2.4.0",
     "invariant": "^2.2.1",
     "keycode": "^2.1.2",
-    "react-overlays": "^0.6.10",
+    "react-overlays": "^0.7.0",
     "react-prop-types": "^0.4.0",
     "uncontrollable": "^4.0.1",
     "warning": "^3.0.0"

--- a/test/DropdownMenuSpec.js
+++ b/test/DropdownMenuSpec.js
@@ -125,7 +125,7 @@ describe('<Dropdown.Menu>', () => {
       button.click();
 
       requestClose.should.have.been.calledOnce;
-      requestClose.getCall(0).args.length.should.equal(0);
+      requestClose.getCall(0).args.length.should.equal(1);
     });
 
     describe('Keyboard Navigation', () => {


### PR DESCRIPTION
I think this is better as a major bump...safer. I'd like to not do that, but `prop-types` really isn't actually supported on < 15.3