### PR TITLE
Force hide tooltip when clicking on OverlayTrigger

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -269,7 +269,11 @@ class OverlayTrigger extends React.Component {
     // FIXME: The logic here for passing through handlers on this component is
     // inconsistent. We shouldn't be passing any of these props through.
 
-    triggerProps.onClick = createChainedFunction(childProps.onClick, onClick);
+    triggerProps.onClick = createChainedFunction(
+      this.handleDelayedHide,
+      childProps.onClick,
+      onClick
+    );
 
     if (isOneOf('click', trigger)) {
       triggerProps.onClick = createChainedFunction(


### PR DESCRIPTION
This prevent tooltip to remain open if hover area became disabled.

See discussion at #2969 