### PR TITLE
Upgraded codecov because execSync subdependency fails to install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-bootstrap",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1927,13 +1927,12 @@
       "dev": true
     },
     "codecov": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-1.0.1.tgz",
-      "integrity": "sha1-lyYM6sDpa47ajVYgBlWKU6E53/0=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/codecov/-/codecov-2.3.0.tgz",
+      "integrity": "sha1-rSWixuBELRN0DZ1N27mj4nFDMPQ=",
       "dev": true,
       "requires": {
         "argv": "0.0.2",
-        "execSync": "1.0.2",
         "request": "2.81.0",
         "urlgrey": "0.4.4"
       }
@@ -3273,15 +3272,6 @@
       "requires": {
         "md5.js": "1.3.4",
         "safe-buffer": "5.1.1"
-      }
-    },
-    "execSync": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/execSync/-/execSync-1.0.2.tgz",
-      "integrity": "sha1-H0LtpYIiUYAFMiTs3T/Rlg/bMTk=",
-      "dev": true,
-      "requires": {
-        "temp": "0.5.1"
       }
     },
     "execa": {
@@ -9610,33 +9600,6 @@
           "dev": true,
           "requires": {
             "loose-envify": "1.3.1"
-          }
-        }
-      }
-    },
-    "temp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/temp/-/temp-0.5.1.tgz",
-      "integrity": "sha1-d6sZx5qntZPL5PrCRBdoytmHuN8=",
-      "dev": true,
-      "requires": {
-        "rimraf": "2.1.4"
-      },
-      "dependencies": {
-        "graceful-fs": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
-          "integrity": "sha1-FaSAaldUfLLS2/J/QuiajDRRs2Q=",
-          "dev": true,
-          "optional": true
-        },
-        "rimraf": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.1.4.tgz",
-          "integrity": "sha1-Wm62Lu2gaPUe3lDymz5c0i89m7I=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "1.2.3"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "brfs": "^1.4.3",
     "chai": "^3.5.0",
     "child-process-promise": "^2.0.3",
-    "codecov": "^1.0.1",
+    "codecov": "^2.2.0",
     "codemirror": "^5.16.0",
     "colors": "^1.1.2",
     "cross-env": "^2.0.0",


### PR DESCRIPTION
With "newer" node versions (>= 11) you are not able to run `npm install` on react-bootstrap because of execSync became a native node extension and fails (https://github.com/mgutz/execSync/issues/36) with

`Attempting to compile native extensions.`

Upgrading codecov to 2.X.X solves the problem because they dropped dependency to execSync.