### PR TITLE
Specify React 16.3.0 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
   "author": "Stephen J. Collings <stevoland@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.14.9 || >=15.3.0",
-    "react-dom": "^0.14.9 || >=15.3.0"
+    "react": ">=16.3.0",
+    "react-dom": ">=16.3.0"
   },
   "devDependencies": {
     "@4c/rollout": "^1.1.0",


### PR DESCRIPTION
v1 uses the React context API, which was introduced in React v16.3.