### PR TITLE
Fixes #2365: CollapseOnSelect in Responsive Navbars prevents external links from working

### DIFF
--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -28,7 +28,7 @@ class NavItem extends React.Component {
   }
 
   handleClick(e) {
-    if (this.props.onSelect) {
+    if (this.props.onSelect && this.props.onSelect.name !== 'bound handleCollapse') {
       e.preventDefault();
 
       if (!this.props.disabled) {


### PR DESCRIPTION
See the issue for more information.