### PR TITLE
andrewnystrom:patch-1: Fix spelling mistake regarding Alert component. 

### DIFF
--- a/www/src/examples/Alert/DismissibleControlled.js
+++ b/www/src/examples/Alert/DismissibleControlled.js
@@ -1,4 +1,4 @@
-class AlertDismissable extends React.Component {
+class AlertDismissible extends React.Component {
   constructor(props) {
     super(props);
 
@@ -31,4 +31,4 @@ class AlertDismissable extends React.Component {
   }
 }
 
-render(<AlertDismissable />);
+render(<AlertDismissible />);


### PR DESCRIPTION
[Re: issue # 3503](https://github.com/react-bootstrap/react-bootstrap/issues/3503)

### Details:
1. The documentation notes that you can pass the `dismissable` (spelled with an "a") prop to an Alert component. However, it should be `dismissible` (spelled with an "i"). I've come to understand that the documentation in `master` is correct, however, the live version of the documentation is not and needs to be refreshed. 
2. The refactored code fixes the spelling error in the `AlertDismissable` class and renames it to the more appropriate `AlertDismissible` for the sake of consistency. 