### PR TITLE
Add v4 support for layout utility

### DIFF
--- a/src/Layout.js
+++ b/src/Layout.js
@@ -1,0 +1,277 @@
+import classNames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+import elementType from 'prop-types-extra/lib/elementType';
+
+const camelCaseToHyphen = str =>
+  str.replace(/[A-Z]/g, match => `-${match.toLowerCase()}`);
+
+const flexAlignPropTypes = PropTypes.oneOf([
+  'start',
+  'end',
+  'center',
+  'baseline',
+  'stretch'
+]);
+
+const displayPropTypes = PropTypes.oneOf([
+  'none',
+  'inline',
+  'inline-block',
+  'block',
+  'table',
+  'table-cell',
+  'table-row',
+  'flex',
+  'inline-flex'
+]);
+
+const flexDirectionPropTypes = PropTypes.oneOf([
+  'row',
+  'row-reverse',
+  'column',
+  'column-reverse'
+]);
+
+const flexWrapPropTypes = PropTypes.oneOf(['nowrap', 'wrap', 'wrap-reverse']);
+
+const justifyContentPropTypes = PropTypes.oneOf([
+  'start',
+  'end',
+  'center',
+  'between',
+  'around'
+]);
+
+const spaceUtilSizePropTypes = PropTypes.oneOfType([
+  PropTypes.number,
+  PropTypes.oneOf(['auto'])
+]);
+
+const spaceUtilPropTypes = PropTypes.oneOfType([
+  spaceUtilSizePropTypes,
+  PropTypes.shape({
+    /**
+     *
+     * the key is the side of spacing utility,
+     * t - for classes that set margin-top or padding-top
+     * b - for classes that set margin-bottom or padding-bottom
+     * l - for classes that set margin-left or padding-left
+     * r - for classes that set margin-right or padding-right
+     * x - for classes that set both *-left and *-right
+     * y - for classes that set both *-top and *-bottom
+     * all - for classes that set a margin or padding on all 4 sides of the element
+     * (because we cannot set "" as key, use "all" to represent blank side here)
+     * see the boostrap doc
+     * https://getbootstrap.com/docs/4.0/utilities/spacing/#how-it-works
+     *
+     */
+    t: spaceUtilSizePropTypes,
+    b: spaceUtilSizePropTypes,
+    l: spaceUtilSizePropTypes,
+    r: spaceUtilSizePropTypes,
+    x: spaceUtilSizePropTypes,
+    y: spaceUtilSizePropTypes,
+    all: spaceUtilSizePropTypes
+  })
+]);
+
+const breakpointPropTypes = PropTypes.shape({
+  /**
+   *
+   * display utility,
+   * see the boostrap doc
+   * https://getbootstrap.com/docs/4.0/utilities/display/
+   *
+   */
+
+  display: displayPropTypes,
+
+  /**
+   *
+   * flex utilities,
+   * see the boostrap doc
+   * https://getbootstrap.com/docs/4.0/utilities/flex/
+   *
+   */
+
+  alignContent: flexAlignPropTypes,
+  alignItem: flexAlignPropTypes,
+  alignSelf: flexAlignPropTypes,
+  flexDirection: flexDirectionPropTypes,
+  flexWrap: flexWrapPropTypes,
+  justifyContent: justifyContentPropTypes,
+  order: PropTypes.number,
+
+  /**
+   *
+   * spacing utilities,
+   * see the boostrap doc
+   * https://getbootstrap.com/docs/4.0/utilities/spacing/
+   * can be number , "auto", or object,
+   * if passing number or "auto" it will set spacing on all 4 sides of the element
+   *
+   */
+
+  m: spaceUtilPropTypes,
+  p: spaceUtilPropTypes
+});
+
+class Layout extends React.Component {
+  /**
+   *
+   * Combination component of bootstrap V4 layout utility
+   * (display / flex / spacing / visibility)
+   * https://getbootstrap.com/docs/4.0/layout/utilities-for-layout/
+   *
+   */
+
+  static propTypes = {
+    /**
+     *
+     * for Extra small devices Phones (<576px)
+     *
+     */
+    xs: breakpointPropTypes,
+
+    /**
+     *
+     * for Small devices Tablets (≥576px)
+     *
+     */
+    sm: breakpointPropTypes,
+
+    /**
+     *
+     * for Medium devices Desktops (≥768px)
+     *
+     */
+    md: breakpointPropTypes,
+
+    /**
+     *
+     * for Large devices Desktops (≥992px)
+     *
+     */
+    lg: breakpointPropTypes,
+
+    /**
+     *
+     * for Large devices Desktops (≥1200px)
+     *
+     */
+    xl: breakpointPropTypes,
+
+    /**
+     *
+     * custom class name
+     *
+     */
+    className: PropTypes.string,
+
+    /**
+     *
+     * add `d-print-{display}` className on the element
+     *
+     */
+    print: displayPropTypes,
+    /**
+     *
+     * add 'visible' or 'invisible' className on the element
+     *
+     */
+    visible: PropTypes.bool,
+    componentClass: elementType
+  };
+
+  static defaultProps = {
+    className: '',
+    componentClass: 'div'
+  };
+
+  buildVisibleClassName = visible => {
+    if (typeof visible !== 'boolean') {
+      return '';
+    }
+    return visible ? 'visible' : 'invisible';
+  };
+
+  buildPrintClassName = print => {
+    if (!print) {
+      return '';
+    }
+    return `d-print-${print}`;
+  };
+
+  buildLayoutClassName = breakpoints => {
+    const classNameList = Object.keys(breakpoints).map(bp =>
+      this.buildBreakpointClassName(bp, breakpoints[bp])
+    );
+    return classNames(classNameList);
+  };
+
+  buildBreakpointClassName = (breakpoint, breakpointProps) => {
+    if (typeof breakpointProps !== 'object') {
+      return '';
+    }
+    const bpAbbrev = breakpoint === 'xs' ? '' : `${breakpoint}-`;
+    const classNameList = Object.keys(breakpointProps).map(propName => {
+      const value = breakpointProps[propName];
+      if (propName === 'm' || propName === 'p') {
+        return this.buildSpacingClassName({ propName, value, bpAbbrev });
+      }
+      const suffix = `-${bpAbbrev}${value}`;
+      let prefix = '';
+      if (propName === 'display') {
+        prefix = 'd';
+      } else if (propName === 'flexDirection' || propName === 'flexWrap') {
+        prefix = 'flex';
+      } else {
+        prefix = camelCaseToHyphen(propName);
+      }
+      return `${prefix}${suffix}`;
+    });
+    return classNames(classNameList);
+  };
+
+  buildSpacingClassName = ({ propName, bpAbbrev, value }) => {
+    if (typeof value === 'number' || value === 'auto') {
+      const size = value;
+      return `${propName}-${bpAbbrev}${size}`;
+    }
+    if (typeof value === 'object') {
+      const classNameList = Object.keys(value).map(side => {
+        const size = value[side];
+        const prefix = side === 'all' ? propName : `${propName}${side}`;
+        return `${prefix}-${bpAbbrev}${size}`;
+      });
+      return classNames(classNameList);
+    }
+    return '';
+  };
+
+  render() {
+    const {
+      className: customClassName,
+      componentClass,
+      print,
+      visible,
+      xs,
+      sm,
+      md,
+      lg,
+      xl,
+      ...props
+    } = this.props;
+    const className = classNames(
+      this.buildVisibleClassName(visible),
+      this.buildPrintClassName(print),
+      this.buildLayoutClassName({ xs, sm, md, lg, xl }),
+      customClassName
+    );
+    const Component = componentClass;
+    return <Component className={className} {...props} />;
+  }
+}
+
+export default Layout;

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ export Image from './Image';
 export Figure from './Figure';
 export InputGroup from './InputGroup';
 export Jumbotron from './Jumbotron';
