### PR TITLE
Improve documentation

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -51,7 +51,7 @@ const propTypes = {
    *   isOpen: boolean,
    *   event: SyntheticEvent,
    *   metadata: {
-   *     source: 'select' | 'click' | 'rootCloose' | 'keydown'
+   *     source: 'select' | 'click' | 'rootClose' | 'keydown'
    *   }
    * ): void
    * ```

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -46,7 +46,7 @@ class DropdownMenu extends React.Component {
      * (listed here) are passed through to the `as` Component.
      *
      * If providing a custom, non DOM, component. the `show`, `close` and `alignRight` props
-     * are also injected and should be handled appropriatedly.
+     * are also injected and should be handled appropriately.
      */
     as: elementType,
 

--- a/src/DropdownToggle.js
+++ b/src/DropdownToggle.js
@@ -21,7 +21,6 @@ class DropdownToggle extends React.Component {
      * @default 'dropdown-toggle'
      */
     bsPrefix: PropTypes.string,
-    title: PropTypes.string,
 
     /**
      * An html id attribute, necessary for assistive technologies, such as screen readers.


### PR DESCRIPTION
`title` is a prop for for [`<DropdownButton>`](https://react-bootstrap.netlify.com/components/dropdowns/#dropdown-button-props) and  [`<SplitButton>`](https://react-bootstrap.netlify.com/components/dropdowns/#split-button-props), but not for [`<Dropdown.Toggle>`](https://react-bootstrap.netlify.com/components/dropdowns/#dropdown-toggle-props). 

(A `title` passed to [`<Dropdown.Toggle>`](https://react-bootstrap.netlify.com/components/dropdowns/#dropdown-toggle-props) will just [got forward to its child](https://github.com/react-bootstrap/react-bootstrap/blob/master/src/DropdownToggle.js#L73).)