### PR TITLE
Change Navbar expand prop TypeScript definition to allow false value.

### DIFF
--- a/types/components/Navbar.d.ts
+++ b/types/components/Navbar.d.ts
@@ -12,7 +12,7 @@ declare class NavbarText<
 
 export interface NavbarProps {
   variant?: 'light' | 'dark';
-  expand?: true | 'sm' | 'md' | 'lg' | 'xl';
+  expand?: false | true | 'sm' | 'md' | 'lg' | 'xl';
   bg?: string;
   fixed?: 'top' | 'bottom';
   sticky?: 'top' | 'bottom';

--- a/types/components/Navbar.d.ts
+++ b/types/components/Navbar.d.ts
@@ -12,7 +12,7 @@ declare class NavbarText<
 
 export interface NavbarProps {
   variant?: 'light' | 'dark';
-  expand?: false | true | 'sm' | 'md' | 'lg' | 'xl';
+  expand?: boolean | 'sm' | 'md' | 'lg' | 'xl';
   bg?: string;
   fixed?: 'top' | 'bottom';
   sticky?: 'top' | 'bottom';


### PR DESCRIPTION
It's already supported by the JS code and it allows the navbar never to
expand.

Fix #4174 