### PR TITLE
ToggleButton Component: Typo in props

### DIFF
--- a/types/components/ToggleButton.d.ts
+++ b/types/components/ToggleButton.d.ts
@@ -8,7 +8,7 @@ export interface ToggleButtonProps {
   type?: 'checkbox' | 'radio';
   name?: string;
   checked?: boolean;
-  diabled?: boolean;
+  disabled?: boolean;
   onChange?: React.ChangeEventHandler<this>;
   value: unknown;
   inputRef?: React.LegacyRef<this>;


### PR DESCRIPTION
Found a typo in the ToggleButton component, which blocks disabling Togglebuttons.