### PR TITLE
Docs for toggle button group

### DIFF
--- a/www/src/examples/ToggleButtonGroupControlled.js
+++ b/www/src/examples/ToggleButtonGroupControlled.js
@@ -2,27 +2,26 @@ class ToggleButtonGroupControlled extends React.Component {
   constructor(props, context) {
     super(props, context);
 
+    this.handleChange = this.handleChange.bind(this);
+
     this.state = {
       value: [1, 3]
     };
-
-    this.onChange = e => this.setState({ value: e.target.value });
   }
 
-  // onChange = (value) => {
-  //   this.setState({ value });
-  // };
+  handleChange(e) {
+    this.setState({ value: e });
+  }
 
   render() {
     return (
       <ToggleButtonGroup
         type="checkbox"
         value={this.state.value}
-        onChange={this.onChange}
+        onChange={this.handleChange}
       >
         <ToggleButton value={1}>Checkbox 1 (pre-checked)</ToggleButton>
         <ToggleButton value={2}>Checkbox 2</ToggleButton>
-
         <ToggleButton value={3}>Checkbox 3 (pre-checked)</ToggleButton>
         <ToggleButton value={4} disabled>
           Checkbox 4 (disabled)

--- a/www/src/examples/ToggleButtonGroupControlled.js
+++ b/www/src/examples/ToggleButtonGroupControlled.js
@@ -1,0 +1,35 @@
+class ToggleButtonGroupControlled extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = {
+      value: [1, 3]
+    };
+
+    this.onChange = e => this.setState({ value: e.target.value });
+  }
+
+  // onChange = (value) => {
+  //   this.setState({ value });
+  // };
+
+  render() {
+    return (
+      <ToggleButtonGroup
+        type="checkbox"
+        value={this.state.value}
+        onChange={this.onChange}
+      >
+        <ToggleButton value={1}>Checkbox 1 (pre-checked)</ToggleButton>
+        <ToggleButton value={2}>Checkbox 2</ToggleButton>
+
+        <ToggleButton value={3}>Checkbox 3 (pre-checked)</ToggleButton>
+        <ToggleButton value={4} disabled>
+          Checkbox 4 (disabled)
+        </ToggleButton>
+      </ToggleButtonGroup>
+    );
+  }
+}
+
+render(<ToggleButtonGroupControlled />);

--- a/www/src/examples/ToggleButtonGroupUncontrolled.js
+++ b/www/src/examples/ToggleButtonGroupUncontrolled.js
@@ -1,0 +1,23 @@
+const toggleButtonGroups = (
+  <div>
+    <ButtonToolbar>
+      <ToggleButtonGroup type="checkbox" defaultValue={[1, 3]}>
+        <ToggleButton value={1}>Checkbox 1 (pre-checked)</ToggleButton>
+        <ToggleButton value={2}>Checkbox 2</ToggleButton>
+
+        <ToggleButton value={3}>Checkbox 3 (pre-checked)</ToggleButton>
+      </ToggleButtonGroup>
+    </ButtonToolbar>
+
+    <ButtonToolbar>
+      <ToggleButtonGroup type="radio" name="options" defaultValue={1}>
+        <ToggleButton value={1}>Radio 1 (pre-checked)</ToggleButton>
+        <ToggleButton value={2}>Radio 2</ToggleButton>
+
+        <ToggleButton value={3}>Radio 3</ToggleButton>
+      </ToggleButtonGroup>
+    </ButtonToolbar>
+  </div>
+);
+
+render(toggleButtonGroups);

--- a/www/src/examples/ToggleButtonGroupUncontrolled.js
+++ b/www/src/examples/ToggleButtonGroupUncontrolled.js
@@ -1,21 +1,17 @@
-const toggleButtonGroups = (
-  <div>
-    <ButtonToolbar>
-      <ToggleButtonGroup type="checkbox" defaultValue={[1, 3]}>
-        <ToggleButton value={1}>Checkbox 1 (pre-checked)</ToggleButton>
-        <ToggleButton value={2}>Checkbox 2</ToggleButton>
-        <ToggleButton value={3}>Checkbox 3 (pre-checked)</ToggleButton>
-      </ToggleButtonGroup>
-    </ButtonToolbar>
+<div>
+  <ButtonToolbar>
+    <ToggleButtonGroup type="checkbox" defaultValue={[1, 3]}>
+      <ToggleButton value={1}>Checkbox 1 (pre-checked)</ToggleButton>
+      <ToggleButton value={2}>Checkbox 2</ToggleButton>
+      <ToggleButton value={3}>Checkbox 3 (pre-checked)</ToggleButton>
+    </ToggleButtonGroup>
+  </ButtonToolbar>
 
-    <ButtonToolbar>
-      <ToggleButtonGroup type="radio" name="options" defaultValue={1}>
-        <ToggleButton value={1}>Radio 1 (pre-checked)</ToggleButton>
-        <ToggleButton value={2}>Radio 2</ToggleButton>
-        <ToggleButton value={3}>Radio 3</ToggleButton>
-      </ToggleButtonGroup>
-    </ButtonToolbar>
-  </div>
-);
-
-render(toggleButtonGroups);
+  <ButtonToolbar>
+    <ToggleButtonGroup type="radio" name="options" defaultValue={1}>
+      <ToggleButton value={1}>Radio 1 (pre-checked)</ToggleButton>
+      <ToggleButton value={2}>Radio 2</ToggleButton>
+      <ToggleButton value={3}>Radio 3</ToggleButton>
+    </ToggleButtonGroup>
+  </ButtonToolbar>
+</div>;

--- a/www/src/examples/ToggleButtonGroupUncontrolled.js
+++ b/www/src/examples/ToggleButtonGroupUncontrolled.js
@@ -4,7 +4,6 @@ const toggleButtonGroups = (
       <ToggleButtonGroup type="checkbox" defaultValue={[1, 3]}>
         <ToggleButton value={1}>Checkbox 1 (pre-checked)</ToggleButton>
         <ToggleButton value={2}>Checkbox 2</ToggleButton>
-
         <ToggleButton value={3}>Checkbox 3 (pre-checked)</ToggleButton>
       </ToggleButtonGroup>
     </ButtonToolbar>
@@ -13,7 +12,6 @@ const toggleButtonGroups = (
       <ToggleButtonGroup type="radio" name="options" defaultValue={1}>
         <ToggleButton value={1}>Radio 1 (pre-checked)</ToggleButton>
         <ToggleButton value={2}>Radio 2</ToggleButton>
-
         <ToggleButton value={3}>Radio 3</ToggleButton>
       </ToggleButtonGroup>
     </ButtonToolbar>

--- a/www/src/pages/components/button-group.js
+++ b/www/src/pages/components/button-group.js
@@ -123,6 +123,20 @@ export default function ButtonGroupSection({ data }) {
         selected <code>eventKey</code> for radio groups.
       </p>
 
+      <div className="bs-callout bs-callout-warning">
+        <h4>Bootstrap JS issue</h4>
+        <p>
+          There is a known{' '}
+          <a href="https://github.com/react-bootstrap/react-bootstrap/issues/2774">
+            issue
+          </a>{' '}
+          when including Bootstrap JS while using Toggle Button Groups.
+          Therefore it is advised not use Bootstrap JS in conjunction with{' '}
+          <code>{'<ToggleButtonGroup>'}</code> and{' '}
+          <code>{'<ToggleButton>'}</code>.
+        </p>
+      </div>
+
       <h4>Uncontrolled</h4>
       <ReactPlayground codeText={ToggleButtonGroupUncontrolled} />
       <h4>Controlled</h4>

--- a/www/src/pages/components/button-group.js
+++ b/www/src/pages/components/button-group.js
@@ -11,13 +11,17 @@ import ButtonGroupNested from '../../examples/ButtonGroupNested';
 import ButtonGroupVertical from '../../examples/ButtonGroupVertical';
 import ButtonGroupBlock from '../../examples/ButtonGroupBlock';
 import ButtonGroupJustified from '../../examples/ButtonGroupJustified';
+import ToggleButtonGroupControlled from '../../examples/ToggleButtonGroupControlled';
+import ToggleButtonGroupUncontrolled from '../../examples/ToggleButtonGroupUncontrolled';
 
 export default function ButtonGroupSection({ data }) {
   return (
     <div className="bs-docs-section">
       <h2 className="page-header">
         <Anchor id="btn-groups">Button groups</Anchor>{' '}
-        <small>ButtonGroup, ButtonToolbar</small>
+        <small>
+          ButtonGroup, ButtonToolbar, ToggleButtonGroup, ToggleButton
+        </small>
       </h2>
 
       <p className="lead">
@@ -109,16 +113,62 @@ export default function ButtonGroupSection({ data }) {
       <ReactPlayground codeText={ButtonGroupJustified} />
 
       <h3>
+        <Anchor id="btn-groups-checkbox-radio">Checkbox / Radio</Anchor>
+      </h3>
+      <p>
+        For checkboxes or radio buttons styled as Bootstrap buttons, use the
+        <code>{'<ToggleButtonGroup>'}</code> and <code>{'<ToggleButton>'}</code>
+        components. The group behaves as a form component, where the value is an
+        array of the selected <code>eventKey</code>s for checkbox groups or the
+        selected <code>eventKey</code> for radio groups.
+      </p>
+
+      <h4>Uncontrolled</h4>
+      <ReactPlayground codeText={ToggleButtonGroupUncontrolled} />
+      <h4>Controlled</h4>
+      <ReactPlayground codeText={ToggleButtonGroupControlled} />
+
+      <h3>
         <Anchor id="btn-groups-props">Props</Anchor>
       </h3>
-      <PropTable metadata={data.metadata} />
+
+      <h4>
+        <Anchor id="btn-groups-group-props">ButtonGroup</Anchor>
+      </h4>
+      <PropTable metadata={data.ButtonGroup} />
+
+      <h4>
+        <Anchor id="btn-groups-toolbar-props">ButtonToolbar</Anchor>
+      </h4>
+      <PropTable metadata={data.ButtonToolbar} />
+
+      <h4>
+        <Anchor id="btn-groups-toggle-group-props">ToggleButtonGroup</Anchor>
+      </h4>
+      <PropTable metadata={data.ToggleButtonGroup} />
+
+      <h4>
+        <Anchor id="btn-groups-toggle-btn-props">ToggleButton</Anchor>
+      </h4>
+      <PropTable metadata={data.ToggleButton} />
     </div>
   );
 }
 
 export const query = graphql`
   query ButtonGroupQuery {
-    metadata: componentMetadata(displayName: { eq: "ButtonGroup" }) {
+    ButtonGroup: componentMetadata(displayName: { eq: "ButtonGroup" }) {
+      ...PropTable_metadata
+    }
+    ButtonToolbar: componentMetadata(displayName: { eq: "ButtonToolbar" }) {
+      ...PropTable_metadata
+    }
+    ToggleButtonGroup: componentMetadata(
+      displayName: { eq: "ToggleButtonGroup" }
+    ) {
+      ...PropTable_metadata
+    }
+    ToggleButton: componentMetadata(displayName: { eq: "ToggleButton" }) {
       ...PropTable_metadata
     }
   }


### PR DESCRIPTION
Since part of the documentation got dropped with the switch to gatsby this PR adds `ToggleButtonGroup` and `ToggleButton` back to the Button Groups documentation section and includes all relevant props.

In addition the warning for using Bootstrap JS with the toggle groups as outlined in https://github.com/react-bootstrap/react-bootstrap/issues/2774 is added.

Can you please review the wording of the Bootstrap JS warning?

Note: I think there is still more documentation to be added but I will do this in a seperate PR.

Thanks :)
