### PR TITLE
Fix migrating.mdx

### DIFF
--- a/www/src/pages/migrating.mdx
+++ b/www/src/pages/migrating.mdx
@@ -130,14 +130,6 @@ via context to allow intermediate nesting of child components
 
 - renamed to `FormLabel` (also exported on `Form` as `Form.Label`)
 
-### FormGroup
-
-- renamed to `FormGroup` (also exported on `Form` as `Form.Group`)
-
-### FormControl
-
-- renamed to `FormControl` (also exported on `Form` as `Form.Control`)
-
 ### Checkbox and Radio
 
 - Consolidated into a single component. Component's name is `FormCheck` (also exported on `Form` as `Form.Check`)


### PR DESCRIPTION
FormGroup and FormControl are still available in v1 and therefore I think these are not breaking changes.