### PR TITLE
Add backdropClassName to Modal props to allow extra class names on backdrop

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -32,6 +32,12 @@ const propTypes = {
   backdrop: PropTypes.oneOf(['static', true, false]),
 
   /**
+   * Add an optional extra class name to .modal-backdrop
+   * It could end up looking like class="modal-backdrop foo-modal-backdrop in".
+   */
+  backdropClassName: PropTypes.string,
+
+  /**
    * Close the modal when escape key is pressed
    */
   keyboard: PropTypes.bool,
@@ -206,6 +212,7 @@ class Modal extends React.Component {
   render() {
     const {
       backdrop,
+      backdropClassName,
       animation,
       show,
       dialogComponentClass: Dialog,
@@ -230,7 +237,7 @@ class Modal extends React.Component {
         onEntering={createChainedFunction(onEntering, this.handleEntering)}
         onExited={createChainedFunction(onExited, this.handleExited)}
         backdrop={backdrop}
-        backdropClassName={classNames(prefix(props, 'backdrop'), inClassName)}
+        backdropClassName={classNames(prefix(props, 'backdrop'), backdropClassName, inClassName)}
         containerClassName={prefix(props, 'open')}
         transition={animation ? Fade : undefined}
         dialogTransitionTimeout={Modal.TRANSITION_DURATION}

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -109,6 +109,18 @@ describe('<Modal>', () => {
     assert.ok(baseModal.backdrop.className.match(/\bmymodal-backdrop\b/));
   });
 
+  it('Should use backdropClassName to add classes to the backdrop', () => {
+    const noOp = () => {};
+    const instance = render(
+      <Modal show backdropClassName="my-modal-backdrop" onHide={noOp}>
+        <strong>Message</strong>
+      </Modal>
+    , mountPoint);
+
+    const baseModal = ReactTestUtils.findRenderedComponentWithType(instance, BaseModal);
+    assert.ok(baseModal.backdrop.className.match(/\bmodal-backdrop my-modal-backdrop\b/));
+  });
+
   it('Should pass bsSize to the dialog', () => {
     const noOp = () => {};
     const instance = render(


### PR DESCRIPTION
Similar to how <Modal/> allows `dialogClassName` to add class names on top of `modal`, it would be convenient to be able to add class names to the backdrop. Currently the only option is to modify the bsClass.