### PR TITLE
docs: Fix PopoverContained sample

### DIFF
--- a/www/src/examples/Overlays/PopoverContained.js
+++ b/www/src/examples/Overlays/PopoverContained.js
@@ -3,9 +3,9 @@ function Example() {
   const [target, setTarget] = useState(null);
   const ref = useRef(null);
 
-  const handleClick = ({ target }) => {
+  const handleClick = event => {
     setShow(!show);
-    setTarget(target);
+    setTarget(event.target);
   };
 
   return (

--- a/www/src/examples/Overlays/PopoverContained.js
+++ b/www/src/examples/Overlays/PopoverContained.js
@@ -3,9 +3,9 @@ function Example() {
   const [target, setTarget] = useState(null);
   const ref = useRef(null);
 
-  const handleClick = ({ targ }) => {
+  const handleClick = ({ target }) => {
     setShow(!show);
-    setTarget(targ);
+    setTarget(target);
   };
 
   return (


### PR DESCRIPTION
Fix example here => https://react-bootstrap.github.io/components/overlays/#overlays-container

Event shall be destructured into a "target" variable in order handle click to work properly.