### PR TITLE
use onMouseDown instead of onClick for Modal close

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -247,7 +247,7 @@ class Modal extends React.Component {
           {...dialogProps}
           style={{ ...this.state.style, ...style }}
           className={classNames(className, inClassName)}
-          onClick={backdrop === true ? this.handleDialogClick : null}
+          onMouseDown={backdrop === true ? this.handleDialogClick : null}
         >
           {children}
         </Dialog>


### PR DESCRIPTION
This prevents the modal from closing when the user clicks inside the modal, drags the cursor into the backdrop and releases. This is discussed in issue #1785 