### PR TITLE
PaginationItem documentation upgrade

### DIFF
--- a/src/PaginationItem.js
+++ b/src/PaginationItem.js
@@ -7,11 +7,16 @@ import SafeAnchor from './SafeAnchor';
 
 const propTypes = {
   eventKey: PropTypes.any,
+  /** A CSS class to be applied to the <li> of the PaginationItem. */
   className: PropTypes.string,
+  /** A callback fired when this PaginationItem is selected. */
   onSelect: PropTypes.func,
+  /** Disables the PaginationItem. */
   disabled: PropTypes.bool,
+  /** Styles PaginationItem as active, and renders a `<span>` instead of an `<a>`. */
   active: PropTypes.bool,
-  activeLabel: PropTypes.string.isRequired
+  /** An accessible label indicating the active state.. */
+  activeLabel: PropTypes.string
 };
 
 const defaultProps = {
@@ -46,7 +51,9 @@ PaginationItem.defaultProps = defaultProps;
 function createButton(name, defaultValue, label = name) {
   return class extends React.Component {
     static displayName = name;
+
     static propTypes = { disabled: PropTypes.bool };
+
     render() {
       const { disabled, children, className, ...props } = this.props;
       const Component = disabled ? 'span' : SafeAnchor;


### PR DESCRIPTION
Removed `required` flag for `activeLabel` prop because this prop is not required in the `master` and `next` branches and this prop is not visible on the component docs page, and the `react-bootstrap@0.32.4` throws a warning because I'm not setting this prop on my code, as the following:

```jsx
<Pagination.Item key={page} active={page === selectedPage} onClick={() => onChange(page)}>
```

If you can guide me, I can add the `Props` table for the `PaginationItem` component on the docs page: https://react-bootstrap.github.io/components/pagination.