### PR TITLE
fix: build step due execa version bump (fix #3964)

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -23,7 +23,8 @@ const step = (name, root, fn) => async () => {
   console.log(cyan('Built: ') + green(name));
 };
 
-const shell = cmd => execa.shell(cmd, { stdio: ['pipe', 'pipe', 'inherit'] });
+const shell = cmd =>
+  execa(cmd, { stdio: ['pipe', 'pipe', 'inherit'], shell: true });
 
 const has = t => !targets.length || targets.includes(t);
 


### PR DESCRIPTION
Release notes: https://github.com/sindresorhus/execa/releases/tag/v2.0.0

https://github.com/react-bootstrap/react-bootstrap/issues/3964