### PR TITLE
Fix clean method to return Promise always

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -15,7 +15,7 @@ const libRoot = path.join(__dirname, '../lib');
 const distRoot = path.join(libRoot, 'dist');
 const esRoot = path.join(libRoot, 'es');
 
-const clean = async () => fse.existsSync(libRoot) && fse.remove(libRoot);
+const clean = () => fse.existsSync(libRoot) && fse.removeSync(libRoot);
 
 const step = (name, root, fn) => async () => {
   console.log(cyan('Building: ') + green(name));
@@ -75,15 +75,13 @@ console.log(
   green(`Building targets: ${targets.length ? targets.join(', ') : 'all'}\n`),
 );
 
-clean()
-  .then(() =>
-    Promise.all([
-      has('lib') && buildLib(),
-      has('es') && buildEsm(),
-      has('dist') && buildDist(),
-    ]),
-  )
-  .catch(err => {
-    if (err) console.error(red(err.stack || err.toString()));
-    process.exit(1);
-  });
+clean();
+
+Promise.all([
+  has('lib') && buildLib(),
+  has('es') && buildEsm(),
+  has('dist') && buildDist(),
+]).catch(err => {
+  if (err) console.error(red(err.stack || err.toString()));
+  process.exit(1);
+});

--- a/tools/build.js
+++ b/tools/build.js
@@ -15,7 +15,7 @@ const libRoot = path.join(__dirname, '../lib');
 const distRoot = path.join(libRoot, 'dist');
 const esRoot = path.join(libRoot, 'es');
 
-const clean = () => fse.existsSync(libRoot) && fse.remove(libRoot);
+const clean = async () => fse.existsSync(libRoot) && fse.remove(libRoot);
 
 const step = (name, root, fn) => async () => {
   console.log(cyan('Building: ') + green(name));


### PR DESCRIPTION
```
~/Code/react-bootstrap/tools/build.js:79
  .then(() =>
   ^

TypeError: clean(...).then is not a function
    at Object.<anonymous> (~/react-bootstrap/tools/build.js:79:4)
    at Module._compile (internal/modules/cjs/loader.js:688:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:699:10)
    at Module.load (internal/modules/cjs/loader.js:598:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:537:12)
    at Function.Module._load (internal/modules/cjs/loader.js:529:3)
    at Function.Module.runMain (internal/modules/cjs/loader.js:741:12)
    at startup (internal/bootstrap/node.js:285:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:739:3)
```

At 79 lines in build.js, it using `.then` method. But the current clean method returns `false | Promise`. So, if there is no lib directory, it throws the above error because `clean()` will returns `false` rather than `Promise<false>`.

```js
clean()
  .then(() =>
    ...
  )
```