### PR TITLE
 test(Accordion): change accordion spec to test closer to design

### DIFF
--- a/src/AccordionCollapse.js
+++ b/src/AccordionCollapse.js
@@ -26,5 +26,6 @@ const AccordionCollapse = React.forwardRef(
 );
 
 AccordionCollapse.propTypes = propTypes;
+AccordionCollapse.displayName = 'AccordionCollapse';
 
 export default AccordionCollapse;

--- a/test/AccordionSpec.js
+++ b/test/AccordionSpec.js
@@ -9,29 +9,8 @@ describe('<Accordion>', () => {
     mount(<Accordion />).assertSingle('div');
   });
 
-  it('should not add any new elements', () => {
-    let wrapper = mount(
-      <Accordion>
-        <Card>
-          <Card.Header>
-            <Accordion.Toggle eventKey="0" />
-          </Card.Header>
-          <Accordion.Collapse eventKey="0">
-            <Card.Body>body text</Card.Body>
-          </Accordion.Collapse>
-        </Card>
-      </Accordion>,
-    );
-
-    wrapper.children().should.have.length(1);
-
-    let card = wrapper.find('.card');
-
-    card.children().should.have.length(2);
-  });
-
-  it('should only have one card collapsed', () => {
-    let wrapper = mount(
+  it('should only have second card collapsed', () => {
+    const wrapper = mount(
       <Accordion defaultActiveKey="0">
         <Card>
           <Card.Header>
@@ -51,18 +30,21 @@ describe('<Accordion>', () => {
         </Card>
       </Accordion>,
     );
-    let collapses = wrapper.find('.accordion-collapse');
+    const collapses = wrapper.find('AccordionCollapse');
 
-    collapses.forEach((collapse, i) => {
-      collapse
-        .props()
-        .className.endsWith('show')
-        .should.equal(i === 0);
-    });
+    collapses
+      .at(0)
+      .getDOMNode()
+      .className.should.include('show');
+    collapses
+      .at(1)
+      .getDOMNode()
+      .className.should.include('collapse');
   });
-  it('should fire the onClick callback only once', () => {
-    let onClickSpy = sinon.spy();
-    mount(
+
+  it('should expand next card and collapse current card on click', () => {
+    const onClickSpy = sinon.spy();
+    const wrapper = mount(
       <Accordion>
         <Card>
           <Card.Header>
@@ -81,16 +63,30 @@ describe('<Accordion>', () => {
           </Accordion.Collapse>
         </Card>
       </Accordion>,
-    )
-      .find('.card-header')
-      .at(0)
+    );
+    wrapper
+      .find('CardHeader')
+      .at(1)
       .find('button')
       .simulate('click');
 
-    expect(onClickSpy).to.be.calledOnce;
-  });
+    onClickSpy.should.be.calledOnce;
 
-  it('Should have div as default component', () => {
-    mount(<Accordion />).assertSingle('div');
+    const collapses = wrapper.find('AccordionCollapse');
+
+    collapses
+      .at(0)
+      .getDOMNode()
+      .className.should.include('collapse');
+
+    // Enzyme doesn't really provide support for async utilities
+    // on components, but in an ideal setup we should be testing for
+    // this className to be `show` after the collapsing animation is done
+    // (which is possible in `@testing-library` via `waitForElement`).
+    // https://testing-library.com/docs/dom-testing-library/api-async#waitforelement
+    collapses
+      .at(1)
+      .getDOMNode()
+      .className.should.include('collapsing');
   });
 });


### PR DESCRIPTION
A general re-write of the way we test the Accordion component,
as the previous behavior wasn't explicitely testing the
functionality of the Accordion component.