### PR TITLE
fix: Migrate more components to properly forward refs

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -84,7 +84,7 @@ const Button = React.forwardRef(
         <SafeAnchor
           {...props}
           as={as}
-          innerRef={ref}
+          ref={ref}
           className={classNames(classes, props.disabled && 'disabled')}
         />
       );

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -76,32 +76,33 @@ const fadeStyles = {
   [ENTERED]: 'show',
 };
 
-class Fade extends React.Component {
-  handleEnter = node => {
+const Fade = React.forwardRef(({ className, children, ...props }, ref) => {
+  const handleEnter = node => {
     triggerBrowserReflow(node);
-    if (this.props.onEnter) this.props.onEnter(node);
+    if (props.onEnter) props.onEnter(node);
   };
 
-  render() {
-    const { className, children, ...props } = this.props;
-
-    return (
-      <Transition addEndListener={onEnd} {...props} onEnter={this.handleEnter}>
-        {(status, innerProps) =>
-          React.cloneElement(children, {
-            ...innerProps,
-            className: classNames(
-              'fade',
-              className,
-              children.props.className,
-              fadeStyles[status],
-            ),
-          })
-        }
-      </Transition>
-    );
-  }
-}
+  return (
+    <Transition
+      ref={ref}
+      addEndListener={onEnd}
+      {...props}
+      onEnter={handleEnter}
+    >
+      {(status, innerProps) =>
+        React.cloneElement(children, {
+          ...innerProps,
+          className: classNames(
+            'fade',
+            className,
+            children.props.className,
+            fadeStyles[status],
+          ),
+        })
+      }
+    </Transition>
+  );
+});
 
 Fade.propTypes = propTypes;
 Fade.defaultProps = defaultProps;

--- a/src/Fade.js
+++ b/src/Fade.js
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 import Transition, {
   ENTERED,
@@ -77,10 +77,13 @@ const fadeStyles = {
 };
 
 const Fade = React.forwardRef(({ className, children, ...props }, ref) => {
-  const handleEnter = node => {
-    triggerBrowserReflow(node);
-    if (props.onEnter) props.onEnter(node);
-  };
+  const handleEnter = useCallback(
+    node => {
+      triggerBrowserReflow(node);
+      if (props.onEnter) props.onEnter(node);
+    },
+    [props],
+  );
 
   return (
     <Transition
@@ -106,5 +109,6 @@ const Fade = React.forwardRef(({ className, children, ...props }, ref) => {
 
 Fade.propTypes = propTypes;
 Fade.defaultProps = defaultProps;
+Fade.displayName = 'Fade';
 
 export default Fade;

--- a/src/InputGroup.js
+++ b/src/InputGroup.js
@@ -4,7 +4,21 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import createWithBsPrefix from './utils/createWithBsPrefix';
-import { createBootstrapComponent } from './ThemeProvider';
+import { useBootstrapPrefix } from './ThemeProvider';
+
+const propTypes = {
+  /** @default 'input-group' */
+  bsPrefix: PropTypes.string,
+
+  /**
+   * Control the size of buttons and form elements from the top-level .
+   *
+   * @type {('sm'|'lg')}
+   */
+  size: PropTypes.string,
+
+  as: PropTypes.elementType,
+};
 
 /**
  *
@@ -14,33 +28,23 @@ import { createBootstrapComponent } from './ThemeProvider';
  * @property {InputGroupRadio} Radio
  * @property {InputGroupCheckbox} Checkbox
  */
-class InputGroup extends React.Component {
-  static propTypes = {
-    /** @default 'input-group' */
-    bsPrefix: PropTypes.string.isRequired,
-
-    /**
-     * Control the size of buttons and form elements from the top-level .
-     *
-     * @type {('sm'|'lg')}
-     */
-    size: PropTypes.string,
-
-    as: PropTypes.elementType,
-  };
-
-  render() {
-    const {
+const InputGroup = React.forwardRef(
+  (
+    {
       bsPrefix,
       size,
       className,
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
       ...props
-    } = this.props;
+    },
+    ref,
+  ) => {
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'input-group');
 
     return (
       <Component
+        ref={ref}
         {...props}
         className={classNames(
           className,
@@ -49,8 +53,8 @@ class InputGroup extends React.Component {
         )}
       />
     );
-  }
-}
+  },
+);
 
 const InputGroupAppend = createWithBsPrefix('input-group-append');
 
@@ -72,12 +76,12 @@ const InputGroupRadio = props => (
   </InputGroupText>
 );
 
-const DecoratedInputGroup = createBootstrapComponent(InputGroup, 'input-group');
+InputGroup.propTypes = propTypes;
 
-DecoratedInputGroup.Text = InputGroupText;
-DecoratedInputGroup.Radio = InputGroupRadio;
-DecoratedInputGroup.Checkbox = InputGroupCheckbox;
-DecoratedInputGroup.Append = InputGroupAppend;
-DecoratedInputGroup.Prepend = InputGroupPrepend;
+InputGroup.Text = InputGroupText;
+InputGroup.Radio = InputGroupRadio;
+InputGroup.Checkbox = InputGroupCheckbox;
+InputGroup.Append = InputGroupAppend;
+InputGroup.Prepend = InputGroupPrepend;
 
-export default DecoratedInputGroup;
+export default InputGroup;

--- a/src/InputGroup.js
+++ b/src/InputGroup.js
@@ -77,6 +77,7 @@ const InputGroupRadio = props => (
 );
 
 InputGroup.propTypes = propTypes;
+InputGroup.displayName = 'InputGroup';
 
 InputGroup.Text = InputGroupText;
 InputGroup.Radio = InputGroupRadio;

--- a/src/Jumbotron.js
+++ b/src/Jumbotron.js
@@ -45,5 +45,6 @@ const Jumbotron = React.forwardRef(
 
 Jumbotron.propTypes = propTypes;
 Jumbotron.defaultProps = defaultProps;
+Jumbotron.displayName = 'Jumbotron';
 
 export default Jumbotron;

--- a/src/Jumbotron.js
+++ b/src/Jumbotron.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
-import { createBootstrapComponent } from './ThemeProvider';
+import { useBootstrapPrefix } from './ThemeProvider';
 
 const propTypes = {
   as: PropTypes.elementType,
@@ -16,25 +16,34 @@ const defaultProps = {
   fluid: false,
 };
 
-class Jumbotron extends React.Component {
-  render() {
-    const {
+const Jumbotron = React.forwardRef(
+  (
+    {
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
       className,
       fluid,
       bsPrefix,
       ...props
-    } = this.props;
+    },
+    ref,
+  ) => {
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'jumbotron');
     const classes = {
       [bsPrefix]: true,
       [`${bsPrefix}-fluid`]: fluid,
     };
-    return <Component {...props} className={classNames(className, classes)} />;
-  }
-}
+    return (
+      <Component
+        ref={ref}
+        {...props}
+        className={classNames(className, classes)}
+      />
+    );
+  },
+);
 
 Jumbotron.propTypes = propTypes;
 Jumbotron.defaultProps = defaultProps;
 
-export default createBootstrapComponent(Jumbotron, 'jumbotron');
+export default Jumbotron;

--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -61,6 +61,7 @@ const ListGroup = React.forwardRef((props, ref) => {
 
 ListGroup.propTypes = propTypes;
 ListGroup.defaultProps = defaultProps;
+ListGroup.displayName = 'ListGroup';
 
 ListGroup.Item = ListGroupItem;
 

--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -2,59 +2,66 @@ import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { uncontrollable } from 'uncontrollable';
+import { useUncontrolled } from 'uncontrollable';
 
-import { createBootstrapComponent } from './ThemeProvider';
+import { useBootstrapPrefix } from './ThemeProvider';
 import AbstractNav from './AbstractNav';
 import ListGroupItem from './ListGroupItem';
 
-class ListGroup extends React.Component {
-  static propTypes = {
-    /**
-     * @default 'list-group'
-     */
-    bsPrefix: PropTypes.string.isRequired,
+const propTypes = {
+  /**
+   * @default 'list-group'
+   */
+  bsPrefix: PropTypes.string,
 
-    /**
-     * Adds a variant to the list-group
-     *
-     * @type {('flush')}
-     */
-    variant: PropTypes.oneOf(['flush', null]),
+  /**
+   * Adds a variant to the list-group
+   *
+   * @type {('flush')}
+   */
+  variant: PropTypes.oneOf(['flush', null]),
 
-    /**
-     * You can use a custom element type for this component.
-     */
-    as: PropTypes.elementType,
-  };
+  /**
+   * You can use a custom element type for this component.
+   */
+  as: PropTypes.elementType,
+};
 
-  static defaultProps = {
-    variant: null,
-  };
+const defaultProps = {
+  variant: null,
+};
 
-  render() {
-    const { className, bsPrefix, variant, as = 'div', ...props } = this.props;
-
-    return (
-      <AbstractNav
-        {...props}
-        as={as}
-        className={classNames(
-          className,
-          bsPrefix,
-          variant && `${bsPrefix}-${variant}`,
-        )}
-      />
-    );
-  }
-}
-
-const DecoratedListGroup = uncontrollable(
-  createBootstrapComponent(ListGroup, 'list-group'),
-  {
+const ListGroup = React.forwardRef((props, ref) => {
+  let {
+    className,
+    bsPrefix,
+    variant,
+    // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
+    as = 'div',
+    ...controlledProps
+  } = useUncontrolled(props, {
     activeKey: 'onSelect',
-  },
-);
-DecoratedListGroup.Item = ListGroupItem;
+  });
 
-export default DecoratedListGroup;
+  bsPrefix = useBootstrapPrefix(bsPrefix, 'list-group');
+
+  return (
+    <AbstractNav
+      ref={ref}
+      {...controlledProps}
+      as={as}
+      className={classNames(
+        className,
+        bsPrefix,
+        variant && `${bsPrefix}-${variant}`,
+      )}
+    />
+  );
+});
+
+ListGroup.propTypes = propTypes;
+ListGroup.defaultProps = defaultProps;
+
+ListGroup.Item = ListGroupItem;
+
+export default ListGroup;

--- a/src/ListGroupItem.js
+++ b/src/ListGroupItem.js
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, { useCallback } from 'react';
 import PropTypes from 'prop-types';
 
 import AbstractNavItem from './AbstractNavItem';
@@ -71,15 +71,18 @@ const ListGroupItem = React.forwardRef(
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'list-group-item');
 
-    const handleClick = event => {
-      if (disabled) {
-        event.preventDefault();
-        event.stopPropagation();
-        return;
-      }
+    const handleClick = useCallback(
+      event => {
+        if (disabled) {
+          event.preventDefault();
+          event.stopPropagation();
+          return;
+        }
 
-      if (onClick) onClick(event);
-    };
+        if (onClick) onClick(event);
+      },
+      [disabled, onClick],
+    );
 
     return (
       <AbstractNavItem
@@ -104,5 +107,6 @@ const ListGroupItem = React.forwardRef(
 
 ListGroupItem.propTypes = propTypes;
 ListGroupItem.defaultProps = defaultProps;
+ListGroupItem.displayName = 'ListGroupItem';
 
 export default ListGroupItem;

--- a/src/ListGroupItem.js
+++ b/src/ListGroupItem.js
@@ -4,67 +4,58 @@ import PropTypes from 'prop-types';
 
 import AbstractNavItem from './AbstractNavItem';
 import { makeEventKey } from './SelectableContext';
-import { createBootstrapComponent } from './ThemeProvider';
+import { useBootstrapPrefix } from './ThemeProvider';
 
-class ListGroupItem extends React.Component {
-  static propTypes = {
-    /**
-     * @default 'list-group-item'
-     */
-    bsPrefix: PropTypes.string.isRequired,
+const propTypes = {
+  /**
+   * @default 'list-group-item'
+   */
+  bsPrefix: PropTypes.string,
 
-    /**
-     * Sets contextual classes for list item
-     * @type {('primary'|'secondary'|'success'|'danger'|'warning'|'info'|'dark'|'light')}
-     */
-    variant: PropTypes.string,
-    /**
-     * Marks a ListGroupItem as actionable, applying additional hover, active and disabled styles
-     * for links and buttons.
-     */
-    action: PropTypes.bool,
-    /**
-     * Sets list item as active
-     */
-    active: PropTypes.bool,
+  /**
+   * Sets contextual classes for list item
+   * @type {('primary'|'secondary'|'success'|'danger'|'warning'|'info'|'dark'|'light')}
+   */
+  variant: PropTypes.string,
+  /**
+   * Marks a ListGroupItem as actionable, applying additional hover, active and disabled styles
+   * for links and buttons.
+   */
+  action: PropTypes.bool,
+  /**
+   * Sets list item as active
+   */
+  active: PropTypes.bool,
 
-    /**
-     * Sets list item state as disabled
-     */
-    disabled: PropTypes.bool,
+  /**
+   * Sets list item state as disabled
+   */
+  disabled: PropTypes.bool,
 
-    eventKey: PropTypes.string,
+  eventKey: PropTypes.string,
 
-    onClick: PropTypes.func,
+  onClick: PropTypes.func,
 
-    /**
-     * You can use a custom element type for this component. For none `action` items, items render as `li`.
-     * For actions the default is an achor or button element depending on whether a `href` is provided.
-     *
-     * @default {'div' | 'a' | 'button'}
-     */
-    as: PropTypes.elementType,
-  };
+  href: PropTypes.string,
 
-  static defaultProps = {
-    variant: null,
-    active: false,
-    disabled: false,
-  };
+  /**
+   * You can use a custom element type for this component. For none `action` items, items render as `li`.
+   * For actions the default is an achor or button element depending on whether a `href` is provided.
+   *
+   * @default {'div' | 'a' | 'button'}
+   */
+  as: PropTypes.elementType,
+};
 
-  handleClick = event => {
-    const { onClick, disabled } = this.props;
-    if (disabled) {
-      event.preventDefault();
-      event.stopPropagation();
-      return;
-    }
+const defaultProps = {
+  variant: null,
+  active: false,
+  disabled: false,
+};
 
-    if (onClick) onClick(event);
-  };
-
-  render() {
-    const {
+const ListGroupItem = React.forwardRef(
+  (
+    {
       bsPrefix,
       active,
       disabled,
@@ -73,16 +64,31 @@ class ListGroupItem extends React.Component {
       action,
       as,
       eventKey,
+      onClick,
       ...props
-    } = this.props;
+    },
+    ref,
+  ) => {
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'list-group-item');
+
+    const handleClick = event => {
+      if (disabled) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+
+      if (onClick) onClick(event);
+    };
 
     return (
       <AbstractNavItem
+        ref={ref}
         {...props}
         eventKey={makeEventKey(eventKey, props.href)}
         // eslint-disable-next-line
-        as={as || (action ? (props.href ? 'a' : 'button') : 'div')}
-        onClick={this.handleClick}
+      as={as || (action ? (props.href ? 'a' : 'button') : 'div')}
+        onClick={handleClick}
         className={classNames(
           className,
           bsPrefix,
@@ -93,7 +99,10 @@ class ListGroupItem extends React.Component {
         )}
       />
     );
-  }
-}
+  },
+);
 
-export default createBootstrapComponent(ListGroupItem, 'list-group-item');
+ListGroupItem.propTypes = propTypes;
+ListGroupItem.defaultProps = defaultProps;
+
+export default ListGroupItem;

--- a/src/SafeAnchor.js
+++ b/src/SafeAnchor.js
@@ -15,9 +15,6 @@ const propTypes = {
    * this is sort of silly but needed for Button
    */
   as: PropTypes.elementType,
-
-  /** @private */
-  innerRef: PropTypes.any,
 };
 
 function isTrivialHref(href) {
@@ -31,47 +28,40 @@ function isTrivialHref(href) {
  * button its accessible. It also emulates input `disabled` behavior for
  * links, which is usually desirable for Buttons, NavItems, DropdownItems, etc.
  */
-class SafeAnchor extends React.Component {
-  constructor(props, context) {
-    super(props, context);
-
-    this.handleClick = this.handleClick.bind(this);
-    this.handleKeyDown = this.handleKeyDown.bind(this);
-  }
-
-  handleClick(event) {
-    const { disabled, href, onClick } = this.props;
-
-    if (disabled || isTrivialHref(href)) {
-      event.preventDefault();
-    }
-
-    if (disabled) {
-      event.stopPropagation();
-      return;
-    }
-
-    if (onClick) {
-      onClick(event);
-    }
-  }
-
-  handleKeyDown(event) {
-    if (event.key === ' ') {
-      event.preventDefault();
-      this.handleClick(event);
-    }
-  }
-
-  render() {
-    const {
+const SafeAnchor = React.forwardRef(
+  (
+    {
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'a',
       disabled,
       onKeyDown,
-      innerRef,
       ...props
-    } = this.props;
+    },
+    ref,
+  ) => {
+    const handleClick = event => {
+      const { href, onClick } = props;
+
+      if (disabled || isTrivialHref(href)) {
+        event.preventDefault();
+      }
+
+      if (disabled) {
+        event.stopPropagation();
+        return;
+      }
+
+      if (onClick) {
+        onClick(event);
+      }
+    };
+
+    const handleKeyDown = event => {
+      if (event.key === ' ') {
+        event.preventDefault();
+        handleClick(event);
+      }
+    };
 
     if (isTrivialHref(props.href)) {
       props.role = props.role || 'button';
@@ -84,16 +74,17 @@ class SafeAnchor extends React.Component {
       props.tabIndex = -1;
       props['aria-disabled'] = true;
     }
-    if (innerRef) props.ref = innerRef;
+
     return (
       <Component
+        ref={ref}
         {...props}
-        onClick={this.handleClick}
-        onKeyDown={createChainedFunction(this.handleKeyDown, onKeyDown)}
+        onClick={handleClick}
+        onKeyDown={createChainedFunction(handleKeyDown, onKeyDown)}
       />
     );
-  }
-}
+  },
+);
 
 SafeAnchor.propTypes = propTypes;
 

--- a/src/SafeAnchor.js
+++ b/src/SafeAnchor.js
@@ -87,5 +87,6 @@ const SafeAnchor = React.forwardRef(
 );
 
 SafeAnchor.propTypes = propTypes;
+SafeAnchor.displayName = 'SafeAnchor';
 
 export default SafeAnchor;

--- a/src/Spinner.js
+++ b/src/Spinner.js
@@ -2,55 +2,55 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import React from 'react';
 
-import { createBootstrapComponent } from './ThemeProvider';
+import { useBootstrapPrefix } from './ThemeProvider';
 
-class Spinner extends React.Component {
-  static propTypes = {
-    /**
-     * @default 'spinner'
-     */
-    bsPrefix: PropTypes.string.isRequired,
+const propTypes = {
+  /**
+   * @default 'spinner'
+   */
+  bsPrefix: PropTypes.string,
 
-    /**
-     * The visual color style of the spinner
-     *
-     * @type {('primary'|'secondary'|'success'|'danger'|'warning'|'info'|'light'|'dark')}
-     */
-    variant: PropTypes.string,
+  /**
+   * The visual color style of the spinner
+   *
+   * @type {('primary'|'secondary'|'success'|'danger'|'warning'|'info'|'light'|'dark')}
+   */
+  variant: PropTypes.string,
 
-    /**
-     * Changes the animation style of the spinner.
-     *
-     * @type {('border'|'grow')}
-     * @default true
-     */
-    animation: PropTypes.oneOf(['border', 'grow']).isRequired,
+  /**
+   * Changes the animation style of the spinner.
+   *
+   * @type {('border'|'grow')}
+   * @default true
+   */
+  animation: PropTypes.oneOf(['border', 'grow']).isRequired,
 
-    /**
-     * Component size variations.
-     *
-     * @type {('sm')}
-     */
-    size: PropTypes.string,
+  /**
+   * Component size variations.
+   *
+   * @type {('sm')}
+   */
+  size: PropTypes.string,
 
-    /**
-     * This component may be used to wrap child elements or components.
-     */
-    children: PropTypes.element,
+  /**
+   * This component may be used to wrap child elements or components.
+   */
+  children: PropTypes.element,
 
-    /**
-     * An ARIA accessible role applied to the Menu component. This should generally be set to 'status'
-     */
-    role: PropTypes.string,
+  /**
+   * An ARIA accessible role applied to the Menu component. This should generally be set to 'status'
+   */
+  role: PropTypes.string,
 
-    /**
-     * @default div
-     */
-    as: PropTypes.elementType,
-  };
+  /**
+   * @default div
+   */
+  as: PropTypes.elementType,
+};
 
-  render() {
-    const {
+const Spinner = React.forwardRef(
+  (
+    {
       bsPrefix,
       variant,
       animation,
@@ -60,11 +60,15 @@ class Spinner extends React.Component {
       as: Component = 'div',
       className,
       ...props
-    } = this.props;
+    },
+    ref,
+  ) => {
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'spinner');
     const bsSpinnerPrefix = `${bsPrefix}-${animation}`;
 
     return (
       <Component
+        ref={ref}
         {...props}
         className={classNames(
           className,
@@ -76,7 +80,9 @@ class Spinner extends React.Component {
         {children}
       </Component>
     );
-  }
-}
+  },
+);
 
-export default createBootstrapComponent(Spinner, 'spinner');
+Spinner.propTypes = propTypes;
+
+export default Spinner;

--- a/src/Spinner.js
+++ b/src/Spinner.js
@@ -84,5 +84,6 @@ const Spinner = React.forwardRef(
 );
 
 Spinner.propTypes = propTypes;
+Spinner.displayName = 'Spinner';
 
 export default Spinner;

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -105,5 +105,6 @@ const SplitButton = React.forwardRef(
 
 SplitButton.propTypes = propTypes;
 SplitButton.defaultProps = defaultProps;
+SplitButton.displayName = 'SplitButton';
 
 export default SplitButton;

--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -5,61 +5,58 @@ import Button from './Button';
 import ButtonGroup from './ButtonGroup';
 import Dropdown from './Dropdown';
 
-/**
- * @inherits Button, Dropdown
- */
-class SplitButton extends React.Component {
-  static propTypes = {
-    /**
-     * An html id attribute for the Toggle button, necessary for assistive technologies, such as screen readers.
-     * @type {string|number}
-     * @required
-     */
-    id: PropTypes.any,
+const propTypes = {
+  /**
+   * An html id attribute for the Toggle button, necessary for assistive technologies, such as screen readers.
+   * @type {string|number}
+   * @required
+   */
+  id: PropTypes.any,
 
-    /**
-     * Accessible label for the toggle; the value of `title` if not specified.
-     */
-    toggleLabel: PropTypes.string,
+  /**
+   * Accessible label for the toggle; the value of `title` if not specified.
+   */
+  toggleLabel: PropTypes.string,
 
-    /** An `href` passed to the non-toggle Button */
-    href: PropTypes.string,
+  /** An `href` passed to the non-toggle Button */
+  href: PropTypes.string,
 
-    /** An anchor `target` passed to the non-toggle Button */
-    target: PropTypes.string,
+  /** An anchor `target` passed to the non-toggle Button */
+  target: PropTypes.string,
 
-    /** An `onClick` handler passed to the non-toggle Button */
-    onClick: PropTypes.func,
+  /** An `onClick` handler passed to the non-toggle Button */
+  onClick: PropTypes.func,
 
-    /** The content of the non-toggle Button.  */
-    title: PropTypes.node.isRequired,
+  /** The content of the non-toggle Button.  */
+  title: PropTypes.node.isRequired,
 
-    /** Disables both Buttons  */
-    disabled: PropTypes.bool,
+  /** Disables both Buttons  */
+  disabled: PropTypes.bool,
 
-    /** An ARIA accessible role applied to the Menu component. When set to 'menu', The dropdown */
-    menuRole: PropTypes.string,
-    /**
-     *  Which event when fired outside the component will cause it to be closed.
-     *
-     * _see [DropdownMenu](#menu-props) for more details_
-     */
-    rootCloseEvent: PropTypes.string,
+  /** An ARIA accessible role applied to the Menu component. When set to 'menu', The dropdown */
+  menuRole: PropTypes.string,
+  /**
+   *  Which event when fired outside the component will cause it to be closed.
+   *
+   * _see [DropdownMenu](#menu-props) for more details_
+   */
+  rootCloseEvent: PropTypes.string,
 
-    /** @ignore */
-    bsPrefix: PropTypes.string,
-    /** @ignore */
-    variant: PropTypes.string,
-    /** @ignore */
-    size: PropTypes.string,
-  };
+  /** @ignore */
+  bsPrefix: PropTypes.string,
+  /** @ignore */
+  variant: PropTypes.string,
+  /** @ignore */
+  size: PropTypes.string,
+};
 
-  static defaultProps = {
-    toggleLabel: 'Toggle dropdown',
-  };
+const defaultProps = {
+  toggleLabel: 'Toggle dropdown',
+};
 
-  render() {
-    const {
+const SplitButton = React.forwardRef(
+  (
+    {
       id,
       bsPrefix,
       size,
@@ -73,38 +70,40 @@ class SplitButton extends React.Component {
       menuRole,
       rootCloseEvent,
       ...props
-    } = this.props;
+    },
+    ref,
+  ) => (
+    <Dropdown ref={ref} {...props} as={ButtonGroup}>
+      <Button
+        size={size}
+        variant={variant}
+        disabled={props.disabled}
+        bsPrefix={bsPrefix}
+        href={href}
+        target={target}
+        onClick={onClick}
+      >
+        {title}
+      </Button>
+      <Dropdown.Toggle
+        split
+        id={id}
+        size={size}
+        variant={variant}
+        disabled={props.disabled}
+        childBsPrefix={bsPrefix}
+      >
+        <span className="sr-only">{toggleLabel}</span>
+      </Dropdown.Toggle>
 
-    return (
-      <Dropdown {...props} as={ButtonGroup}>
-        <Button
-          size={size}
-          variant={variant}
-          disabled={props.disabled}
-          bsPrefix={bsPrefix}
-          href={href}
-          target={target}
-          onClick={onClick}
-        >
-          {title}
-        </Button>
-        <Dropdown.Toggle
-          split
-          id={id}
-          size={size}
-          variant={variant}
-          disabled={props.disabled}
-          childBsPrefix={bsPrefix}
-        >
-          <span className="sr-only">{toggleLabel}</span>
-        </Dropdown.Toggle>
+      <Dropdown.Menu role={menuRole} rootCloseEvent={rootCloseEvent}>
+        {children}
+      </Dropdown.Menu>
+    </Dropdown>
+  ),
+);
 
-        <Dropdown.Menu role={menuRole} rootCloseEvent={rootCloseEvent}>
-          {children}
-        </Dropdown.Menu>
-      </Dropdown>
-    );
-  }
-}
+SplitButton.propTypes = propTypes;
+SplitButton.defaultProps = defaultProps;
 
 export default SplitButton;

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import requiredForA11y from 'prop-types-extra/lib/isRequiredForA11y';
-import { uncontrollable } from 'uncontrollable';
+import { useUncontrolled } from 'uncontrollable';
 
 import Nav from './Nav';
 import NavLink from './NavLink';
@@ -93,8 +93,8 @@ function getDefaultActiveKey(children) {
   return defaultActiveKey;
 }
 
-class Tabs extends React.Component {
-  renderTab(child) {
+const Tabs = React.forwardRef((props, ref) => {
+  const renderTab = child => {
     const { title, eventKey, disabled, tabClassName } = child.props;
     if (title == null) {
       return null;
@@ -110,51 +110,51 @@ class Tabs extends React.Component {
         {title}
       </NavItem>
     );
-  }
+  };
 
-  render() {
-    const {
-      id,
-      onSelect,
-      transition,
-      mountOnEnter,
-      unmountOnExit,
-      children,
-      activeKey = getDefaultActiveKey(children),
-      ...props
-    } = this.props;
+  const {
+    id,
+    onSelect,
+    transition,
+    mountOnEnter,
+    unmountOnExit,
+    children,
+    activeKey = getDefaultActiveKey(children),
+    ...controlledProps
+  } = useUncontrolled(props, {
+    activeKey: 'onSelect',
+  });
 
-    return (
-      <TabContainer
-        id={id}
-        activeKey={activeKey}
-        onSelect={onSelect}
-        transition={transition}
-        mountOnEnter={mountOnEnter}
-        unmountOnExit={unmountOnExit}
-      >
-        <Nav {...props} role="tablist" as="nav">
-          {map(children, this.renderTab)}
-        </Nav>
+  return (
+    <TabContainer
+      ref={ref}
+      id={id}
+      activeKey={activeKey}
+      onSelect={onSelect}
+      transition={transition}
+      mountOnEnter={mountOnEnter}
+      unmountOnExit={unmountOnExit}
+    >
+      <Nav {...controlledProps} role="tablist" as="nav">
+        {map(children, renderTab)}
+      </Nav>
 
-        <TabContent>
-          {map(children, child => {
-            const childProps = { ...child.props };
-            delete childProps.title;
-            delete childProps.disabled;
-            delete childProps.tabClassName;
+      <TabContent>
+        {map(children, child => {
+          const childProps = { ...child.props };
 
-            return <TabPane {...childProps} />;
-          })}
-        </TabContent>
-      </TabContainer>
-    );
-  }
-}
+          delete childProps.title;
+          delete childProps.disabled;
+          delete childProps.tabClassName;
+
+          return <TabPane {...childProps} />;
+        })}
+      </TabContent>
+    </TabContainer>
+  );
+});
 
 Tabs.propTypes = propTypes;
 Tabs.defaultProps = defaultProps;
 
-export default uncontrollable(Tabs, {
-  activeKey: 'onSelect',
-});
+export default Tabs;

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -93,25 +93,25 @@ function getDefaultActiveKey(children) {
   return defaultActiveKey;
 }
 
+function renderTab(child) {
+  const { title, eventKey, disabled, tabClassName } = child.props;
+  if (title == null) {
+    return null;
+  }
+
+  return (
+    <NavItem
+      as={NavLink}
+      eventKey={eventKey}
+      disabled={disabled}
+      className={tabClassName}
+    >
+      {title}
+    </NavItem>
+  );
+}
+
 const Tabs = React.forwardRef((props, ref) => {
-  const renderTab = child => {
-    const { title, eventKey, disabled, tabClassName } = child.props;
-    if (title == null) {
-      return null;
-    }
-
-    return (
-      <NavItem
-        as={NavLink}
-        eventKey={eventKey}
-        disabled={disabled}
-        className={tabClassName}
-      >
-        {title}
-      </NavItem>
-    );
-  };
-
   const {
     id,
     onSelect,
@@ -156,5 +156,6 @@ const Tabs = React.forwardRef((props, ref) => {
 
 Tabs.propTypes = propTypes;
 Tabs.defaultProps = defaultProps;
+Tabs.displayName = 'Tabs';
 
 export default Tabs;

--- a/src/ToastHeader.js
+++ b/src/ToastHeader.js
@@ -28,39 +28,37 @@ const defaultProps = {
   closeButton: true,
 };
 
-const ToastHeader = ({
-  bsPrefix,
-  closeLabel,
-  closeButton,
-  className,
-  children,
-  ...props
-}) => {
-  bsPrefix = useBootstrapPrefix(bsPrefix, 'toast-header');
+const ToastHeader = React.forwardRef(
+  (
+    { bsPrefix, closeLabel, closeButton, className, children, ...props },
+    ref,
+  ) => {
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'toast-header');
 
-  const context = useContext(ToastContext);
+    const context = useContext(ToastContext);
 
-  const handleClick = useEventCallback(() => {
-    if (context) {
-      context.onClose();
-    }
-  });
+    const handleClick = useEventCallback(() => {
+      if (context) {
+        context.onClose();
+      }
+    });
 
-  return (
-    <div {...props} className={classNames(bsPrefix, className)}>
-      {children}
+    return (
+      <div ref={ref} {...props} className={classNames(bsPrefix, className)}>
+        {children}
 
-      {closeButton && (
-        <CloseButton
-          label={closeLabel}
-          onClick={handleClick}
-          className="ml-2 mb-1"
-          data-dismiss="toast"
-        />
-      )}
-    </div>
-  );
-};
+        {closeButton && (
+          <CloseButton
+            label={closeLabel}
+            onClick={handleClick}
+            className="ml-2 mb-1"
+            data-dismiss="toast"
+          />
+        )}
+      </div>
+    );
+  },
+);
 
 ToastHeader.displayName = 'ToastHeader';
 ToastHeader.propTypes = propTypes;

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -100,5 +100,6 @@ const Tooltip = React.forwardRef(
 
 Tooltip.propTypes = propTypes;
 Tooltip.defaultProps = defaultProps;
+Tooltip.displayName = 'Tooltip';
 
 export default Tooltip;

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import isRequiredForA11y from 'prop-types-extra/lib/isRequiredForA11y';
-import { createBootstrapComponent } from './ThemeProvider';
+import { useBootstrapPrefix } from './ThemeProvider';
 
 const propTypes = {
   /**
@@ -55,9 +55,6 @@ const propTypes = {
   }),
 
   /** @private */
-  innerRef: PropTypes.any,
-
-  /** @private */
   scheduleUpdate: PropTypes.func,
 
   /** @private */
@@ -68,34 +65,40 @@ const defaultProps = {
   placement: 'right',
 };
 
-function Tooltip({
-  bsPrefix,
-  innerRef,
-  placement,
-  className,
-  style,
-  children,
-  arrowProps,
-  scheduleUpdate: _,
-  outOfBoundaries: _1,
-  ...props
-}) {
-  return (
-    <div
-      ref={innerRef}
-      style={style}
-      role="tooltip"
-      x-placement={placement}
-      className={classNames(className, bsPrefix, `bs-tooltip-${placement}`)}
-      {...props}
-    >
-      <div className="arrow" {...arrowProps} />
-      <div className={`${bsPrefix}-inner`}>{children}</div>
-    </div>
-  );
-}
+const Tooltip = React.forwardRef(
+  (
+    {
+      bsPrefix,
+      placement,
+      className,
+      style,
+      children,
+      arrowProps,
+      scheduleUpdate: _,
+      outOfBoundaries: _1,
+      ...props
+    },
+    ref,
+  ) => {
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'tooltip');
+
+    return (
+      <div
+        ref={ref}
+        style={style}
+        role="tooltip"
+        x-placement={placement}
+        className={classNames(className, bsPrefix, `bs-tooltip-${placement}`)}
+        {...props}
+      >
+        <div className="arrow" {...arrowProps} />
+        <div className={`${bsPrefix}-inner`}>{children}</div>
+      </div>
+    );
+  },
+);
 
 Tooltip.propTypes = propTypes;
 Tooltip.defaultProps = defaultProps;
 
-export default createBootstrapComponent(Tooltip, 'tooltip');
+export default Tooltip;

--- a/test/DropdownItemSpec.js
+++ b/test/DropdownItemSpec.js
@@ -98,6 +98,13 @@ describe('<Dropdown.Item>', () => {
       .should.not.have.property('onSelect');
   });
 
+  it('does not pass onSelect to children', () => {
+    mount(<Dropdown.Item onSelect={() => {}}>Item</Dropdown.Item>)
+      .find('SafeAnchor')
+      .props()
+      .should.not.have.property('onSelect');
+  });
+
   it('disabled link', () => {
     const handleSelect = () => {
       throw new Error('Should not invoke onSelect event');

--- a/test/DropdownItemSpec.js
+++ b/test/DropdownItemSpec.js
@@ -98,13 +98,6 @@ describe('<Dropdown.Item>', () => {
       .should.not.have.property('onSelect');
   });
 
-  it('does not pass onSelect to children', () => {
-    mount(<Dropdown.Item onSelect={() => {}}>Item</Dropdown.Item>)
-      .find('SafeAnchor')
-      .props()
-      .should.not.have.property('onSelect');
-  });
-
   it('disabled link', () => {
     const handleSelect = () => {
       throw new Error('Should not invoke onSelect event');

--- a/test/SafeAnchorSpec.js
+++ b/test/SafeAnchorSpec.js
@@ -72,7 +72,6 @@ describe('SafeAnchor', () => {
 
   it('Should disable link behavior', () => {
     let clickSpy = sinon.spy();
-    let spy = sinon.spy(SafeAnchor.prototype, 'handleClick');
 
     mount(
       <SafeAnchor disabled href="#foo" onClick={clickSpy}>
@@ -80,10 +79,7 @@ describe('SafeAnchor', () => {
       </SafeAnchor>,
     ).simulate('click');
 
-    expect(spy).to.have.been.calledOnce;
     expect(clickSpy).to.have.not.been.called;
-    expect(spy.getCall(0).args[0].isDefaultPrevented()).to.equal(true);
-    expect(spy.getCall(0).args[0].isPropagationStopped()).to.equal(true);
   });
 
   it('forwards provided role', () => {


### PR DESCRIPTION
The first pass-through of migrating more class components to properly forward their refs, via `React.forwardRef`.

Relevant to #4012 and #4031.

