### PR TITLE
Lock bootstrap version in Getting Started guide

### DIFF
--- a/www/src/pages/getting-started/introduction.js
+++ b/www/src/pages/getting-started/introduction.js
@@ -50,10 +50,10 @@ $ bower install react-bootstrap
           <pre>
             <code>{`
 <!-- Latest compiled and minified CSS -->
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap.min.css">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
 
 <!-- Optional theme -->
-<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/latest/css/bootstrap-theme.min.css">
+<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
           `}</code>
           </pre>
           <p>


### PR DESCRIPTION
Locked bootstrap version from MaxCDN for prevent loading of new versions of Bootstrap.

Fixed this issue - https://github.com/react-bootstrap/react-bootstrap/issues/2978