### PR TITLE
chore(ci): Using latest Chrome and Firefox releases to perform CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
 
 addons:
   chrome: stable
-  firefox: stable
+  firefox: latest
 
 before_install:
   - export DISPLAY=:99.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 
+dist: xenial
+
 language: node_js
 node_js:
   - "10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ cache:
     - node_modules
     - www/node_modules
 
+before_install:	
+  - export CHROME_BIN=chromium-browser	
+  - export DISPLAY=:99.0
+
 install:
   - yarn bootstrap
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 sudo: false
 
-dist: xenial
-
 language: node_js
 node_js:
-  - "10"
+  - lts/*
 
 env:
   - BROWSER=ChromeCi
@@ -16,9 +14,13 @@ cache:
     - node_modules
     - www/node_modules
 
-before_install:	
-  - export CHROME_BIN=chromium-browser	
+addons:
+  chrome: stable
+  firefox: stable
+
+before_install:
   - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
 
 install:
   - yarn bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,6 @@ cache:
     - node_modules
     - www/node_modules
 
-before_install:
-  - export CHROME_BIN=chromium-browser
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-
 install:
   - yarn bootstrap
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 language: node_js
 node_js:
   - lts/*


### PR DESCRIPTION
Before:

| Browser | Version |
| --------- | -------- |
| Firefox   | 56 |
| Chrome | 62 |

After: 

| Browser | Version |
| --------- | -------- |
| Firefox   | 66 |
| Chrome | 73 |

Should fix #3635. I guess just a Firefox bug which is now fixed.