### PR TITLE
Fixes a typo in the Badges documentation

### DIFF
--- a/www/src/pages/components/badge.mdx
+++ b/www/src/pages/components/badge.mdx
@@ -25,8 +25,12 @@ will simply be presented with the content of the badge. Depending on the
 specific situation, these badges may seem like random additional words or
 numbers at the end of a sentence, link, or button. Unless the context is
 clear, consider including additional context with a visually hidden piece
-of additional text. ## Contextual variations Add any of the below
-mentioned modifier classes to change the appearance of a badge.
+of additional text.
+
+## Contextual variations
+
+Add any of the below mentioned modifier classes to change the
+appearance of a badge.
 
 <ReactPlayground codeText={BadgeVariations} />
 


### PR DESCRIPTION
Fixes a typo in the markdown formatting in the badges documentation. 

Changes: 
- Formatting changes to `www/src/pages/components/badge.mdx`