### PR TITLE
fix(types): add missing Popover and Modal props

### DIFF
--- a/types/components/Modal.d.ts
+++ b/types/components/Modal.d.ts
@@ -21,9 +21,11 @@ export interface ModalProps extends TransitionCallbacks {
   enforceFocus?: boolean;
   restoreFocus?: boolean;
   show?: boolean;
+  onShow?: () => void;
   onHide?: () => void;
   container?: any;
   scrollable?: boolean;
+  onEscapeKeyDown?: () => void;
 }
 
 declare class Modal<

--- a/types/components/Popover.d.ts
+++ b/types/components/Popover.d.ts
@@ -11,6 +11,7 @@ export interface PopoverProps {
   placement?: Placement;
   title?: React.ReactNode;
   arrowProps?: { ref: any; style: object };
+  content?: boolean;
 }
 
 declare class Popover extends BsPrefixComponent<'div', PopoverProps> {


### PR DESCRIPTION
This PR updates the type definitions for the Popover and Modal components.

Over time new props have been added to the Modal and Popover components, but these new props are not yet included in the respective typescript type definitions.