### PR TITLE
feat: Add Float Classes

### DIFF
--- a/src/ThemeProvider.js
+++ b/src/ThemeProvider.js
@@ -36,44 +36,44 @@ function createBootstrapComponent(Component, opts) {
   // If it's a functional component make sure we don't break it with a ref
   const { prefix, forwardRefAs = isClassy ? 'ref' : 'innerRef' } = opts;
 
-  return forwardRef(
-    // eslint-disable-next-line react/prop-types
-    ({ className, float, ...props }, ref) => {
-      props[forwardRefAs] = ref;
-      const prefixes = useContext(ThemeContext);
-      let floats = null;
-      if (float && Object.keys(float).length > 0) {
-        floats = Object.entries(float).reduce(
-          (acc, [property, value]) =>
-            acc +
-            (property !== 'default'
-              ? `float-${property}-${value} `
-              : `float-${value} `),
-          '',
-        );
-      }
-      return (
-        <Component
-          {...props}
-          className={classNames(className, floats)}
-          // eslint-disable-next-line react/prop-types
-          bsPrefix={props.bsPrefix || prefixes.get(prefix) || prefix}
-        />
+  const BootstrapComponent = ({ className, float, ...props }, ref) => {
+    props[forwardRefAs] = ref;
+    const prefixes = useContext(ThemeContext);
+    let floats = null;
+    if (float && Object.keys(float).length > 0) {
+      floats = Object.entries(float).reduce(
+        (acc, [property, value]) =>
+          acc +
+          (property !== 'default'
+            ? `float-${property}-${value} `
+            : `float-${value} `),
+        '',
       );
-    },
-    { displayName: `Bootstrap(${Component.displayName || Component.name})` },
-  );
-}
+    }
+    return (
+      <Component
+        {...props}
+        className={classNames(className, floats)}
+        // eslint-disable-next-line react/prop-types
+        bsPrefix={props.bsPrefix || prefixes.get(prefix) || prefix}
+      />
+    );
+  };
 
-createBootstrapComponent.propTypes = {
-  float: PropTypes.exact({
-    default: PropTypes.string,
-    sm: PropTypes.string,
-    md: PropTypes.string,
-    lg: PropTypes.string,
-    xl: PropTypes.string,
-  }),
-};
+  BootstrapComponent.propTypes = {
+    float: PropTypes.exact({
+      default: PropTypes.string,
+      sm: PropTypes.string,
+      md: PropTypes.string,
+      lg: PropTypes.string,
+      xl: PropTypes.string,
+    }),
+  };
+
+  return forwardRef(BootstrapComponent, {
+    displayName: `Bootstrap(${Component.displayName || Component.name})`,
+  });
+}
 
 export { createBootstrapComponent, Consumer as ThemeConsumer };
 export default ThemeProvider;

--- a/src/ThemeProvider.js
+++ b/src/ThemeProvider.js
@@ -1,4 +1,6 @@
 import PropTypes from 'prop-types';
+import classNames from 'classnames';
+
 import forwardRef from '@restart/context/forwardRef';
 import React, { useContext } from 'react';
 
