### PR TITLE
Default all NavItems in Tabs to have tabindex="0"

### DIFF
--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -82,7 +82,12 @@ class Tabs extends React.Component {
     }
 
     return (
-      <NavItem eventKey={eventKey} disabled={disabled} className={tabClassName}>
+      <NavItem
+        eventKey={eventKey}
+        disabled={disabled}
+        className={tabClassName}
+        tabIndex={0}
+      >
         {title}
       </NavItem>
     );


### PR DESCRIPTION
The `active` logic will take care of making the inactive ones un-focusable, leaving only the active NavItem as a focusable element.

Currently, the tabs are skipped over when using a keyboard to tab through the on-screen elements.