### PR TITLE
Remove fill from docs

### DIFF
--- a/docs/examples/PanelListGroupFill.js
+++ b/docs/examples/PanelListGroupFill.js
@@ -1,7 +1,7 @@
 const panelInstance = (
   <Panel collapsible defaultExpanded header="Panel heading">
     Some default panel content here.
-    <ListGroup fill>
+    <ListGroup>
       <ListGroupItem>Item 1</ListGroupItem>
       <ListGroupItem>Item 2</ListGroupItem>
       <ListGroupItem>&hellip;</ListGroupItem>

--- a/docs/src/sections/PanelSection.js
+++ b/docs/src/sections/PanelSection.js
@@ -33,7 +33,6 @@ export default function PanelSection() {
       <ReactPlayground codeText={Samples.PanelContextual} />
 
       <h3><Anchor id="panels-tables">With tables and list groups</Anchor></h3>
-      <p>Add the <code>fill</code> prop to <code>&lt;Table /&gt;</code> or <code>&lt;ListGroup /&gt;</code> elements to make them fill the panel.</p>
       <ReactPlayground codeText={Samples.PanelListGroupFill} />
 
       <h3><Anchor id="panels-controlled">Controlled PanelGroups</Anchor></h3>


### PR DESCRIPTION
It doesn't look like the fill property is necessary anymore, so it can be removed from the docs.