### PR TITLE
Update ResponsiveEmbed example

### DIFF
--- a/www/src/examples/ResponsiveEmbed.js
+++ b/www/src/examples/ResponsiveEmbed.js
@@ -1,5 +1,5 @@
 <div style={{ width: 660, height: 'auto' }}>
-  <ResponsiveEmbed aspect="a16by9">
+  <ResponsiveEmbed aspectRatio="16by9">
     <embed type="image/svg+xml" src="/TheresaKnott_castle.svg" />
   </ResponsiveEmbed>
 </div>;


### PR DESCRIPTION
Updated to be to be consistent with documented API. Without this, the example would produce a type error as follows:

```
TypeScript error in /home/rod/git/projectphoenix/src/components/post.tsx(32,4):
Type '{ children: Element; aspect: string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<ResponsiveEmbed> & Readonly<ReplaceProps<"div", BsPrefixProps<"div"> & ResponsiveEmbedProps>> & Readonly<{ children?: ReactNode; }>'.
  Property 'aspect' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<ResponsiveEmbed> & Readonly<ReplaceProps<"div", BsPrefixProps<"div"> & ResponsiveEmbedProps>> & Readonly<{ children?: ReactNode; }>'.  TS2322

    30 |         </Card.Title>
    31 |         <Badge variant="primary">example_tag</Badge>
  > 32 |         <ResponsiveEmbed aspect="a16by9">
       |          ^
    33 |           <iframe title={props.title} src={props.embedLink}/>
    34 |         </ResponsiveEmbed>
    35 |         <span className="icon-list"
```

`aspect` changed to `aspectRatio` as documented and the "a" was removed so that `aspectRatio` would be one of the options `'21by9' | '16by9' | '4by3' | '1by1'`