### PR TITLE
Altering "verticallyCenter" prop reference to "centered"

### DIFF
--- a/www/src/pages/components/modal.js
+++ b/www/src/pages/components/modal.js
@@ -98,7 +98,7 @@ export default withLayout(function ModalSection({ data }) {
         Vertically centered
       </LinkedHeading>
       <p>
-        You can vertically center a modal by passing the "verticallyCenter"
+        You can vertically center a modal by passing the "centered"
         prop.
       </p>
       <ReactPlayground codeText={ModalVerticallyCentered} />

--- a/www/src/pages/components/modal.js
+++ b/www/src/pages/components/modal.js
@@ -97,10 +97,7 @@ export default withLayout(function ModalSection({ data }) {
       <LinkedHeading h="3" id="modal-vertically-centered">
         Vertically centered
       </LinkedHeading>
-      <p>
-        You can vertically center a modal by passing the "centered"
-        prop.
-      </p>
+      <p>You can vertically center a modal by passing the "centered" prop.</p>
       <ReactPlayground codeText={ModalVerticallyCentered} />
 
       <LinkedHeading h="3" id="modal-grid">


### PR DESCRIPTION
When reading through the docs I noticed that the name used in the docs to Vertically center the modal is incorrect.