### PR TITLE
fix(types): add scrollable to ModalProps interface to match component

### DIFF
--- a/types/components/Modal.d.ts
+++ b/types/components/Modal.d.ts
@@ -27,6 +27,7 @@ export interface ModalProps extends TransitionCallbacks {
   show?: boolean;
   onHide?: () => void;
   container?: any;
+  scrollable?: boolean;
 }
 
 declare class Modal<


### PR DESCRIPTION
This is to resolve issue #3741 where the `Modal.d.ts` file is missing the `scrollable` flag in the `ModalProps` interface, while the `proptypes` for the component have the flag.