@@ -35,12 +37,25 @@ function createBootstrapComponent(Component, opts) {
   const { prefix, forwardRefAs = isClassy ? 'ref' : 'innerRef' } = opts;
 
   return forwardRef(
-    ({ ...props }, ref) => {
+    // eslint-disable-next-line react/prop-types
+    ({ className, float, ...props }, ref) => {
       props[forwardRefAs] = ref;
       const prefixes = useContext(ThemeContext);
+      let floats = null;
+      if (float && Object.keys(float).length > 0) {
+        floats = Object.entries(float).reduce(
+          (acc, [property, value]) =>
+            acc +
+            (property !== 'default'
+              ? `float-${property}-${value} `
+              : `float-${value} `),
+          '',
+        );
+      }
       return (
         <Component
           {...props}
+          className={classNames(className, floats)}
           // eslint-disable-next-line react/prop-types
           bsPrefix={props.bsPrefix || prefixes.get(prefix) || prefix}
         />
@@ -49,6 +64,16 @@ function createBootstrapComponent(Component, opts) {
     { displayName: `Bootstrap(${Component.displayName || Component.name})` },
   );
 }
+
+createBootstrapComponent.propTypes = {
+  float: PropTypes.exact({
+    default: PropTypes.string,
+    sm: PropTypes.string,
+    md: PropTypes.string,
+    lg: PropTypes.string,
+    xl: PropTypes.string,
+  }),
+};
 
 export { createBootstrapComponent, Consumer as ThemeConsumer };
 export default ThemeProvider;

--- a/www/src/components/SideNav.js
+++ b/www/src/components/SideNav.js
@@ -103,7 +103,7 @@ const TocSubLink = styled(TocLink)`
 
 const gettingStarted = ['introduction', 'theming', 'support'];
 
-const layout = ['float', 'grid', 'media'];
+const layout = ['grid', 'media'];
 
 const components = [
   'alerts',
@@ -135,7 +135,12 @@ const components = [
   'toasts',
 ];
 
-const utilities = ['transitions', 'responsive-embed', 'react-overlays'];
+const utilities = [
+  'float',
+  'transitions',
+  'responsive-embed',
+  'react-overlays',
+];
 
 // We need to configure this
 function attachSearch(ref) {

--- a/www/src/components/SideNav.js
+++ b/www/src/components/SideNav.js
@@ -103,7 +103,7 @@ const TocSubLink = styled(TocLink)`
 
 const gettingStarted = ['introduction', 'theming', 'support'];
 
-const layout = ['grid', 'media'];
+const layout = ['float', 'grid', 'media'];
 
 const components = [
   'alerts',

--- a/www/src/examples/Float/ToastExample.js
+++ b/www/src/examples/Float/ToastExample.js
@@ -1,0 +1,20 @@
+<>
+  <Toast float={{ md: 'right' }}>
+    <Toast.Header>
+      <strong className="mr-auto">Bootstrap</strong>
+      <small>11 mins ago</small>
+    </Toast.Header>
+    <Toast.Body>
+      Hello, world! This is a toast message, using float right
+    </Toast.Body>
+  </Toast>
+  <Toast float={{ md: 'none' }}>
+    <Toast.Header>
+      <strong className="mr-auto">Bootstrap</strong>
+      <small>11 mins ago</small>
+    </Toast.Header>
+    <Toast.Body>
+      Hello, world! This is a toast message, using float none
+    </Toast.Body>
+  </Toast>
+</>;

--- a/www/src/pages/utilities/float.mdx
+++ b/www/src/pages/utilities/float.mdx
@@ -1,0 +1,34 @@
+
+import ReactPlayground from '../../components/ReactPlayground';
+
+import ToastExample from '../../examples/Float/ToastExample';
+
+# Float
+
+Bootstrap allows for floats to be toggled on any Bootstrap component,
+so this re-implementation aims to provide the same support.
+
+## Supported Components
+
+TODO: Find all instances of components implementing `createBootstrapComponent`
+
+## Basic Example
+
+For the supported components, passing in an object to the `float` prop
+with valid properties will allow to use the power of Bootstrap float classes
+
+<ReactPlayground codeText={ToastExample} />
+
+## Supported Props
+
+These are the list of properties that can be in the `float` prop object:
+- default
+- sm
+- md
+- lg
+- xl
+
+Out of these properties, the following values can be passsed in:
+- left
+- right
+- none


### PR DESCRIPTION
This is an initial attempt at supporting float classes functionality as per the [upstream docs](https://getbootstrap.com/docs/4.3/utilities/float/).

The implementation attempts to do this by injecting the functionality in a utility HOC used by some of the components (`createBootstrapComponent`). However, not all components utilize this HOC, so some of the components might have to be migrated to use it, or the functionality might need to be injected into another utility HOC used by components.

Fixes #3744.