### PR TITLE
Add defaultActiveKey to NavProps in Nav.d.ts

### DIFF
--- a/types/components/Nav.d.ts
+++ b/types/components/Nav.d.ts
@@ -10,6 +10,7 @@ export interface NavProps {
   cardHeaderBsPrefix?: string;
   variant?: 'tabs' | 'pills';
   activeKey?: unknown;
+  defaultActiveKey?: unknown;
   fill?: boolean;
   justify?: boolean;
   onSelect?: SelectCallback;


### PR DESCRIPTION
Open issue https://github.com/react-bootstrap/react-bootstrap/issues/3623

The [documentation for the Nav component](https://react-bootstrap.netlify.com/components/navs) lists `defaultActiveKey` as a supported property.

In this case I didn't add a specific type for Typescript but instead just used the existing type for `activeKey` from `NavProps`. This matches the typing of `Tab.d.ts`