### PR TITLE
feat: adds support for horizontal list groups via layout prop

### DIFF
--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -58,7 +58,8 @@ const ListGroup = React.forwardRef((props, ref) => {
 
   let horizontalVariant;
   if (horizontal) {
-    horizontalVariant = horizontal === true ? 'horizontal' : `horizontal-${horizontal}`;
+    horizontalVariant =
+      horizontal === true ? 'horizontal' : `horizontal-${horizontal}`;
   } else {
     horizontalVariant = null;
   }

--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -24,18 +24,11 @@ const propTypes = {
   /**
    * Changes the flow of the list group items from vertical to horizontal.
    * A value of `null` (the default) sets it to vertical for all breakpoints;
-   * `horizontal` sets it go horizontal for all breakpoints, while `horizontal-{sm|md|lg|xl}`
+   * Just including the prop sets it for all breakpoints, while `{sm|md|lg|xl}`
    * makes the list group horizontal starting at that breakpoint’s `min-width`.
-   * @type {('horizontal'|'horizontal-sm'|'horizontal-md'|'horizontal-lg'|'horizontal-xl')}
+   * @type {(true|'sm'|'md'|'lg'|'xl')}
    */
-  layout: PropTypes.oneOf([
-    'horizontal',
-    'horizontal-sm',
-    'horizontal-md',
-    'horizontal-lg',
-    'horizontal-xl',
-    null,
-  ]),
+  horizontal: PropTypes.oneOf([true, 'sm', 'md', 'lg', 'xl', null]),
 
   /**
    * You can use a custom element type for this component.
@@ -45,7 +38,7 @@ const propTypes = {
 
 const defaultProps = {
   variant: null,
-  layout: null,
+  horizontal: null,
 };
 
 const ListGroup = React.forwardRef((props, ref) => {
@@ -53,7 +46,7 @@ const ListGroup = React.forwardRef((props, ref) => {
     className,
     bsPrefix,
     variant,
-    layout,
+    horizontal,
     // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
     as = 'div',
     ...controlledProps
@@ -62,6 +55,10 @@ const ListGroup = React.forwardRef((props, ref) => {
   });
 
   bsPrefix = useBootstrapPrefix(bsPrefix, 'list-group');
+  let horziontalString = 'horizontal';
+  if (horizontal && horizontal !== true) {
+    horziontalString = `horizontal-${horizontal}`;
+  }
 
   return (
     <AbstractNav
@@ -72,7 +69,7 @@ const ListGroup = React.forwardRef((props, ref) => {
         className,
         bsPrefix,
         variant && `${bsPrefix}-${variant}`,
-        layout && `${bsPrefix}-${layout}`,
+        horizontal && `${bsPrefix}-${horziontalString}`,
       )}
     />
   );

--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -55,9 +55,12 @@ const ListGroup = React.forwardRef((props, ref) => {
   });
 
   bsPrefix = useBootstrapPrefix(bsPrefix, 'list-group');
-  let horziontalString = 'horizontal';
-  if (horizontal && horizontal !== true) {
-    horziontalString = `horizontal-${horizontal}`;
+
+  let horizontalVariant;
+  if (horizontal) {
+    horizontalVariant = horizontal === true ? 'horizontal' : `horizontal-${horizontal}`;
+  } else {
+    horizontalVariant = null;
   }
 
   return (
@@ -69,7 +72,7 @@ const ListGroup = React.forwardRef((props, ref) => {
         className,
         bsPrefix,
         variant && `${bsPrefix}-${variant}`,
-        horizontal && `${bsPrefix}-${horziontalString}`,
+        horizontalVariant && `${bsPrefix}-${horizontalVariant}`,
       )}
     />
   );

--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -48,8 +48,6 @@ const defaultProps = {
   layout: null,
 };
 
-const horizontalPrefix = 'list-group';
-
 const ListGroup = React.forwardRef((props, ref) => {
   let {
     className,
@@ -74,7 +72,7 @@ const ListGroup = React.forwardRef((props, ref) => {
         className,
         bsPrefix,
         variant && `${bsPrefix}-${variant}`,
-        layout && `${horizontalPrefix}-${layout}`,
+        layout && `${bsPrefix}-${layout}`,
       )}
     />
   );

--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
+import warning from 'warning';
 
 import { useUncontrolled } from 'uncontrollable';
 
@@ -63,6 +64,11 @@ const ListGroup = React.forwardRef((props, ref) => {
   } else {
     horizontalVariant = null;
   }
+
+  warning(
+    !(horizontal && variant === 'flush'),
+    '`variant="flush"` and `horizontal` should not be used together.',
+  );
 
   return (
     <AbstractNav

--- a/src/ListGroup.js
+++ b/src/ListGroup.js
@@ -22,6 +22,22 @@ const propTypes = {
   variant: PropTypes.oneOf(['flush', null]),
 
   /**
+   * Changes the flow of the list group items from vertical to horizontal.
+   * A value of `null` (the default) sets it to vertical for all breakpoints;
+   * `horizontal` sets it go horizontal for all breakpoints, while `horizontal-{sm|md|lg|xl}`
+   * makes the list group horizontal starting at that breakpoint’s `min-width`.
+   * @type {('horizontal'|'horizontal-sm'|'horizontal-md'|'horizontal-lg'|'horizontal-xl')}
+   */
+  layout: PropTypes.oneOf([
+    'horizontal',
+    'horizontal-sm',
+    'horizontal-md',
+    'horizontal-lg',
+    'horizontal-xl',
+    null,
+  ]),
+
+  /**
    * You can use a custom element type for this component.
    */
   as: PropTypes.elementType,
@@ -29,13 +45,17 @@ const propTypes = {
 
 const defaultProps = {
   variant: null,
+  layout: null,
 };
+
+const horizontalPrefix = 'list-group';
 
 const ListGroup = React.forwardRef((props, ref) => {
   let {
     className,
     bsPrefix,
     variant,
+    layout,
     // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
     as = 'div',
     ...controlledProps
@@ -54,6 +74,7 @@ const ListGroup = React.forwardRef((props, ref) => {
         className,
         bsPrefix,
         variant && `${bsPrefix}-${variant}`,
+        layout && `${horizontalPrefix}-${layout}`,
       )}
     />
   );

--- a/test/ListGroupSpec.js
+++ b/test/ListGroupSpec.js
@@ -22,6 +22,26 @@ describe('<ListGroup>', () => {
     );
   });
 
+  it('accepts global horizontal', () => {
+    mount(<ListGroup layout="horizontal" />).assertSingle(
+      'div.list-group.list-group-horizontal',
+    );
+  });
+  it('accepts responsive horizontal', () => {
+    mount(<ListGroup layout="horizontal-sm" />).assertSingle(
+      'div.list-group.list-group-horizontal-sm',
+    );
+    mount(<ListGroup layout="horizontal-md" />).assertSingle(
+      'div.list-group.list-group-horizontal-md',
+    );
+    mount(<ListGroup layout="horizontal-lg" />).assertSingle(
+      'div.list-group.list-group-horizontal-lg',
+    );
+    mount(<ListGroup layout="horizontal-xl" />).assertSingle(
+      'div.list-group.list-group-horizontal-xl',
+    );
+  });
+
   it('accepts as prop', () => {
     mount(<ListGroup as="ul" />).assertSingle('ul.list-group');
   });

--- a/test/ListGroupSpec.js
+++ b/test/ListGroupSpec.js
@@ -3,6 +3,8 @@ import { mount } from 'enzyme';
 
 import ListGroup from '../src/ListGroup';
 
+import { shouldWarn } from './helpers';
+
 describe('<ListGroup>', () => {
   it('Should render correctly "list-group"', () => {
     mount(<ListGroup />).assertSingle('div.list-group');
@@ -40,6 +42,11 @@ describe('<ListGroup>', () => {
     mount(<ListGroup horizontal="xl" />).assertSingle(
       'div.list-group.list-group-horizontal-xl',
     );
+  });
+
+  it('throws a warning if flush and horizontal are used', () => {
+    shouldWarn('together');
+    mount(<ListGroup horizontal variant="flush" />);
   });
 
   it('accepts as prop', () => {

--- a/test/ListGroupSpec.js
+++ b/test/ListGroupSpec.js
@@ -23,21 +23,21 @@ describe('<ListGroup>', () => {
   });
 
   it('accepts global horizontal', () => {
-    mount(<ListGroup layout="horizontal" />).assertSingle(
+    mount(<ListGroup horizontal />).assertSingle(
       'div.list-group.list-group-horizontal',
     );
   });
   it('accepts responsive horizontal', () => {
-    mount(<ListGroup layout="horizontal-sm" />).assertSingle(
+    mount(<ListGroup horizontal="sm" />).assertSingle(
       'div.list-group.list-group-horizontal-sm',
     );
-    mount(<ListGroup layout="horizontal-md" />).assertSingle(
+    mount(<ListGroup horizontal="md" />).assertSingle(
       'div.list-group.list-group-horizontal-md',
     );
-    mount(<ListGroup layout="horizontal-lg" />).assertSingle(
+    mount(<ListGroup horizontal="lg" />).assertSingle(
       'div.list-group.list-group-horizontal-lg',
     );
-    mount(<ListGroup layout="horizontal-xl" />).assertSingle(
+    mount(<ListGroup horizontal="xl" />).assertSingle(
       'div.list-group.list-group-horizontal-xl',
     );
   });

--- a/www/src/examples/ListGroup/Horizontal.js
+++ b/www/src/examples/ListGroup/Horizontal.js
@@ -1,4 +1,4 @@
-<ListGroup layout="horizontal">
+<ListGroup horizontal>
   <ListGroup.Item>This</ListGroup.Item>
   <ListGroup.Item>ListGroup</ListGroup.Item>
   <ListGroup.Item>renders</ListGroup.Item>

--- a/www/src/examples/ListGroup/Horizontal.js
+++ b/www/src/examples/ListGroup/Horizontal.js
@@ -1,0 +1,6 @@
+<ListGroup layout="horizontal">
+  <ListGroup.Item>This</ListGroup.Item>
+  <ListGroup.Item>ListGroup</ListGroup.Item>
+  <ListGroup.Item>renders</ListGroup.Item>
+  <ListGroup.Item>horizontally!</ListGroup.Item>
+</ListGroup>;

--- a/www/src/examples/ListGroup/HorizontalResponsive.js
+++ b/www/src/examples/ListGroup/HorizontalResponsive.js
@@ -1,0 +1,8 @@
+['sm', 'md', 'lg', 'xl'].map((breakpoint, idx) => (
+  <ListGroup layout={`horizontal-${breakpoint}`} className="my-2" key={idx}>
+    <ListGroup.Item>This ListGroup</ListGroup.Item>
+    <ListGroup.Item>renders horizontally</ListGroup.Item>
+    <ListGroup.Item>on {breakpoint}</ListGroup.Item>
+    <ListGroup.Item>and above!</ListGroup.Item>
+  </ListGroup>
+));

--- a/www/src/examples/ListGroup/HorizontalResponsive.js
+++ b/www/src/examples/ListGroup/HorizontalResponsive.js
@@ -1,5 +1,5 @@
 ['sm', 'md', 'lg', 'xl'].map((breakpoint, idx) => (
-  <ListGroup layout={`horizontal-${breakpoint}`} className="my-2" key={idx}>
+  <ListGroup horizontal={breakpoint} className="my-2" key={idx}>
     <ListGroup.Item>This ListGroup</ListGroup.Item>
     <ListGroup.Item>renders horizontally</ListGroup.Item>
     <ListGroup.Item>on {breakpoint}</ListGroup.Item>

--- a/www/src/pages/components/list-group.mdx
+++ b/www/src/pages/components/list-group.mdx
@@ -82,14 +82,14 @@ edge-to-edge in a parent container [such as a `Card`](/components/cards/#list-gr
 
 ### Horizontal
 
-Change the `layout` prop to `horizontal` to make the ListGroup render horizontally. Currently **horizontal list groups cannot be combined with flush list groups.**
+Use the `horizontal` prop to make the ListGroup render horizontally. Currently **horizontal list groups cannot be combined with flush list groups.**
 
 <ReactPlayground
   codeText={ListGroupHorizontal}
   exampleClassName={styles.listGroup}
 />
 
-There are responsive variants to `layout`; `horizontal-{sm|md|lg|xl}` makes the list group horizontal starting at that breakpoint’s `min-width`.
+There are responsive variants to `horizontal`: setting it to `{sm|md|lg|xl}` makes the list group horizontal starting at that breakpoint’s `min-width`.
 
 <ReactPlayground
   codeText={ListGroupHorizontalResponsive}

--- a/www/src/pages/components/list-group.mdx
+++ b/www/src/pages/components/list-group.mdx
@@ -12,6 +12,8 @@ import ListGroupDisabled from '../../examples/ListGroup/Disabled';
 import ListGroupStyle from '../../examples/ListGroup/Style';
 import ListGroupStyleActions from '../../examples/ListGroup/StyleActions';
 import ListGroupFlush from '../../examples/ListGroup/Flush';
+import ListGroupHorizontal from '../../examples/ListGroup/Horizontal';
+import ListGroupHorizontalResponsive from '../../examples/ListGroup/HorizontalResponsive';
 import ListGroupTabs from '../../examples/ListGroup/Tabs';
 
 import styles from '../../css/examples.module.scss';
@@ -75,6 +77,22 @@ edge-to-edge in a parent container [such as a `Card`](/components/cards/#list-gr
 
 <ReactPlayground
   codeText={ListGroupFlush}
+  exampleClassName={styles.listGroup}
+/>
+
+### Horizontal
+
+Change the `layout` prop to `horizontal` to make the ListGroup render horizontally. Currently **horizontal list groups cannot be combined with flush list groups.**
+
+<ReactPlayground
+  codeText={ListGroupHorizontal}
+  exampleClassName={styles.listGroup}
+/>
+
+There are responsive variants to `layout`; `horizontal-{sm|md|lg|xl}` makes the list group horizontal starting at that breakpoint’s `min-width`.
+
+<ReactPlayground
+  codeText={ListGroupHorizontalResponsive}
   exampleClassName={styles.listGroup}
 />
 


### PR DESCRIPTION
This PR aims to implement the requested feature in #4410, exposing a prop to allow for [horizontal list groups](https://getbootstrap.com/docs/4.3/components/list-group/#horizontal). The prop, `horizontal`, is stringly-typed and supports six values:
* `null` - vertical flow. This is the default
* `true`/boolean attribute - list group items flow horizontally across all breakpoints
* `sm` - list group items flow horizontally for `sm` viewports and above
* `md` - list group items flow horizontally for `md` viewports and above
* `lg` - list group items flow horizontally for `lg` viewports and above
* `xl` - list group items flow horizontally for `xl` viewports and above

In addition, there's a styling conflict with horizontal list groups and using the `flush` variant, as noted in [the Bootstrap documentation](https://getbootstrap.com/docs/4.3/components/list-group/#horizontal), so I added a warning when that happens (and a test to make sure the warning gets logged).

I documented the changes to the API, added a section in the documentation explaining the feature, and wrote some pretty minor tests.

Note: I'm new to contributing to `react-bootstrap`, so I'm not sure if this solution (the implementation or the documentation) is the best way to do it. Please let me know if I should change anything!