### PR TITLE
Fix React.DOM.code deprecation warning: Remove deprecated use of React.DOM.code

### DIFF
--- a/docs/src/sections/ModalSection.js
+++ b/docs/src/sections/ModalSection.js
@@ -36,14 +36,16 @@ export default function ModalSection() {
       <h3><Anchor id="modals-contained">Contained Modal</Anchor></h3>
       <p>You will need to add the following css to your project and ensure that your container has the <code>modal-container</code> class.</p>
       <pre>
-        {React.DOM.code(null,
-          '.modal-container {\n' +
-          '  position: relative;\n' +
-          '}\n' +
-          '.modal-container .modal, .modal-container .modal-backdrop {\n' +
-          '  position: absolute;\n' +
-          '}\n',
-        )}
+        <code>
+          {
+            '.modal-container {\n' +
+            '  position: relative;\n' +
+            '}\n' +
+            '.modal-container .modal, .modal-container .modal-backdrop {\n' +
+            '  position: absolute;\n' +
+            '}\n'
+          }
+        </code>
       </pre>
       <ReactPlayground codeText={Samples.ModalContained} />
 


### PR DESCRIPTION
Summary:
------------
We're getting this warning:
`Warning: Accessing factories like React.DOM.code has been deprecated and will be removed in v16.0+. Use the react-dom-factories package instead.  Version 1.0 provides a drop-in replacement. For more info, see https://fb.me/react-dom-factories`
<img width="1898" alt="screen shot 2017-12-15 at 11 46 15 am" src="https://user-images.githubusercontent.com/7256178/34057926-f7281018-e18d-11e7-918b-df742d6e55b3.png">


Changes Proposed:
--------------------
- [x] Remove use of `React.DOM.code` in our docs and replace it with `<code>` tags.