### PR TITLE
Fix alignRight type

### DIFF
--- a/types/components/DropdownMenu.d.ts
+++ b/types/components/DropdownMenu.d.ts
@@ -5,7 +5,7 @@ import { BsPrefixComponent, SelectCallback } from './helpers';
 export interface DropdownMenuProps {
   show?: true;
   flip?: true;
-  alignRight?: true;
+  alignRight?: boolean;
   onSelect?: SelectCallback;
   rootCloseEvent?: 'click' | 'mousedown';
   popperConfig?: object;

--- a/types/components/DropdownMenu.d.ts
+++ b/types/components/DropdownMenu.d.ts
@@ -3,8 +3,8 @@ import * as React from 'react';
 import { BsPrefixComponent, SelectCallback } from './helpers';
 
 export interface DropdownMenuProps {
-  show?: true;
-  flip?: true;
+  show?: boolean;
+  flip?: boolean;
   alignRight?: boolean;
   onSelect?: SelectCallback;
   rootCloseEvent?: 'click' | 'mousedown';


### PR DESCRIPTION
Change from `alignRight?: true` to `alignRight?: boolean`

PropTypes of `DropdownMenu` state that alignRight is a boolean and can be undefined (`alignRight: PropTypes.bool`) but the TypeScript definitions don't allow `false`. 
