### PR TITLE
fix(Modal): set display block always, fixes #3399

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -226,7 +226,6 @@ class Modal extends React.Component {
 
   handleEnter = (node, ...args) => {
     if (node) {
-      node.style.display = 'block';
       this.updateDialogStyle(node);
     }
 
@@ -241,7 +240,6 @@ class Modal extends React.Component {
   };
 
   handleExited = (node, ...args) => {
-    if (node) node.style.display = ''; // RHL removes it sometimes
     if (this.props.onExited) this.props.onExited(...args);
 
     // FIXME: This should work even when animation is disabled.
@@ -340,7 +338,7 @@ class Modal extends React.Component {
             onExiting,
             manager,
             ref: this.setModalRef,
-            style: { ...style, ...this.state.style },
+            style: { ...style, display: 'block', ...this.state.style },
             className: classNames(className, bsPrefix),
             containerClassName: `${bsPrefix}-open`,
             transition: animation ? DialogTransition : undefined,

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -226,6 +226,7 @@ class Modal extends React.Component {
 
   handleEnter = (node, ...args) => {
     if (node) {
+      node.style.display = 'block';
       this.updateDialogStyle(node);
     }
 
@@ -240,6 +241,7 @@ class Modal extends React.Component {
   };
 
   handleExited = (node, ...args) => {
+    if (node) node.style.display = ''; // RHL removes it sometimes
     if (this.props.onExited) this.props.onExited(...args);
 
     // FIXME: This should work even when animation is disabled.
@@ -318,6 +320,13 @@ class Modal extends React.Component {
     } = this.props;
 
     const clickHandler = backdrop === true ? this.handleClick : null;
+    const baseModalStyle = {
+      ...style,
+      ...this.state.style,
+    };
+
+    // Sets `display` always block when `animation` is false
+    if (!animation) baseModalStyle.display = 'block';
 
     return (
       <ModalContext.Provider value={this.modalContext}>
@@ -338,7 +347,7 @@ class Modal extends React.Component {
             onExiting,
             manager,
             ref: this.setModalRef,
-            style: { ...style, display: 'block', ...this.state.style },
+            style: baseModalStyle,
             className: classNames(className, bsPrefix),
             containerClassName: `${bsPrefix}-open`,
             transition: animation ? DialogTransition : undefined,

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -22,6 +22,18 @@ describe('<Modal>', () => {
       .should.equal('Message');
   });
 
+  it('Should sets `display: block` to `div.modal` when animation is false', () => {
+    const node = mount(
+      <Modal show animation={false}>
+        <strong>Message</strong>
+      </Modal>,
+    )
+      .find('div.modal')
+      .getDOMNode();
+
+    expect(node.style.display).to.equal('block');
+  });
+
   it('Should close the modal when the modal dialog is clicked', done => {
     const doneOp = () => {
       done();


### PR DESCRIPTION
We started setting `display: block` to div.modal at onEnter timing of Transition at Pull #3187. But when we set `animation={false}` to Modal, the Transition object is not created and therefore onEnter (=handleEnter) is not called. This causes empty modal when animation set `false` (I think this is the issue #3399 ). This PR tries to fix this behavior by setting the modal's display style to `block` always.

I think this doesn't break existing behavior because as @jquense says
> we don't allow modals to be in the DOM prior to showing 

the modal's dom element doesn't exist before rendering. So I think it's safe to set display always `block`.