### PR TITLE
docs(input-group): fix typo in description

### DIFF
--- a/www/src/pages/components/input-group.js
+++ b/www/src/pages/components/input-group.js
@@ -47,8 +47,8 @@ export default withLayout(function InputGroupSection({ data }) {
         Multiple inputs
       </LinkedHeading>
       <p>
-        While multiple inputs are supported visually, validation styles are
-        only available for input groups with a single input.
+        While multiple inputs are supported visually, validation styles are only
+        available for input groups with a single input.
       </p>
       <ReactPlayground codeText={MultipleInputs} />
       <LinkedHeading h="2" id="input-group-multiple-addons">

--- a/www/src/pages/components/input-group.js
+++ b/www/src/pages/components/input-group.js
@@ -47,7 +47,7 @@ export default withLayout(function InputGroupSection({ data }) {
         Multiple inputs
       </LinkedHeading>
       <p>
-        While multiple inputss are supported visually, validation styles are
+        While multiple inputs are supported visually, validation styles are
         only available for input groups with a single input.
       </p>
       <ReactPlayground codeText={MultipleInputs} />


### PR DESCRIPTION
Fix small typo in Forms -> input groups -> multiple inputs section

![Screen Shot 2019-06-03 at 1 03 26 PM](https://user-images.githubusercontent.com/5257160/58830895-38a57400-8600-11e9-8537-ff4be934af0c.png)
