### PR TITLE
Fix Table component TypeScript types

### DIFF
--- a/types/components/Table.d.ts
+++ b/types/components/Table.d.ts
@@ -5,6 +5,7 @@ import { BsPrefixComponent } from './helpers';
 export interface TableProps {
   striped?: boolean;
   bordered?: boolean;
+  borderless?: boolean;
   hover?: boolean;
   size?: string;
   variant?: string;


### PR DESCRIPTION
Hi, during work with this awesome library I have noticed, that there is a missing prop 'borderless' in TypeScript type definition of Table component. I think it was accidentally missed in this PR #3473.