### PR TITLE
Migrate doc examples to functional components

### DIFF
--- a/www/.eslintrc.js
+++ b/www/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
       rules: {
         'comma-dangle': 'off',
         'no-console': 'off',
+        'no-undef': 'off'
       },
     },
   ],

--- a/www/.eslintrc.js
+++ b/www/.eslintrc.js
@@ -32,7 +32,6 @@ module.exports = {
       rules: {
         'comma-dangle': 'off',
         'no-console': 'off',
-        'no-undef': 'off'
       },
     },
   ],

--- a/www/src/components/ReactPlayground.js
+++ b/www/src/components/ReactPlayground.js
@@ -3,7 +3,7 @@
 import classNames from 'classnames';
 import styled, { css } from 'astroturf';
 import qsa from 'dom-helpers/query/querySelectorAll';
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import * as ReactBootstrap from 'react-bootstrap';
@@ -21,6 +21,8 @@ import PlaceholderImage from './PlaceholderImage';
 import Sonnet from './Sonnet';
 
 const scope = {
+  useEffect,
+  useState,
   ...ReactBootstrap,
   ReactDOM,
   classNames,

--- a/www/src/components/ReactPlayground.js
+++ b/www/src/components/ReactPlayground.js
@@ -3,7 +3,7 @@
 import classNames from 'classnames';
 import styled, { css } from 'astroturf';
 import qsa from 'dom-helpers/query/querySelectorAll';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 import * as ReactBootstrap from 'react-bootstrap';
@@ -22,6 +22,7 @@ import Sonnet from './Sonnet';
 
 const scope = {
   useEffect,
+  useRef,
   useState,
   ...ReactBootstrap,
   ReactDOM,

--- a/www/src/examples/.eslintrc
+++ b/www/src/examples/.eslintrc
@@ -7,6 +7,9 @@
     "react/no-multi-comp": "off"
   },
   "globals": {
+    "useState": false,
+    "useEffect": false,
+    "useRef": false,
     "render": false,
     "classNames": false,
     "React": false,

--- a/www/src/examples/Alert/Dismissible.js
+++ b/www/src/examples/Alert/Dismissible.js
@@ -1,28 +1,19 @@
-class AlertDismissibleExample extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      show: true,
-    };
-  }
+function AlertDismissibleExample() {
+  const [show, setShow] = React.useState(true);
 
-  render() {
-    const handleDismiss = () => this.setState({ show: false });
-    const handleShow = () => this.setState({ show: true });
-    if (this.state.show) {
-      return (
-        <Alert variant="danger" onClose={handleDismiss} dismissible>
-          <Alert.Heading>Oh snap! You got an error!</Alert.Heading>
-          <p>
-            Change this and that and try again. Duis mollis, est non commodo
-            luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.
-            Cras mattis consectetur purus sit amet fermentum.
-          </p>
-        </Alert>
-      );
-    }
-    return <Button onClick={handleShow}>Show Alert</Button>;
+  if (show) {
+    return (
+      <Alert variant="danger" onClose={() => setShow(false)} dismissible>
+        <Alert.Heading>Oh snap! You got an error!</Alert.Heading>
+        <p>
+          Change this and that and try again. Duis mollis, est non commodo
+          luctus, nisi erat porttitor ligula, eget lacinia odio sem nec elit.
+          Cras mattis consectetur purus sit amet fermentum.
+        </p>
+      </Alert>
+    );
   }
+  return <Button onClick={() => setShow(true)}>Show Alert</Button>;
 }
 
 render(<AlertDismissibleExample />);

--- a/www/src/examples/Alert/Dismissible.js
+++ b/www/src/examples/Alert/Dismissible.js
@@ -1,5 +1,5 @@
 function AlertDismissibleExample() {
-  const [show, setShow] = React.useState(true);
+  const [show, setShow] = useState(true);
 
   if (show) {
     return (

--- a/www/src/examples/Alert/DismissibleControlled.js
+++ b/www/src/examples/Alert/DismissibleControlled.js
@@ -1,34 +1,26 @@
-class AlertDismissible extends React.Component {
-  constructor(props) {
-    super(props);
+function AlertDismissible() {
+  const [show, setShow] = React.useState(true);
 
-    this.state = { show: true };
-  }
+  return (
+    <>
+      <Alert show={show} variant="success">
+        <Alert.Heading>How's it going?!</Alert.Heading>
+        <p>
+          Duis mollis, est non commodo luctus, nisi erat porttitor ligula, eget
+          lacinia odio sem nec elit. Cras mattis consectetur purus sit amet
+          fermentum.
+        </p>
+        <hr />
+        <div className="d-flex justify-content-end">
+          <Button onClick={() => setShow(false)} variant="outline-success">
+            Close me ya'll!
+          </Button>
+        </div>
+      </Alert>
 
-  render() {
-    const handleHide = () => this.setState({ show: false });
-    const handleShow = () => this.setState({ show: true });
-    return (
-      <>
-        <Alert show={this.state.show} variant="success">
-          <Alert.Heading>How's it going?!</Alert.Heading>
-          <p>
-            Duis mollis, est non commodo luctus, nisi erat porttitor ligula,
-            eget lacinia odio sem nec elit. Cras mattis consectetur purus sit
-            amet fermentum.
-          </p>
-          <hr />
-          <div className="d-flex justify-content-end">
-            <Button onClick={handleHide} variant="outline-success">
-              Close me ya'll!
-            </Button>
-          </div>
-        </Alert>
-
-        {!this.state.show && <Button onClick={handleShow}>Show Alert</Button>}
-      </>
-    );
-  }
+      {!show && <Button onClick={() => setShow(true)}>Show Alert</Button>}
+    </>
+  );
 }
 
 render(<AlertDismissible />);

--- a/www/src/examples/Alert/DismissibleControlled.js
+++ b/www/src/examples/Alert/DismissibleControlled.js
@@ -1,5 +1,5 @@
 function AlertDismissible() {
-  const [show, setShow] = React.useState(true);
+  const [show, setShow] = useState(true);
 
   return (
     <>

--- a/www/src/examples/Button/Loading.js
+++ b/www/src/examples/Button/Loading.js
@@ -2,38 +2,28 @@ function simulateNetworkRequest() {
   return new Promise(resolve => setTimeout(resolve, 2000));
 }
 
-class LoadingButton extends React.Component {
-  constructor(props, context) {
-    super(props, context);
+function LoadingButton() {
+  const [isLoading, setLoading] = React.useState(false);
 
-    this.handleClick = this.handleClick.bind(this);
-
-    this.state = {
-      isLoading: false,
-    };
-  }
-
-  handleClick() {
-    this.setState({ isLoading: true }, () => {
+  React.useEffect(() => {
+    if (isLoading) {
       simulateNetworkRequest().then(() => {
-        this.setState({ isLoading: false });
+        setLoading(false);
       });
-    });
-  }
+    }
+  }, [isLoading]);
 
-  render() {
-    const { isLoading } = this.state;
+  const handleClick = () => setLoading(true);
 
-    return (
-      <Button
-        variant="primary"
-        disabled={isLoading}
-        onClick={!isLoading ? this.handleClick : null}
-      >
-        {isLoading ? 'Loading…' : 'Click to load'}
-      </Button>
-    );
-  }
+  return (
+    <Button
+      variant="primary"
+      disabled={isLoading}
+      onClick={!isLoading ? handleClick : null}
+    >
+      {isLoading ? 'Loading…' : 'Click to load'}
+    </Button>
+  );
 }
 
 render(<LoadingButton />);

--- a/www/src/examples/Button/Loading.js
+++ b/www/src/examples/Button/Loading.js
@@ -3,9 +3,9 @@ function simulateNetworkRequest() {
 }
 
 function LoadingButton() {
-  const [isLoading, setLoading] = React.useState(false);
+  const [isLoading, setLoading] = useState(false);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (isLoading) {
       simulateNetworkRequest().then(() => {
         setLoading(false);

--- a/www/src/examples/Button/ToggleButtonGroupControlled.js
+++ b/www/src/examples/Button/ToggleButtonGroupControlled.js
@@ -1,5 +1,5 @@
 function ToggleButtonGroupControlled() {
-  const [value, setValue] = React.useState([1, 3]);
+  const [value, setValue] = useState([1, 3]);
 
   const handleChange = val => setValue(val);
 

--- a/www/src/examples/Button/ToggleButtonGroupControlled.js
+++ b/www/src/examples/Button/ToggleButtonGroupControlled.js
@@ -1,7 +1,7 @@
 function ToggleButtonGroupControlled() {
   const [value, setValue] = useState([1, 3]);
 
-  const handleChange = val => setValue(val);
+  const handleChange = (val, event) => setValue(val);
 
   return (
     <ToggleButtonGroup type="checkbox" value={value} onChange={handleChange}>

--- a/www/src/examples/Button/ToggleButtonGroupControlled.js
+++ b/www/src/examples/Button/ToggleButtonGroupControlled.js
@@ -1,7 +1,13 @@
 function ToggleButtonGroupControlled() {
   const [value, setValue] = useState([1, 3]);
 
-  const handleChange = (val, event) => setValue(val);
+  /*
+   * The second argument that will be passed to
+   * `handleChange` from `ToggleButtonGroup`
+   * is the SyntheticEvent object, but we are
+   * not using it in this example so we will omit it.
+   */
+  const handleChange = val => setValue(val);
 
   return (
     <ToggleButtonGroup type="checkbox" value={value} onChange={handleChange}>

--- a/www/src/examples/Button/ToggleButtonGroupControlled.js
+++ b/www/src/examples/Button/ToggleButtonGroupControlled.js
@@ -1,31 +1,15 @@
-class ToggleButtonGroupControlled extends React.Component {
-  constructor(props, context) {
-    super(props, context);
+function ToggleButtonGroupControlled() {
+  const [value, setValue] = React.useState([1, 3]);
 
-    this.handleChange = this.handleChange.bind(this);
+  const handleChange = val => setValue(val);
 
-    this.state = {
-      value: [1, 3],
-    };
-  }
-
-  handleChange(value, event) {
-    this.setState({ value });
-  }
-
-  render() {
-    return (
-      <ToggleButtonGroup
-        type="checkbox"
-        value={this.state.value}
-        onChange={this.handleChange}
-      >
-        <ToggleButton value={1}>Option 1</ToggleButton>
-        <ToggleButton value={2}>Option 2</ToggleButton>
-        <ToggleButton value={3}>Option 3</ToggleButton>
-      </ToggleButtonGroup>
-    );
-  }
+  return (
+    <ToggleButtonGroup type="checkbox" value={value} onChange={handleChange}>
+      <ToggleButton value={1}>Option 1</ToggleButton>
+      <ToggleButton value={2}>Option 2</ToggleButton>
+      <ToggleButton value={3}>Option 3</ToggleButton>
+    </ToggleButtonGroup>
+  );
 }
 
 render(<ToggleButtonGroupControlled />);

--- a/www/src/examples/Carousel/Controlled.js
+++ b/www/src/examples/Carousel/Controlled.js
@@ -1,71 +1,57 @@
-class ControlledCarousel extends React.Component {
-  constructor(props, context) {
-    super(props, context);
+function ControlledCarousel() {
+  const [state, setState] = React.useState({ index: 0, direction: null });
 
-    this.handleSelect = this.handleSelect.bind(this);
-
-    this.state = {
-      index: 0,
-      direction: null,
-    };
-  }
-
-  handleSelect(selectedIndex, e) {
-    this.setState({
+  const handleSelect = (selectedIndex, e) =>
+    setState({
       index: selectedIndex,
       direction: e.direction,
     });
-  }
 
-  render() {
-    const { index, direction } = this.state;
+  return (
+    <Carousel
+      activeIndex={state.index}
+      direction={state.direction}
+      onSelect={handleSelect}
+    >
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=First slide&bg=373940"
+          alt="First slide"
+        />
+        <Carousel.Caption>
+          <h3>First slide label</h3>
+          <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
+        </Carousel.Caption>
+      </Carousel.Item>
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=Second slide&bg=282c34"
+          alt="Third slide"
+        />
 
-    return (
-      <Carousel
-        activeIndex={index}
-        direction={direction}
-        onSelect={this.handleSelect}
-      >
-        <Carousel.Item>
-          <img
-            className="d-block w-100"
-            src="holder.js/800x400?text=First slide&bg=373940"
-            alt="First slide"
-          />
-          <Carousel.Caption>
-            <h3>First slide label</h3>
-            <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
-          </Carousel.Caption>
-        </Carousel.Item>
-        <Carousel.Item>
-          <img
-            className="d-block w-100"
-            src="holder.js/800x400?text=Second slide&bg=282c34"
-            alt="Third slide"
-          />
+        <Carousel.Caption>
+          <h3>Second slide label</h3>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        </Carousel.Caption>
+      </Carousel.Item>
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=Third slide&bg=20232a"
+          alt="Third slide"
+        />
 
-          <Carousel.Caption>
-            <h3>Second slide label</h3>
-            <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-          </Carousel.Caption>
-        </Carousel.Item>
-        <Carousel.Item>
-          <img
-            className="d-block w-100"
-            src="holder.js/800x400?text=Third slide&bg=20232a"
-            alt="Third slide"
-          />
-
-          <Carousel.Caption>
-            <h3>Third slide label</h3>
-            <p>
-              Praesent commodo cursus magna, vel scelerisque nisl consectetur.
-            </p>
-          </Carousel.Caption>
-        </Carousel.Item>
-      </Carousel>
-    );
-  }
+        <Carousel.Caption>
+          <h3>Third slide label</h3>
+          <p>
+            Praesent commodo cursus magna, vel scelerisque nisl consectetur.
+          </p>
+        </Carousel.Caption>
+      </Carousel.Item>
+    </Carousel>
+  );
 }
 
 render(<ControlledCarousel />);

--- a/www/src/examples/Carousel/Controlled.js
+++ b/www/src/examples/Carousel/Controlled.js
@@ -1,18 +1,14 @@
 function ControlledCarousel() {
-  const [state, setState] = useState({ index: 0, direction: null });
+  const [index, setIndex] = useState(0);
+  const [direction, setDirection] = useState(null);
 
-  const handleSelect = (selectedIndex, e) =>
-    setState({
-      index: selectedIndex,
-      direction: e.direction,
-    });
+  const handleSelect = (selectedIndex, e) => {
+    setIndex(selectedIndex);
+    setDirection(e.direction);
+  };
 
   return (
-    <Carousel
-      activeIndex={state.index}
-      direction={state.direction}
-      onSelect={handleSelect}
-    >
+    <Carousel activeIndex={index} direction={direction} onSelect={handleSelect}>
       <Carousel.Item>
         <img
           className="d-block w-100"

--- a/www/src/examples/Carousel/Controlled.js
+++ b/www/src/examples/Carousel/Controlled.js
@@ -1,5 +1,5 @@
 function ControlledCarousel() {
-  const [state, setState] = React.useState({ index: 0, direction: null });
+  const [state, setState] = useState({ index: 0, direction: null });
 
   const handleSelect = (selectedIndex, e) =>
     setState({

--- a/www/src/examples/Collapse.js
+++ b/www/src/examples/Collapse.js
@@ -1,33 +1,24 @@
-class Example extends React.Component {
-  constructor(props, context) {
-    super(props, context);
+function Example() {
+  const [open, setOpen] = React.useState(false);
 
-    this.state = {
-      open: false,
-    };
-  }
-
-  render() {
-    const { open } = this.state;
-    return (
-      <>
-        <Button
-          onClick={() => this.setState({ open: !open })}
-          aria-controls="example-collapse-text"
-          aria-expanded={open}
-        >
-          click
-        </Button>
-        <Collapse in={this.state.open}>
-          <div id="example-collapse-text">
-            Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus
-            terry richardson ad squid. Nihil anim keffiyeh helvetica, craft beer
-            labore wes anderson cred nesciunt sapiente ea proident.
-          </div>
-        </Collapse>
-      </>
-    );
-  }
+  return (
+    <>
+      <Button
+        onClick={() => setOpen(!open)}
+        aria-controls="example-collapse-text"
+        aria-expanded={open}
+      >
+        click
+      </Button>
+      <Collapse in={open}>
+        <div id="example-collapse-text">
+          Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus
+          terry richardson ad squid. Nihil anim keffiyeh helvetica, craft beer
+          labore wes anderson cred nesciunt sapiente ea proident.
+        </div>
+      </Collapse>
+    </>
+  );
 }
 
 render(<Example />);

--- a/www/src/examples/Collapse.js
+++ b/www/src/examples/Collapse.js
@@ -1,5 +1,5 @@
 function Example() {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
 
   return (
     <>

--- a/www/src/examples/Fade.js
+++ b/www/src/examples/Fade.js
@@ -1,33 +1,24 @@
-class Example extends React.Component {
-  constructor(props, context) {
-    super(props, context);
+function Example() {
+  const [open, setOpen] = React.useState(false);
 
-    this.state = {
-      open: false,
-    };
-  }
-
-  render() {
-    const { open } = this.state;
-    return (
-      <>
-        <Button
-          onClick={() => this.setState({ open: !open })}
-          aria-controls="example-fade-text"
-          aria-expanded={open}
-        >
-          Toggle text
-        </Button>
-        <Fade in={this.state.open}>
-          <div id="example-fade-text">
-            Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus
-            terry richardson ad squid. Nihil anim keffiyeh helvetica, craft beer
-            labore wes anderson cred nesciunt sapiente ea proident.
-          </div>
-        </Fade>
-      </>
-    );
-  }
+  return (
+    <>
+      <Button
+        onClick={() => setOpen(!open)}
+        aria-controls="example-fade-text"
+        aria-expanded={open}
+      >
+        Toggle text
+      </Button>
+      <Fade in={open}>
+        <div id="example-fade-text">
+          Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus
+          terry richardson ad squid. Nihil anim keffiyeh helvetica, craft beer
+          labore wes anderson cred nesciunt sapiente ea proident.
+        </div>
+      </Fade>
+    </>
+  );
 }
 
 render(<Example />);

--- a/www/src/examples/Fade.js
+++ b/www/src/examples/Fade.js
@@ -1,5 +1,5 @@
 function Example() {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
 
   return (
     <>

--- a/www/src/examples/Form/ValidationNative.js
+++ b/www/src/examples/Form/ValidationNative.js
@@ -1,5 +1,5 @@
 function FormExample() {
-  const [validated, setValidated] = React.useState(false);
+  const [validated, setValidated] = useState(false);
 
   const handleSubmit = event => {
     const form = event.currentTarget;

--- a/www/src/examples/Form/ValidationNative.js
+++ b/www/src/examples/Form/ValidationNative.js
@@ -1,100 +1,90 @@
-class FormExample extends React.Component {
-  constructor(...args) {
-    super(...args);
+function FormExample() {
+  const [validated, setValidated] = React.useState(false);
 
-    this.state = { validated: false };
-  }
-
-  handleSubmit(event) {
+  const handleSubmit = event => {
     const form = event.currentTarget;
     if (form.checkValidity() === false) {
       event.preventDefault();
       event.stopPropagation();
     }
-    this.setState({ validated: true });
-  }
 
-  render() {
-    const { validated } = this.state;
-    return (
-      <Form
-        noValidate
-        validated={validated}
-        onSubmit={e => this.handleSubmit(e)}
-      >
-        <Form.Row>
-          <Form.Group as={Col} md="4" controlId="validationCustom01">
-            <Form.Label>First name</Form.Label>
-            <Form.Control
-              required
-              type="text"
-              placeholder="First name"
-              defaultValue="Mark"
-            />
-            <Form.Control.Feedback>Looks good!</Form.Control.Feedback>
-          </Form.Group>
-          <Form.Group as={Col} md="4" controlId="validationCustom02">
-            <Form.Label>Last name</Form.Label>
-            <Form.Control
-              required
-              type="text"
-              placeholder="Last name"
-              defaultValue="Otto"
-            />
-            <Form.Control.Feedback>Looks good!</Form.Control.Feedback>
-          </Form.Group>
-          <Form.Group as={Col} md="4" controlId="validationCustomUsername">
-            <Form.Label>Username</Form.Label>
-            <InputGroup>
-              <InputGroup.Prepend>
-                <InputGroup.Text id="inputGroupPrepend">@</InputGroup.Text>
-              </InputGroup.Prepend>
-              <Form.Control
-                type="text"
-                placeholder="Username"
-                aria-describedby="inputGroupPrepend"
-                required
-              />
-              <Form.Control.Feedback type="invalid">
-                Please choose a username.
-              </Form.Control.Feedback>
-            </InputGroup>
-          </Form.Group>
-        </Form.Row>
-        <Form.Row>
-          <Form.Group as={Col} md="6" controlId="validationCustom03">
-            <Form.Label>City</Form.Label>
-            <Form.Control type="text" placeholder="City" required />
-            <Form.Control.Feedback type="invalid">
-              Please provide a valid city.
-            </Form.Control.Feedback>
-          </Form.Group>
-          <Form.Group as={Col} md="3" controlId="validationCustom04">
-            <Form.Label>State</Form.Label>
-            <Form.Control type="text" placeholder="State" required />
-            <Form.Control.Feedback type="invalid">
-              Please provide a valid state.
-            </Form.Control.Feedback>
-          </Form.Group>
-          <Form.Group as={Col} md="3" controlId="validationCustom05">
-            <Form.Label>Zip</Form.Label>
-            <Form.Control type="text" placeholder="Zip" required />
-            <Form.Control.Feedback type="invalid">
-              Please provide a valid zip.
-            </Form.Control.Feedback>
-          </Form.Group>
-        </Form.Row>
-        <Form.Group>
-          <Form.Check
+    setValidated(true);
+  };
+
+  return (
+    <Form noValidate validated={validated} onSubmit={handleSubmit}>
+      <Form.Row>
+        <Form.Group as={Col} md="4" controlId="validationCustom01">
+          <Form.Label>First name</Form.Label>
+          <Form.Control
             required
-            label="Agree to terms and conditions"
-            feedback="You must agree before submitting."
+            type="text"
+            placeholder="First name"
+            defaultValue="Mark"
           />
+          <Form.Control.Feedback>Looks good!</Form.Control.Feedback>
         </Form.Group>
-        <Button type="submit">Submit form</Button>
-      </Form>
-    );
-  }
+        <Form.Group as={Col} md="4" controlId="validationCustom02">
+          <Form.Label>Last name</Form.Label>
+          <Form.Control
+            required
+            type="text"
+            placeholder="Last name"
+            defaultValue="Otto"
+          />
+          <Form.Control.Feedback>Looks good!</Form.Control.Feedback>
+        </Form.Group>
+        <Form.Group as={Col} md="4" controlId="validationCustomUsername">
+          <Form.Label>Username</Form.Label>
+          <InputGroup>
+            <InputGroup.Prepend>
+              <InputGroup.Text id="inputGroupPrepend">@</InputGroup.Text>
+            </InputGroup.Prepend>
+            <Form.Control
+              type="text"
+              placeholder="Username"
+              aria-describedby="inputGroupPrepend"
+              required
+            />
+            <Form.Control.Feedback type="invalid">
+              Please choose a username.
+            </Form.Control.Feedback>
+          </InputGroup>
+        </Form.Group>
+      </Form.Row>
+      <Form.Row>
+        <Form.Group as={Col} md="6" controlId="validationCustom03">
+          <Form.Label>City</Form.Label>
+          <Form.Control type="text" placeholder="City" required />
+          <Form.Control.Feedback type="invalid">
+            Please provide a valid city.
+          </Form.Control.Feedback>
+        </Form.Group>
+        <Form.Group as={Col} md="3" controlId="validationCustom04">
+          <Form.Label>State</Form.Label>
+          <Form.Control type="text" placeholder="State" required />
+          <Form.Control.Feedback type="invalid">
+            Please provide a valid state.
+          </Form.Control.Feedback>
+        </Form.Group>
+        <Form.Group as={Col} md="3" controlId="validationCustom05">
+          <Form.Label>Zip</Form.Label>
+          <Form.Control type="text" placeholder="Zip" required />
+          <Form.Control.Feedback type="invalid">
+            Please provide a valid zip.
+          </Form.Control.Feedback>
+        </Form.Group>
+      </Form.Row>
+      <Form.Group>
+        <Form.Check
+          required
+          label="Agree to terms and conditions"
+          feedback="You must agree before submitting."
+        />
+      </Form.Group>
+      <Button type="submit">Submit form</Button>
+    </Form>
+  );
 }
 
 render(<FormExample />);

--- a/www/src/examples/Modal/Basic.js
+++ b/www/src/examples/Modal/Basic.js
@@ -1,47 +1,31 @@
-class Example extends React.Component {
-  constructor(props, context) {
-    super(props, context);
+function Example() {
+  const [show, setShow] = React.useState(false);
 
-    this.handleShow = this.handleShow.bind(this);
-    this.handleClose = this.handleClose.bind(this);
+  const handleClose = () => setShow(false);
+  const handleShow = () => setShow(true);
 
-    this.state = {
-      show: false,
-    };
-  }
+  return (
+    <>
+      <Button variant="primary" onClick={handleShow}>
+        Launch demo modal
+      </Button>
 
-  handleClose() {
-    this.setState({ show: false });
-  }
-
-  handleShow() {
-    this.setState({ show: true });
-  }
-
-  render() {
-    return (
-      <>
-        <Button variant="primary" onClick={this.handleShow}>
-          Launch demo modal
-        </Button>
-
-        <Modal show={this.state.show} onHide={this.handleClose}>
-          <Modal.Header closeButton>
-            <Modal.Title>Modal heading</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>Woohoo, you're reading this text in a modal!</Modal.Body>
-          <Modal.Footer>
-            <Button variant="secondary" onClick={this.handleClose}>
-              Close
-            </Button>
-            <Button variant="primary" onClick={this.handleClose}>
-              Save Changes
-            </Button>
-          </Modal.Footer>
-        </Modal>
-      </>
-    );
-  }
+      <Modal show={show} onHide={handleClose}>
+        <Modal.Header closeButton>
+          <Modal.Title>Modal heading</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>Woohoo, you're reading this text in a modal!</Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleClose}>
+            Close
+          </Button>
+          <Button variant="primary" onClick={handleClose}>
+            Save Changes
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
 }
 
 render(<Example />);

--- a/www/src/examples/Modal/Basic.js
+++ b/www/src/examples/Modal/Basic.js
@@ -1,5 +1,5 @@
 function Example() {
-  const [show, setShow] = React.useState(false);
+  const [show, setShow] = useState(false);
 
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);

--- a/www/src/examples/Modal/CustomSizing.js
+++ b/www/src/examples/Modal/CustomSizing.js
@@ -1,53 +1,37 @@
-class Example extends React.Component {
-  constructor(props, context) {
-    super(props, context);
+function Example() {
+  const [show, setShow] = React.useState(false);
 
-    this.state = {
-      show: false,
-    };
+  return (
+    <>
+      <Button variant="primary" onClick={() => setShow(true)}>
+        Custom Width Modal
+      </Button>
 
-    this.handleShow = () => {
-      this.setState({ show: true });
-    };
-
-    this.handleHide = () => {
-      this.setState({ show: false });
-    };
-  }
-
-  render() {
-    return (
-      <>
-        <Button variant="primary" onClick={this.handleShow}>
-          Custom Width Modal
-        </Button>
-
-        <Modal
-          show={this.state.show}
-          onHide={this.handleHide}
-          dialogClassName="modal-90w"
-          aria-labelledby="example-custom-modal-styling-title"
-        >
-          <Modal.Header closeButton>
-            <Modal.Title id="example-custom-modal-styling-title">
-              Custom Modal Styling
-            </Modal.Title>
-          </Modal.Header>
-          <Modal.Body>
-            <p>
-              Ipsum molestiae natus adipisci modi eligendi? Debitis amet quae
-              unde commodi aspernatur enim, consectetur. Cumque deleniti
-              temporibus ipsam atque a dolores quisquam quisquam adipisci
-              possimus laboriosam. Quibusdam facilis doloribus debitis! Sit
-              quasi quod accusamus eos quod. Ab quos consequuntur eaque quo rem!
-              Mollitia reiciendis porro quo magni incidunt dolore amet atque
-              facilis ipsum deleniti rem!
-            </p>
-          </Modal.Body>
-        </Modal>
-      </>
-    );
-  }
+      <Modal
+        show={show}
+        onHide={() => setShow(false)}
+        dialogClassName="modal-90w"
+        aria-labelledby="example-custom-modal-styling-title"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title id="example-custom-modal-styling-title">
+            Custom Modal Styling
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <p>
+            Ipsum molestiae natus adipisci modi eligendi? Debitis amet quae unde
+            commodi aspernatur enim, consectetur. Cumque deleniti temporibus
+            ipsam atque a dolores quisquam quisquam adipisci possimus
+            laboriosam. Quibusdam facilis doloribus debitis! Sit quasi quod
+            accusamus eos quod. Ab quos consequuntur eaque quo rem! Mollitia
+            reiciendis porro quo magni incidunt dolore amet atque facilis ipsum
+            deleniti rem!
+          </p>
+        </Modal.Body>
+      </Modal>
+    </>
+  );
 }
 
 render(<Example />);

--- a/www/src/examples/Modal/CustomSizing.js
+++ b/www/src/examples/Modal/CustomSizing.js
@@ -1,5 +1,5 @@
 function Example() {
-  const [show, setShow] = React.useState(false);
+  const [show, setShow] = useState(false);
 
   return (
     <>

--- a/www/src/examples/Modal/DefaultSizing.js
+++ b/www/src/examples/Modal/DefaultSizing.js
@@ -1,6 +1,6 @@
 function Example() {
-  const [smShow, setSmShow] = React.useState(false);
-  const [lgShow, setLgShow] = React.useState(false);
+  const [smShow, setSmShow] = useState(false);
+  const [lgShow, setLgShow] = useState(false);
 
   return (
     <ButtonToolbar>

--- a/www/src/examples/Modal/DefaultSizing.js
+++ b/www/src/examples/Modal/DefaultSizing.js
@@ -1,56 +1,41 @@
-class Example extends React.Component {
-  constructor(props, context) {
-    super(props, context);
+function Example() {
+  const [smShow, setSmShow] = React.useState(false);
+  const [lgShow, setLgShow] = React.useState(false);
 
-    this.state = {
-      smShow: false,
-      lgShow: false,
-    };
-  }
+  return (
+    <ButtonToolbar>
+      <Button onClick={() => setSmShow(true)}>Small modal</Button>
+      <Button onClick={() => setLgShow(true)}>Large modal</Button>
 
-  render() {
-    let smClose = () => this.setState({ smShow: false });
-    let lgClose = () => this.setState({ lgShow: false });
+      <Modal
+        size="sm"
+        show={smShow}
+        onHide={() => setSmShow(false)}
+        aria-labelledby="example-modal-sizes-title-sm"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title id="example-modal-sizes-title-sm">
+            Small Modal
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>...</Modal.Body>
+      </Modal>
 
-    return (
-      <ButtonToolbar>
-        <Button onClick={() => this.setState({ smShow: true })}>
-          Small modal
-        </Button>
-        <Button onClick={() => this.setState({ lgShow: true })}>
-          Large modal
-        </Button>
-
-        <Modal
-          size="sm"
-          show={this.state.smShow}
-          onHide={smClose}
-          aria-labelledby="example-modal-sizes-title-sm"
-        >
-          <Modal.Header closeButton>
-            <Modal.Title id="example-modal-sizes-title-sm">
-              Small Modal
-            </Modal.Title>
-          </Modal.Header>
-          <Modal.Body>...</Modal.Body>
-        </Modal>
-
-        <Modal
-          size="lg"
-          show={this.state.lgShow}
-          onHide={lgClose}
-          aria-labelledby="example-modal-sizes-title-lg"
-        >
-          <Modal.Header closeButton>
-            <Modal.Title id="example-modal-sizes-title-lg">
-              Large Modal
-            </Modal.Title>
-          </Modal.Header>
-          <Modal.Body>...</Modal.Body>
-        </Modal>
-      </ButtonToolbar>
-    );
-  }
+      <Modal
+        size="lg"
+        show={lgShow}
+        onHide={() => setLgShow(false)}
+        aria-labelledby="example-modal-sizes-title-lg"
+      >
+        <Modal.Header closeButton>
+          <Modal.Title id="example-modal-sizes-title-lg">
+            Large Modal
+          </Modal.Title>
+        </Modal.Header>
+        <Modal.Body>...</Modal.Body>
+      </Modal>
+    </ButtonToolbar>
+  );
 }
 
 render(<Example />);

--- a/www/src/examples/Modal/Grid.js
+++ b/www/src/examples/Modal/Grid.js
@@ -38,7 +38,7 @@ function MydModalWithGrid(props) {
 }
 
 function App() {
-  const [modalShow, setModalShow] = React.useState(false);
+  const [modalShow, setModalShow] = useState(false);
 
   return (
     <ButtonToolbar>

--- a/www/src/examples/Modal/Grid.js
+++ b/www/src/examples/Modal/Grid.js
@@ -1,67 +1,54 @@
-class MydModalWithGrid extends React.Component {
-  render() {
-    return (
-      <Modal {...this.props} aria-labelledby="contained-modal-title-vcenter">
-        <Modal.Header closeButton>
-          <Modal.Title id="contained-modal-title-vcenter">
-            Using Grid in Modal
-          </Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <Container>
-            <Row className="show-grid">
-              <Col xs={12} md={8}>
-                <code>.col-xs-12 .col-md-8</code>
-              </Col>
-              <Col xs={6} md={4}>
-                <code>.col-xs-6 .col-md-4</code>
-              </Col>
-            </Row>
+function MydModalWithGrid(props) {
+  return (
+    <Modal {...props} aria-labelledby="contained-modal-title-vcenter">
+      <Modal.Header closeButton>
+        <Modal.Title id="contained-modal-title-vcenter">
+          Using Grid in Modal
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Container>
+          <Row className="show-grid">
+            <Col xs={12} md={8}>
+              <code>.col-xs-12 .col-md-8</code>
+            </Col>
+            <Col xs={6} md={4}>
+              <code>.col-xs-6 .col-md-4</code>
+            </Col>
+          </Row>
 
-            <Row className="show-grid">
-              <Col xs={6} md={4}>
-                <code>.col-xs-6 .col-md-4</code>
-              </Col>
-              <Col xs={6} md={4}>
-                <code>.col-xs-6 .col-md-4</code>
-              </Col>
-              <Col xs={6} md={4}>
-                <code>.col-xs-6 .col-md-4</code>
-              </Col>
-            </Row>
-          </Container>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button onClick={this.props.onHide}>Close</Button>
-        </Modal.Footer>
-      </Modal>
-    );
-  }
+          <Row className="show-grid">
+            <Col xs={6} md={4}>
+              <code>.col-xs-6 .col-md-4</code>
+            </Col>
+            <Col xs={6} md={4}>
+              <code>.col-xs-6 .col-md-4</code>
+            </Col>
+            <Col xs={6} md={4}>
+              <code>.col-xs-6 .col-md-4</code>
+            </Col>
+          </Row>
+        </Container>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button onClick={props.onHide}>Close</Button>
+      </Modal.Footer>
+    </Modal>
+  );
 }
 
-class App extends React.Component {
-  constructor(...args) {
-    super(...args);
+function App() {
+  const [modalShow, setModalShow] = React.useState(false);
 
-    this.state = { modalShow: false };
-  }
+  return (
+    <ButtonToolbar>
+      <Button variant="primary" onClick={() => setModalShow(true)}>
+        Launch modal with grid
+      </Button>
 
-  render() {
-    let modalClose = () => this.setState({ modalShow: false });
-
-    return (
-      <ButtonToolbar>
-        <Button
-          variant="primary"
-          onClick={() => this.setState({ modalShow: true })}
-        >
-          Launch modal with grid
-        </Button>
-
-        <MydModalWithGrid show={this.state.modalShow} onHide={modalClose} />
-      </ButtonToolbar>
-    );
-  }
+      <MydModalWithGrid show={modalShow} onHide={() => setModalShow(false)} />
+    </ButtonToolbar>
+  );
 }
 
 render(<App />);

--- a/www/src/examples/Modal/VerticallyCentered.js
+++ b/www/src/examples/Modal/VerticallyCentered.js
@@ -1,59 +1,46 @@
-class MyVerticallyCenteredModal extends React.Component {
-  render() {
-    return (
-      <Modal
-        {...this.props}
-        size="lg"
-        aria-labelledby="contained-modal-title-vcenter"
-        centered
-      >
-        <Modal.Header closeButton>
-          <Modal.Title id="contained-modal-title-vcenter">
-            Modal heading
-          </Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <h4>Centered Modal</h4>
-          <p>
-            Cras mattis consectetur purus sit amet fermentum. Cras justo odio,
-            dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta
-            ac consectetur ac, vestibulum at eros.
-          </p>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button onClick={this.props.onHide}>Close</Button>
-        </Modal.Footer>
-      </Modal>
-    );
-  }
+function MyVerticallyCenteredModal(props) {
+  return (
+    <Modal
+      {...props}
+      size="lg"
+      aria-labelledby="contained-modal-title-vcenter"
+      centered
+    >
+      <Modal.Header closeButton>
+        <Modal.Title id="contained-modal-title-vcenter">
+          Modal heading
+        </Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <h4>Centered Modal</h4>
+        <p>
+          Cras mattis consectetur purus sit amet fermentum. Cras justo odio,
+          dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac
+          consectetur ac, vestibulum at eros.
+        </p>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button onClick={props.onHide}>Close</Button>
+      </Modal.Footer>
+    </Modal>
+  );
 }
 
-class App extends React.Component {
-  constructor(...args) {
-    super(...args);
+function App() {
+  const [modalShow, setModalShow] = React.useState(false);
 
-    this.state = { modalShow: false };
-  }
+  return (
+    <ButtonToolbar>
+      <Button variant="primary" onClick={() => setModalShow(true)}>
+        Launch vertically centered modal
+      </Button>
 
-  render() {
-    let modalClose = () => this.setState({ modalShow: false });
-
-    return (
-      <ButtonToolbar>
-        <Button
-          variant="primary"
-          onClick={() => this.setState({ modalShow: true })}
-        >
-          Launch vertically centered modal
-        </Button>
-
-        <MyVerticallyCenteredModal
-          show={this.state.modalShow}
-          onHide={modalClose}
-        />
-      </ButtonToolbar>
-    );
-  }
+      <MyVerticallyCenteredModal
+        show={modalShow}
+        onHide={() => setModalShow(false)}
+      />
+    </ButtonToolbar>
+  );
 }
 
 render(<App />);

--- a/www/src/examples/Nav/Dropdown.js
+++ b/www/src/examples/Nav/Dropdown.js
@@ -1,38 +1,32 @@
-class NavDropdownExample extends React.Component {
-  handleSelect(eventKey) {
-    alert(`selected ${eventKey}`);
-  }
+function NavDropdownExample() {
+  const handleSelect = eventKey => alert(`selected ${eventKey}`);
 
-  render() {
-    return (
-      <Nav variant="pills" activeKey="1" onSelect={k => this.handleSelect(k)}>
-        <Nav.Item>
-          <Nav.Link eventKey="1" href="#/home">
-            NavLink 1 content
-          </Nav.Link>
-        </Nav.Item>
-        <Nav.Item>
-          <Nav.Link eventKey="2" title="Item">
-            NavLink 2 content
-          </Nav.Link>
-        </Nav.Item>
-        <Nav.Item>
-          <Nav.Link eventKey="3" disabled>
-            NavLink 3 content
-          </Nav.Link>
-        </Nav.Item>
-        <NavDropdown title="Dropdown" id="nav-dropdown">
-          <NavDropdown.Item eventKey="4.1">Action</NavDropdown.Item>
-          <NavDropdown.Item eventKey="4.2">Another action</NavDropdown.Item>
-          <NavDropdown.Item eventKey="4.3">
-            Something else here
-          </NavDropdown.Item>
-          <NavDropdown.Divider />
-          <NavDropdown.Item eventKey="4.4">Separated link</NavDropdown.Item>
-        </NavDropdown>
-      </Nav>
-    );
-  }
+  return (
+    <Nav variant="pills" activeKey="1" onSelect={handleSelect}>
+      <Nav.Item>
+        <Nav.Link eventKey="1" href="#/home">
+          NavLink 1 content
+        </Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="2" title="Item">
+          NavLink 2 content
+        </Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="3" disabled>
+          NavLink 3 content
+        </Nav.Link>
+      </Nav.Item>
+      <NavDropdown title="Dropdown" id="nav-dropdown">
+        <NavDropdown.Item eventKey="4.1">Action</NavDropdown.Item>
+        <NavDropdown.Item eventKey="4.2">Another action</NavDropdown.Item>
+        <NavDropdown.Item eventKey="4.3">Something else here</NavDropdown.Item>
+        <NavDropdown.Divider />
+        <NavDropdown.Item eventKey="4.4">Separated link</NavDropdown.Item>
+      </NavDropdown>
+    </Nav>
+  );
 }
 
 render(<NavDropdownExample />);

--- a/www/src/examples/Overlays/Overlay.js
+++ b/www/src/examples/Overlays/Overlay.js
@@ -1,50 +1,39 @@
-class Example extends React.Component {
-  constructor(...args) {
-    super(...args);
+function Example() {
+  const [show, setShow] = React.useState(false);
+  const [target, setTarget] = React.useState(null);
 
-    this.attachRef = target => this.setState({ target });
-    this.state = {
-      show: false,
-    };
-  }
+  const attachRef = targ => setTarget(targ);
 
-  render() {
-    const { show, target } = this.state;
-    return (
-      <>
-        <Button
-          variant="danger"
-          ref={this.attachRef}
-          onClick={() => this.setState({ show: !show })}
-        >
-          Click me to see
-        </Button>
-        <Overlay target={target} show={show} placement="right">
-          {({
-            placement,
-            scheduleUpdate,
-            arrowProps,
-            outOfBoundaries,
-            show: _show,
-            ...props
-          }) => (
-            <div
-              {...props}
-              style={{
-                backgroundColor: 'rgba(255, 100, 100, 0.85)',
-                padding: '2px 10px',
-                color: 'white',
-                borderRadius: 3,
-                ...props.style,
-              }}
-            >
-              Simple tooltip
-            </div>
-          )}
-        </Overlay>
-      </>
-    );
-  }
+  return (
+    <>
+      <Button variant="danger" ref={attachRef} onClick={() => setShow(!show)}>
+        Click me to see
+      </Button>
+      <Overlay target={target} show={show} placement="right">
+        {({
+          placement,
+          scheduleUpdate,
+          arrowProps,
+          outOfBoundaries,
+          show: _show,
+          ...props
+        }) => (
+          <div
+            {...props}
+            style={{
+              backgroundColor: 'rgba(255, 100, 100, 0.85)',
+              padding: '2px 10px',
+              color: 'white',
+              borderRadius: 3,
+              ...props.style,
+            }}
+          >
+            Simple tooltip
+          </div>
+        )}
+      </Overlay>
+    </>
+  );
 }
 
 render(<Example />);

--- a/www/src/examples/Overlays/Overlay.js
+++ b/www/src/examples/Overlays/Overlay.js
@@ -1,6 +1,6 @@
 function Example() {
-  const [show, setShow] = React.useState(false);
-  const [target, setTarget] = React.useState(null);
+  const [show, setShow] = useState(false);
+  const [target, setTarget] = useState(null);
 
   const attachRef = targ => setTarget(targ);
 

--- a/www/src/examples/Overlays/Overlay.js
+++ b/www/src/examples/Overlays/Overlay.js
@@ -1,15 +1,13 @@
 function Example() {
   const [show, setShow] = useState(false);
-  const [target, setTarget] = useState(null);
-
-  const attachRef = targ => setTarget(targ);
+  const target = useRef(null);
 
   return (
     <>
-      <Button variant="danger" ref={attachRef} onClick={() => setShow(!show)}>
+      <Button variant="danger" ref={target} onClick={() => setShow(!show)}>
         Click me to see
       </Button>
-      <Overlay target={target} show={show} placement="right">
+      <Overlay target={target.current} show={show} placement="right">
         {({
           placement,
           scheduleUpdate,

--- a/www/src/examples/Overlays/PopoverContained.js
+++ b/www/src/examples/Overlays/PopoverContained.js
@@ -1,38 +1,33 @@
-class Example extends React.Component {
-  constructor(props, context) {
-    super(props, context);
+function Example() {
+  const [show, setShow] = useState(false);
+  const [target, setTarget] = useState(null);
+  const ref = useRef(null);
 
-    this.handleClick = ({ target }) => {
-      this.setState(s => ({ target, show: !s.show }));
-    };
+  const handleClick = ({ targ }) => {
+    setShow(!show);
+    setTarget(targ);
+  };
 
-    this.state = {
-      show: false,
-    };
-  }
+  return (
+    <ButtonToolbar ref={ref}>
+      <Button onClick={handleClick}>Holy guacamole!</Button>
 
-  render() {
-    return (
-      <ButtonToolbar>
-        <Button onClick={this.handleClick}>Holy guacamole!</Button>
-
-        <Overlay
-          show={this.state.show}
-          target={this.state.target}
-          placement="bottom"
-          container={this}
-          containerPadding={20}
-        >
-          <Popover id="popover-contained">
-            <Popover.Title as="h3">Popover bottom</Popover.Title>
-            <Popover.Content>
-              <strong>Holy guacamole!</strong> Check this info.
-            </Popover.Content>
-          </Popover>
-        </Overlay>
-      </ButtonToolbar>
-    );
-  }
+      <Overlay
+        show={show}
+        target={target}
+        placement="bottom"
+        container={ref.current}
+        containerPadding={20}
+      >
+        <Popover id="popover-contained">
+          <Popover.Title as="h3">Popover bottom</Popover.Title>
+          <Popover.Content>
+            <strong>Holy guacamole!</strong> Check this info.
+          </Popover.Content>
+        </Popover>
+      </Overlay>
+    </ButtonToolbar>
+  );
 }
 
 render(<Example />);

--- a/www/src/examples/Overlays/ScheduleUpdate.js
+++ b/www/src/examples/Overlays/ScheduleUpdate.js
@@ -1,15 +1,16 @@
-class UpdatingPopover extends React.Component {
-  componentDidUpdate(prevProps) {
-    if (prevProps.children !== this.props.children) {
+const UpdatingPopover = React.forwardRef(
+  ({ scheduleUpdate, children, ...props }, ref) => {
+    useEffect(() => {
       console.log('updating!');
-      this.props.scheduleUpdate();
-    }
-  }
-
-  render() {
-    return <Popover {...this.props} />;
-  }
-}
+      scheduleUpdate();
+    }, [children, scheduleUpdate]);
+    return (
+      <Popover ref={ref} {...props}>
+        {children}
+      </Popover>
+    );
+  },
+);
 
 const longContent = `
   Very long

--- a/www/src/examples/Overlays/ScheduleUpdate.js
+++ b/www/src/examples/Overlays/ScheduleUpdate.js
@@ -19,9 +19,9 @@ const longContent = `
 const shortContent = 'Short and sweet!';
 
 function Example() {
-  const [content, setContent] = React.useState(shortContent);
+  const [content, setContent] = useState(shortContent);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const timerId = setInterval(() => {
       setContent(content === shortContent ? longContent : shortContent);
     }, 3000);

--- a/www/src/examples/Overlays/ScheduleUpdate.js
+++ b/www/src/examples/Overlays/ScheduleUpdate.js
@@ -18,34 +18,27 @@ const longContent = `
 `;
 const shortContent = 'Short and sweet!';
 
-class Example extends React.Component {
-  constructor(props, context) {
-    super(props, context);
-    this.state = { content: shortContent };
-  }
+function Example() {
+  const [content, setContent] = React.useState(shortContent);
 
-  componentDidMount() {
-    this.timer = setInterval(() => {
-      this.setState(state => ({
-        content: state.content === shortContent ? longContent : shortContent,
-      }));
+  React.useEffect(() => {
+    const timerId = setInterval(() => {
+      setContent(content === shortContent ? longContent : shortContent);
     }, 3000);
-  }
 
-  render() {
-    const { content } = this.state;
+    return () => clearInterval(timerId);
+  });
 
-    return (
-      <OverlayTrigger
-        trigger="click"
-        overlay={
-          <UpdatingPopover id="popover-contained">{content}</UpdatingPopover>
-        }
-      >
-        <Button onClick={this.handleClick}>Holy guacamole!</Button>
-      </OverlayTrigger>
-    );
-  }
+  return (
+    <OverlayTrigger
+      trigger="click"
+      overlay={
+        <UpdatingPopover id="popover-contained">{content}</UpdatingPopover>
+      }
+    >
+      <Button>Holy guacamole!</Button>
+    </OverlayTrigger>
+  );
 }
 
 render(<Example />);

--- a/www/src/examples/Overlays/TooltipOverlay.js
+++ b/www/src/examples/Overlays/TooltipOverlay.js
@@ -1,31 +1,23 @@
-class Example extends React.Component {
-  constructor(...args) {
-    super(...args);
+function Example() {
+  const [show, setShow] = React.useState(false);
+  const [target, setTarget] = React.useState(null);
 
-    this.attachRef = target => this.setState({ target });
-    this.state = { show: false };
-  }
+  const attachRef = targ => setTarget(targ);
 
-  render() {
-    const { show, target } = this.state;
-    return (
-      <>
-        <Button
-          ref={this.attachRef}
-          onClick={() => this.setState({ show: !show })}
-        >
-          Click me!
-        </Button>
-        <Overlay target={target} show={show} placement="right">
-          {props => (
-            <Tooltip id="overlay-example" {...props}>
-              My Tooltip
-            </Tooltip>
-          )}
-        </Overlay>
-      </>
-    );
-  }
+  return (
+    <>
+      <Button ref={attachRef} onClick={() => setShow(!show)}>
+        Click me!
+      </Button>
+      <Overlay target={target} show={show} placement="right">
+        {props => (
+          <Tooltip id="overlay-example" {...props}>
+            My Tooltip
+          </Tooltip>
+        )}
+      </Overlay>
+    </>
+  );
 }
 
 render(<Example />);

--- a/www/src/examples/Overlays/TooltipOverlay.js
+++ b/www/src/examples/Overlays/TooltipOverlay.js
@@ -1,15 +1,13 @@
 function Example() {
   const [show, setShow] = useState(false);
-  const [target, setTarget] = useState(null);
-
-  const attachRef = targ => setTarget(targ);
+  const target = useRef(null);
 
   return (
     <>
-      <Button ref={attachRef} onClick={() => setShow(!show)}>
+      <Button ref={target} onClick={() => setShow(!show)}>
         Click me!
       </Button>
-      <Overlay target={target} show={show} placement="right">
+      <Overlay target={target.current} show={show} placement="right">
         {props => (
           <Tooltip id="overlay-example" {...props}>
             My Tooltip

--- a/www/src/examples/Overlays/TooltipOverlay.js
+++ b/www/src/examples/Overlays/TooltipOverlay.js
@@ -1,6 +1,6 @@
 function Example() {
-  const [show, setShow] = React.useState(false);
-  const [target, setTarget] = React.useState(null);
+  const [show, setShow] = useState(false);
+  const [target, setTarget] = useState(null);
 
   const attachRef = targ => setTarget(targ);
 

--- a/www/src/examples/Tabs/Controlled.js
+++ b/www/src/examples/Tabs/Controlled.js
@@ -1,5 +1,5 @@
 function ControlledTabs() {
-  const [key, setKey] = React.useState('home');
+  const [key, setKey] = useState('home');
 
   return (
     <Tabs id="controlled-tab-example" activeKey={key} onSelect={k => setKey(k)}>

--- a/www/src/examples/Tabs/Controlled.js
+++ b/www/src/examples/Tabs/Controlled.js
@@ -1,30 +1,19 @@
-class ControlledTabs extends React.Component {
-  constructor(props, context) {
-    super(props, context);
-    this.state = {
-      key: 'home',
-    };
-  }
+function ControlledTabs() {
+  const [key, setKey] = React.useState('home');
 
-  render() {
-    return (
-      <Tabs
-        id="controlled-tab-example"
-        activeKey={this.state.key}
-        onSelect={key => this.setState({ key })}
-      >
-        <Tab eventKey="home" title="Home">
-          <Sonnet />
-        </Tab>
-        <Tab eventKey="profile" title="Profile">
-          <Sonnet />
-        </Tab>
-        <Tab eventKey="contact" title="Contact" disabled>
-          <Sonnet />
-        </Tab>
-      </Tabs>
-    );
-  }
+  return (
+    <Tabs id="controlled-tab-example" activeKey={key} onSelect={k => setKey(k)}>
+      <Tab eventKey="home" title="Home">
+        <Sonnet />
+      </Tab>
+      <Tab eventKey="profile" title="Profile">
+        <Sonnet />
+      </Tab>
+      <Tab eventKey="contact" title="Contact" disabled>
+        <Sonnet />
+      </Tab>
+    </Tabs>
+  );
 }
 
 render(<ControlledTabs />);

--- a/www/src/examples/Toast/Autohide.js
+++ b/www/src/examples/Toast/Autohide.js
@@ -1,39 +1,27 @@
-class Example extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      show: false,
-    };
-  }
+function Example() {
+  const [show, setShow] = React.useState(false);
 
-  render() {
-    const { show } = this.state;
-    const handleShow = () => this.setState({ show: true });
-    const handleClose = () => this.setState({ show: false });
-    return (
-      <Row>
-        <Col xs={6}>
-          <Toast onClose={handleClose} show={show} delay={3000} autohide>
-            <Toast.Header>
-              <img
-                src="holder.js/20x20?text=%20"
-                className="rounded mr-2"
-                alt=""
-              />
-              <strong className="mr-auto">Bootstrap</strong>
-              <small>11 mins ago</small>
-            </Toast.Header>
-            <Toast.Body>
-              Woohoo, you're reading this text in a Toast!
-            </Toast.Body>
-          </Toast>
-        </Col>
-        <Col xs={6}>
-          <Button onClick={handleShow}>Show Toast</Button>
-        </Col>
-      </Row>
-    );
-  }
+  return (
+    <Row>
+      <Col xs={6}>
+        <Toast onClose={() => setShow(false)} show={show} delay={3000} autohide>
+          <Toast.Header>
+            <img
+              src="holder.js/20x20?text=%20"
+              className="rounded mr-2"
+              alt=""
+            />
+            <strong className="mr-auto">Bootstrap</strong>
+            <small>11 mins ago</small>
+          </Toast.Header>
+          <Toast.Body>Woohoo, you're reading this text in a Toast!</Toast.Body>
+        </Toast>
+      </Col>
+      <Col xs={6}>
+        <Button onClick={() => setShow(true)}>Show Toast</Button>
+      </Col>
+    </Row>
+  );
 }
 
 render(<Example />);

--- a/www/src/examples/Toast/Autohide.js
+++ b/www/src/examples/Toast/Autohide.js
@@ -1,5 +1,5 @@
 function Example() {
-  const [show, setShow] = React.useState(false);
+  const [show, setShow] = useState(false);
 
   return (
     <Row>

--- a/www/src/examples/Toast/Dismissible.js
+++ b/www/src/examples/Toast/Dismissible.js
@@ -1,63 +1,52 @@
-class Example extends React.Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      showA: true,
-      showB: true,
-    };
-  }
+function Example() {
+  const [showA, setShowA] = React.useState(true);
+  const [showB, setShowB] = React.useState(true);
 
-  render() {
-    const { showA, showB } = this.state;
-    const toggleShowA = () => this.setState({ showA: !showA });
-    const toggleShowB = () => this.setState({ showB: !showB });
-    return (
-      <Row>
-        <Col xs={6}>
-          <Toast show={showA} onClose={toggleShowA}>
-            <Toast.Header>
-              <img
-                src="holder.js/20x20?text=%20"
-                className="rounded mr-2"
-                alt=""
-              />
-              <strong className="mr-auto">Bootstrap</strong>
-              <small>11 mins ago</small>
-            </Toast.Header>
-            <Toast.Body>
-              Woohoo, you're reading this text in a Toast!
-            </Toast.Body>
-          </Toast>
-        </Col>
-        <Col xs={6}>
-          <Button onClick={toggleShowA}>
-            Toggle Toast <strong>with</strong> Animation
-          </Button>
-        </Col>
-        <Col xs={6} className="my-1">
-          <Toast onClose={toggleShowB} show={showB} animation={false}>
-            <Toast.Header>
-              <img
-                src="holder.js/20x20?text=%20"
-                className="rounded mr-2"
-                alt=""
-              />
-              <strong className="mr-auto">Bootstrap</strong>
-              <small>11 mins ago</small>
-            </Toast.Header>
-            <Toast.Body>
-              Woohoo, you're reading this text in a Toast!
-            </Toast.Body>
-          </Toast>
-        </Col>
-        <Col xs={6}>
-          <Button onClick={toggleShowB}>
-            Toggle Toast <strong>without</strong> Animation
-          </Button>
-        </Col>
-      </Row>
-    );
-  }
+  const toggleShowA = () => setShowA(!showA);
+  const toggleShowB = () => setShowB(!showB);
+
+  return (
+    <Row>
+      <Col xs={6}>
+        <Toast show={showA} onClose={toggleShowA}>
+          <Toast.Header>
+            <img
+              src="holder.js/20x20?text=%20"
+              className="rounded mr-2"
+              alt=""
+            />
+            <strong className="mr-auto">Bootstrap</strong>
+            <small>11 mins ago</small>
+          </Toast.Header>
+          <Toast.Body>Woohoo, you're reading this text in a Toast!</Toast.Body>
+        </Toast>
+      </Col>
+      <Col xs={6}>
+        <Button onClick={toggleShowA}>
+          Toggle Toast <strong>with</strong> Animation
+        </Button>
+      </Col>
+      <Col xs={6} className="my-1">
+        <Toast onClose={toggleShowB} show={showB} animation={false}>
+          <Toast.Header>
+            <img
+              src="holder.js/20x20?text=%20"
+              className="rounded mr-2"
+              alt=""
+            />
+            <strong className="mr-auto">Bootstrap</strong>
+            <small>11 mins ago</small>
+          </Toast.Header>
+          <Toast.Body>Woohoo, you're reading this text in a Toast!</Toast.Body>
+        </Toast>
+      </Col>
+      <Col xs={6}>
+        <Button onClick={toggleShowB}>
+          Toggle Toast <strong>without</strong> Animation
+        </Button>
+      </Col>
+    </Row>
+  );
 }
 
 render(<Example />);

--- a/www/src/examples/Toast/Dismissible.js
+++ b/www/src/examples/Toast/Dismissible.js
@@ -1,6 +1,6 @@
 function Example() {
-  const [showA, setShowA] = React.useState(true);
-  const [showB, setShowB] = React.useState(true);
+  const [showA, setShowA] = useState(true);
+  const [showB, setShowB] = useState(true);
 
   const toggleShowA = () => setShowA(!showA);
   const toggleShowB = () => setShowB(!showB);


### PR DESCRIPTION
With the release of React hooks, it seems appropriate to migrate our simple controlled component examples in our docs to use them. This will give users straightforward examples on how to use our API with React hooks.

Note: Although this is a complete re-write of most of the class component examples, there are still class component examples in our docs that we won't be able to migrate to function components. This is mostly due to them implementing parts of our API that requires the example components to be instantiated (e.g. passing in the `container` prop for `Overlay` shown in this [example](https://github.com/react-bootstrap/react-bootstrap/blob/b0ed370f667d4d8afdfd59375f4240cc653380b1/www/src/examples/Overlays/PopoverContained.js#L23)).