### PR TITLE
Fix minification

### DIFF
--- a/tools/build-dist.js
+++ b/tools/build-dist.js
@@ -23,7 +23,7 @@ function config(optimize) {
       rules: [rules.js({ ...babelOptions, cacheDirectory: true })]
     },
     plugins: [
-      optimize && plugins.uglify(),
+      optimize && plugins.uglify({ exclude: undefined }),
       plugins.moduleConcatenation(),
       plugins.define({
         'process.env': {

--- a/www/src/components/PageFooter.js
+++ b/www/src/components/PageFooter.js
@@ -53,21 +53,22 @@ class PageFooter extends React.Component {
               target="_blank"
             >
               MIT
-            </a>{'. '}
+            </a>
+            {'. '}
             Documentation based, in part, on{' '}
             <a
               href="https://getbootstrap.com/docs/3.3/"
               rel="noopener noreferrer"
               target="_blank"
             >
-              bootstrap 
+              bootstrap
             </a>; licensed under{' '}
             <a
               href="https://creativecommons.org/licenses/by/3.0/"
               rel="noopener noreferrer"
               target="_blank"
             >
-              CC BY 3.0 
+              CC BY 3.0
             </a>
           </p>
           <ul className="bs-docs-footer-links muted">

--- a/www/src/pages/components/overlays.js
+++ b/www/src/pages/components/overlays.js
@@ -34,8 +34,8 @@ export default function OverlaySection({ data }) {
         You don't need to use the provided <code>Tooltip</code> or{' '}
         <code>Popover</code> components. Creating custom overlays is as easy as
         wrapping some markup in an <code>Overlay</code> component. Make sure to
-        pass down the <code>className</code> and <code>style</code> props to
-        the wrapped element to make positioning and transitions work.
+        pass down the <code>className</code> and <code>style</code> props to the
+        wrapped element to make positioning and transitions work.
       </p>
       <ReactPlayground codeText={OverlayCustom} />
 


### PR DESCRIPTION
Fixes https://github.com/react-bootstrap/react-bootstrap/issues/3005

What's happening here is that the default `excludes` on webpack-atoms actually matches `react-bootstrap.min.js`. I don't think we _want_ that `excludes` there, but I was seeing weird stuff when I upgraded to v5 there.