### PR TITLE
Bugfix/styled components

### DIFF
--- a/src/AbstractNav.js
+++ b/src/AbstractNav.js
@@ -27,9 +27,7 @@ class AbstractNav extends React.Component {
     activeKey: PropTypes.any,
   };
 
-  static defaultProps = {
-    as: 'ul',
-  };
+  static defaultProps = {};
 
   constructor(...args) {
     super(...args);
@@ -112,7 +110,7 @@ class AbstractNav extends React.Component {
 
   render() {
     const {
-      as: Component,
+      as: Component = 'ul',
       onSelect: _,
       parentOnSelect: _0,
       getControlledId: _1,

--- a/src/AbstractNav.js
+++ b/src/AbstractNav.js
@@ -27,8 +27,6 @@ class AbstractNav extends React.Component {
     activeKey: PropTypes.any,
   };
 
-  static defaultProps = {};
-
   constructor(...args) {
     super(...args);
 
@@ -110,6 +108,7 @@ class AbstractNav extends React.Component {
 
   render() {
     const {
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'ul',
       onSelect: _,
       parentOnSelect: _0,

--- a/src/Accordion.js
+++ b/src/Accordion.js
@@ -22,13 +22,11 @@ const propTypes = {
   defaultActiveKey: PropTypes.string,
 };
 
-const defaultProps = {
-  as: 'div',
-};
+const defaultProps = {};
 
 const Accordion = React.forwardRef((props, ref) => {
   let {
-    as: Component,
+    as: Component = 'div',
     activeKey,
     bsPrefix,
     children,

--- a/src/Accordion.js
+++ b/src/Accordion.js
@@ -22,10 +22,9 @@ const propTypes = {
   defaultActiveKey: PropTypes.string,
 };
 
-const defaultProps = {};
-
 const Accordion = React.forwardRef((props, ref) => {
   let {
+    // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
     as: Component = 'div',
     activeKey,
     bsPrefix,
@@ -55,7 +54,6 @@ const Accordion = React.forwardRef((props, ref) => {
 });
 
 Accordion.propTypes = propTypes;
-Accordion.defaultProps = defaultProps;
 
 Accordion.Toggle = AccordionToggle;
 Accordion.Collapse = AccordionCollapse;

--- a/src/AccordionToggle.js
+++ b/src/AccordionToggle.js
@@ -19,12 +19,13 @@ const propTypes = {
   children: PropTypes.element,
 };
 
-const defaultProps = {
-  as: 'button',
-};
+const defaultProps = {};
 
 const AccordionToggle = React.forwardRef(
-  ({ as: Component, children, eventKey, onClick, ...props }, ref) => {
+  (
+    { as: Component = 'button', children, eventKey, onClick, ...props },
+    ref,
+  ) => {
     const onSelect = useContext(SelectableContext);
 
     return (

--- a/src/AccordionToggle.js
+++ b/src/AccordionToggle.js
@@ -19,11 +19,16 @@ const propTypes = {
   children: PropTypes.element,
 };
 
-const defaultProps = {};
-
 const AccordionToggle = React.forwardRef(
   (
-    { as: Component = 'button', children, eventKey, onClick, ...props },
+    {
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
+      as: Component = 'button',
+      children,
+      eventKey,
+      onClick,
+      ...props
+    },
     ref,
   ) => {
     const onSelect = useContext(SelectableContext);
@@ -44,6 +49,5 @@ const AccordionToggle = React.forwardRef(
 );
 
 AccordionToggle.propTypes = propTypes;
-AccordionToggle.defaultProps = defaultProps;
 
 export default AccordionToggle;

--- a/src/Breadcrumb.js
+++ b/src/Breadcrumb.js
@@ -26,7 +26,6 @@ const propTypes = {
 const defaultProps = {
   label: 'breadcrumb',
   listProps: {},
-  as: 'nav',
 };
 
 const Breadcrumb = React.forwardRef(
@@ -37,7 +36,7 @@ const Breadcrumb = React.forwardRef(
       listProps,
       children,
       label,
-      as: Component,
+      as: Component = 'nav',
       ...props
     },
     ref,

--- a/src/Breadcrumb.js
+++ b/src/Breadcrumb.js
@@ -36,6 +36,7 @@ const Breadcrumb = React.forwardRef(
       listProps,
       children,
       label,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'nav',
       ...props
     },

--- a/src/BreadcrumbItem.js
+++ b/src/BreadcrumbItem.js
@@ -36,6 +36,7 @@ const defaultProps = {
 };
 
 const BreadcrumbItem = React.forwardRef(
+  // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
   ({ bsPrefix, active, className, as: Component = 'li', ...props }, ref) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'breadcrumb-item');
 

--- a/src/BreadcrumbItem.js
+++ b/src/BreadcrumbItem.js
@@ -33,11 +33,10 @@ const propTypes = {
 
 const defaultProps = {
   active: false,
-  as: 'li',
 };
 
 const BreadcrumbItem = React.forwardRef(
-  ({ bsPrefix, active, className, as: Component, ...props }, ref) => {
+  ({ bsPrefix, active, className, as: Component = 'li', ...props }, ref) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'breadcrumb-item');
 
     const { href, title, target, ...elementProps } = props;

--- a/src/ButtonGroup.js
+++ b/src/ButtonGroup.js
@@ -41,7 +41,6 @@ const defaultProps = {
   vertical: false,
   toggle: false,
   role: 'group',
-  as: 'div',
 };
 
 const ButtonGroup = React.forwardRef((props, ref) => {
@@ -51,7 +50,7 @@ const ButtonGroup = React.forwardRef((props, ref) => {
     toggle,
     vertical,
     className,
-    as: Component,
+    as: Component = 'div',
     ...rest
   } = props;
 

--- a/src/ButtonGroup.js
+++ b/src/ButtonGroup.js
@@ -50,6 +50,7 @@ const ButtonGroup = React.forwardRef((props, ref) => {
     toggle,
     vertical,
     className,
+    // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
     as: Component = 'div',
     ...rest
   } = props;

--- a/src/Card.js
+++ b/src/Card.js
@@ -50,7 +50,6 @@ const propTypes = {
 };
 
 const defaultProps = {
-  as: 'div',
   body: false,
 };
 
@@ -64,7 +63,7 @@ const Card = React.forwardRef(
       border,
       body,
       children,
-      as: Component,
+      as: Component = 'div',
       ...props
     },
     ref,

--- a/src/Card.js
+++ b/src/Card.js
@@ -63,6 +63,7 @@ const Card = React.forwardRef(
       border,
       body,
       children,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
       ...props
     },

--- a/src/CardImg.js
+++ b/src/CardImg.js
@@ -26,6 +26,7 @@ const defaultProps = {
 };
 
 const CardImg = React.forwardRef(
+  // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
   ({ bsPrefix, className, variant, as: Component = 'img', ...props }, ref) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'card-img');
 

--- a/src/CardImg.js
+++ b/src/CardImg.js
@@ -22,12 +22,11 @@ const propTypes = {
 };
 
 const defaultProps = {
-  as: 'img',
   variant: null,
 };
 
 const CardImg = React.forwardRef(
-  ({ bsPrefix, className, variant, as: Component, ...props }, ref) => {
+  ({ bsPrefix, className, variant, as: Component = 'img', ...props }, ref) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'card-img');
 
     return (

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -422,6 +422,7 @@ class Carousel extends React.Component {
 
   render() {
     const {
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
       bsPrefix,
       slide,

--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -102,7 +102,6 @@ const propTypes = {
 };
 
 const defaultProps = {
-  as: 'div',
   slide: true,
   fade: false,
   interval: 5000,
@@ -423,7 +422,7 @@ class Carousel extends React.Component {
 
   render() {
     const {
-      as: Component,
+      as: Component = 'div',
       bsPrefix,
       slide,
       fade,

--- a/src/Col.js
+++ b/src/Col.js
@@ -70,9 +70,8 @@ const propTypes = {
   xl: column,
 };
 
-const defaultProps = {};
-
 const Col = React.forwardRef(
+  // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
   ({ bsPrefix, className, as: Component = 'div', ...props }, ref) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'col');
     const spans = [];
@@ -116,6 +115,5 @@ const Col = React.forwardRef(
 
 Col.displayName = 'Col';
 Col.propTypes = propTypes;
-Col.defaultProps = defaultProps;
 
 export default Col;

--- a/src/Col.js
+++ b/src/Col.js
@@ -70,12 +70,10 @@ const propTypes = {
   xl: column,
 };
 
-const defaultProps = {
-  as: 'div',
-};
+const defaultProps = {};
 
 const Col = React.forwardRef(
-  ({ bsPrefix, className, as: Component, ...props }, ref) => {
+  ({ bsPrefix, className, as: Component = 'div', ...props }, ref) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'col');
     const spans = [];
     const classes = [];

--- a/src/Container.js
+++ b/src/Container.js
@@ -21,12 +21,11 @@ const propTypes = {
 };
 
 const defaultProps = {
-  as: 'div',
   fluid: false,
 };
 
 const Container = React.forwardRef(
-  ({ bsPrefix, fluid, as: Component, className, ...props }, ref) => {
+  ({ bsPrefix, fluid, as: Component = 'div', className, ...props }, ref) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'container');
     return (
       <Component

--- a/src/Container.js
+++ b/src/Container.js
@@ -25,6 +25,7 @@ const defaultProps = {
 };
 
 const Container = React.forwardRef(
+  // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
   ({ bsPrefix, fluid, as: Component = 'div', className, ...props }, ref) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'container');
     return (

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -96,6 +96,7 @@ const Dropdown = React.forwardRef((uncontrolledProps, ref) => {
     onSelect,
     onToggle,
     focusFirstItemOnShow,
+    // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
     as: Component = 'div',
     navbar: _4,
     ...props

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -83,7 +83,6 @@ const propTypes = {
 };
 
 const defaultProps = {
-  as: 'div',
   navbar: false,
 };
 
@@ -97,7 +96,7 @@ const Dropdown = React.forwardRef((uncontrolledProps, ref) => {
     onSelect,
     onToggle,
     focusFirstItemOnShow,
-    as: Component,
+    as: Component = 'div',
     navbar: _4,
     ...props
   } = useUncontrolled(uncontrolledProps, { show: 'onToggle' });

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -57,7 +57,6 @@ const propTypes = {
 
 const defaultProps = {
   alignRight: false,
-  as: 'div',
   flip: true,
 };
 
@@ -71,7 +70,7 @@ const DropdownMenu = React.forwardRef(
       flip,
       popperConfig,
       show: showProps,
-      as: Component,
+      as: Component = 'div',
       ...props
     },
     ref,

--- a/src/DropdownMenu.js
+++ b/src/DropdownMenu.js
@@ -70,6 +70,7 @@ const DropdownMenu = React.forwardRef(
       flip,
       popperConfig,
       show: showProps,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
       ...props
     },

--- a/src/Feedback.js
+++ b/src/Feedback.js
@@ -14,11 +14,10 @@ const propTypes = {
 
 const defaultProps = {
   type: 'valid',
-  as: 'div',
 };
 
 const Feedback = React.forwardRef(
-  ({ as: Component, className, type, ...props }, ref) => (
+  ({ as: Component = 'div', className, type, ...props }, ref) => (
     <Component
       {...props}
       ref={ref}

--- a/src/Feedback.js
+++ b/src/Feedback.js
@@ -17,6 +17,7 @@ const defaultProps = {
 };
 
 const Feedback = React.forwardRef(
+  // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
   ({ as: Component = 'div', className, type, ...props }, ref) => (
     <Component
       {...props}

--- a/src/Form.js
+++ b/src/Form.js
@@ -42,12 +42,18 @@ const propTypes = {
 
 const defaultProps = {
   inline: false,
-  as: 'form',
 };
 
 const Form = React.forwardRef(
   (
-    { bsPrefix, inline, className, validated, as: Component, ...props },
+    {
+      bsPrefix,
+      inline,
+      className,
+      validated,
+      as: Component = 'form',
+      ...props
+    },
     ref,
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'form');

--- a/src/Form.js
+++ b/src/Form.js
@@ -51,6 +51,7 @@ const Form = React.forwardRef(
       inline,
       className,
       validated,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'form',
       ...props
     },

--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -75,8 +75,6 @@ const propTypes = {
   isInvalid: PropTypes.bool,
 };
 
-const defaultProps = {};
-
 const FormControl = React.forwardRef(
   (
     {
@@ -89,6 +87,7 @@ const FormControl = React.forwardRef(
       isInvalid,
       plaintext,
       readOnly,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'input',
       ...props
     },
@@ -134,7 +133,6 @@ const FormControl = React.forwardRef(
 
 FormControl.displayName = 'FormControl';
 FormControl.propTypes = propTypes;
-FormControl.defaultProps = defaultProps;
 
 FormControl.Feedback = Feedback;
 

--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -75,9 +75,7 @@ const propTypes = {
   isInvalid: PropTypes.bool,
 };
 
-const defaultProps = {
-  as: 'input',
-};
+const defaultProps = {};
 
 const FormControl = React.forwardRef(
   (
@@ -91,7 +89,7 @@ const FormControl = React.forwardRef(
       isInvalid,
       plaintext,
       readOnly,
-      as: Component,
+      as: Component = 'input',
       ...props
     },
     ref,

--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -29,13 +29,18 @@ const propTypes = {
   _ref: PropTypes.any,
 };
 
-const defaultProps = {
-  as: 'div',
-};
+const defaultProps = {};
 
 const FormGroup = React.forwardRef(
   (
-    { bsPrefix, className, children, controlId, as: Component, ...props },
+    {
+      bsPrefix,
+      className,
+      children,
+      controlId,
+      as: Component = 'div',
+      ...props
+    },
     ref,
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'form-group');

--- a/src/FormGroup.js
+++ b/src/FormGroup.js
@@ -29,8 +29,6 @@ const propTypes = {
   _ref: PropTypes.any,
 };
 
-const defaultProps = {};
-
 const FormGroup = React.forwardRef(
   (
     {
@@ -38,6 +36,7 @@ const FormGroup = React.forwardRef(
       className,
       children,
       controlId,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
       ...props
     },
@@ -62,6 +61,5 @@ const FormGroup = React.forwardRef(
 
 FormGroup.displayName = 'FormGroup';
 FormGroup.propTypes = propTypes;
-FormGroup.defaultProps = defaultProps;
 
 export default FormGroup;

--- a/src/FormText.js
+++ b/src/FormText.js
@@ -27,9 +27,8 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-const defaultProps = {};
-
 const FormText = React.forwardRef(
+  // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
   ({ bsPrefix, className, as: Component = 'small', ...props }, ref) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'form-text');
     return (
@@ -44,6 +43,5 @@ const FormText = React.forwardRef(
 
 FormText.displayName = 'FormText';
 FormText.propTypes = propTypes;
-FormText.defaultProps = defaultProps;
 
 export default FormText;

--- a/src/FormText.js
+++ b/src/FormText.js
@@ -27,12 +27,10 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-const defaultProps = {
-  as: 'small',
-};
+const defaultProps = {};
 
 const FormText = React.forwardRef(
-  ({ bsPrefix, className, as: Component, ...props }, ref) => {
+  ({ bsPrefix, className, as: Component = 'small', ...props }, ref) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'form-text');
     return (
       <Component

--- a/src/InputGroup.js
+++ b/src/InputGroup.js
@@ -6,6 +6,8 @@ import React from 'react';
 import createWithBsPrefix from './utils/createWithBsPrefix';
 import { createBootstrapComponent } from './ThemeProvider';
 
+const defaultProps = {};
+
 /**
  *
  * @property {InputGroupAppend} Append
@@ -29,12 +31,14 @@ class InputGroup extends React.Component {
     as: PropTypes.elementType,
   };
 
-  static defaultProps = {
-    as: 'div',
-  };
-
   render() {
-    const { bsPrefix, size, className, as: Component, ...props } = this.props;
+    const {
+      bsPrefix,
+      size,
+      className,
+      as: Component = 'div',
+      ...props
+    } = this.props;
 
     return (
       <Component
@@ -70,6 +74,8 @@ const InputGroupRadio = props => (
 );
 
 const DecoratedInputGroup = createBootstrapComponent(InputGroup, 'input-group');
+
+DecoratedInputGroup.defaultProps = defaultProps;
 
 DecoratedInputGroup.Text = InputGroupText;
 DecoratedInputGroup.Radio = InputGroupRadio;

--- a/src/InputGroup.js
+++ b/src/InputGroup.js
@@ -6,8 +6,6 @@ import React from 'react';
 import createWithBsPrefix from './utils/createWithBsPrefix';
 import { createBootstrapComponent } from './ThemeProvider';
 
-const defaultProps = {};
-
 /**
  *
  * @property {InputGroupAppend} Append
@@ -36,6 +34,7 @@ class InputGroup extends React.Component {
       bsPrefix,
       size,
       className,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
       ...props
     } = this.props;
@@ -74,8 +73,6 @@ const InputGroupRadio = props => (
 );
 
 const DecoratedInputGroup = createBootstrapComponent(InputGroup, 'input-group');
-
-DecoratedInputGroup.defaultProps = defaultProps;
 
 DecoratedInputGroup.Text = InputGroupText;
 DecoratedInputGroup.Radio = InputGroupRadio;

--- a/src/Jumbotron.js
+++ b/src/Jumbotron.js
@@ -4,22 +4,27 @@ import classNames from 'classnames';
 
 import { createBootstrapComponent } from './ThemeProvider';
 
-const propTypes = {
-  as: PropTypes.elementType,
-  /** Make the jumbotron full width, and without rounded corners */
-  fluid: PropTypes.bool,
-  /** @default 'jumbotron' */
-  bsPrefix: PropTypes.string,
-};
-
 const defaultProps = {
-  as: 'div',
   fluid: false,
 };
 
 class Jumbotron extends React.Component {
+  static propTypes = {
+    as: PropTypes.elementType,
+    /** Make the jumbotron full width, and without rounded corners */
+    fluid: PropTypes.bool,
+    /** @default 'jumbotron' */
+    bsPrefix: PropTypes.string,
+  };
+
   render() {
-    const { as: Component, className, fluid, bsPrefix, ...props } = this.props;
+    const {
+      as: Component = 'div',
+      className,
+      fluid,
+      bsPrefix,
+      ...props
+    } = this.props;
     const classes = {
       [bsPrefix]: true,
       [`${bsPrefix}-fluid`]: fluid,
@@ -28,7 +33,8 @@ class Jumbotron extends React.Component {
   }
 }
 
-Jumbotron.propTypes = propTypes;
-Jumbotron.defaultProps = defaultProps;
+const BootstrapJumbotron = createBootstrapComponent(Jumbotron, 'jumbotron');
 
-export default createBootstrapComponent(Jumbotron, 'jumbotron');
+BootstrapJumbotron.defaultProps = defaultProps;
+
+export default BootstrapJumbotron;

--- a/src/Jumbotron.js
+++ b/src/Jumbotron.js
@@ -4,21 +4,22 @@ import classNames from 'classnames';
 
 import { createBootstrapComponent } from './ThemeProvider';
 
+const propTypes = {
+  as: PropTypes.elementType,
+  /** Make the jumbotron full width, and without rounded corners */
+  fluid: PropTypes.bool,
+  /** @default 'jumbotron' */
+  bsPrefix: PropTypes.string,
+};
+
 const defaultProps = {
   fluid: false,
 };
 
 class Jumbotron extends React.Component {
-  static propTypes = {
-    as: PropTypes.elementType,
-    /** Make the jumbotron full width, and without rounded corners */
-    fluid: PropTypes.bool,
-    /** @default 'jumbotron' */
-    bsPrefix: PropTypes.string,
-  };
-
   render() {
     const {
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
       className,
       fluid,
@@ -33,8 +34,7 @@ class Jumbotron extends React.Component {
   }
 }
 
-const BootstrapJumbotron = createBootstrapComponent(Jumbotron, 'jumbotron');
+Jumbotron.propTypes = propTypes;
+Jumbotron.defaultProps = defaultProps;
 
-BootstrapJumbotron.defaultProps = defaultProps;
-
-export default BootstrapJumbotron;
+export default createBootstrapComponent(Jumbotron, 'jumbotron');

--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -29,16 +29,16 @@ class ListGroup extends React.Component {
   };
 
   static defaultProps = {
-    as: 'div',
     variant: null,
   };
 
   render() {
-    const { className, bsPrefix, variant, ...props } = this.props;
+    const { className, bsPrefix, variant, as = 'div', ...props } = this.props;
 
     return (
       <AbstractNav
         {...props}
+        as={as}
         className={classNames(
           className,
           bsPrefix,

--- a/src/Media.js
+++ b/src/Media.js
@@ -14,13 +14,12 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-const defaultProps = {
-  as: 'div',
-};
+const defaultProps = {};
 
 const Media = React.forwardRef(
-  ({ bsPrefix, className, as: Component, ...props }, ref) => {
+  ({ bsPrefix, className, as: Component = 'div', ...props }, ref) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'media');
+
     return (
       <Component
         {...props}

--- a/src/Media.js
+++ b/src/Media.js
@@ -14,9 +14,8 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-const defaultProps = {};
-
 const Media = React.forwardRef(
+  // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
   ({ bsPrefix, className, as: Component = 'div', ...props }, ref) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'media');
 
@@ -32,7 +31,6 @@ const Media = React.forwardRef(
 
 Media.displayName = 'Media';
 Media.propTypes = propTypes;
-Media.defaultProps = defaultProps;
 
 Media.Body = createWithBsPrefix('media-body');
 

--- a/src/Nav.js
+++ b/src/Nav.js
@@ -88,12 +88,11 @@ const propTypes = {
 const defaultProps = {
   justify: false,
   fill: false,
-  as: 'div',
 };
 
 const Nav = React.forwardRef((uncontrolledProps, ref) => {
   let {
-    as,
+    as = 'div',
     bsPrefix,
     variant,
     fill,

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -16,13 +16,12 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-const defaultProps = {
-  as: 'div',
-};
+const defaultProps = {};
 
 const NavItem = React.forwardRef(
-  ({ bsPrefix, className, children, as: Component, ...props }, ref) => {
+  ({ bsPrefix, className, children, as: Component = 'div', ...props }, ref) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'nav-item');
+
     return (
       <Component
         {...props}

--- a/src/NavItem.js
+++ b/src/NavItem.js
@@ -16,9 +16,8 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-const defaultProps = {};
-
 const NavItem = React.forwardRef(
+  // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
   ({ bsPrefix, className, children, as: Component = 'div', ...props }, ref) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'nav-item');
 
@@ -36,6 +35,5 @@ const NavItem = React.forwardRef(
 
 NavItem.displayName = 'NavItem';
 NavItem.propTypes = propTypes;
-NavItem.defaultProps = defaultProps;
 
 export default NavItem;

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -117,7 +117,6 @@ const propTypes = {
 };
 
 const defaultProps = {
-  as: 'nav',
   expand: true,
   variant: 'light',
   collapseOnSelect: false,
@@ -169,7 +168,7 @@ class Navbar extends React.Component {
       sticky,
       className,
       children,
-      as: Component,
+      as: Component = 'nav',
       expanded: _1,
       onToggle: _2,
       onSelect: _3,
@@ -210,13 +209,13 @@ class Navbar extends React.Component {
 }
 
 Navbar.propTypes = propTypes;
-Navbar.defaultProps = defaultProps;
 
 const DecoratedNavbar = createBootstrapComponent(
   uncontrollable(Navbar, { expanded: 'onToggle' }),
   'navbar',
 );
 
+DecoratedNavbar.defaultProps = defaultProps;
 DecoratedNavbar.Brand = NavbarBrand;
 DecoratedNavbar.Toggle = NavbarToggle;
 DecoratedNavbar.Collapse = NavbarCollapse;

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -168,6 +168,7 @@ class Navbar extends React.Component {
       sticky,
       className,
       children,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'nav',
       expanded: _1,
       onToggle: _2,
@@ -209,13 +210,13 @@ class Navbar extends React.Component {
 }
 
 Navbar.propTypes = propTypes;
+Navbar.defaultProps = defaultProps;
 
 const DecoratedNavbar = createBootstrapComponent(
   uncontrollable(Navbar, { expanded: 'onToggle' }),
   'navbar',
 );
 
-DecoratedNavbar.defaultProps = defaultProps;
 DecoratedNavbar.Brand = NavbarBrand;
 DecoratedNavbar.Toggle = NavbarToggle;
 DecoratedNavbar.Collapse = NavbarCollapse;

--- a/src/NavbarToggle.js
+++ b/src/NavbarToggle.js
@@ -35,6 +35,7 @@ const NavbarToggle = React.forwardRef(
       className,
       children,
       label,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'button',
       onClick,
       ...props

--- a/src/NavbarToggle.js
+++ b/src/NavbarToggle.js
@@ -26,12 +26,19 @@ const propTypes = {
 
 const defaultProps = {
   label: 'Toggle navigation',
-  as: 'button',
 };
 
 const NavbarToggle = React.forwardRef(
   (
-    { bsPrefix, className, children, label, as: Component, onClick, ...props },
+    {
+      bsPrefix,
+      className,
+      children,
+      label,
+      as: Component = 'button',
+      onClick,
+      ...props
+    },
     ref,
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'navbar-toggler');

--- a/src/Row.js
+++ b/src/Row.js
@@ -17,10 +17,15 @@ class Row extends React.Component {
     as: PropTypes.elementType,
   };
 
+  static defaultProps = {
+    noGutters: false,
+  };
+
   render() {
     const {
       bsPrefix,
       noGutters,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
       className,
       ...props
@@ -35,10 +40,4 @@ class Row extends React.Component {
   }
 }
 
-const BootstrapRow = createBootstrapComponent(Row, 'row');
-
-BootstrapRow.defaultProps = {
-  noGutters: false,
-};
-
-export default BootstrapRow;
+export default createBootstrapComponent(Row, 'row');

--- a/src/Row.js
+++ b/src/Row.js
@@ -17,16 +17,11 @@ class Row extends React.Component {
     as: PropTypes.elementType,
   };
 
-  static defaultProps = {
-    as: 'div',
-    noGutters: false,
-  };
-
   render() {
     const {
       bsPrefix,
       noGutters,
-      as: Component,
+      as: Component = 'div',
       className,
       ...props
     } = this.props;
@@ -40,4 +35,10 @@ class Row extends React.Component {
   }
 }
 
-export default createBootstrapComponent(Row, 'row');
+const BootstrapRow = createBootstrapComponent(Row, 'row');
+
+BootstrapRow.defaultProps = {
+  noGutters: false,
+};
+
+export default BootstrapRow;

--- a/src/SafeAnchor.js
+++ b/src/SafeAnchor.js
@@ -20,9 +20,7 @@ const propTypes = {
   innerRef: PropTypes.any,
 };
 
-const defaultProps = {
-  as: 'a',
-};
+const defaultProps = {};
 
 function isTrivialHref(href) {
   return !href || href.trim() === '#';
@@ -69,7 +67,7 @@ class SafeAnchor extends React.Component {
 
   render() {
     const {
-      as: Component,
+      as: Component = 'a',
       disabled,
       onKeyDown,
       innerRef,

--- a/src/SafeAnchor.js
+++ b/src/SafeAnchor.js
@@ -20,8 +20,6 @@ const propTypes = {
   innerRef: PropTypes.any,
 };
 
-const defaultProps = {};
-
 function isTrivialHref(href) {
   return !href || href.trim() === '#';
 }
@@ -67,6 +65,7 @@ class SafeAnchor extends React.Component {
 
   render() {
     const {
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'a',
       disabled,
       onKeyDown,
@@ -97,6 +96,5 @@ class SafeAnchor extends React.Component {
 }
 
 SafeAnchor.propTypes = propTypes;
-SafeAnchor.defaultProps = defaultProps;
 
 export default SafeAnchor;

--- a/src/Spinner.js
+++ b/src/Spinner.js
@@ -56,6 +56,7 @@ class Spinner extends React.Component {
       animation,
       size,
       children,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
       className,
       ...props
@@ -78,8 +79,4 @@ class Spinner extends React.Component {
   }
 }
 
-const BootstrapSpinner = createBootstrapComponent(Spinner, 'spinner');
-
-BootstrapSpinner.defaultProps = {};
-
-export default BootstrapSpinner;
+export default createBootstrapComponent(Spinner, 'spinner');

--- a/src/Spinner.js
+++ b/src/Spinner.js
@@ -49,10 +49,6 @@ class Spinner extends React.Component {
     as: PropTypes.elementType,
   };
 
-  static defaultProps = {
-    as: 'div',
-  };
-
   render() {
     const {
       bsPrefix,
@@ -60,11 +56,10 @@ class Spinner extends React.Component {
       animation,
       size,
       children,
-      as,
+      as: Component = 'div',
       className,
       ...props
     } = this.props;
-    const Component = as;
     const bsSpinnerPrefix = `${bsPrefix}-${animation}`;
 
     return (
@@ -83,4 +78,8 @@ class Spinner extends React.Component {
   }
 }
 
-export default createBootstrapComponent(Spinner, 'spinner');
+const BootstrapSpinner = createBootstrapComponent(Spinner, 'spinner');
+
+BootstrapSpinner.defaultProps = {};
+
+export default BootstrapSpinner;

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -15,14 +15,11 @@ class TabContent extends React.Component {
   };
 
   render() {
+    // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
     const { bsPrefix, as: Component = 'div', className, ...props } = this.props;
 
     return <Component {...props} className={classNames(className, bsPrefix)} />;
   }
 }
 
-const BootstrapTabContent = createBootstrapComponent(TabContent, 'tab-content');
-
-BootstrapTabContent.defaultProps = {};
-
-export default BootstrapTabContent;
+export default createBootstrapComponent(TabContent, 'tab-content');

--- a/src/TabContent.js
+++ b/src/TabContent.js
@@ -14,15 +14,15 @@ class TabContent extends React.Component {
     as: PropTypes.elementType,
   };
 
-  static defaultProps = {
-    as: 'div',
-  };
-
   render() {
-    const { bsPrefix, as: Component, className, ...props } = this.props;
+    const { bsPrefix, as: Component = 'div', className, ...props } = this.props;
 
     return <Component {...props} className={classNames(className, bsPrefix)} />;
   }
 }
 
-export default createBootstrapComponent(TabContent, 'tab-content');
+const BootstrapTabContent = createBootstrapComponent(TabContent, 'tab-content');
+
+BootstrapTabContent.defaultProps = {};
+
+export default BootstrapTabContent;

--- a/src/TabPane.js
+++ b/src/TabPane.js
@@ -128,6 +128,7 @@ const TabPane = React.forwardRef((props, ref) => {
     mountOnEnter,
     unmountOnExit,
     transition: Transition,
+    // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
     as: Component = 'div',
     eventKey: _,
     ...rest

--- a/src/test/ButtonGroup.js
+++ b/src/test/ButtonGroup.js
@@ -51,6 +51,7 @@ const ButtonGroup = React.forwardRef((props, ref) => {
     toggle,
     vertical,
     className,
+    // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
     as: Component = 'div',
     ...rest
   } = props;

--- a/src/test/ButtonGroup.js
+++ b/src/test/ButtonGroup.js
@@ -42,7 +42,6 @@ const defaultProps = {
   vertical: false,
   toggle: false,
   role: 'group',
-  as: 'div',
 };
 
 const ButtonGroup = React.forwardRef((props, ref) => {
@@ -52,7 +51,7 @@ const ButtonGroup = React.forwardRef((props, ref) => {
     toggle,
     vertical,
     className,
-    as: Component,
+    as: Component = 'div',
     ...rest
   } = props;
 

--- a/test/AccordionSpec.js
+++ b/test/AccordionSpec.js
@@ -90,10 +90,6 @@ describe('<Accordion>', () => {
     expect(onClickSpy).to.be.calledOnce;
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(Accordion.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have div as default component', () => {
     mount(<Accordion />).assertSingle('div');
   });

--- a/test/AccordionSpec.js
+++ b/test/AccordionSpec.js
@@ -89,4 +89,12 @@ describe('<Accordion>', () => {
 
     expect(onClickSpy).to.be.calledOnce;
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(Accordion.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have div as default component', () => {
+    mount(<Accordion />).assertSingle('div');
+  });
 });

--- a/test/AccordionToggleSpec.js
+++ b/test/AccordionToggleSpec.js
@@ -4,10 +4,6 @@ import { mount } from 'enzyme';
 import AccordionToggle from '../src/AccordionToggle';
 
 describe('<AccordionToggle>', () => {
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(AccordionToggle.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have button as default component', () => {
     mount(<AccordionToggle eventKey="" />).assertSingle('button');
   });

--- a/test/AccordionToggleSpec.js
+++ b/test/AccordionToggleSpec.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import AccordionToggle from '../src/AccordionToggle';
+
+describe('<AccordionToggle>', () => {
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(AccordionToggle.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have button as default component', () => {
+    mount(<AccordionToggle eventKey="" />).assertSingle('button');
+  });
+});

--- a/test/BreadcrumbItemSpec.js
+++ b/test/BreadcrumbItemSpec.js
@@ -119,4 +119,12 @@ describe('<Breadcrumb.Item>', () => {
       .prop('target')
       .should.eq('_blank');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(Breadcrumb.Item.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have li as default component', () => {
+    mount(<Breadcrumb.Item />).assertSingle('li');
+  });
 });

--- a/test/BreadcrumbItemSpec.js
+++ b/test/BreadcrumbItemSpec.js
@@ -120,10 +120,6 @@ describe('<Breadcrumb.Item>', () => {
       .should.eq('_blank');
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(Breadcrumb.Item.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have li as default component', () => {
     mount(<Breadcrumb.Item />).assertSingle('li');
   });

--- a/test/BreadcrumbSpec.js
+++ b/test/BreadcrumbSpec.js
@@ -34,10 +34,6 @@ describe('<Breadcrumb>', () => {
       .should.have.length(1);
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(Breadcrumb.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have nav as default component', () => {
     mount(<Breadcrumb />).assertSingle('nav');
   });

--- a/test/BreadcrumbSpec.js
+++ b/test/BreadcrumbSpec.js
@@ -33,4 +33,12 @@ describe('<Breadcrumb>', () => {
       .find('nav[aria-label="breadcrumb"]')
       .should.have.length(1);
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(Breadcrumb.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have nav as default component', () => {
+    mount(<Breadcrumb />).assertSingle('nav');
+  });
 });

--- a/test/ButtonGroupSpec.js
+++ b/test/ButtonGroupSpec.js
@@ -37,4 +37,12 @@ describe('ButtonGroup', () => {
       </ButtonGroup>,
     ).assertSingle('.btn-group.btn-group-toggle');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(ButtonGroup.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have div as default component', () => {
+    mount(<ButtonGroup />).assertSingle('div');
+  });
 });

--- a/test/ButtonGroupSpec.js
+++ b/test/ButtonGroupSpec.js
@@ -38,10 +38,6 @@ describe('ButtonGroup', () => {
     ).assertSingle('.btn-group.btn-group-toggle');
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(ButtonGroup.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have div as default component', () => {
     mount(<ButtonGroup />).assertSingle('div');
   });

--- a/test/CardImgSpec.js
+++ b/test/CardImgSpec.js
@@ -30,10 +30,6 @@ describe('<CardImg>', () => {
       mount(<CardImg variant="bottom" />).assertSingle('.card-img-bottom');
     });
 
-    it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-      expect(CardImg.defaultProps.as).to.be.undefined;
-    });
-
     it('Should have img as default component', () => {
       mount(<CardImg />).assertSingle('img');
     });

--- a/test/CardImgSpec.js
+++ b/test/CardImgSpec.js
@@ -29,5 +29,13 @@ describe('<CardImg>', () => {
     it('bottom', () => {
       mount(<CardImg variant="bottom" />).assertSingle('.card-img-bottom');
     });
+
+    it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+      expect(CardImg.defaultProps.as).to.be.undefined;
+    });
+
+    it('Should have img as default component', () => {
+      mount(<CardImg />).assertSingle('img');
+    });
   });
 });

--- a/test/CardSpec.js
+++ b/test/CardSpec.js
@@ -44,10 +44,6 @@ describe('<Card>', () => {
     mount(<Card body>test</Card>).assertSingle('.card-body');
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(Card.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have div as default component', () => {
     const wrapper = mount(<Card />);
     expect(wrapper.find('div').length).to.equal(1);

--- a/test/CardSpec.js
+++ b/test/CardSpec.js
@@ -43,4 +43,13 @@ describe('<Card>', () => {
   it('allows for the body shorthand', () => {
     mount(<Card body>test</Card>).assertSingle('.card-body');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(Card.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have div as default component', () => {
+    const wrapper = mount(<Card />);
+    expect(wrapper.find('div').length).to.equal(1);
+  });
 });

--- a/test/CarouselSpec.js
+++ b/test/CarouselSpec.js
@@ -233,4 +233,13 @@ describe('<Carousel>', () => {
     wrapper.find('.carousel-indicators > li').length.should.equal(1);
     wrapper.find('div.carousel-item').length.should.equal(1);
   });
+
+  // it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+  //   expect(Carousel.defaultProps.as).to.be.undefined;
+  // });
+
+  it('Should have div as default component', () => {
+    const wrapper = mount(<Carousel>{items}</Carousel>);
+    wrapper.find('div').length.should.equal(4);
+  });
 });

--- a/test/CarouselSpec.js
+++ b/test/CarouselSpec.js
@@ -234,10 +234,6 @@ describe('<Carousel>', () => {
     wrapper.find('div.carousel-item').length.should.equal(1);
   });
 
-  // it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-  //   expect(Carousel.defaultProps.as).to.be.undefined;
-  // });
-
   it('Should have div as default component', () => {
     const wrapper = mount(<Carousel>{items}</Carousel>);
     wrapper.find('div').length.should.equal(4);

--- a/test/ColSpec.js
+++ b/test/ColSpec.js
@@ -27,10 +27,6 @@ describe('Col', () => {
     ).assertSingle('.col-md-8.order-md-1.col-4.offset-1.order-lg-last');
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(Col.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have div as default component', () => {
     mount(<Col />).assertSingle('div');
   });

--- a/test/ColSpec.js
+++ b/test/ColSpec.js
@@ -26,4 +26,12 @@ describe('Col', () => {
       />,
     ).assertSingle('.col-md-8.order-md-1.col-4.offset-1.order-lg-last');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(Col.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have div as default component', () => {
+    mount(<Col />).assertSingle('div');
+  });
 });

--- a/test/ContainerSpec.js
+++ b/test/ContainerSpec.js
@@ -18,10 +18,6 @@ describe('<Container>', () => {
     mount(<Container as="section" />).assertSingle('section.container');
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(Container.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have div as default component', () => {
     mount(<Container />).assertSingle('div');
   });

--- a/test/ContainerSpec.js
+++ b/test/ContainerSpec.js
@@ -17,4 +17,12 @@ describe('<Container>', () => {
   it('allows custom elements instead of "div"', () => {
     mount(<Container as="section" />).assertSingle('section.container');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(Container.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have div as default component', () => {
+    mount(<Container />).assertSingle('div');
+  });
 });

--- a/test/DropdownMenuSpec.js
+++ b/test/DropdownMenuSpec.js
@@ -33,8 +33,4 @@ describe('<Dropdown.Menu>', () => {
       </DropdownMenu>,
     ).assertSingle('.dropdown-menu-right');
   });
-
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(DropdownMenu.defaultProps.as).to.be.undefined;
-  });
 });

--- a/test/DropdownMenuSpec.js
+++ b/test/DropdownMenuSpec.js
@@ -33,4 +33,8 @@ describe('<Dropdown.Menu>', () => {
       </DropdownMenu>,
     ).assertSingle('.dropdown-menu-right');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(DropdownMenu.defaultProps.as).to.be.undefined;
+  });
 });

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -253,10 +253,6 @@ describe('<Dropdown>', () => {
     wrapper.assertSingle('div.my-menu');
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(Dropdown.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have div as default component', () => {
     const wrapper = mount(<Dropdown />);
     expect(wrapper.find('div').length).to.equal(1);

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -252,4 +252,13 @@ describe('<Dropdown>', () => {
     wrapper.assertSingle('button.my-toggle');
     wrapper.assertSingle('div.my-menu');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(Dropdown.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have div as default component', () => {
+    const wrapper = mount(<Dropdown />);
+    expect(wrapper.find('div').length).to.equal(1);
+  });
 });

--- a/test/FeedbackSpec.js
+++ b/test/FeedbackSpec.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import Feedback from '../src/Feedback';
+
+describe('<Feedback>', () => {
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(Feedback.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have div as default component', () => {
+    mount(<Feedback />).assertSingle('div');
+  });
+});

--- a/test/FeedbackSpec.js
+++ b/test/FeedbackSpec.js
@@ -4,10 +4,6 @@ import { mount } from 'enzyme';
 import Feedback from '../src/Feedback';
 
 describe('<Feedback>', () => {
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(Feedback.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have div as default component', () => {
     mount(<Feedback />).assertSingle('div');
   });

--- a/test/FormControlSpec.js
+++ b/test/FormControlSpec.js
@@ -76,4 +76,12 @@ describe('<FormControl>', () => {
       'input.form-control.form-control-lg',
     );
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(FormControl.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have input as default component', () => {
+    mount(<FormControl />).assertSingle('input');
+  });
 });

--- a/test/FormControlSpec.js
+++ b/test/FormControlSpec.js
@@ -77,10 +77,6 @@ describe('<FormControl>', () => {
     );
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(FormControl.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have input as default component', () => {
     mount(<FormControl />).assertSingle('input');
   });

--- a/test/FormGroupSpec.js
+++ b/test/FormGroupSpec.js
@@ -37,10 +37,6 @@ describe('<FormGroup>', () => {
     wrapper.assertSingle('input[id="my-control"]');
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(FormGroup.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have div as default component', () => {
     const wrapper = mount(<FormGroup />);
     expect(wrapper.find('div').length).to.equal(1);

--- a/test/FormGroupSpec.js
+++ b/test/FormGroupSpec.js
@@ -36,4 +36,13 @@ describe('<FormGroup>', () => {
     wrapper.assertSingle('label[htmlFor="my-control"]');
     wrapper.assertSingle('input[id="my-control"]');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(FormGroup.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have div as default component', () => {
+    const wrapper = mount(<FormGroup />);
+    expect(wrapper.find('div').length).to.equal(1);
+  });
 });

--- a/test/FormSpec.js
+++ b/test/FormSpec.js
@@ -24,4 +24,12 @@ describe('<Form>', () => {
       .assertSingle('fieldset.my-form')
       .assertSingle('FormGroup');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(Form.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have form as default component', () => {
+    mount(<Form />).assertSingle('form');
+  });
 });

--- a/test/FormSpec.js
+++ b/test/FormSpec.js
@@ -25,10 +25,6 @@ describe('<Form>', () => {
       .assertSingle('FormGroup');
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(Form.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have form as default component', () => {
     mount(<Form />).assertSingle('form');
   });

--- a/test/FormTextSpec.js
+++ b/test/FormTextSpec.js
@@ -16,10 +16,6 @@ describe('<FormText>', () => {
     ).to.equal('Help contents');
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(FormText.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have small as default component', () => {
     mount(<FormText />).assertSingle('small');
   });

--- a/test/FormTextSpec.js
+++ b/test/FormTextSpec.js
@@ -15,4 +15,12 @@ describe('<FormText>', () => {
         .text(),
     ).to.equal('Help contents');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(FormText.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have small as default component', () => {
+    mount(<FormText />).assertSingle('small');
+  });
 });

--- a/test/InputGroupSpec.js
+++ b/test/InputGroupSpec.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import InputGroup from '../src/InputGroup';
+
+describe('<InputGroup>', () => {
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(InputGroup.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have div as default component', () => {
+    const wrapper = mount(<InputGroup />);
+    expect(wrapper.find('div').length).to.equal(1);
+  });
+});

--- a/test/InputGroupSpec.js
+++ b/test/InputGroupSpec.js
@@ -4,10 +4,6 @@ import { mount } from 'enzyme';
 import InputGroup from '../src/InputGroup';
 
 describe('<InputGroup>', () => {
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(InputGroup.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have div as default component', () => {
     const wrapper = mount(<InputGroup />);
     expect(wrapper.find('div').length).to.equal(1);

--- a/test/JumbotronSpec.js
+++ b/test/JumbotronSpec.js
@@ -25,11 +25,6 @@ describe('<Jumbotron>', () => {
       </Jumbotron>,
     ).assertSingle('section.jumbotron strong');
   });
-
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(Jumbotron.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have div as default component', () => {
     mount(<Jumbotron />).assertSingle('div');
   });

--- a/test/JumbotronSpec.js
+++ b/test/JumbotronSpec.js
@@ -25,4 +25,12 @@ describe('<Jumbotron>', () => {
       </Jumbotron>,
     ).assertSingle('section.jumbotron strong');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(Jumbotron.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have div as default component', () => {
+    mount(<Jumbotron />).assertSingle('div');
+  });
 });

--- a/test/MediaSpec.js
+++ b/test/MediaSpec.js
@@ -15,4 +15,12 @@ describe('Media', () => {
   it('should allow custom elements instead of "div"', () => {
     mount(<Media as="section" />).assertSingle('section.media');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(Media.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have div as default component', () => {
+    mount(<Media />).assertSingle('div');
+  });
 });

--- a/test/MediaSpec.js
+++ b/test/MediaSpec.js
@@ -16,10 +16,6 @@ describe('Media', () => {
     mount(<Media as="section" />).assertSingle('section.media');
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(Media.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have div as default component', () => {
     mount(<Media />).assertSingle('div');
   });

--- a/test/NavItemSpec.js
+++ b/test/NavItemSpec.js
@@ -15,4 +15,12 @@ describe('<NavItem>', () => {
   it('should allow custom elements instead of "div"', () => {
     mount(<NavItem as="section" />).assertSingle('section.nav-item');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(NavItem.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have div as default component', () => {
+    mount(<NavItem />).assertSingle('div');
+  });
 });

--- a/test/NavItemSpec.js
+++ b/test/NavItemSpec.js
@@ -16,10 +16,6 @@ describe('<NavItem>', () => {
     mount(<NavItem as="section" />).assertSingle('section.nav-item');
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(NavItem.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have div as default component', () => {
     mount(<NavItem />).assertSingle('div');
   });

--- a/test/NavSpec.js
+++ b/test/NavSpec.js
@@ -202,6 +202,14 @@ describe('<Nav>', () => {
       expect(instance.prop('activeKey')).to.equal('5');
       expect(document.activeElement).to.equal(anchors.at(4).getDOMNode());
     });
+
+    it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+      expect(Nav.defaultProps.as).to.be.undefined;
+    });
+
+    it('Should have div as default component', () => {
+      mount(<Nav />).assertSingle('div');
+    });
   });
 
   describe('Web Accessibility', () => {

--- a/test/NavSpec.js
+++ b/test/NavSpec.js
@@ -203,10 +203,6 @@ describe('<Nav>', () => {
       expect(document.activeElement).to.equal(anchors.at(4).getDOMNode());
     });
 
-    it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-      expect(Nav.defaultProps.as).to.be.undefined;
-    });
-
     it('Should have div as default component', () => {
       mount(<Nav />).assertSingle('div');
     });

--- a/test/NavbarSpec.js
+++ b/test/NavbarSpec.js
@@ -223,4 +223,13 @@ describe('<Navbar>', () => {
     expect(selectSpy).to.be.calledOnce;
     expect(selectSpy).to.be.calledWith('#home');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(Navbar.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have nav as default component', () => {
+    const wrapper = mount(<Navbar />);
+    expect(wrapper.find('nav').length).to.equal(1);
+  });
 });

--- a/test/NavbarSpec.js
+++ b/test/NavbarSpec.js
@@ -224,10 +224,6 @@ describe('<Navbar>', () => {
     expect(selectSpy).to.be.calledWith('#home');
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(Navbar.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have nav as default component', () => {
     const wrapper = mount(<Navbar />);
     expect(wrapper.find('nav').length).to.equal(1);

--- a/test/NavbarToggleSpec.js
+++ b/test/NavbarToggleSpec.js
@@ -4,10 +4,6 @@ import { mount } from 'enzyme';
 import NavbarToggle from '../src/NavbarToggle';
 
 describe('<NavbarToggle>', () => {
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(NavbarToggle.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have button as default component', () => {
     mount(<NavbarToggle />).assertSingle('button');
   });

--- a/test/NavbarToggleSpec.js
+++ b/test/NavbarToggleSpec.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import NavbarToggle from '../src/NavbarToggle';
+
+describe('<NavbarToggle>', () => {
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(NavbarToggle.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have button as default component', () => {
+    mount(<NavbarToggle />).assertSingle('button');
+  });
+});

--- a/test/RowSpec.js
+++ b/test/RowSpec.js
@@ -15,4 +15,8 @@ describe('Row', () => {
   it('should allow custom elements instead of "div"', () => {
     mount(<Row as="section" />).assertSingle('section.row');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(Row.defaultProps.as).to.be.undefined;
+  });
 });

--- a/test/RowSpec.js
+++ b/test/RowSpec.js
@@ -15,8 +15,4 @@ describe('Row', () => {
   it('should allow custom elements instead of "div"', () => {
     mount(<Row as="section" />).assertSingle('section.row');
   });
-
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(Row.defaultProps.as).to.be.undefined;
-  });
 });

--- a/test/SafeAnchorSpec.js
+++ b/test/SafeAnchorSpec.js
@@ -120,10 +120,6 @@ describe('SafeAnchor', () => {
     ).to.not.exist;
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(SafeAnchor.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have a as default component', () => {
     mount(<SafeAnchor />).assertSingle('a');
   });

--- a/test/SafeAnchorSpec.js
+++ b/test/SafeAnchorSpec.js
@@ -119,4 +119,12 @@ describe('SafeAnchor', () => {
         .prop('role'),
     ).to.not.exist;
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(SafeAnchor.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have a as default component', () => {
+    mount(<SafeAnchor />).assertSingle('a');
+  });
 });

--- a/test/SpinnerSpec.js
+++ b/test/SpinnerSpec.js
@@ -27,4 +27,12 @@ describe('<Spinner>', () => {
       </Spinner>,
     ).assertSingle('div.spinner-grow span#testChild');
   });
+
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(Spinner.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have div as default component', () => {
+    mount(<Spinner animation="border" />).assertSingle('div');
+  });
 });

--- a/test/SpinnerSpec.js
+++ b/test/SpinnerSpec.js
@@ -28,10 +28,6 @@ describe('<Spinner>', () => {
     ).assertSingle('div.spinner-grow span#testChild');
   });
 
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(Spinner.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have div as default component', () => {
     mount(<Spinner animation="border" />).assertSingle('div');
   });

--- a/test/TabContentSpec.js
+++ b/test/TabContentSpec.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import TabContent from '../src/TabContent';
+
+describe('<TabContent>', () => {
+  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
+    expect(TabContent.defaultProps.as).to.be.undefined;
+  });
+
+  it('Should have div as default component', () => {
+    mount(<TabContent />).assertSingle('div');
+  });
+});

--- a/test/TabContentSpec.js
+++ b/test/TabContentSpec.js
@@ -4,10 +4,6 @@ import { mount } from 'enzyme';
 import TabContent from '../src/TabContent';
 
 describe('<TabContent>', () => {
-  it('Should define default "as" in prop destructuring instead of deafultProps', () => {
-    expect(TabContent.defaultProps.as).to.be.undefined;
-  });
-
   it('Should have div as default component', () => {
     mount(<TabContent />).assertSingle('div');
   });


### PR DESCRIPTION
Fix to #3595 based on the suggestion by @nguyenquyhy 
- Moved all defaultProps "as" to props destructuring instead of defaultProps
- Added tests for *most* instances
- - Tests that defaultProps doesn't contain "as"
- - Tests that the component still renders with the correct default element
- - I Decided to leave the defaultProps even if it's now empty.

For any component that uses createBootstrapComponent I either used or made a const for the returned object and added the defaultProps to that. For InputGroup for example I added the defaultProps to the DecoratedInputGroup, instead of to the InputGroup directly. Thats necessary to check if the class contains "as" in defaultProps. **Though I'm not sure if this is the best way!**

Any class that had the defaultProps set as a static member of the class, has been moved out of the class definition and defined as ClassName.defaultProps = {}

Didn't manage to get those tests to work with Carousel as setting defaultProps on the DecoratedCarousel lead to
` Uncaught Error: Warning: Failed prop type: You have provided a 'activeIndex' prop to 'Carousel' without an 'onSelect' handler prop. This will render a read-only field. If the field should be mutable use 'defaultActiveIndex'. Otherwise, set 'onSelect'.`

Didn't make the tests for AbstractNav either, but maybe that's fine?