### PR TITLE
fix: Allow tab to un/mount with transition

### DIFF
--- a/src/TabContainer.js
+++ b/src/TabContainer.js
@@ -32,9 +32,9 @@ const propTypes = {
   },
 
   /**
-   * Sets a default animation strategy for all children `<TabPane>`s. Use
-   * `false` to disable, `true` to enable the default `<Fade>` animation or
-   * a react-transition-group v2 `<Transition/>` component.
+   * Sets a default animation strategy for all children `<TabPane>`s.
+   * Defaults to `<Fade>` animation; else, use `false` to disable, or a
+   * custom react-transition-group `<Transition/>` component.
    *
    * @type {{Transition | false}}
    * @default {Fade}

--- a/src/TabPane.js
+++ b/src/TabPane.js
@@ -27,9 +27,9 @@ const propTypes = {
   active: PropTypes.bool,
 
   /**
-   * Use animation when showing or hiding `<TabPane>`s. Use `false` to disable,
-   * `true` to enable the default `<Fade>` animation or
-   * a react-transition-group v2 `<Transition/>` component.
+   * Use animation when showing or hiding `<TabPane>`s. Defaults to `<Fade>`
+   * animation, else use `false` to disable or a react-transition-group
+   * `<Transition/>` component.
    */
   transition: PropTypes.oneOfType([PropTypes.bool, PropTypes.elementType]),
 
@@ -136,7 +136,7 @@ const TabPane = React.forwardRef((props, ref) => {
 
   const prefix = useBootstrapPrefix(bsPrefix, 'tab-pane');
 
-  if (!active && unmountOnExit) return null;
+  if (!active && !Transition && unmountOnExit) return null;
 
   let pane = (
     <Component

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -29,9 +29,9 @@ const propTypes = {
   variant: PropTypes.string,
 
   /**
-   * Sets a default animation strategy for all children `<TabPane>`s. Use
-   * `false` to disable, `true` to enable the default `<Fade>` animation or
-   * a react-transition-group v2 `<Transition/>` component.
+   * Sets a default animation strategy for all children `<TabPane>`s.
+   * Defaults to `<Fade>` animation, else use `false` to disable or a
+   * react-transition-group `<Transition/>` component.
    *
    * @type {Transition | false}
    * @default {Fade}


### PR DESCRIPTION
## Overview

The Tabpane component has a bug where when set to unmount on exit, any transitions are ignored. The solution was already discussed in issue #3497 by @sisp and @jquense ; I am shepherding it to the library.

## Demo
 
@sisp created a [codesandbox](https://codesandbox.io/s/xl5n993np4) showing how in the latest release of react-bootstrap `<TabPane ... unmountOnExit=true />` on does not execute the transition between tabs.

Refs #3497