### PR TITLE
fix(Collapse): remove 0px menu height on resize and expand/collapse

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -163,7 +163,7 @@ class Collapse extends React.Component {
   };
 
   handleExiting = elem => {
-    elem.style[this.getDimension()] = '0';
+    elem.style[this.getDimension()] = null;
   };
 
   // for testing

--- a/test/CollapseSpec.js
+++ b/test/CollapseSpec.js
@@ -130,7 +130,7 @@ describe('<Collapse>', () => {
       assert.equal(node.style.height, '');
 
       wrapper.setState({ in: false });
-      assert.equal(node.style.height, '0px');
+      assert.equal(node.style.height, '');
     });
 
     it('Should transition from collapsing to not collapsing', done => {
@@ -146,11 +146,11 @@ describe('<Collapse>', () => {
       assert.equal(node.className, 'collapsing');
     });
 
-    it('Should have 0px height after transition complete', done => {
+    it('Should have no height after transition complete', done => {
       let node = wrapper.getDOMNode();
 
       function onExited() {
-        assert.ok(node.style.height === '0px');
+        assert.equal(node.style.height, '');
         done();
       }
 


### PR DESCRIPTION
Fixes #3394

Found this issue while I was attempting to create a Bootstrap menu without a Navbar.Brand component (I just wanted links).  The problem I ran into was when the browser was re-sized to show the collapsed menu and the collapsed menu was expanded, then collapsed and finally the browser was resized to show the full menu, the menu's height was set to 0px.

I have put a full comment in the issue referenced above.  