### PR TITLE
Add v4 support for tables

### DIFF
--- a/src/PageItem.js
+++ b/src/PageItem.js
@@ -49,7 +49,7 @@ function createButton(name, defaultValue, label = name) {
   return class extends React.Component {
     static displayName = name;
     render() {
-      const { children, className, ...props } = this.props;
+      const { children, ...props } = this.props;
       delete props.active;
       return (
         <PageItem {...props}>

--- a/src/Table.js
+++ b/src/Table.js
@@ -2,63 +2,88 @@ import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import {
-  bsClass,
-  getClassSet,
-  prefix,
-  splitBsProps
-} from './utils/bootstrapUtils';
-
-const propTypes = {
-  inverse: PropTypes.bool,
-  striped: PropTypes.bool,
-  bordered: PropTypes.bool,
-  condensed: PropTypes.bool,
-  hover: PropTypes.bool,
-  responsive: PropTypes.bool
-};
-
-const defaultProps = {
-  inverse: false,
-  bordered: false,
-  condensed: false,
-  hover: false,
-  responsive: false,
-  striped: false
-};
+import { createBootstrapComponent } from './ThemeProvider';
 
 class Table extends React.Component {
+  static propTypes = {
+    /**
+     * @default 'table'
+     */
+    bsPrefix: PropTypes.string,
+
+    /**
+     * Adds zebra-striping to any table row within the `<tbody>`.
+     */
+    striped: PropTypes.bool,
+
+    /**
+     * Adds borders on all sides of the table and cells.
+     */
+    bordered: PropTypes.bool,
+
+    /**
+     * Enable a hover state on table rows within a `<tbody>`.
+     */
+    hover: PropTypes.bool,
+
+    /**
+     * Make tables more compact by cutting cell padding in half by setting
+     * size as `sm`.
+     */
+    size: PropTypes.string,
+
+    /**
+     * Invert the colors of the table — with light text on dark backgrounds
+     * by setting variant as `dark`.
+     */
+    variant: PropTypes.string,
+
+    /**
+     * Responsive tables allow tables to be scrolled horizontally with ease.
+     * Across every breakpoint, use `responsive` for horizontally
+     * scrolling tables. Responsive tables are wrapped automatically in a `div`.
+     * Use `responsive="sm"`, `responsive="md"`, `responsive="lg"`, or
+     * `responsive="xl"` as needed to create responsive tables up to
+     * a particular breakpoint. From that breakpoint and up, the table will
+     * behave normally and not scroll horizontally.
+     */
+    responsive: PropTypes.oneOfType([PropTypes.bool, PropTypes.string])
+  };
+
   render() {
     const {
-      inverse,
+      bsPrefix,
       striped,
       bordered,
-      condensed,
       hover,
+      size,
+      variant,
       responsive,
-      className,
       ...props
     } = this.props;
 
-    const [bsProps, elementProps] = splitBsProps(props);
-
-    const classes = {
-      ...getClassSet(bsProps),
-      [prefix(bsProps, 'responsive')]: responsive,
-      [prefix(bsProps, 'inverse')]: inverse,
-      [prefix(bsProps, 'striped')]: striped,
-      [prefix(bsProps, 'bordered')]: bordered,
-      [prefix(bsProps, 'condensed')]: condensed,
-      [prefix(bsProps, 'hover')]: hover
-    };
-
-    return (
-      <table {...elementProps} className={classNames(className, classes)} />
+    const classes = classNames(
+      bsPrefix,
+      variant && `${bsPrefix}-${variant}`,
+      size && `${bsPrefix}-${size}`,
+      striped && `${bsPrefix}-striped`,
+      bordered && `${bsPrefix}-bordered`,
+      hover && `${bsPrefix}-hover`
     );
+
+    const table = <table {...props} className={classes} />;
+
+    if (responsive) {
+      let responsiveClass = `${bsPrefix}-responsive`;
+      if (typeof responsive === 'string') {
+        responsiveClass = `${responsiveClass}-${responsive}`;
+      }
+
+      return <div className={responsiveClass}>{table}</div>;
+    }
+
+    return table;
   }
 }
 
-Table.propTypes = propTypes;
-Table.defaultProps = defaultProps;
-
-export default bsClass('table', Table);
+export default createBootstrapComponent(Table, 'table');

--- a/stories/Table.js
+++ b/stories/Table.js
@@ -5,7 +5,7 @@ import Table from '../src/Table';
 
 storiesOf('Table ', module)
   .add('Table basic', () => (
-    <Table striped bordered condensed hover>
+    <Table striped bordered hover>
       <thead>
         <tr>
           <th>#</th>
@@ -35,8 +35,39 @@ storiesOf('Table ', module)
       </tbody>
     </Table>
   ))
-  .add('Table inverse', () => (
-    <Table inverse striped bordered condensed hover>
+  .add('Table small', () => (
+    <Table striped bordered hover size="sm">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Username</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr className="table-primary">
+          <td>1</td>
+          <td>Mark</td>
+          <td>Otto</td>
+          <td>@mdo</td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>Jacob</td>
+          <td>Thornton</td>
+          <td>@fat</td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td colSpan="2">Larry the Bird</td>
+          <td>@twitter</td>
+        </tr>
+      </tbody>
+    </Table>
+  ))
+  .add('Table dark', () => (
+    <Table striped bordered hover variant="dark">
       <thead>
         <tr>
           <th>#</th>
@@ -68,6 +99,130 @@ storiesOf('Table ', module)
   ))
   .add('Table responsive', () => (
     <Table responsive>
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Username</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr className="table-primary">
+          <td>1</td>
+          <td>Mark</td>
+          <td>Otto</td>
+          <td>@mdo</td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>Jacob</td>
+          <td>Thornton</td>
+          <td>@fat</td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td colSpan="2">Larry the Bird</td>
+          <td>@twitter</td>
+        </tr>
+      </tbody>
+    </Table>
+  ))
+  .add('Table responsive-sm', () => (
+    <Table responsive="sm">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Username</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr className="table-primary">
+          <td>1</td>
+          <td>Mark</td>
+          <td>Otto</td>
+          <td>@mdo</td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>Jacob</td>
+          <td>Thornton</td>
+          <td>@fat</td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td colSpan="2">Larry the Bird</td>
+          <td>@twitter</td>
+        </tr>
+      </tbody>
+    </Table>
+  ))
+  .add('Table responsive-md', () => (
+    <Table responsive="md">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Username</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr className="table-primary">
+          <td>1</td>
+          <td>Mark</td>
+          <td>Otto</td>
+          <td>@mdo</td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>Jacob</td>
+          <td>Thornton</td>
+          <td>@fat</td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td colSpan="2">Larry the Bird</td>
+          <td>@twitter</td>
+        </tr>
+      </tbody>
+    </Table>
+  ))
+  .add('Table responsive-lg', () => (
+    <Table responsive="lg">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Username</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr className="table-primary">
+          <td>1</td>
+          <td>Mark</td>
+          <td>Otto</td>
+          <td>@mdo</td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>Jacob</td>
+          <td>Thornton</td>
+          <td>@fat</td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td colSpan="2">Larry the Bird</td>
+          <td>@twitter</td>
+        </tr>
+      </tbody>
+    </Table>
+  ))
+  .add('Table responsive-xl', () => (
+    <Table responsive="xl">
       <thead>
         <tr>
           <th>#</th>

--- a/test/TableSpec.js
+++ b/test/TableSpec.js
@@ -32,11 +32,14 @@ describe('Table', () => {
     );
   });
 
-  it('Should have correct class when condensed', () => {
-    let instance = ReactTestUtils.renderIntoDocument(<Table condensed />);
-    assert.ok(
-      ReactDOM.findDOMNode(instance).className.match(/\btable-condensed\b/)
-    );
+  it('Should have correct class when small', () => {
+    let instance = ReactTestUtils.renderIntoDocument(<Table size="sm" />);
+    assert.ok(ReactDOM.findDOMNode(instance).className.match(/\btable-sm\b/));
+  });
+
+  it('Should have correct class when dark', () => {
+    let instance = ReactTestUtils.renderIntoDocument(<Table variant="dark" />);
+    assert.ok(ReactDOM.findDOMNode(instance).className.match(/\btable-dark\b/));
   });
 
   it('Should have responsive wrapper', () => {
@@ -46,6 +49,13 @@ describe('Table', () => {
     );
     assert.ok(
       ReactDOM.findDOMNode(instance).firstChild.className.match(/\btable\b/)
+    );
+  });
+
+  it('Should have responsive breakpoints', () => {
+    let instance = ReactTestUtils.renderIntoDocument(<Table responsive="sm" />);
+    assert.ok(
+      ReactDOM.findDOMNode(instance).className.match(/\btable-responsive-sm\b/)
     );
   });
 });

--- a/www/src/examples/TableDark.js
+++ b/www/src/examples/TableDark.js
@@ -1,4 +1,4 @@
-<Table striped bordered hover>
+<Table striped bordered hover variant="dark">
   <thead>
     <tr>
       <th>#</th>

--- a/www/src/examples/TableResponsiveBreakpoints.js
+++ b/www/src/examples/TableResponsiveBreakpoints.js
@@ -1,0 +1,170 @@
+<div>
+  <Table responsive="sm">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+      </tr>
+    </tbody>
+  </Table>
+  <Table responsive="md">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+      </tr>
+    </tbody>
+  </Table>
+  <Table responsive="lg">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+      </tr>
+    </tbody>
+  </Table>
+  <Table responsive="xl">
+    <thead>
+      <tr>
+        <th>#</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+        <th>Table heading</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+        <td>Table cell</td>
+      </tr>
+    </tbody>
+  </Table>
+</div>;

--- a/www/src/examples/TableSmall.js
+++ b/www/src/examples/TableSmall.js
@@ -1,4 +1,4 @@
-<Table striped bordered hover>
+<Table striped bordered hover size="sm">
   <thead>
     <tr>
       <th>#</th>

--- a/www/src/pages/components/table.js
+++ b/www/src/pages/components/table.js
@@ -6,31 +6,70 @@ import PropTable from '../../components/PropTable';
 import ReactPlayground from '../../components/ReactPlayground';
 
 import TableBasic from '../../examples/TableBasic';
+import TableSmall from '../../examples/TableSmall';
+import TableDark from '../../examples/TableDark';
 import TableResponsive from '../../examples/TableResponsive';
+import TableResponsiveBreakpoints from '../../examples/TableResponsiveBreakpoints';
 
 export default function TableSection({ data }) {
   return (
     <div className="bs-docs-section">
       <h2 className="page-header">
-        <Anchor id="tables">Tables</Anchor> <small>Table</small>
+        <Anchor id="tables">Tables</Anchor>
       </h2>
 
       <p>
-        Use the <code>striped</code>, <code>bordered</code>,{' '}
-        <code>condensed</code> and <code>hover</code> props to customise the
-        table.
+        Use the <code>striped</code>, <code>bordered</code> and{' '}
+        <code>hover</code> props to customise the table.
       </p>
       <ReactPlayground codeText={TableBasic} />
+
+      <h3>
+        <Anchor id="table-small">Small Table</Anchor>
+      </h3>
+      <p>
+        Use <code>size="sm"</code> to make tables compact by cutting cell
+        padding in half.
+      </p>
+      <ReactPlayground codeText={TableSmall} />
+
+      <h3>
+        <Anchor id="table-inverted">Inverted Table</Anchor>
+      </h3>
+      <p>
+        Use <code>variant="dark"</code> to invert the colors of the table and
+        get light text on a dark background.
+      </p>
+      <ReactPlayground codeText={TableDark} />
 
       <h2>
         <Anchor id="table-responsive">Responsive</Anchor>
       </h2>
       <p>
-        Add <code>responsive</code> prop to make them scroll horizontally up to
-        small devices (under 768px). When viewing on anything larger than 768px
-        wide, you will not see any difference in these tables.
+        Responsive tables allow tables to be scrolled horizontally with ease.
+      </p>
+
+      <h3>
+        <Anchor id="table-responsive-always">Always Responsive</Anchor>
+      </h3>
+      <p>
+        Across every breakpoint, use <code>responsive</code> for horizontally
+        scrolling tables. Responsive tables are wrapped automatically in a{' '}
+        <code>div</code>.
       </p>
       <ReactPlayground codeText={TableResponsive} />
+
+      <h3>
+        <Anchor id="table-responsive-breakpoint">Breakpoint specific</Anchor>
+      </h3>
+      <p>
+        Use <code>responsive="sm"</code>, <code>responsive="md"</code>,{' '}
+        <code>responsive="lg"</code>, or <code>responsive="xl"</code> as needed
+        to create responsive tables up to a particular breakpoint. From that
+        breakpoint and up, the table will behave normally and not scroll
+        horizontally.
+      </p>
+      <ReactPlayground codeText={TableResponsiveBreakpoints} />
 
       <h3>
         <Anchor id="table-props">Props</Anchor>


### PR DESCRIPTION
PR for implementing #3055

- Changed `table-condensed` to `table-sm`.
- Changed `table-inverse` to `table-dark`. There was a confusion caused by the [migration guide](https://getbootstrap.com/docs/4.0/migration/#tables) but I guess I will go fix it there too.
- Brought back the wrapping div for responsive tables. There is again a conflict between the migration guide and the [documentation](https://getbootstrap.com/docs/4.0/content/tables/#responsive-tables).