### PR TITLE
fix(Nav): set activeKey and activeHref to lowerCase

### DIFF
--- a/src/Nav.js
+++ b/src/Nav.js
@@ -342,8 +342,8 @@ class Nav extends React.Component {
               childOnSelect
             ),
             active,
-            activekey,
-            activehref,
+            activekey: activeKey,
+            activehref: activeHref,
             onSelect: childOnSelect
           });
         })}

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -342,8 +342,8 @@ class Nav extends React.Component {
               childOnSelect
             ),
             active,
-            activeKey,
-            activeHref,
+            activekey,
+            activehref,
             onSelect: childOnSelect
           });
         })}


### PR DESCRIPTION
The 	`activeKey` and `activeHref` property on the `Nav` component are throwing a React warning in my console. I'm not sure what those attributes are used for, but if I do as the warning asks and make the properties lowercase instead of camel-case, the errors go away.

<img src="https://i.imgur.com/FrTcNYM.png" />

Cool library by the way. Thanks to the contributors.