### PR TITLE
Pass Context.Consumer to context toolbox

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -145,7 +145,7 @@ const UncontrolledDropdown = createBootstrapComponent(
 );
 
 const DecoratedDropdown = mapContextToProps(
-  SelectableContext.Consumer,
+  SelectableContext,
   (onSelect, props) => ({
     onSelect: chain(props.onSelect, onSelect),
   }),

--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -141,7 +141,7 @@ const mapContext = ({ controlId }, { id }) => {
 };
 
 const DecoratedFormControl = mapContextToProps(
-  FormContext.Consumer,
+  FormContext,
   mapContext,
   createBootstrapComponent(FormControl, {
     prefix: 'form-control',

--- a/src/FormLabel.js
+++ b/src/FormLabel.js
@@ -82,7 +82,7 @@ const mapContext = ({ controlId }, { htmlFor }) => {
 };
 
 export default mapContextToProps(
-  FormContext.Consumer,
+  FormContext,
   mapContext,
   createBootstrapComponent(FormLabel, 'form-label'),
 );

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -138,7 +138,7 @@ const UncontrolledNav = uncontrollable(createBootstrapComponent(Nav, 'nav'), {
 });
 
 const DecoratedNav = mapContextToProps(
-  [NavbarContext.Consumer, CardContext.Consumer],
+  [NavbarContext, CardContext],
   (navbarContext, cardContext, { navbar }) => {
     if (!navbarContext && !cardContext) return {};
 

--- a/src/TabPane.js
+++ b/src/TabPane.js
@@ -150,7 +150,7 @@ class TabPane extends React.Component {
 }
 
 export default mapContextToProps(
-  TabContext.Consumer,
+  TabContext,
   (context, props) => {
     if (!context) return null;
     const { activeKey, getControlledId, getControllerId, ...rest } = context;

--- a/www/src/components/Heading.js
+++ b/www/src/components/Heading.js
@@ -43,7 +43,7 @@ class Heading extends React.Component {
 }
 
 export default mapContextToProps(
-  TocContext,
+  TocContext.Consumer,
   c => ({ registerNode: c.registerNode }),
   Heading,
 );


### PR DESCRIPTION
As outlined in https://github.com/4Catalyzer/react-context-toolbox/issues/9, context toolbox needs to only use `Context.Consumer` since it can't navigate to the `Consumer` property reliably.