### PR TITLE
Changed ProgressBar check to work with proxied components

### DIFF
--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -30,7 +30,12 @@ function onlyProgressBar(props, propName, componentName) {
       return;
     }
 
-    // eslint-disable-next-line no-use-before-define
+    /**
+     * Compare types in a way that works with libraries that patch and proxy
+     * components like react-hot-loader.
+     *
+     * see https://github.com/gaearon/react-hot-loader#checking-element-types
+     */
     const element = <ProgressBar />;
     if (child.type === element.type) return;
 

--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -31,7 +31,8 @@ function onlyProgressBar(props, propName, componentName) {
     }
 
     // eslint-disable-next-line no-use-before-define
-    if (child.type === ProgressBar) return;
+    const element = <ProgressBar />;
+    if (child.type === element.type) return;
 
     const childIdentifier = React.isValidElement(child)
       ? child.type.displayName || child.type.name || child.type


### PR DESCRIPTION
Fixes #2963

This is the recommended way of doing Component type checking in react hot loader v3. The updated version in v4 using `areComponentsEqual` doesn't seem to work correctly, but this method still seems to work with v4. 

I don't really know how to add any new tests to show this work with RHL, but all the current tests still work. 