### PR TITLE
fix wrong type definition in Popover

### DIFF
--- a/types/components/Popover.d.ts
+++ b/types/components/Popover.d.ts
@@ -7,7 +7,7 @@ import { BsPrefixComponent } from './helpers';
 interface PopoverProps {
   id: string | number;
   placement?: Placement;
-  title?: string;
+  title?: React.ReactNode;
   arrowProps?: { ref: any; style: object };
 }
 


### PR DESCRIPTION
according to the documentation, the `title` prop in `Popover` component should be `node` not `string`