### PR TITLE
remove magic in Typescript definitions to avoid false positives

### DIFF
--- a/types/components/Accordion.d.ts
+++ b/types/components/Accordion.d.ts
@@ -10,9 +10,7 @@ export interface AccordionProps {
   defaultActiveKey?: string;
 }
 
-declare class Accordion<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, AccordionProps> {
+declare class Accordion extends BsPrefixComponent<'div', AccordionProps> {
   static Toggle: typeof AccordionToggle;
   static Collapse: typeof AccordionCollapse;
 }

--- a/types/components/AccordionToggle.d.ts
+++ b/types/components/AccordionToggle.d.ts
@@ -7,14 +7,6 @@ export interface AccordionToggleProps {
   onClick?: (event?: React.SyntheticEvent) => void;
 }
 
-export interface useAccordionToggle {
-  (eventKey: string, onClick: (event?: React.SyntheticEvent) => void): (
-    event?: React.SyntheticEvent,
-  ) => void;
-}
-
-declare class AccordionToggle<
-  As extends React.ElementType = 'button'
-> extends BsPrefixComponent<As, AccordionToggleProps> {}
+declare class AccordionToggle extends BsPrefixComponent<'button', AccordionToggleProps> {}
 
 export default AccordionToggle;

--- a/types/components/Badge.d.ts
+++ b/types/components/Badge.d.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { BsPrefixComponent } from './helpers';
 
-export interface BadgeProps {
+export interface BadgeProps extends React.HTMLProps<HTMLSpanElement> {
   bsPrefix?: string;
   variant?:
     | 'primary'
@@ -15,8 +14,6 @@ export interface BadgeProps {
   pill?: boolean;
 }
 
-declare class Badge<
-  As extends React.ElementType = 'span'
-> extends BsPrefixComponent<As, BadgeProps> {}
+declare const Badge: React.ForwardRefExoticComponent<BadgeProps>;
 
 export default Badge;

--- a/types/components/Breadcrumb.d.ts
+++ b/types/components/Breadcrumb.d.ts
@@ -9,9 +9,7 @@ export interface BreadcrumbProps {
   listProps?: React.OlHTMLAttributes<any>;
 }
 
-declare class Breadcrumb<
-  As extends React.ElementType = 'nav'
-> extends BsPrefixComponent<As, BreadcrumbProps> {
+declare class Breadcrumb extends BsPrefixComponent<'nav', BreadcrumbProps> {
   static Item: typeof BreadcrumbItem;
 }
 

--- a/types/components/BreadcrumbItem.d.ts
+++ b/types/components/BreadcrumbItem.d.ts
@@ -9,8 +9,6 @@ export interface BreadcrumbItemProps {
   title?: React.ReactNode;
 }
 
-declare class BreadcrumbItem<
-  As extends React.ElementType = 'li'
-> extends BsPrefixComponent<As, BreadcrumbItemProps> {}
+declare class BreadcrumbItem extends BsPrefixComponent<'li', BreadcrumbItemProps> {}
 
 export default BreadcrumbItem;

--- a/types/components/Button.d.ts
+++ b/types/components/Button.d.ts
@@ -2,35 +2,38 @@ import * as React from 'react';
 
 import { BsPrefixComponent } from './helpers';
 
+export type ButtonVariant =
+  | 'primary'
+  | 'secondary'
+  | 'success'
+  | 'danger'
+  | 'warning'
+  | 'info'
+  | 'dark'
+  | 'light'
+  | 'link'
+  | 'outline-primary'
+  | 'outline-secondary'
+  | 'outline-success'
+  | 'outline-danger'
+  | 'outline-warning'
+  | 'outline-info'
+  | 'outline-dark'
+  | 'outline-light';
+
+export type ButtonSize = 'sm' | 'lg';
+export type ButtonType = 'button' | 'reset' | 'submit';
+
 export interface ButtonProps {
   active?: boolean;
   block?: boolean;
-  variant?:
-    | 'primary'
-    | 'secondary'
-    | 'success'
-    | 'danger'
-    | 'warning'
-    | 'info'
-    | 'dark'
-    | 'light'
-    | 'link'
-    | 'outline-primary'
-    | 'outline-secondary'
-    | 'outline-success'
-    | 'outline-danger'
-    | 'outline-warning'
-    | 'outline-info'
-    | 'outline-dark'
-    | 'outline-light';
-  size?: 'sm' | 'lg';
-  type?: 'button' | 'reset' | 'submit';
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  type?: ButtonType;
   href?: string;
   disabled?: boolean;
 }
 
-declare class Button<
-  As extends React.ElementType = 'button'
-> extends BsPrefixComponent<As, ButtonProps> {}
+declare class Button extends BsPrefixComponent<'button', ButtonProps> {}
 
 export default Button;

--- a/types/components/ButtonGroup.d.ts
+++ b/types/components/ButtonGroup.d.ts
@@ -9,8 +9,6 @@ export interface ButtonGroupProps {
   vertical?: boolean;
 }
 
-declare class ButtonGroup<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, ButtonGroupProps> {}
+declare class ButtonGroup extends BsPrefixComponent<'div', ButtonGroupProps> {}
 
 export default ButtonGroup;

--- a/types/components/Card.d.ts
+++ b/types/components/Card.d.ts
@@ -69,9 +69,7 @@ export interface CardProps {
   body?: boolean;
 }
 
-declare class Card<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, CardProps> {
+declare class Card extends BsPrefixComponent<'div', CardProps> {
   static Img: typeof CardImg;
   static Title: typeof CardTitle;
   static Subtitle: typeof CardSubtitle;

--- a/types/components/CardImg.d.ts
+++ b/types/components/CardImg.d.ts
@@ -6,8 +6,6 @@ export interface CardImgProps {
   variant?: 'top' | 'bottom';
 }
 
-declare class CardImg<
-  As extends React.ElementType = 'img'
-> extends BsPrefixComponent<As, CardImgProps> {}
+declare class CardImg extends BsPrefixComponent<'img', CardImgProps> {}
 
 export default CardImg;

--- a/types/components/Carousel.d.ts
+++ b/types/components/Carousel.d.ts
@@ -25,9 +25,7 @@ export interface CarouselProps {
   touch?: boolean;
 }
 
-declare class Carousel<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, CarouselProps> {
+declare class Carousel extends BsPrefixComponent<'div', CarouselProps> {
   static Item: typeof CarouselItem;
   static Caption: typeof CarouselCaption;
 }

--- a/types/components/Col.d.ts
+++ b/types/components/Col.d.ts
@@ -29,8 +29,6 @@ export interface ColProps {
   xl?: ColSpec;
 }
 
-declare class Col<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, ColProps> {}
+declare class Col extends BsPrefixComponent<'div', ColProps> {}
 
 export default Col;

--- a/types/components/Container.d.ts
+++ b/types/components/Container.d.ts
@@ -6,8 +6,6 @@ export interface ContainerProps {
   fluid?: boolean;
 }
 
-declare class Container<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, ContainerProps> {}
+declare class Container extends BsPrefixComponent<'div', ContainerProps> {}
 
 export default Container;

--- a/types/components/Dropdown.d.ts
+++ b/types/components/Dropdown.d.ts
@@ -27,9 +27,7 @@ export interface DropdownProps {
   onSelect?: SelectCallback;
 }
 
-declare class Dropdown<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, DropdownProps> {
+declare class Dropdown extends BsPrefixComponent<'div', DropdownProps> {
   static Toggle: typeof DropdownToggle;
   static Menu: typeof DropdownMenu;
   static Item: typeof DropdownItem;

--- a/types/components/DropdownButton.d.ts
+++ b/types/components/DropdownButton.d.ts
@@ -3,25 +3,22 @@ import * as React from 'react';
 import Dropdown from './Dropdown';
 import DropdownToggle from './DropdownToggle';
 
-import { ReplaceProps } from './helpers';
+import { BsPrefixComponent } from './helpers';
+import { ButtonVariant, ButtonSize } from './Button';
 
-type PropsFromToggle = Partial<
-  Pick<
-    React.ComponentPropsWithRef<typeof DropdownToggle>,
-    'href' | 'size' | 'variant' | 'disabled'
-  >
->;
-
-export interface DropdownButtonProps extends PropsFromToggle {
+export interface DropdownButtonProps {
   id: string;
   title: React.ReactNode;
   menuRole?: string;
   rootCloseEvent?: 'click' | 'mousedown';
   bsPrefix?: string;
+
+  href?: string;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  disabled?: boolean;
 }
 
-declare class DropdownButton extends React.Component<
-  ReplaceProps<typeof Dropdown, DropdownButtonProps>
-> {}
+declare class DropdownButton extends BsPrefixComponent<'button', DropdownButtonProps> {}
 
 export default DropdownButton;

--- a/types/components/DropdownItem.d.ts
+++ b/types/components/DropdownItem.d.ts
@@ -13,8 +13,6 @@ export interface DropdownItemProps {
   onSelect?: SelectCallback;
 }
 
-declare class DropdownItem<
-  As extends React.ElementType = typeof SafeAnchor
-> extends BsPrefixComponent<As, DropdownItemProps> {}
+declare class DropdownItem extends BsPrefixComponent<typeof SafeAnchor, DropdownItemProps> {}
 
 export default DropdownItem;

--- a/types/components/DropdownMenu.d.ts
+++ b/types/components/DropdownMenu.d.ts
@@ -11,8 +11,6 @@ export interface DropdownMenuProps {
   popperConfig?: object;
 }
 
-declare class DropdownMenu<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, DropdownMenuProps> {}
+declare class DropdownMenu extends BsPrefixComponent<'div', DropdownMenuProps> {}
 
 export default DropdownMenu;

--- a/types/components/DropdownToggle.d.ts
+++ b/types/components/DropdownToggle.d.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 
-import Button from './Button';
+import Button, { ButtonVariant, ButtonSize } from './Button';
 
 import { BsPrefixComponent } from './helpers';
 
@@ -8,10 +8,13 @@ export interface DropdownToggleProps {
   id: string;
   split?: boolean;
   childBsPrefix?: string;
+
+  href?: string;
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  disabled?: boolean;
 }
 
-declare class DropdownToggle<
-  As extends React.ElementType = typeof Button
-> extends BsPrefixComponent<As, DropdownToggleProps> {}
+declare class DropdownToggle extends BsPrefixComponent<typeof Button, DropdownToggleProps> {}
 
 export default DropdownToggle;

--- a/types/components/Feedback.d.ts
+++ b/types/components/Feedback.d.ts
@@ -7,8 +7,6 @@ export interface FeedbackProps {
   type?: 'valid' | 'invalid';
 }
 
-declare class Feedback<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, FeedbackProps> {}
+declare class Feedback extends BsPrefixComponent<'div', FeedbackProps> {}
 
 export default Feedback;

--- a/types/components/Form.d.ts
+++ b/types/components/Form.d.ts
@@ -18,9 +18,7 @@ export interface FormProps {
   validated?: boolean;
 }
 
-declare class Form<
-  As extends React.ElementType = 'form'
-> extends BsPrefixComponent<As, FormProps> {
+declare class Form extends BsPrefixComponent<'form', FormProps> {
   static Row: typeof FormRow;
   static Group: typeof FormGroup;
   static Control: typeof FormControl;

--- a/types/components/FormCheck.d.ts
+++ b/types/components/FormCheck.d.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
+
 import FormCheckInput from './FormCheckInput';
 import FormCheckLabel from './FormCheckLabel';
+
 import { BsPrefixComponent } from './helpers';
 
 export interface FormCheckProps {
@@ -18,9 +20,7 @@ export interface FormCheckProps {
   feedback?: React.ReactNode;
 }
 
-declare class FormCheck<
-  As extends React.ElementType = 'input'
-> extends BsPrefixComponent<As, FormCheckProps> {
+declare class FormCheck extends BsPrefixComponent<'input', FormCheckProps> {
   static Input: typeof FormCheckInput;
   static Label: typeof FormCheckLabel;
 }

--- a/types/components/FormControl.d.ts
+++ b/types/components/FormControl.d.ts
@@ -1,5 +1,7 @@
 import * as React from 'react';
+
 import Feedback from './Feedback';
+
 import { BsPrefixComponent } from './helpers';
 
 export interface FormControlProps {
@@ -16,10 +18,8 @@ export interface FormControlProps {
   isInvalid?: boolean;
 }
 
-declare class FormControl<
-  As extends React.ElementType = 'input'
-> extends BsPrefixComponent<As, FormControlProps> {
+declare class Form extends BsPrefixComponent<'input', FormControlProps> {
   static Feedback: typeof Feedback;
 }
 
-export default FormControl;
+export default Form;

--- a/types/components/FormGroup.d.ts
+++ b/types/components/FormGroup.d.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+
 import { BsPrefixComponent } from './helpers';
 
 export interface FormGroupProps {
@@ -6,8 +7,6 @@ export interface FormGroupProps {
   controlId?: string;
 }
 
-declare class FormGroup<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, FormGroupProps> {}
+declare class Form extends BsPrefixComponent<'div', FormGroupProps> {}
 
-export default FormGroup;
+export default Form;

--- a/types/components/FormText.d.ts
+++ b/types/components/FormText.d.ts
@@ -7,8 +7,6 @@ export interface FormTextProps {
   muted?: boolean;
 }
 
-declare class FormText<
-  As extends React.ElementType = 'small'
-> extends BsPrefixComponent<As, FormTextProps> {}
+declare class FormText extends BsPrefixComponent<'small', FormTextProps> {}
 
 export default FormText;

--- a/types/components/InputGroup.d.ts
+++ b/types/components/InputGroup.d.ts
@@ -22,9 +22,7 @@ export interface InputGroupProps {
   size?: 'sm' | 'lg';
 }
 
-declare class InputGroup<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, InputGroupProps> {
+declare class InputGroup extends BsPrefixComponent<'div', InputGroupProps> {
   static Append: typeof InputGroupAppend;
   static Prepend: typeof InputGroupPrepend;
   static Text: typeof InputGroupText;

--- a/types/components/Jumbotron.d.ts
+++ b/types/components/Jumbotron.d.ts
@@ -6,8 +6,6 @@ export interface JumbotronProps {
   fluid?: boolean;
 }
 
-declare class Jumbotron<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, JumbotronProps> {}
+declare class Jumbotron extends BsPrefixComponent<'div', JumbotronProps> {}
 
 export default Jumbotron;

--- a/types/components/ListGroup.d.ts
+++ b/types/components/ListGroup.d.ts
@@ -11,9 +11,7 @@ export interface ListGroupProps {
   onSelect?: SelectCallback;
 }
 
-declare class ListGroup<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, ListGroupProps> {
+declare class ListGroup extends BsPrefixComponent<'div', ListGroupProps> {
   static Item: typeof ListGroupItem;
 }
 

--- a/types/components/ListGroupItem.d.ts
+++ b/types/components/ListGroupItem.d.ts
@@ -17,8 +17,6 @@ export interface ListGroupItemProps {
     | 'light';
 }
 
-declare class ListGroupItem<
-  As extends React.ElementType = 'a'
-> extends BsPrefixComponent<As, ListGroupItemProps> {}
+declare class ListGroupItem extends BsPrefixComponent<'a', ListGroupItemProps> {}
 
 export default ListGroupItem;

--- a/types/components/Modal.d.ts
+++ b/types/components/Modal.d.ts
@@ -28,9 +28,7 @@ export interface ModalProps extends TransitionCallbacks {
   onEscapeKeyDown?: () => void;
 }
 
-declare class Modal<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, ModalProps> {
+declare class Modal extends BsPrefixComponent<'div', ModalProps> {
   static Body: typeof ModalBody;
   static Header: typeof ModalHeader;
   static Title: typeof ModalTitle;

--- a/types/components/ModalHeader.d.ts
+++ b/types/components/ModalHeader.d.ts
@@ -8,8 +8,6 @@ export interface ModalHeaderProps {
   onHide?: () => void;
 }
 
-declare class ModalHeader<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, ModalHeaderProps> {}
+declare class ModalHeader extends BsPrefixComponent<'div', ModalHeaderProps> {}
 
 export default ModalHeader;

--- a/types/components/Nav.d.ts
+++ b/types/components/Nav.d.ts
@@ -19,9 +19,7 @@ export interface NavProps {
   onKeyDown?: React.KeyboardEventHandler<this>;
 }
 
-declare class Nav<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, NavProps> {
+declare class Nav extends BsPrefixComponent<'div', NavProps> {
   static Item: typeof NavItem;
   static Link: typeof NavLink;
 }

--- a/types/components/NavItem.d.ts
+++ b/types/components/NavItem.d.ts
@@ -6,8 +6,6 @@ export interface NavItemProps {
   role?: string;
 }
 
-declare class NavItem<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, NavItemProps> {}
+declare class NavItem extends BsPrefixComponent<'div', NavItemProps> {}
 
 export default NavItem;

--- a/types/components/NavLink.d.ts
+++ b/types/components/NavLink.d.ts
@@ -13,8 +13,6 @@ export interface NavLinkProps {
   eventKey?: unknown;
 }
 
-declare class NavLink<
-  As extends React.ElementType = typeof SafeAnchor
-> extends BsPrefixComponent<As, NavLinkProps> {}
+declare class NavLink extends BsPrefixComponent<typeof SafeAnchor, NavLinkProps> { }
 
 export default NavLink;

--- a/types/components/Navbar.d.ts
+++ b/types/components/Navbar.d.ts
@@ -23,9 +23,7 @@ export interface NavbarProps {
   role?: string;
 }
 
-declare class Navbar<
-  As extends React.ElementType = 'nav'
-> extends BsPrefixComponent<As, NavbarProps> {
+declare class Navbar extends BsPrefixComponent<'nav', NavbarProps> {
   static Brand: typeof NavbarBrand;
   static Toggle: typeof NavbarToggle;
   static Collapse: typeof NavbarCollapse;

--- a/types/components/NavbarBrand.d.ts
+++ b/types/components/NavbarBrand.d.ts
@@ -6,8 +6,6 @@ export interface NavbarBrandProps {
   href?: string;
 }
 
-declare class NavbarBrand<
-  As extends React.ElementType = 'a'
-> extends BsPrefixComponent<As, NavbarBrandProps> {}
+declare class NavbarBrand extends BsPrefixComponent<'a', NavbarBrandProps> {}
 
 export default NavbarBrand;

--- a/types/components/NavbarToggle.d.ts
+++ b/types/components/NavbarToggle.d.ts
@@ -6,8 +6,6 @@ export interface NavbarToggleProps {
   label?: string;
 }
 
-declare class NavbarToggle<
-  As extends React.ElementType = 'button'
-> extends BsPrefixComponent<As, NavbarToggleProps> {}
+declare class NavbarToggle extends BsPrefixComponent<'button', NavbarToggleProps> {}
 
 export default NavbarToggle;

--- a/types/components/Row.d.ts
+++ b/types/components/Row.d.ts
@@ -6,8 +6,6 @@ export interface RowProps {
   noGutters?: boolean;
 }
 
-declare class Row<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, RowProps> {}
+declare class Row extends BsPrefixComponent<'div', RowProps> {}
 
 export default Row;

--- a/types/components/SafeAnchor.d.ts
+++ b/types/components/SafeAnchor.d.ts
@@ -8,11 +8,9 @@ export interface SafeAnchorProps {
   onKeyDown?: React.KeyboardEventHandler<this>;
   disabled?: boolean;
   role?: string;
-  tabIndex: number | string;
+  tabIndex?: number | string;
 }
 
-declare class SafeAnchor<
-  As extends React.ElementType = 'a'
-> extends BsPrefixComponent<As, SafeAnchorProps> {}
+declare class SafeAnchor extends BsPrefixComponent<'a', SafeAnchorProps> {}
 
 export default SafeAnchor;

--- a/types/components/Spinner.d.ts
+++ b/types/components/Spinner.d.ts
@@ -18,8 +18,6 @@ export interface SpinnerProps {
   bsPrefix?: string;
 }
 
-declare class Spinner<
-  As extends React.ElementType = typeof Spinner
-> extends BsPrefixComponent<As, SpinnerProps> {}
+declare class Spinner extends BsPrefixComponent<'div', SpinnerProps> {}
 
 export default Spinner;

--- a/types/components/SplitButton.d.ts
+++ b/types/components/SplitButton.d.ts
@@ -3,16 +3,10 @@ import * as React from 'react';
 import DropdownToggle from './DropdownToggle';
 import Dropdown from './Dropdown';
 
-import { ReplaceProps } from './helpers';
+import { ReplaceProps, BsPrefixComponent } from './helpers';
+import { ButtonVariant, ButtonSize } from './Button';
 
-type PropsFromToggle = Partial<
-  Pick<
-    React.ComponentPropsWithRef<typeof DropdownToggle>,
-    'size' | 'variant' | 'disabled'
-  >
->;
-
-export interface SplitButtonProps extends PropsFromToggle {
+export interface SplitButtonProps  {
   id: string | number;
   toggleLabel?: string;
   href?: string;
@@ -22,10 +16,12 @@ export interface SplitButtonProps extends PropsFromToggle {
   menuRole?: string;
   rootCloseEvent?: 'click' | 'mousedown';
   bsPrefix?: string;
+
+  variant?: ButtonVariant;
+  size?: ButtonSize;
+  disabled?: boolean;
 }
 
-declare class SplitButton extends React.Component<
-  ReplaceProps<typeof Dropdown, SplitButtonProps>
-> {}
+declare class SplitButton extends BsPrefixComponent<'div', SplitButtonProps> {}
 
 export default SplitButton;

--- a/types/components/Tab.d.ts
+++ b/types/components/Tab.d.ts
@@ -6,16 +6,14 @@ import TabPane from './TabPane';
 
 import { BsPrefixComponent } from './helpers';
 
-export interface TabProps extends React.ComponentPropsWithRef<typeof TabPane> {
+export interface TabProps extends Omit<React.ComponentPropsWithRef<typeof TabPane>, "title"> {
   eventKey?: unknown;
   title: React.ReactNode;
   disabled?: boolean;
   tabClassName?: string;
 }
 
-declare class Tab<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, TabProps> {
+declare class Tab extends BsPrefixComponent<'div', TabProps> {
   static Container: typeof TabContainer;
   static Content: typeof TabContent;
   static Pane: typeof TabPane;

--- a/types/components/TabPane.d.ts
+++ b/types/components/TabPane.d.ts
@@ -11,8 +11,6 @@ export interface TabPaneProps extends TransitionCallbacks {
   unmountOnExit?: boolean;
 }
 
-declare class TabPane<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, TabPaneProps> {}
+declare class TabPane extends BsPrefixComponent<'div', TabPaneProps> {}
 
 export default TabPane;

--- a/types/components/Tabs.d.ts
+++ b/types/components/Tabs.d.ts
@@ -15,8 +15,6 @@ export interface TabsProps {
   unmountOnExit?: boolean;
 }
 
-declare class Tabs<
-  As extends React.ElementType = typeof Nav
-> extends BsPrefixComponent<As, TabsProps> {}
+declare class Tabs extends BsPrefixComponent<typeof Nav, TabsProps> {}
 
 export default Tabs;

--- a/types/components/ToastHeader.d.ts
+++ b/types/components/ToastHeader.d.ts
@@ -7,8 +7,6 @@ export interface ToastHeaderProps {
   closeButton?: boolean;
 }
 
-declare class ToastHeader<
-  As extends React.ElementType = 'div'
-> extends BsPrefixComponent<As, ToastHeaderProps> {}
+declare class ToastHeader extends BsPrefixComponent<'div', ToastHeaderProps> {}
 
 export default ToastHeader;

--- a/types/components/ToggleButton.d.ts
+++ b/types/components/ToggleButton.d.ts
@@ -8,15 +8,13 @@ export interface ToggleButtonProps {
   type?: 'checkbox' | 'radio';
   name?: string;
   checked?: boolean;
-  disabled?: boolean;
+  diabled?: boolean;
   onChange?: React.ChangeEventHandler<this>;
   value: unknown;
   inputRef?: React.LegacyRef<this>;
   innerRef?: React.LegacyRef<this>;
 }
 
-declare class ToggleButton<
-  As extends React.ElementType = typeof Button
-> extends BsPrefixComponent<As, ToggleButtonProps> {}
+declare class ToggleButton extends BsPrefixComponent<typeof Button, ToggleButtonProps> {}
 
 export default ToggleButton;

--- a/types/components/helpers.d.ts
+++ b/types/components/helpers.d.ts
@@ -8,18 +8,18 @@ export type ReplaceProps<Inner extends React.ElementType, P> = Omit<
 > &
   P;
 
-export interface BsPrefixProps<As extends React.ElementType> {
-  as?: As;
+export interface BsPrefixProps {
+  as?: React.ElementType;
   bsPrefix?: string;
 }
 
 export class BsPrefixComponent<
   As extends React.ElementType,
   P = {}
-> extends React.Component<ReplaceProps<As, BsPrefixProps<As> & P>> {}
+> extends React.Component<ReplaceProps<As, BsPrefixProps & P>> {}
 
 export type SelectCallback = (
-  eventKey: string,
+  eventKey: unknown,
   e: React.SyntheticEvent<unknown>,
 ) => void;
 


### PR DESCRIPTION
As part of the general update of [Signum Framework](https://github.com/signumsoftware/framework) to TypeScript 3.6, React 16.9 and functional components I'm happy to take again a dependency to react-bootstrap (I removed a few years ago due to lacking Bootstrap 4 update). 

Unfortunately, I realize that the auto-completion of attributes was missing in many cases and that extra attributes where not being marked as errors... making the typing quite useless. 

After diving deep in the react-bootstrap / react typings I found the problem is in the inference in the pattern: 

```TS
declare class Tab<	
  As extends React.ElementType = 'div'	
> extends BsPrefixComponent<As, TabProps>
```

The intention here is to say: take all the attributes in As (typically 'div') and override them with the ones in TabProps in case on conflict. 

But inference doesn't work like this. If you add some extra attributes (without changing `as`) somehow TS ends up inferring 'any' (or some custom object type with the wrong attributes included on it) and produces no error. 

This means almost any value in statically typing react-bootstrap is lot. 

I have confirmation from private email with @glenjamin about this behaviour. 

> You are correct that they never really worked, but AllHTMLAttributes also wouldn’t work with custom elements.

As I don't think that TS is able to express the complicated relationship between 'as' attribute and all the other ones reliably (much less easy to understand...), I've change the code to the more simple and limited version. 

```TS
declare class Tab extends BsPrefixComponent<'div', TabProps> {
```

This means the type will allow all the props in 'div' overriden by TabProps, if you want to use a different component, and set some custom attribute that is not also in 'div' you will need to hack it with `any`: 

```TS
<Tab as="Button" {...{variant: "secondary"} as any}>
</Tab>
```

but for the general case, the works very well in practice, with reliable autocomplete and detecting more than 40 errors in my codebase that were previously silent. 
