### PR TITLE
added description for carousel interval prop

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -17,6 +17,10 @@ import ValidComponentChildren from './utils/ValidComponentChildren';
 const propTypes = {
   slide: PropTypes.bool,
   indicators: PropTypes.bool,
+  /**
+   * The amount of time to delay between automatically cycling an item.
+   * If `0`, carousel will not automatically cycle.
+   */
   interval: PropTypes.number,
   controls: PropTypes.bool,
   pauseOnHover: PropTypes.bool,

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -19,7 +19,7 @@ const propTypes = {
   indicators: PropTypes.bool,
   /**
    * The amount of time to delay between automatically cycling an item.
-   * If `0`, carousel will not automatically cycle.
+   * If `null`, carousel will not automatically cycle.
    */
   interval: PropTypes.number,
   controls: PropTypes.bool,


### PR DESCRIPTION
Bootstrap's documentation for carousel says that `interval` should be set to `false` to prevent automatic cycling, but this is a failing prop in react-bootstrap. Clarifying that `interval={0}` should be used to prevent automatic cycling in react-bootstrap could be helpful.