### PR TITLE
Add documentation note about rootCloseEvent being unavailable to custom dropdowns

### DIFF
--- a/docs/src/sections/DropdownSection.js
+++ b/docs/src/sections/DropdownSection.js
@@ -57,6 +57,15 @@ export default function DropdownSection() {
       <p>
         For those that want to customize everything, you can forgo the included Toggle and Menu components, and create your own. In order to tell the Dropdown component what role your custom components play, add a special prop <code>bsRole</code> to your menu or toggle components. The Dropdown expects at least one component with <code>bsRole="toggle"</code> and exactly one with <code>bsRole="menu"</code>. Custom toggle and menu components must be able to accept refs.
       </p>
+      <div className="bs-callout bs-callout-warning">
+        <h4>Using <code>rootCloseEvent</code> with custom dropdown components</h4>
+        <p>
+          If you want to use the <code>rootCloseEvent</code> prop with your custom dropdown components, you will have to pass the <code>rootCloseEvent</code> to <code>{ '<RootCloseWrapper>' }</code> in your custom dropdown menu component <a href="https://github.com/react-bootstrap/react-bootstrap/blob/e41e041709045db657ac02c46fa4ff2df4e339a3/src/DropdownMenu.js#L115-L119">similarly to how it is implemented in <code>{ '<Dropdown.Menu>' }</code></a>.
+        </p>
+        <p>
+          You will have to add <code>react-overlays</code> as a dependency and import <code>{ '<RootCloseWrapper>' }</code> from <code>react-overlays</code> yourself like: <code>import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper'</code>.
+        </p>
+      </div>
       <ReactPlayground codeText={Samples.DropdownButtonCustomMenu} />
 
       <h3><Anchor id="btn-dropdowns-props">Props</Anchor></h3>

--- a/docs/src/sections/DropdownSection.js
+++ b/docs/src/sections/DropdownSection.js
@@ -60,7 +60,7 @@ export default function DropdownSection() {
       <div className="bs-callout bs-callout-warning">
         <h4>Using <code>rootCloseEvent</code> with custom dropdown components</h4>
         <p>
-          If you want to use the <code>rootCloseEvent</code> prop with your custom dropdown components, you will have to pass the <code>rootCloseEvent</code> to <code>{ '<RootCloseWrapper>' }</code> in your custom dropdown menu component <a href="https://github.com/react-bootstrap/react-bootstrap/blob/e41e041709045db657ac02c46fa4ff2df4e339a3/src/DropdownMenu.js#L115-L119">similarly to how it is implemented in <code>{ '<Dropdown.Menu>' }</code></a>.
+          If you want to use the <code>rootCloseEvent</code> prop with your custom dropdown components, you will have to pass the <code>rootCloseEvent</code> to <code>{ '<RootCloseWrapper>' }</code> in your custom dropdown menu component <a href="https://github.com/react-bootstrap/react-bootstrap/blob/v0.31.5/src/DropdownMenu.js#L115-L119">similarly to how it is implemented in <code>{ '<Dropdown.Menu>' }</code></a>.
         </p>
         <p>
           You will have to add <code>react-overlays</code> as a dependency and import <code>{ '<RootCloseWrapper>' }</code> from <code>react-overlays</code> yourself like: <code>import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper'</code>.

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -98,7 +98,7 @@ const propTypes = {
    *
    * *Note: For custom dropdown components, you will have to pass the
    * `rootCloseEvent` to `<RootCloseWrapper>` in your custom dropdown menu
-   * component ([similarly to how it is implemented in `<Dropdown.Menu>`](https://github.com/react-bootstrap/react-bootstrap/blob/e41e041709045db657ac02c46fa4ff2df4e339a3/src/DropdownMenu.js#L115-L119)).*
+   * component ([similarly to how it is implemented in `<Dropdown.Menu>`](https://github.com/react-bootstrap/react-bootstrap/blob/v0.31.5/src/DropdownMenu.js#L115-L119)).*
    */
   rootCloseEvent: PropTypes.oneOf(['click', 'mousedown']),
 

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -96,8 +96,9 @@ const propTypes = {
   /**
    * Which event when fired outside the component will cause it to be closed
    *
-   * *Note: `rootCloseEvent` will not work with custom dropdowns because it is
-   * implemented internally by `<Dropdown.Menu>`.*
+   * *Note: For custom dropdown components, you will have to pass the
+   * `rootCloseEvent` to `<RootCloseWrapper>` in your custom dropdown menu
+   * component ([similarly to how it is implemented in `<Dropdown.Menu>`](https://github.com/react-bootstrap/react-bootstrap/blob/e41e041709045db657ac02c46fa4ff2df4e339a3/src/DropdownMenu.js#L115-L119)).*
    */
   rootCloseEvent: PropTypes.oneOf(['click', 'mousedown']),
 

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -95,6 +95,9 @@ const propTypes = {
 
   /**
    * Which event when fired outside the component will cause it to be closed
+   *
+   * *Note: `rootCloseEvent` will not work with custom dropdowns because it is
+   * implemented internally by `<Dropdown.Menu>`.*
    */
   rootCloseEvent: PropTypes.oneOf(['click', 'mousedown']),
 


### PR DESCRIPTION
Summary
-----------
The documentation about `rootCloseEvent` for Dropdown does not indicate that it is not usable for `CustomDropdown`.

Changes proposed
-------------------
- [x] Add note about `rootCloseEvent` not working for custom dropdowns due it being implemented internally by `<Dropdown.Menu>`.

-------------------
Fixes #2891