### PR TITLE
V4 ProgressBar

### DIFF
--- a/src/ProgressBar.js
+++ b/src/ProgressBar.js
@@ -58,7 +58,7 @@ const propTypes = {
   label: PropTypes.node,
   srOnly: PropTypes.bool,
   striped: PropTypes.bool,
-  active: PropTypes.bool,
+  animated: PropTypes.bool,
   children: onlyProgressBar,
 
   /**
@@ -70,7 +70,7 @@ const propTypes = {
 const defaultProps = {
   min: 0,
   max: 100,
-  active: false,
+  animated: false,
   isChild: false,
   srOnly: false,
   striped: false
@@ -89,19 +89,19 @@ class ProgressBar extends React.Component {
     label,
     srOnly,
     striped,
-    active,
+    animated,
     className,
     style,
+    bsStyle,
     ...props
   }) {
     const [bsProps, elementProps] = splitBsProps(props);
-
     const classes = {
       ...getClassSet(bsProps),
-      active,
-      [prefix(bsProps, 'striped')]: active || striped
+      [prefix({ bsClass: 'bg' }, bsStyle)]: bsStyle !== undefined,
+      [prefix(bsProps, 'animated')]: animated,
+      [prefix(bsProps, 'striped')]: animated || striped
     };
-
     return (
       <div
         {...elementProps}
@@ -131,7 +131,7 @@ class ProgressBar extends React.Component {
       label,
       srOnly,
       striped,
-      active,
+      animated,
       bsClass,
       bsStyle,
       className,
@@ -152,7 +152,7 @@ class ProgressBar extends React.Component {
               label,
               srOnly,
               striped,
-              active,
+              animated,
               bsClass,
               bsStyle
             })}

--- a/test/ProgressBarSpec.js
+++ b/test/ProgressBarSpec.js
@@ -40,10 +40,7 @@ describe('<ProgressBar>', () => {
     const instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar min={0} max={10} now={0} bsStyle="success" />
     );
-
-    assert.ok(
-      getProgressBarNode(instance).className.match(/\bprogress-bar-success\b/)
-    );
+    assert.ok(getProgressBarNode(instance).className.match(/\bbg-success\b/));
   });
 
   it('Should have the warning class', () => {
@@ -51,9 +48,7 @@ describe('<ProgressBar>', () => {
       <ProgressBar min={0} max={10} now={0} bsStyle="warning" />
     );
 
-    assert.ok(
-      getProgressBarNode(instance).className.match(/\bprogress-bar-warning\b/)
-    );
+    assert.ok(getProgressBarNode(instance).className.match(/\bbg-warning\b/));
   });
 
   it('Should default to min:0, max:100', () => {
@@ -185,13 +180,13 @@ describe('<ProgressBar>', () => {
 
   it('Should show animated striped bar', () => {
     const instance = ReactTestUtils.renderIntoDocument(
-      <ProgressBar min={1} max={11} now={6} active />
+      <ProgressBar min={1} max={11} now={6} animated />
     );
 
     const barClassName = ReactDOM.findDOMNode(instance).firstChild.className;
 
     assert.ok(barClassName.match(/\bprogress-bar-striped\b/));
-    assert.ok(barClassName.match(/\bactive\b/));
+    assert.ok(barClassName.match(/\banimated\b/));
   });
 
   it('Should show stacked bars', () => {
@@ -212,10 +207,10 @@ describe('<ProgressBar>', () => {
     assert.equal(bar2.style.width, '30%');
   });
 
-  it('Should render active and striped children in stacked bar too', () => {
+  it('Should render animated and striped children in stacked bar too', () => {
     const instance = ReactTestUtils.renderIntoDocument(
       <ProgressBar>
-        <ProgressBar active key={1} now={50} />
+        <ProgressBar animated key={1} now={50} />
         <ProgressBar striped key={2} now={30} />
       </ProgressBar>
     );
@@ -226,12 +221,12 @@ describe('<ProgressBar>', () => {
     assert.ok(wrapper.className.match(/\bprogress\b/));
 
     assert.ok(bar1.className.match(/\bprogress-bar\b/));
-    assert.ok(bar1.className.match(/\bactive\b/));
+    assert.ok(bar1.className.match(/\banimated\b/));
     assert.ok(bar1.className.match(/\bprogress-bar-striped\b/));
 
     assert.ok(bar2.className.match(/\bprogress-bar\b/));
     assert.ok(bar2.className.match(/\bprogress-bar-striped\b/));
-    assert.notOk(bar2.className.match(/\bactive\b/));
+    assert.notOk(bar2.className.match(/\banimated\b/));
   });
 
   it('Should forward className and style to nested bars', () => {


### PR DESCRIPTION
According to [migration guide](https://getbootstrap.com/docs/4.0/migration/) the new changes for the `ProgressBar` component are the following:

- `.active` class now becomes `progress-bar-animated`
  - Changed `active` prop to `animated`

- `.progress-bar-[bgStyle]` now becomes `.bg-[bgStyle]`
  - Props remain the same
  - `.progress-bar-[bgStyle]` is removed
 -  new class added to component `.bg-[bg-style]`