### PR TITLE
Nit: Fix grammar (it's vs its)

### DIFF
--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -148,7 +148,7 @@ export default withLayout(
               </FeatureCard>
 
               <FeatureCard>
-                <h2>Bootstrap at it's core</h2>
+                <h2>Bootstrap at its core</h2>
                 <p>
                   Built with compatibility in mind, we embrace our bootstrap
                   core and strive to be compatible with the world's largest UI


### PR DESCRIPTION
On the home page, replace "it's", the contraction of "it is", with "its", the possesive form.

Unfortunately the syntax highlighting on GitHub is still messed up — maybe changing the file extension to `.jsx` would fix that.