### PR TITLE
fix(AbstractNav): Re-add role attribute to abstract nav

### DIFF
--- a/src/AbstractNav.js
+++ b/src/AbstractNav.js
@@ -126,7 +126,12 @@ const AbstractNav = React.forwardRef(
             getControllerId: getControllerId || noop,
           }}
         >
-          <Component {...props} onKeyDown={handleKeyDown} ref={mergedRef} />
+          <Component
+            {...props}
+            onKeyDown={handleKeyDown}
+            ref={mergedRef}
+            role={role}
+          />
         </NavContext.Provider>
       </SelectableContext.Provider>
     );

--- a/test/NavSpec.js
+++ b/test/NavSpec.js
@@ -217,7 +217,7 @@ describe('<Nav>', () => {
         </Nav>,
       );
 
-      wrapper.assertSingle('.nav[role="tablist"]');
+      wrapper.assertSingle('div.nav[role="tablist"]');
       wrapper.find('a[role="tab"]').length.should.equal(2);
     });
   });

--- a/test/TabContainerSpec.js
+++ b/test/TabContainerSpec.js
@@ -86,8 +86,7 @@ describe('<TabContainer>', () => {
         </div>
       </TabContainer>,
     );
-
-    instance.assertSingle('.nav[role="tablist"]');
+    instance.assertSingle('div.nav[role="tablist"]');
 
     instance
       .find('NavLink a')
@@ -112,7 +111,7 @@ describe('<TabContainer>', () => {
       </TabContainer>,
     );
 
-    instance.assertSingle('.nav[role="navigation"]');
+    instance.assertSingle('div.nav[role="navigation"]');
 
     // make sure its not passed to the Nav.Link
     expect(


### PR DESCRIPTION
Due to changes made in #4031, `AbstractNav` now needs to explicitly pass `role` down to `Component`.

Fixes issue reported in #4313.

Updated tests to catch the problem. 