### PR TITLE
fix Popover outOfBoundaries proptype

### DIFF
--- a/src/Popover.js
+++ b/src/Popover.js
@@ -58,7 +58,7 @@ const propTypes = {
   /** @private */
   scheduleUpdate: PropTypes.func,
   /** @private */
-  outOfBoundaries: PropTypes.func,
+  outOfBoundaries: PropTypes.bool,
   /**
    * Title content
    */


### PR DESCRIPTION
Popover's `outOfBoundaries` proptype should be boolean. (Proptype currently bool in master)

Reference:
 - [React Popper doc](https://github.com/FezVrasta/react-popper)
 - [react-popper/Popper.js](https://github.com/FezVrasta/react-popper/blob/4e35c6f83242aed0397e5d66c7f8ca17475f1977/src/Popper.js)

fixes issue: #3328