### PR TITLE
Added a prop to enable adding classes to the modal-content dom node

### DIFF
--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -15,7 +15,11 @@ const propTypes = {
   /**
    * A css class to apply to the Modal dialog DOM node.
    */
-  dialogClassName: PropTypes.string
+  dialogClassName: PropTypes.string,
+  /**
+   * A css class to apply to the Modal content DOM node.
+   */
+  contentClassName: PropTypes.string
 };
 
 class ModalDialog extends React.Component {
@@ -25,6 +29,7 @@ class ModalDialog extends React.Component {
       className,
       style,
       children,
+      contentClassName,
       ...props
     } = this.props;
     const [bsProps, elementProps] = splitBsProps(props);
@@ -48,7 +53,10 @@ class ModalDialog extends React.Component {
         className={classNames(className, bsClassName)}
       >
         <div className={classNames(dialogClassName, dialogClasses)}>
-          <div className={prefix(bsProps, 'content')} role="document">
+          <div
+            className={classNames(contentClassName, prefix(bsProps, 'content'))}
+            role="document"
+          >
             {children}
           </div>
         </div>

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -235,6 +235,22 @@ describe('<Modal>', () => {
     );
   });
 
+  it('applies a contentClassName to the modal-content when passed ', () => {
+    const noOp = () => {};
+    const instance = render(
+      <Modal show contentClassName="contentTestCss" onHide={noOp}>
+        <strong>Message</strong>
+      </Modal>,
+      mountPoint
+    );
+
+    const dialog = instance._modal
+      .getDialogElement()
+      .querySelector('.modal-content');
+
+    assert.ok(dialog.className.match(/\bcontentTestCss\b/));
+  });
+
   describe('cleanup', () => {
     let offSpy;
 


### PR DESCRIPTION
I needed a way to apply a css class to the modal-content dom node. Making my own custom modalDialogComponent broke the drop in modal transition. This enables a custom class on the modal-content that is prepended to the other classes applied.