### PR TITLE
Navbar toggle correct 'collapsed' className when collapsed

### DIFF
--- a/src/NavbarToggle.js
+++ b/src/NavbarToggle.js
@@ -61,7 +61,7 @@ const NavbarToggle = React.forwardRef(
         ref={ref}
         onClick={handleClick}
         aria-label={label}
-        className={classNames(className, bsPrefix, !!expanded && 'collapsed')}
+        className={classNames(className, bsPrefix, !expanded && 'collapsed')}
       >
         {children || <span className={`${bsPrefix}-icon`} />}
       </Component>

--- a/test/NavbarSpec.js
+++ b/test/NavbarSpec.js
@@ -119,7 +119,7 @@ describe('<Navbar>', () => {
     let collapse = wrapper.find('Collapse');
 
     expect(collapse.is('[in=false]')).to.equal(true);
-    expect(toggle.hasClass('collapsed')).to.equal(false);
+    expect(toggle.hasClass('collapsed')).to.equal(true);
 
     toggle.simulate('click');
 
@@ -127,7 +127,7 @@ describe('<Navbar>', () => {
     collapse = wrapper.find('Collapse');
 
     expect(collapse.is('[in=true]')).to.equal(true);
-    expect(toggle.hasClass('collapsed')).to.equal(true);
+    expect(toggle.hasClass('collapsed')).to.equal(false);
   });
 
   it('Should open external href link in collapseOnSelect', () => {


### PR DESCRIPTION
This pr fixes #4399