### PR TITLE
Fix `import * as PropTypes` to `import PropTypes`

### DIFF
--- a/src/CloseButton.js
+++ b/src/CloseButton.js
@@ -1,4 +1,4 @@
-import * as PropTypes from 'prop-types';
+import PropTypes from 'prop-types';
 import React from 'react';
 
 const propTypes = {


### PR DESCRIPTION
Why it is `import * as PropTypes` ?

`import PropTypes` is fine I think. 