### PR TITLE
add `xl` to modal size enum

### DIFF
--- a/types/components/Modal.d.ts
+++ b/types/components/Modal.d.ts
@@ -13,7 +13,7 @@ import {
 } from './helpers';
 
 export interface ModalProps extends TransitionCallbacks {
-  size?: 'sm' | 'lg';
+  size?: 'sm' | 'lg' | 'xl';
   centered?: boolean;
   backdrop?: 'static' | boolean;
   backdropClassName?: string;


### PR DESCRIPTION
It is a thing: https://github.com/twbs/bootstrap/issues/26952

The approach of only allowing known values is very brittle. It would be better to do:
`size?: 'sm' | 'lg' | 'xl' | string;`
for this sort of thing. Enumerate the known values but allow unknown ones. Happy to take a stab at fixing this globally if others agree.