### PR TITLE
SafeAnchor a11y - Provide keydown handler for "space"

### DIFF
--- a/src/SafeAnchor.js
+++ b/src/SafeAnchor.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import elementType from 'prop-types-extra/lib/elementType';
+import keycode from 'keycode';
 
 const propTypes = {
   href: PropTypes.string,
   onClick: PropTypes.func,
+  onKeyDown: PropTypes.func,
   disabled: PropTypes.bool,
   role: PropTypes.string,
   tabIndex: PropTypes.oneOfType([
@@ -36,6 +38,7 @@ class SafeAnchor extends React.Component {
     super(props, context);
 
     this.handleClick = this.handleClick.bind(this);
+    this.handleKeyDown = this.handleKeyDown.bind(this);
   }
 
   handleClick(event) {
@@ -55,8 +58,14 @@ class SafeAnchor extends React.Component {
     }
   }
 
+  handleKeyDown(event) {
+    if (keycode(event) === 'space') {
+      this.handleClick(event);
+    }
+  }
+
   render() {
-    const { componentClass: Component, disabled, ...props } = this.props;
+    const { componentClass: Component, disabled, onKeyDown, ...props } = this.props;
 
     if (isTrivialHref(props.href)) {
       props.role = props.role || 'button';
@@ -74,6 +83,7 @@ class SafeAnchor extends React.Component {
       <Component
         {...props}
         onClick={this.handleClick}
+        onKeyDown={onKeyDown || this.handleKeyDown}
       />
     );
   }

--- a/src/SafeAnchor.js
+++ b/src/SafeAnchor.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import elementType from 'prop-types-extra/lib/elementType';
-import keycode from 'keycode';
 
 const propTypes = {
   href: PropTypes.string,
@@ -59,7 +58,8 @@ class SafeAnchor extends React.Component {
   }
 
   handleKeyDown(event) {
-    if (keycode(event) === 'space') {
+    event.preventDefault();
+    if (event.key === ' ') {
       this.handleClick(event);
     }
   }

--- a/src/SafeAnchor.js
+++ b/src/SafeAnchor.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import elementType from 'prop-types-extra/lib/elementType';
+import createChainedFunction from './utils/createChainedFunction';
 
 const propTypes = {
   href: PropTypes.string,
@@ -67,6 +68,9 @@ class SafeAnchor extends React.Component {
   render() {
     const { componentClass: Component, disabled, onKeyDown, ...props } = this.props;
 
+    const handleKeyDown = Component === 'a' ?
+      createChainedFunction(this.handleKeyDown, onKeyDown) : onKeyDown;
+
     if (isTrivialHref(props.href)) {
       props.role = props.role || 'button';
       // we want to make sure there is a href attribute on the node
@@ -83,7 +87,7 @@ class SafeAnchor extends React.Component {
       <Component
         {...props}
         onClick={this.handleClick}
-        onKeyDown={onKeyDown || this.handleKeyDown}
+        onKeyDown={handleKeyDown}
       />
     );
   }

--- a/src/SafeAnchor.js
+++ b/src/SafeAnchor.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import elementType from 'prop-types-extra/lib/elementType';
+
 import createChainedFunction from './utils/createChainedFunction';
 
 const propTypes = {
@@ -68,8 +69,6 @@ class SafeAnchor extends React.Component {
   render() {
     const { componentClass: Component, disabled, onKeyDown, ...props } = this.props;
 
-    const handleKeyDown = createChainedFunction(this.handleKeyDown, onKeyDown);
-
     if (isTrivialHref(props.href)) {
       props.role = props.role || 'button';
       // we want to make sure there is a href attribute on the node
@@ -86,7 +85,7 @@ class SafeAnchor extends React.Component {
       <Component
         {...props}
         onClick={this.handleClick}
-        onKeyDown={handleKeyDown}
+        onKeyDown={createChainedFunction(this.handleKeyDown, onKeyDown)}
       />
     );
   }

--- a/src/SafeAnchor.js
+++ b/src/SafeAnchor.js
@@ -59,8 +59,8 @@ class SafeAnchor extends React.Component {
   }
 
   handleKeyDown(event) {
-    event.preventDefault();
     if (event.key === ' ') {
+      event.preventDefault();
       this.handleClick(event);
     }
   }
@@ -68,8 +68,7 @@ class SafeAnchor extends React.Component {
   render() {
     const { componentClass: Component, disabled, onKeyDown, ...props } = this.props;
 
-    const handleKeyDown = Component === 'a' ?
-      createChainedFunction(this.handleKeyDown, onKeyDown) : onKeyDown;
+    const handleKeyDown = createChainedFunction(this.handleKeyDown, onKeyDown);
 
     if (isTrivialHref(props.href)) {
       props.role = props.role || 'button';

--- a/test/SafeAnchorSpec.js
+++ b/test/SafeAnchorSpec.js
@@ -45,7 +45,7 @@ describe('SafeAnchor', () => {
     tsp(<SafeAnchor onClick={handleClick} />)
       .shallowRender()
       .find('a')
-      .trigger('keyDown', { keyCode: 32, preventDefault() {} });
+      .trigger('keyDown', { key: ' ', preventDefault() {} });
 
     handleClick.should.have.been.calledOnce;
   });

--- a/test/SafeAnchorSpec.js
+++ b/test/SafeAnchorSpec.js
@@ -39,6 +39,17 @@ describe('SafeAnchor', () => {
     handleClick.should.have.been.calledOnce;
   });
 
+  it('provides onClick handler as onKeyDown handler for "space"', () => {
+    const handleClick = sinon.spy();
+
+    tsp(<SafeAnchor onClick={handleClick} />)
+      .shallowRender()
+      .find('a')
+      .trigger('keyDown', { keyCode: 32, preventDefault() {} });
+
+    handleClick.should.have.been.calledOnce;
+  });
+
   it('prevents default when no href is provided', () => {
     const handleClick = sinon.spy();
 


### PR DESCRIPTION
~If `onKeyDown` prop is supplied, prefer that.~
If SafeAnchor renders an `a` tag, supply onKeyDown handler for "space" that calls the `onClick` handler.
Test that space bar calls click handler.

Addresses https://github.com/react-bootstrap/react-bootstrap/issues/2681