### PR TITLE
Tab: pass `href` prop down to inner <a> element

### DIFF
--- a/src/Tab.js
+++ b/src/Tab.js
@@ -10,6 +10,8 @@ const propTypes = {
 
   disabled: PropTypes.bool,
 
+  href: PropTypes.string,
+
   title: PropTypes.node,
 
   /**

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import requiredForA11y from 'prop-types-extra/lib/isRequiredForA11y';
+import requiredForA11y from 'react-prop-types/lib/isRequiredForA11y';
 import uncontrollable from 'uncontrollable';
 
 import Nav from './Nav';
@@ -76,7 +76,7 @@ function getDefaultActiveKey(children) {
 
 class Tabs extends React.Component {
   renderTab(child) {
-    const { title, eventKey, disabled, tabClassName } = child.props;
+    const { title, eventKey, disabled, tabClassName, href } = child.props;
     if (title == null) {
       return null;
     }
@@ -86,6 +86,7 @@ class Tabs extends React.Component {
         eventKey={eventKey}
         disabled={disabled}
         className={tabClassName}
+        href={href}
       >
         {title}
       </NavItem>

--- a/test/TabsSpec.js
+++ b/test/TabsSpec.js
@@ -373,6 +373,19 @@ describe('<Tabs>', () => {
     assert.notDeepEqual(myTabClass, myNavItem);
   });
 
+  it('Should pass href to the nav item for all tabs', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Tabs id="test" bsStyle="pills" defaultActiveKey={1} animation={false}>
+        <Tab title="Tab 1" eventKey={1} href="http://example.com">Tab 1 content</Tab>
+      </Tabs>
+    );
+
+    const tabs = ReactTestUtils.scryRenderedComponentsWithType(instance, NavItem);
+    const link1 = ReactTestUtils.findRenderedDOMComponentWithTag(tabs[0], 'a');
+
+    assert.equal(link1.getAttribute('href'), 'http://example.com');
+  });
+
   it('Should pass className, Id, and style to Tabs', () => {
     const instance = ReactTestUtils.renderIntoDocument(
       <Tabs


### PR DESCRIPTION
Allow `href` to be passed to `<Tab>`s. This can be used for normal navigation, or combined with the old `javascript:void(0)` hack to circumvent link-jacking by overzealous hash routers.

```jsx
<Tab title=“Tab 1” href=‘javascript:void(0)’>…</Tab>
```

See #2560, #2476.