### PR TITLE
excluding warning messages for using "Overlay" component

### DIFF
--- a/www/src/examples/Overlays/Overlay.js
+++ b/www/src/examples/Overlays/Overlay.js
@@ -20,7 +20,14 @@ class Example extends React.Component {
           Click me to see
         </Button>
         <Overlay target={target} show={show} placement="right">
-          {({ placement, scheduleUpdate, arrowProps, outOfBoundaries, show, ...props }) => (
+          {({
+            placement,
+            scheduleUpdate,
+            arrowProps,
+            outOfBoundaries,
+            show: _show,
+            ...props
+          }) => (
             <div
               {...props}
               style={{

--- a/www/src/examples/Overlays/Overlay.js
+++ b/www/src/examples/Overlays/Overlay.js
@@ -20,7 +20,7 @@ class Example extends React.Component {
           Click me to see
         </Button>
         <Overlay target={target} show={show} placement="right">
-          {({ placement, scheduleUpdate, arrowProps, ...props }) => (
+          {({ placement, scheduleUpdate, arrowProps, outOfBoundaries, show, ...props }) => (
             <div
               {...props}
               style={{


### PR DESCRIPTION
excluding warning messages for using "Overlay" component, mainly for properties: "outOfBoundaries" and "show".