### PR TITLE
Fix position bug when changing placement for OverlayTrigger

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -129,6 +129,10 @@ class OverlayTrigger extends React.Component {
   }
 
   componentDidUpdate() {
+    if (this.state.show) {
+      ReactDOM.unmountComponentAtNode(this._mountNode);
+      this._mountNode = document.createElement('div');
+    }
     this.renderOverlay();
   }
 


### PR DESCRIPTION
There is a bug when a component changes the placement for an OverlayTrigger.

If for example the original placement is to the right, and the overlay doesn't fit fully into the window, then OverlayTrigger squeezes it (increases height) so that the entire contents are still visible.

Then when the placement is changed to "top", `<Position>` uses the stretched overlay's width and height to compute the new `top` and `left` styles for the overlay.

My PR forces the recreation of the overlay so that it has its original width and height.