### PR TITLE
Change docs footer version reference

### DIFF
--- a/www/src/components/PageFooter.js
+++ b/www/src/components/PageFooter.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import packageJSON from '../../package.json';
+import packageJSON from '../../../package.json';
 
 let version = packageJSON.version;
 


### PR DESCRIPTION
I noticed that the documentation version was 1.0.0 which was looking at the `www/package.json` version number so I directed it to look at `/package.json`.

![image](https://user-images.githubusercontent.com/16972659/35273024-265f5ac8-008b-11e8-8c51-c52d3b4e648a.png)

Alternatively we could change `www/package.json` version number.