### PR TITLE
Fix animated prop name in ProgressBar

### DIFF
--- a/www/src/pages/components/progress.js
+++ b/www/src/pages/components/progress.js
@@ -68,7 +68,7 @@ export default withLayout(function ProgressBarSection({ data }) {
         Animated
       </LinkedHeading>
       <p>
-        Add <code>active</code> prop to animate the stripes right to left. Not
+        Add <code>animated</code> prop to animate the stripes right to left. Not
         available in IE9 and below.
       </p>
       <ReactPlayground codeText={ProgressBarAnimated} />


### PR DESCRIPTION
Fix prop name `active` to `animated` (to v4).