### PR TITLE
Export DropdownItem

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ export CloseButton from './CloseButton';
 export Col from './Col';
 export Collapse from './Collapse';
 export Dropdown from './Dropdown';
+export DropdownItem from './DropdownItem';
 export DropdownButton from './DropdownButton';
 export Fade from './Fade';
 

--- a/test/DropdownItemSpec.js
+++ b/test/DropdownItemSpec.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 
 import Button from '../src/Button';
 import Dropdown from '../src/Dropdown';
+import { DropdownItem } from '../src';
 
 describe('<Dropdown.Item>', () => {
   it('renders divider', () => {
@@ -142,5 +143,11 @@ describe('<Dropdown.Item>', () => {
       .getDOMNode();
 
     assert.equal(anchor.getAttribute('target'), '_blank');
+  });
+});
+
+describe('<DropdownItem />', () => {
+  it('is the alias of Dropdown.Item', () => {
+    assert.equal(DropdownItem, Dropdown.Item);
   });
 });


### PR DESCRIPTION
According to the migration guide and the comments in #3364, Dropdown.Item should be exported as DropdownItem, but it doesn't seem to be exported as that name. This PR fixes it.