### PR TITLE
Fix OverlayTrigger's wrong state when unstable_AsyncMode enabled

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -143,7 +143,7 @@ class OverlayTrigger extends React.Component {
       return;
     }
 
-    if (!this.state.show || this._hoverHideDelay != null) {
+    if (this._hoverHideDelay != null) {
       return;
     }
 
@@ -168,7 +168,7 @@ class OverlayTrigger extends React.Component {
       return;
     }
 
-    if (this.state.show || this._hoverShowDelay != null) {
+    if (this._hoverShowDelay != null) {
       return;
     }
 


### PR DESCRIPTION
In React 16, when unstable_AsyncMode is enabled, `handleDelayedShow` and `handleDelayedHide` of OverlayTrigger  could be fired before value `this.state.hide` changes, and it will make OverlayTrigger can't show or hide overlay correctly.
This pr fixed the bug by removing state check of `handleDelayedHide` and `handleDelayedHide` .