+export Layout from './Layout';
 export ListGroup from './ListGroup';
 export ListGroupItem from './ListGroupItem';
 export Media from './Media';

--- a/test/LayoutSpec.js
+++ b/test/LayoutSpec.js
@@ -1,0 +1,130 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import Layout from '../src/Layout';
+
+describe('<Layout>', () => {
+  it('Should render plain <div> when no prop', () => {
+    const component = shallow(<Layout />);
+    component.find('div').should.have.length(1);
+  });
+  it('Should not has class name when no prop', () => {
+    const component = shallow(<Layout />);
+    component
+      .find('div')
+      .prop('className')
+      .should.equal('');
+  });
+  it('Should have `invisible` class name when visible={false}', () => {
+    const component = shallow(<Layout visible={false} />);
+    component
+      .find('div')
+      .hasClass('invisible')
+      .should.equal(true);
+  });
+  it('Should have print display class name when we pass print prop', () => {
+    const component = shallow(<Layout print="block" />);
+    component
+      .find('div')
+      .hasClass('d-print-block')
+      .should.equal(true);
+  });
+  it('Should have display utility class name with breakpoint prop', () => {
+    const component = shallow(<Layout sm={{ display: 'inline-block' }} />);
+    component
+      .find('div')
+      .hasClass('d-sm-inline-block')
+      .should.equal(true);
+  });
+  it('Should not add breakpoint in class name with xs breakpoint prop', () => {
+    const component = shallow(<Layout xs={{ display: 'inline-block' }} />);
+    component
+      .find('div')
+      .hasClass('d-inline-block')
+      .should.equal(true);
+  });
+  it('Should have flex direction utility with flexDirection in breakpoint prop', () => {
+    const component = shallow(<Layout sm={{ flexDirection: 'row-reverse' }} />);
+    component
+      .find('div')
+      .hasClass('flex-sm-row-reverse')
+      .should.equal(true);
+  });
+  it('Should have align item utility with alignItem in breakpoint prop', () => {
+    const component = shallow(<Layout sm={{ alignItem: 'center' }} />);
+    component
+      .find('div')
+      .hasClass('align-item-sm-center')
+      .should.equal(true);
+  });
+  it('Should have order utility with order number in breakpoint prop', () => {
+    const component = shallow(<Layout sm={{ order: 3 }} />);
+    component
+      .find('div')
+      .hasClass('order-sm-3')
+      .should.equal(true);
+  });
+  it('Should have custom class name with className prop', () => {
+    const customClass = 'customClass';
+    const component = shallow(
+      <Layout sm={{ order: 3 }} className={customClass} />
+    );
+    component
+      .find('div')
+      .hasClass(customClass)
+      .should.equal(true);
+  });
+  it('Should have margin spacing class name with number prop', () => {
+    const component = shallow(<Layout xs={{ m: 3 }} />);
+    component
+      .find('div')
+      .hasClass('m-3')
+      .should.equal(true);
+  });
+  it('Should have margin spacing class name with auto prop', () => {
+    const component = shallow(<Layout sm={{ m: 'auto' }} />);
+    component
+      .find('div')
+      .hasClass('m-sm-auto')
+      .should.equal(true);
+  });
+  it('Should have margin spacing class name with object prop', () => {
+    const component = shallow(<Layout sm={{ m: { x: 1, l: 'auto' } }} />);
+    component
+      .find('div')
+      .hasClass('mx-sm-1')
+      .should.equal(true);
+    component
+      .find('div')
+      .hasClass('ml-sm-auto')
+      .should.equal(true);
+  });
+  it('Should have margin spacing class name with `all` prop', () => {
+    const component = shallow(<Layout sm={{ p: { all: 1  } }} />);
+    component
+      .find('div')
+      .hasClass('p-sm-1')
+      .should.equal(true);
+  });
+  it('Should handle multiple breakpoint props', () => {
+    const component = shallow(
+      <Layout sm={{ m: { x: 1, l: 'auto' } }} xs={{ m: { x: 0, l: 1 } }} />
+    );
+    component
+      .find('div')
+      .hasClass('mx-sm-1')
+      .should.equal(true);
+    component
+      .find('div')
+      .hasClass('ml-sm-auto')
+      .should.equal(true);
+    component
+      .find('div')
+      .hasClass('mx-0')
+      .should.equal(true);
+    component
+      .find('div')
+      .hasClass('ml-1')
+      .should.equal(true);
+  });
+});


### PR DESCRIPTION
So there is a `<Layout />` component wrap all the [layout utility](https://getbootstrap.com/docs/4.0/layout/utilities-for-layout/) in v4. All possible usage should be included in the tests.

And @jquense, where should I create the example page in `/www/src/pages` for this new component(layout or utilities or components?)?