### PR TITLE
fix: DropDownItem prop-types active prop (fix: #3598)

### DIFF
--- a/src/DropdownItem.js
+++ b/src/DropdownItem.js
@@ -65,6 +65,7 @@ const DropdownItem = React.forwardRef(
       href,
       onClick,
       onSelect,
+      active,
       as: Component,
       ...props
     },
@@ -77,10 +78,8 @@ const DropdownItem = React.forwardRef(
     const { activeKey } = navContext || {};
     const key = makeEventKey(eventKey, href);
 
-    const active =
-      props.active == null && key != null
-        ? makeEventKey(activeKey) === key
-        : props.active;
+    const shouldAddActiveClass =
+      !active && key ? makeEventKey(activeKey) === key : active;
 
     const handleClick = useEventCallback(event => {
       // SafeAnchor handles the disabled case, but we handle it here
@@ -100,7 +99,7 @@ const DropdownItem = React.forwardRef(
         className={classNames(
           className,
           prefix,
-          active && 'active',
+          shouldAddActiveClass && 'active',
           disabled && 'disabled',
         )}
         onClick={handleClick}

--- a/src/DropdownItem.js
+++ b/src/DropdownItem.js
@@ -65,7 +65,7 @@ const DropdownItem = React.forwardRef(
       href,
       onClick,
       onSelect,
-      active,
+      active: propActive,
       as: Component,
       ...props
     },
@@ -78,8 +78,10 @@ const DropdownItem = React.forwardRef(
     const { activeKey } = navContext || {};
     const key = makeEventKey(eventKey, href);
 
-    const shouldAddActiveClass =
-      active == null && key != null ? makeEventKey(activeKey) === key : active;
+    const active =
+      propActive == null && key != null
+        ? makeEventKey(activeKey) === key
+        : propActive;
 
     const handleClick = useEventCallback(event => {
       // SafeAnchor handles the disabled case, but we handle it here
@@ -99,7 +101,7 @@ const DropdownItem = React.forwardRef(
         className={classNames(
           className,
           prefix,
-          shouldAddActiveClass && 'active',
+          active && 'active',
           disabled && 'disabled',
         )}
         onClick={handleClick}

--- a/src/DropdownItem.js
+++ b/src/DropdownItem.js
@@ -79,7 +79,7 @@ const DropdownItem = React.forwardRef(
     const key = makeEventKey(eventKey, href);
 
     const shouldAddActiveClass =
-      !active && key ? makeEventKey(activeKey) === key : active;
+      active == null && key != null ? makeEventKey(activeKey) === key : active;
 
     const handleClick = useEventCallback(event => {
       // SafeAnchor handles the disabled case, but we handle it here


### PR DESCRIPTION
Fixes #3598.

I hope it's okay, that I simplified these `== null` and `!= null` statements.  (active var type is `null|bool` and `makeEventKey() is null|String`)