### PR TITLE
fix(types): make column prop optional for Label

### DIFF
--- a/types/components/FormLabel.d.ts
+++ b/types/components/FormLabel.d.ts
@@ -14,7 +14,7 @@ export interface FormLabelOwnProps extends FormLabelBaseProps {
 }
 
 export interface FormLabelWithColProps extends FormLabelBaseProps, ColProps {
-  column: true;
+  column?: true;
 }
 
 export type FormLabelProps = FormLabelWithColProps | FormLabelOwnProps


### PR DESCRIPTION
In IntelliJ IDEA, using `<Form.Label>Email address</Form.Label>` results in `Warning: Element Form.Label doesn't have required attribute column`.
Making `column` optional in `FormLabelWithColProps` fixes it.