### PR TITLE
Update Collapse.d.ts

### DIFF
--- a/types/components/Collapse.d.ts
+++ b/types/components/Collapse.d.ts
@@ -12,7 +12,7 @@ export interface CollapseProps
   dimension?: 'height' | 'width' | (() => 'height' | 'width');
   getDimensionValue?: (
     dimension: number,
-    element: React.ReactElement,
+    element: React.ReactElement<{}>,
   ) => number;
   role?: string;
 }


### PR DESCRIPTION
fix for 
```
>react-scripts build
Creating an optimized production build...
Failed to compile.

node_modules/react-bootstrap/Collapse.d.ts
TypeScript error: Generic type 'ReactElement<P>' requires 1 type argument(s).  TS2314

    13 |   getDimensionValue?: (
    14 |     dimension: number,
  > 15 |     element: React.ReactElement,
       |              ^
    16 |   ) => number;
    17 |   role?: string;
    18 | }
```