### PR TITLE
Render context consumer instead of context itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "popper.js": "^1.14.3",
     "prop-types": "^15.6.2",
     "prop-types-extra": "^1.1.0",
-    "react-context-toolbox": "^1.2.1",
+    "react-context-toolbox": "^1.2.3",
     "react-overlays": "^1.0.0-beta.17",
     "react-prop-types": "^0.4.0",
     "react-transition-group": "^2.4.0",

--- a/src/AbstractNavItem.js
+++ b/src/AbstractNavItem.js
@@ -35,7 +35,7 @@ class AbstractNavItem extends React.Component {
     const navKey = makeEventKey(eventKey, props.href);
 
     return (
-      <SelectableContext>
+      <SelectableContext.Consumer>
         {parentOnSelect => (
           <NavContext.Consumer>
             {navContext => {
@@ -76,7 +76,7 @@ class AbstractNavItem extends React.Component {
             }}
           </NavContext.Consumer>
         )}
-      </SelectableContext>
+      </SelectableContext.Consumer>
     );
   }
 }

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -145,7 +145,7 @@ const UncontrolledDropdown = createBootstrapComponent(
 );
 
 const DecoratedDropdown = mapContextToProps(
-  SelectableContext,
+  SelectableContext.Consumer,
   (onSelect, props) => ({
     onSelect: chain(props.onSelect, onSelect),
   }),

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -76,7 +76,7 @@ class DropdownMenu extends React.Component {
     } = this.props;
 
     return (
-      <NavbarContext>
+      <NavbarContext.Consumer>
         {isNavbar => (
           <BaseDropdownMenu
             flip={flip}
@@ -117,7 +117,7 @@ class DropdownMenu extends React.Component {
             }}
           </BaseDropdownMenu>
         )}
-      </NavbarContext>
+      </NavbarContext.Consumer>
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7777,6 +7777,9 @@ rc@^1.2.7:
 react-context-toolbox@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/react-context-toolbox/-/react-context-toolbox-1.2.2.tgz#3fd9a07b0618ae398d232098a04c2b9f0abdbb86"
+react-context-toolbox@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/react-context-toolbox/-/react-context-toolbox-1.2.3.tgz#381238f60422f6034ca706b56994da147ff87b6d"
 
 react-dev-utils@^5.0.0:
   version "5.0.1"


### PR DESCRIPTION
React 16.6 has a deprecation warning about rendering context directly

Fixes #3347