### PR TITLE
Docs: Fix button size typo

### DIFF
--- a/www/src/pages/components/buttons.mdx
+++ b/www/src/pages/components/buttons.mdx
@@ -50,8 +50,8 @@ the proper ARIA roles for you.
 
 ## Sizes
 
-Fancy larger or smaller buttons? Add `size="large"`,
-`size="small"` for additional sizes.
+Fancy larger or smaller buttons? Add `size="lg"`,
+`size="sm"` for additional sizes.
 
 <ReactPlayground codeText={ButtonSizes} />
 


### PR DESCRIPTION
This fixes button size typo in the docs.