### PR TITLE
Add missing props to Navbar.Collapse

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -15,7 +15,7 @@ const libRoot = path.join(__dirname, '../lib');
 const distRoot = path.join(libRoot, 'dist');
 const esRoot = path.join(libRoot, 'es');
 
-const clean = () => fse.existsSync(libRoot) && fse.remove(libRoot);
+const clean = async () => fse.existsSync(libRoot) && fse.remove(libRoot);
 
 const step = (name, root, fn) => async () => {
   console.log(cyan('Building: ') + green(name));

--- a/types/components/NavbarCollapse.d.ts
+++ b/types/components/NavbarCollapse.d.ts
@@ -1,9 +1,16 @@
 import * as React from 'react';
 
-import Collapse from './Collapse';
+import Collapse, { CollapseProps } from './Collapse';
 
 import { BsPrefixComponent } from './helpers';
 
-declare class NavbarCollapse extends BsPrefixComponent<typeof Collapse> {}
+export interface NavbarCollapseProps
+  extends CollapseProps,
+    React.HTMLAttributes<HTMLDivElement> {}
+
+declare class NavbarCollapse extends BsPrefixComponent<
+  typeof Collapse,
+  NavbarCollapseProps
+> {}
 
 export default NavbarCollapse;


### PR DESCRIPTION
I tried testing this change in a dependent project, but installing the package from local clone just results in `Cannot find module 'react-bootstrap/Navbar'`. To complicate matters, the build setup seems closely tied to the contributors' development environment. The second commit in this PR fixes the build from a clean state; it only ever worked from a dirty state. There is no `prepare` NPM script: is that intentional?

At the least, this can serve as a starting point.

/cc @jquense 