### PR TITLE
#2687 Pass onError and onLoad props to its child image

### DIFF
--- a/src/Thumbnail.js
+++ b/src/Thumbnail.js
@@ -6,10 +6,25 @@ import SafeAnchor from './SafeAnchor';
 import { bsClass, getClassSet, splitBsProps } from './utils/bootstrapUtils';
 
 const propTypes = {
+  /**
+   * src property that is passed down to the image inside this component
+   */
   src: PropTypes.string,
+  /**
+   * alt property that is passed down to the image inside this component
+   */
   alt: PropTypes.string,
+  /**
+   * href property that is passed down to the image inside this component
+   */
   href: PropTypes.string,
+  /**
+   * onError callback that is passed down to the image inside this component
+   */
   onError: PropTypes.func,
+  /**
+   * onLoad callback that is passed down to the image inside this component
+   */
   onLoad: PropTypes.func
 };
 

--- a/src/Thumbnail.js
+++ b/src/Thumbnail.js
@@ -9,11 +9,13 @@ const propTypes = {
   src: PropTypes.string,
   alt: PropTypes.string,
   href: PropTypes.string,
+  onError: PropTypes.func,
+  onLoad: PropTypes.func
 };
 
 class Thumbnail extends React.Component {
   render() {
-    const { src, alt, className, children, ...props } = this.props;
+    const { src, alt, onError, onLoad, className, children, ...props } = this.props;
     const [bsProps, elementProps] = splitBsProps(props);
 
     const Component = elementProps.href ? SafeAnchor : 'div';
@@ -24,7 +26,7 @@ class Thumbnail extends React.Component {
         {...elementProps}
         className={classNames(className, classes)}
       >
-        <img src={src} alt={alt} />
+        <img {...{src, alt, onError, onLoad}} />
 
         {children && (
           <div className="caption">

--- a/test/ThumbnailSpec.js
+++ b/test/ThumbnailSpec.js
@@ -11,7 +11,7 @@ describe('<Thumbnail>', () => {
     alt: 'test',
     onError: () => {},
     onLoad: () => {}
-  }
+  };
   it('Should have a thumbnail class and be an anchor', () => {
     let instance = ReactTestUtils.renderIntoDocument(
       <Thumbnail {...defaultProps} />
@@ -28,9 +28,8 @@ describe('<Thumbnail>', () => {
   });
 
   it('Should have a thumbnail class and be a div', () => {
-    const {href, ...otherProps} = defaultProps;
     let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail {...otherProps} />
+      <Thumbnail src="#" alt="test" />
     );
     assert.ok(ReactDOM.findDOMNode(instance).className.match(/\bthumbnail\b/));
     assert.equal(ReactDOM.findDOMNode(instance).nodeName, 'DIV');
@@ -69,23 +68,21 @@ describe('<Thumbnail>', () => {
 
   it('Should have an img with an onError callback', () => {
     const onErrorSpy = sinon.spy();
-    const {onError, ...otherKeys} = defaultProps;
     let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail {...otherKeys} onError={onErrorSpy} />
+      <Thumbnail src="#" href="#" onLoad={() => {}} onError={onErrorSpy} />
     );
     let img = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'img');
-    ReactTestUtils.Simulate.error(img)
+    ReactTestUtils.Simulate.error(img);
     assert.ok(onErrorSpy.calledOnce);
   });
 
   it('Should have an img with an onLoad callback', () => {
     const onLoadSpy = sinon.spy();
-    const {onLoad, ...otherKeys} = defaultProps;
     let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail {...otherKeys} onLoad={onLoadSpy} />
+      <Thumbnail src="#" href="#" onError={() => {}} onLoad={onLoadSpy} />
     );
     let img = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'img');
-    ReactTestUtils.Simulate.load(img)
+    ReactTestUtils.Simulate.load(img);
     assert.ok(onLoadSpy.calledOnce);
   });
 

--- a/test/ThumbnailSpec.js
+++ b/test/ThumbnailSpec.js
@@ -5,9 +5,16 @@ import ReactTestUtils from 'react-dom/test-utils';
 import Thumbnail from '../src/Thumbnail';
 
 describe('<Thumbnail>', () => {
+  let defaultProps = {
+    href: '#',
+    src: '#',
+    alt: 'test',
+    onError: () => {},
+    onLoad: () => {}
+  }
   it('Should have a thumbnail class and be an anchor', () => {
     let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail href="#" src="#" alt="test" />
+      <Thumbnail {...defaultProps} />
     );
     assert.ok(ReactDOM.findDOMNode(instance).className.match(/\bthumbnail\b/));
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a'));
@@ -15,7 +22,7 @@ describe('<Thumbnail>', () => {
 
   it('Should have an image', () => {
     let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail href="#" src="#" alt="test" />
+      <Thumbnail {...defaultProps} />
     );
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'img'));
   });
@@ -30,14 +37,14 @@ describe('<Thumbnail>', () => {
 
   it('Should have an image', () => {
     let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail src="#" alt="test" />
+      <Thumbnail {...defaultProps} />
     );
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'img'));
   });
 
   it('Should have an inner div with class caption', () => {
     let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail src="#" alt="test">
+      <Thumbnail {...defaultProps} >
         Test
         <div>
           Test child element
@@ -49,7 +56,7 @@ describe('<Thumbnail>', () => {
 
   it('Should have an inner div with class caption in an anchor', () => {
     let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail href="#" src="#" alt="test">
+      <Thumbnail {...defaultProps}>
         Test
         <div>
           Test child element
@@ -58,4 +65,27 @@ describe('<Thumbnail>', () => {
     );
     assert.ok(ReactDOM.findDOMNode(instance).lastChild.className.match(/\bcaption\b/));
   });
+
+  it('Should have an img with an onError callback', () => {
+    const onErrorSpy = sinon.spy();
+    const {onError, ...otherKeys} = defaultProps;
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Thumbnail {...otherKeys} onError={onErrorSpy} />
+    );
+    let img = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'img');
+    ReactTestUtils.Simulate.error(img)
+    assert.ok(onErrorSpy.calledOnce);
+  });
+
+  it('Should have an img with an onLoad callback', () => {
+    const onLoadSpy = sinon.spy();
+    const {onLoad, ...otherKeys} = defaultProps;
+    let instance = ReactTestUtils.renderIntoDocument(
+      <Thumbnail {...otherKeys} onLoad={onLoadSpy} />
+    );
+    let img = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'img');
+    ReactTestUtils.Simulate.load(img)
+    assert.ok(onLoadSpy.calledOnce);
+  });
+
 });

--- a/test/ThumbnailSpec.js
+++ b/test/ThumbnailSpec.js
@@ -28,8 +28,9 @@ describe('<Thumbnail>', () => {
   });
 
   it('Should have a thumbnail class and be a div', () => {
+    const {href, ...otherProps} = defaultProps;
     let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail src="#" alt="test" />
+      <Thumbnail {...otherProps} />
     );
     assert.ok(ReactDOM.findDOMNode(instance).className.match(/\bthumbnail\b/));
     assert.equal(ReactDOM.findDOMNode(instance).nodeName, 'DIV');

--- a/test/ThumbnailSpec.js
+++ b/test/ThumbnailSpec.js
@@ -5,16 +5,9 @@ import ReactTestUtils from 'react-dom/test-utils';
 import Thumbnail from '../src/Thumbnail';
 
 describe('<Thumbnail>', () => {
-  let defaultProps = {
-    href: '#',
-    src: '#',
-    alt: 'test',
-    onError: () => {},
-    onLoad: () => {}
-  };
   it('Should have a thumbnail class and be an anchor', () => {
     let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail {...defaultProps} />
+      <Thumbnail href="#" src="#" alt="test" />
     );
     assert.ok(ReactDOM.findDOMNode(instance).className.match(/\bthumbnail\b/));
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'a'));
@@ -22,7 +15,7 @@ describe('<Thumbnail>', () => {
 
   it('Should have an image', () => {
     let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail {...defaultProps} />
+      <Thumbnail href="#" src="#" alt="test" />
     );
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'img'));
   });
@@ -37,14 +30,14 @@ describe('<Thumbnail>', () => {
 
   it('Should have an image', () => {
     let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail {...defaultProps} />
+      <Thumbnail src="#" alt="test" />
     );
     assert.ok(ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'img'));
   });
 
   it('Should have an inner div with class caption', () => {
     let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail {...defaultProps} >
+      <Thumbnail src="#" alt="test">
         Test
         <div>
           Test child element
@@ -56,7 +49,7 @@ describe('<Thumbnail>', () => {
 
   it('Should have an inner div with class caption in an anchor', () => {
     let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail {...defaultProps}>
+      <Thumbnail href="#" src="#" alt="test">
         Test
         <div>
           Test child element
@@ -68,22 +61,22 @@ describe('<Thumbnail>', () => {
 
   it('Should have an img with an onError callback', () => {
     const onErrorSpy = sinon.spy();
-    let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail src="#" href="#" onLoad={() => {}} onError={onErrorSpy} />
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Thumbnail href="#" src="#" alt="test" onError={onErrorSpy} />
     );
-    let img = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'img');
+    const img = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'img');
     ReactTestUtils.Simulate.error(img);
-    assert.ok(onErrorSpy.calledOnce);
+    expect(onErrorSpy).to.have.been.calledOnce;
   });
 
   it('Should have an img with an onLoad callback', () => {
     const onLoadSpy = sinon.spy();
-    let instance = ReactTestUtils.renderIntoDocument(
-      <Thumbnail src="#" href="#" onError={() => {}} onLoad={onLoadSpy} />
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Thumbnail href="#" src="#" alt="test" onLoad={onLoadSpy} />
     );
-    let img = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'img');
+    const img = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'img');
     ReactTestUtils.Simulate.load(img);
-    assert.ok(onLoadSpy.calledOnce);
+    expect(onLoadSpy).to.have.been.calledOnce;
   });
 
 });


### PR DESCRIPTION
# Description

Addressing https://github.com/react-bootstrap/react-bootstrap/issues/2687

We want to be able to pass the onLoad and onError props from the parent Thumbnail prop to the child img tag. This pull request implements that functionality, as well as adding a few minimal descriptions for each prop in the thumbnail component

* [x] Added tests for the new props
* [x] Check to see if the docs display the new prop types and their descriptions

### opening this pr to pass through CI services

### Also
This is my first pr for this repo so I don't entirely understand the specific pr process for this repo. Please request changes if needed.