### PR TITLE
Added aria-expanded and aria-controls for Collapse toggle issue #2825

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -119,7 +119,20 @@ const propTypes = {
   /**
    * ARIA role of collapsible element
    */
-  role: PropTypes.string
+  role: PropTypes.string,
+
+  /**
+   * ARIA attribute added to the control element conveys the current state of the
+   * collapsible element to assistive technologies.
+   */
+  'aria-expanded': PropTypes.string,
+
+  /**
+   * ARIA attribute must be added to the control element specifying the id of the
+   * collapsible element. Assitive technologies can use thsi attribute to provide
+   * navigation cues.
+   */
+  'aria-controls': PropTypes.string
 };
 
 const defaultProps = {

--- a/www/src/examples/Collapse.js
+++ b/www/src/examples/Collapse.js
@@ -10,11 +10,15 @@ class Example extends React.Component {
   render() {
     return (
       <div>
-        <Button onClick={() => this.setState({ open: !this.state.open })}>
+        <Button
+          onClick={() => this.setState({ open: !this.state.open })}
+          aria-expanded={this.state.open}
+          aria-controls="collapseExample"
+        >
           click
         </Button>
         <Collapse in={this.state.open}>
-          <div>
+          <div id="collapseExample">
             <Well>
               Anim pariatur cliche reprehenderit, enim eiusmod high life
               accusamus terry richardson ad squid. Nihil anim keffiyeh


### PR DESCRIPTION
WAIT. This PR does NOT contain tests. I have a question.

The role attribute of the Collapse component implicitly sets the values of the aria-expanded attribute. With an explicitly defined aria-expanded attribute, how will this conflict be handled?

I think this needs a bit of discussion - I am fairly new to react so please feel free to state the obvious etc.