### PR TITLE
Allow null for Carousel interval in Typescript, fix typo in docs

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -52,7 +52,7 @@ const propTypes = {
   controls: PropTypes.bool,
 
   /**
-   * Temporarily puase the slide interval when the mouse hovers over a slide.
+   * Temporarily pause the slide interval when the mouse hovers over a slide.
    */
   pauseOnHover: PropTypes.bool,
 

--- a/types/components/Carousel.d.ts
+++ b/types/components/Carousel.d.ts
@@ -11,7 +11,7 @@ export interface CarouselProps {
   fade?: boolean;
   wrap?: boolean;
   indicators?: boolean;
-  interval?: number;
+  interval?: number | null;
   controls?: boolean;
   pauseOnHover?: boolean;
   keyboard?: boolean;


### PR DESCRIPTION
The docs in https://github.com/react-bootstrap/react-bootstrap/blob/85550d39e07071322a43de79d28547611c036dae/src/Carousel.js#L43-L47 describe the behavior of setting `interval` to `null`, but `null` is missing in the typescript type definition.