### PR TITLE
Update local docs script name in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React-Bootstrap [![Travis][build-badge]][build] [![npm][npm-badge]][npm]
 
-[Bootstrap 3][bootstrap] components built with [React][react].
+[Bootstrap 4][bootstrap] components built with [React][react].
 
 [![Codecov][codecov-badge]][codecov]
 [![Discord][discord-badge]][discord]
@@ -22,12 +22,13 @@ See the [documentation][documentation] with live editable examples.
 
 Yarn is the our package manager of choice here. Check out setup
 instructions [here](https://yarnpkg.com/en/docs/install) if you don't have it installed already.
+
 After that you can run `yarn run bootstrap` to install all the needed dependencies.
 
 From there you can:
 
 - Run the tests once with `yarn test` (Or run them in watch mode with `yarn run tdd`).
-- Start a local copy of the docs site with `yarn start`
+- Start a local copy of the docs site with `yarn docs`
 - Or build a local copy of the library with `yarn run build`
 
 ## Contributions

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-bootstrap",
   "version": "0.32.1-docs.0",
-  "description": "Bootstrap 3 components built with React",
+  "description": "Bootstrap 4 components built with React",
   "repository": {
     "type": "git",
     "url": "react-bootstrap/react-bootstrap"
@@ -13,6 +13,7 @@
   "module": "es/index.js",
   "scripts": {
     "bootstrap": "yarn && yarn --cwd www",
+    "docs": "yarn --cwd www develop",
     "build": "node tools/build.js",
     "build-docs": "yarn --cwd www run build",
     "start": "yarn --cwd www run develop",


### PR DESCRIPTION
Solves https://github.com/react-bootstrap/react-bootstrap/issues/3203

Also, need input on should we update `yarn run bootstrap` to `yarn run setup`? Consdering the script installs dependencies of both app, the word `setup` sounds better for new developers.


Update readme demo here: https://github.com/abdullahtariq1171/react-bootstrap/tree/v4-support-update-readme