### PR TITLE
fix(form-control): make inputRef backward-compatible with React creat…

### DIFF
--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -32,7 +32,7 @@ const propTypes = {
    * <FormControl inputRef={ref => { this.input = ref; }} />
    * ```
    */
-  inputRef: PropTypes.func
+  inputRef: PropTypes.any,
 };
 
 const defaultProps = {


### PR DESCRIPTION
Hi, I faced an issue with the validation of props for FormControl especially with `inputRef`, if I suddenly passing down a `React.createRef` interface to it there are a warning in console.

There a small fix, hope you could find time to merge it :)

That PR should go to 0.32.4 tag and possibly published as 0.32.5. Thanks for your assistance