### PR TITLE
V4: Fixing Col xs attribute not working

### DIFF
--- a/src/Col.js
+++ b/src/Col.js
@@ -81,7 +81,7 @@ class Col extends React.Component {
         classes.push(
           propValue === true
             ? bsProps.bsClass
-            : prefix(bsProps, `-${propValue}`)
+            : prefix(bsProps, `${propValue}`)
         );
       } else {
         // col-md-3


### PR DESCRIPTION
Hi, a really small bugfix.

The xs attribute on Col did not work properly, it will generate an erroneous class "col--{size}" instead of "col-{size}".