### PR TITLE
fix(types): add bootstrap sizes for Form.Label as column

### DIFF
--- a/types/components/FormLabel.d.ts
+++ b/types/components/FormLabel.d.ts
@@ -17,7 +17,7 @@ export interface FormLabelWithColProps extends FormLabelBaseProps, ColProps {
   column: true;
 }
 
-export type FormLabelProps = FormLabelWithColProps|FormLabelOwnProps
+export type FormLabelProps = FormLabelWithColProps | FormLabelOwnProps
 
 declare class FormLabel extends BsPrefixComponent<'label', FormLabelProps> {}
 

--- a/types/components/FormLabel.d.ts
+++ b/types/components/FormLabel.d.ts
@@ -1,8 +1,9 @@
 import * as React from 'react';
 
 import { BsPrefixComponent } from './helpers';
+import { ColProps } from './Col';
 
-export interface FormLabelProps {
+export interface FormLabelProps extends ColProps {
   htmlFor?: string;
   column?: boolean;
   innerRef?: React.LegacyRef<this>;

--- a/types/components/FormLabel.d.ts
+++ b/types/components/FormLabel.d.ts
@@ -3,12 +3,21 @@ import * as React from 'react';
 import { BsPrefixComponent } from './helpers';
 import { ColProps } from './Col';
 
-export interface FormLabelProps extends ColProps {
+interface FormLabelBaseProps {
   htmlFor?: string;
-  column?: boolean;
   innerRef?: React.LegacyRef<this>;
   srOnly?: boolean;
 }
+
+export interface FormLabelOwnProps extends FormLabelBaseProps {
+  column?: false;
+}
+
+export interface FormLabelWithColProps extends FormLabelBaseProps, ColProps {
+  column: true;
+}
+
+export type FormLabelProps = FormLabelWithColProps|FormLabelOwnProps
 
 declare class FormLabel extends BsPrefixComponent<'label', FormLabelProps> {}
 

--- a/types/simple.test.tsx
+++ b/types/simple.test.tsx
@@ -175,7 +175,7 @@ import {
     </Form.Control>
   </Form.Group>
   <Form.Group controlId="exampleForm.ControlSelect2">
-    <Form.Label>Example multiple select</Form.Label>
+    <Form.Label column={false}>Example multiple select</Form.Label>
     <Form.Control as="select">
       <option>1</option>
       <option>2</option>
@@ -187,6 +187,14 @@ import {
   <Form.Group controlId="exampleForm.ControlTextarea1">
     <Form.Label>Example textarea</Form.Label>
     <Form.Control as="textarea" rows={3} />
+  </Form.Group>
+  <Form.Group as={Row} controlId="exampleForm.HorizontalControl">
+    <Form.Label column sm={2}>
+      Horizontal
+    </Form.Label>
+    <Col sm={10}>
+      <Form.Control type="text" placeholder="Hoizontal" />
+    </Col>
   </Form.Group>
 </Form>;
 


### PR DESCRIPTION
I'm not sure if just extending `FormLabelProps` with `ColProps` is the preferred way to solve this issue or if you would want something that actually enforces that the column size props are only valid when `column` is `true`.

I can make the typing stricter if that's preferred. It also seems like generally types aren't imported around and reused so if that's a problem I can copy them over completely from `Col.d.ts`