### PR TITLE
fix(Navbar): Allow external links to fire

### DIFF
--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -28,12 +28,8 @@ class NavItem extends React.Component {
   }
 
   handleClick(e) {
-    if (this.props.onSelect) {
-      e.preventDefault();
-
-      if (!this.props.disabled) {
-        this.props.onSelect(this.props.eventKey, e);
-      }
+    if (this.props.onSelect && !this.props.disabled) {
+      this.props.onSelect(this.props.eventKey, e);
     }
   }
 

--- a/test/NavbarSpec.js
+++ b/test/NavbarSpec.js
@@ -353,4 +353,34 @@ describe('<Navbar>', () => {
 
     ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'test');
   });
+
+  it('Should open external href link in collapseOnSelect', () => {
+    const selectSpy = sinon.spy();
+    const navItemOnClick = sinon.stub();
+    const instance = ReactTestUtils.renderIntoDocument(
+      <Navbar onSelect={selectSpy}>
+        <Navbar.Header>
+          <Navbar.Toggle />
+        </Navbar.Header>
+        <Navbar.Collapse>
+          <Nav>
+            <NavItem eventKey={1} href="https://www.google.com" onClick={navItemOnClick} />
+          </Nav>
+        </Navbar.Collapse>
+      </Navbar>
+    );
+
+    const link = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'A');
+
+    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link));
+
+    const event = navItemOnClick.getCall(0).args[0];
+    const preventDefaultSpy = sinon.spy(event.preventDefault);
+
+    expect(selectSpy).to.be.calledOnce;
+    expect(navItemOnClick).to.be.calledOnce;
+    expect(event.target.getAttribute('href')).to.be.equal('https://www.google.com');
+    expect(preventDefaultSpy).to.not.be.called;
+    expect(selectSpy).to.be.calledWith(1);
+  });
 });


### PR DESCRIPTION
- Remove preventDefault for NavItem onSelect which was preventing the external link from opening

Fixes #2365. This PR implements the solution suggested by @taion [here](https://github.com/react-bootstrap/react-bootstrap/pull/2711#issuecomment-325151744) in the discussion for #2711.

Tested it out locally and it works perfectly. Let me know if this is not the expected solution for this problem.