### PR TITLE
DropdownButton supports block

### DIFF
--- a/src/DropdownButton.js
+++ b/src/DropdownButton.js
@@ -13,6 +13,13 @@ const propTypes = {
   title: PropTypes.node.isRequired,
   noCaret: PropTypes.bool,
 
+  // The block prop does not work 100% as you'd expect out of the box
+  // Requires extra styling to make it display correctly, but WILL add .btn-block to button element
+  /**
+   * @private
+   */
+  block: PropTypes.bool,
+
   // Override generated docs from <Dropdown>.
   /**
    * @private

--- a/test/DropdownButtonSpec.js
+++ b/test/DropdownButtonSpec.js
@@ -168,6 +168,21 @@ describe('<DropdownButton>', () => {
     assert.ok(buttonNode.disabled);
   });
 
+  it('should add .btn-block to button and not .btn-group', () => {
+    const instance = ReactTestUtils.renderIntoDocument(
+      <DropdownButton title="Title" bsStyle="primary" id="testId" disabled block>
+        <MenuItem eventKey="1">MenuItem 1 content</MenuItem>
+        <MenuItem eventKey="2">MenuItem 2 content</MenuItem>
+      </DropdownButton>,
+    );
+
+    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'BUTTON');
+    assert.ok(buttonNode.className.match(/\bbtn-block\b/));
+
+    const buttonGroupNode = ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'btn-group');
+    assert.ok(!buttonGroupNode.className.match(/\bbtn-bock\b/));
+  });
+
   it('should derive bsClass from parent', () => {
     const instance = ReactTestUtils.renderIntoDocument(
       <DropdownButton title="title" id="test-id" bsClass="my-dropdown">


### PR DESCRIPTION
Related to issue #1680 

The DropdownButton component now supports the block prop. This will add a `.btn-block` class to the button element in the Dropdown.Trigger but will _not_ do anything to the `btn-group` itself. In order to make the `btn-group` display as a block level element, users will need to add additional styling.

I chose to make the `block` prop on DropdownButton a private prop to avoid any confusion with having to add additional styling.