### PR TITLE
Bump react-overlays to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "invariant": "^2.2.1",
     "keycode": "^2.1.2",
     "prop-types": "^15.5.6",
-    "react-overlays": "^0.6.12",
+    "react-overlays": "^0.7.0",
     "react-prop-types": "^0.4.0",
     "uncontrollable": "^4.1.0",
     "warning": "^3.0.0"


### PR DESCRIPTION
- addresses #2588
- this addresses the react 15.5 warnings still present in react-bootstrap because of react-overlays