### PR TITLE
Improve custom overlays docs

### DIFF
--- a/www/src/examples/OverlayCustom.js
+++ b/www/src/examples/OverlayCustom.js
@@ -1,6 +1,7 @@
-function CustomPopover({ style }) {
+function CustomPopover({ className, style }) {
   return (
     <div
+      className={className}
       style={{
         ...style,
         position: 'absolute',

--- a/www/src/pages/components/overlays.js
+++ b/www/src/pages/components/overlays.js
@@ -33,9 +33,9 @@ export default function OverlaySection({ data }) {
       <p>
         You don't need to use the provided <code>Tooltip</code> or{' '}
         <code>Popover</code> components. Creating custom overlays is as easy as
-        wrapping some markup in an <code>Overlay</code> component. To make
-        positioning and transitions work you have to pass down to the wrapped
-        element the <code>className</code> and <code>style</code> props.
+        wrapping some markup in an <code>Overlay</code> component. Make sure to
+        pass down the <code>className</code> and <code>style</code> props to
+        the wrapped element to make positioning and transitions work.
       </p>
       <ReactPlayground codeText={OverlayCustom} />
 

--- a/www/src/pages/components/overlays.js
+++ b/www/src/pages/components/overlays.js
@@ -33,7 +33,9 @@ export default function OverlaySection({ data }) {
       <p>
         You don't need to use the provided <code>Tooltip</code> or{' '}
         <code>Popover</code> components. Creating custom overlays is as easy as
-        wrapping some markup in an <code>Overlay</code> component.
+        wrapping some markup in an <code>Overlay</code> component. To make
+        positioning and transitions work you have to pass down to the wrapped
+        element the <code>className</code> and <code>style</code> props.
       </p>
       <ReactPlayground codeText={OverlayCustom} />
 


### PR DESCRIPTION
Fixes #2997 

I explained in the custom overlays docs the importance of passing down `style` and `className` to the wrapped component.