### PR TITLE
fix: Popover placement prop-types to correct list of props

### DIFF
--- a/src/Popover.js
+++ b/src/Popover.js
@@ -26,23 +26,7 @@ const propTypes = {
    *
    * > This is generally provided by the `Overlay` component positioning the popover
    */
-  placement: PropTypes.oneOf([
-    'auto-start',
-    'auto',
-    'auto-end',
-    'top-start',
-    'top',
-    'top-end',
-    'right-start',
-    'right',
-    'right-end',
-    'bottom-end',
-    'bottom',
-    'bottom-start',
-    'left-end',
-    'left',
-    'left-start',
-  ]),
+  placement: PropTypes.oneOf(['auto', 'top', 'bottom', 'left', 'right']),
 
   /**
    * An Overlay injected set of props for positioning the popover arrow.


### PR DESCRIPTION
The propTypes of the `placement` prop for `Popover` should only be of types:
- auto
- top
- bottom
- left
- right

as per the [bootstrap upstream docs](https://getbootstrap.com/docs/4.0/components/popovers/#options)

Fixes #3951.