### PR TITLE
Support generic `Col` props for FormLabel

### DIFF
--- a/src/FormLabel.js
+++ b/src/FormLabel.js
@@ -23,12 +23,6 @@ const propTypes = {
   htmlFor: PropTypes.string,
 
   /**
-   * Renders the FormLabel as a `<Col>` component (accepting all the same props),
-   * as well as adding additional styling for horizontal forms.
-   */
-  column: PropTypes.bool,
-
-  /**
    * The FormLabel `ref` will be forwarded to the underlying element.
    * Unless the FormLabel is rendered `as` a composite component,
    * it will be a DOM node, when resolved.
@@ -47,19 +41,18 @@ const propTypes = {
 
 const defaultProps = {
   as: 'label',
-  column: false,
   srOnly: false,
 };
 
 function FormLabel({
   as: Component,
   bsPrefix,
-  column,
   srOnly,
   className,
   innerRef,
   ...props
 }) {
+  const column = Component === Col;
   const classes = classNames(
     className,
     bsPrefix,

--- a/src/FormLabel.js
+++ b/src/FormLabel.js
@@ -2,6 +2,7 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import warning from 'warning';
+import { elementType } from 'prop-types-extra';
 
 import mapContextToProps from 'react-context-toolbox/mapContextToProps';
 import Col from './Col';
@@ -13,6 +14,8 @@ const propTypes = {
    * @default 'form-label'
    */
   bsPrefix: PropTypes.string,
+
+  as: elementType,
 
   /**
    * Uses `controlId` from `<FormGroup>` if not explicitly specified.
@@ -43,11 +46,13 @@ const propTypes = {
 };
 
 const defaultProps = {
+  as: 'label',
   column: false,
   srOnly: false,
 };
 
 function FormLabel({
+  as: Component,
   bsPrefix,
   column,
   srOnly,

--- a/test/FormLabelSpec.js
+++ b/test/FormLabelSpec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 
+import Col from '../src/Col';
 import FormLabel from '../src/FormLabel';
 import FormGroup from '../src/FormGroup';
 
@@ -20,9 +21,10 @@ describe('<FormLabel>', () => {
       </FormGroup>,
     ).assertSingle('label[htmlFor="foo"].form-label');
   });
+
   it('should render as a Col', () => {
     mount(
-      <FormLabel column sm={4}>
+      <FormLabel as={Col} sm={4}>
         Label
       </FormLabel>,
     ).assertSingle('label.col-sm-4.col-form-label');

--- a/types/components/FormLabel.d.ts
+++ b/types/components/FormLabel.d.ts
@@ -2,13 +2,13 @@ import * as React from 'react';
 
 import { BsPrefixComponent } from './helpers';
 
-interface FeedbackProps {
+interface FormLabelProps {
   htmlFor?: string;
   column?: boolean;
   innerRef?: React.LegacyRef<this>;
   srOnly?: boolean;
 }
 
-declare class Feedback extends BsPrefixComponent<'label', FeedbackProps> {}
+declare class FormLabel extends BsPrefixComponent<'label', FormLabelProps> {}
 
-export default Feedback;
+export default FormLabel;

--- a/types/components/FormLabel.d.ts
+++ b/types/components/FormLabel.d.ts
@@ -4,11 +4,12 @@ import { BsPrefixComponent } from './helpers';
 
 interface FormLabelProps {
   htmlFor?: string;
-  column?: boolean;
   innerRef?: React.LegacyRef<this>;
   srOnly?: boolean;
 }
 
-declare class FormLabel extends BsPrefixComponent<'label', FormLabelProps> {}
+declare class FormLabel<
+  As extends React.ReactType = 'label'
+> extends BsPrefixComponent<As, FormLabelProps> {}
 
 export default FormLabel;


### PR DESCRIPTION
The initial motivation of this PR is to resolve the typing error reported in #3481.

IMO, we should replace the `column` prop in `FormLabel` component with `as`, also because it can make the API more consistent, since passing in the `as` prop is a common pattern that is used across the other components in this package.
