### PR TITLE
fix typings for Components passing props to other component

### DIFF
--- a/types/components/Alert.d.ts
+++ b/types/components/Alert.d.ts
@@ -5,6 +5,7 @@ import SafeAnchor, { SafeAnchorProps } from './SafeAnchor';
 import { BsPrefixComponent, BsPrefixComponentClass } from './helpers';
 
 export class AlertLink<
+  // Need to use BsPrefixComponentClass to get proper type checking.
   As extends React.ElementType = BsPrefixComponentClass<'a', SafeAnchorProps>
 > extends BsPrefixComponent<As> {}
 

--- a/types/components/Alert.d.ts
+++ b/types/components/Alert.d.ts
@@ -1,11 +1,11 @@
 import * as React from 'react';
 
-import SafeAnchor from './SafeAnchor';
+import SafeAnchor, { SafeAnchorProps } from './SafeAnchor';
 
-import { BsPrefixComponent } from './helpers';
+import { BsPrefixComponent, BsPrefixComponentClass } from './helpers';
 
 export class AlertLink<
-  As extends React.ElementType = typeof SafeAnchor
+  As extends React.ElementType = BsPrefixComponentClass<'a', SafeAnchorProps>
 > extends BsPrefixComponent<As> {}
 
 export class AlertHeading<

--- a/types/components/DropdownItem.d.ts
+++ b/types/components/DropdownItem.d.ts
@@ -2,7 +2,11 @@ import * as React from 'react';
 
 import SafeAnchor, { SafeAnchorProps } from './SafeAnchor';
 
-import { BsPrefixComponent, SelectCallback, BsPrefixComponentClass } from './helpers';
+import {
+  BsPrefixComponent,
+  SelectCallback,
+  BsPrefixComponentClass,
+} from './helpers';
 
 export interface DropdownItemProps {
   active?: boolean;

--- a/types/components/DropdownItem.d.ts
+++ b/types/components/DropdownItem.d.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-import SafeAnchor from './SafeAnchor';
+import SafeAnchor, { SafeAnchorProps } from './SafeAnchor';
 
-import { BsPrefixComponent, SelectCallback } from './helpers';
+import { BsPrefixComponent, SelectCallback, BsPrefixComponentClass } from './helpers';
 
 export interface DropdownItemProps {
   active?: boolean;
@@ -14,7 +14,7 @@ export interface DropdownItemProps {
 }
 
 declare class DropdownItem<
-  As extends React.ElementType = typeof SafeAnchor
+  As extends React.ElementType = BsPrefixComponentClass<'a', SafeAnchorProps>
 > extends BsPrefixComponent<As, DropdownItemProps> {}
 
 export default DropdownItem;

--- a/types/components/DropdownItem.d.ts
+++ b/types/components/DropdownItem.d.ts
@@ -18,6 +18,7 @@ export interface DropdownItemProps {
 }
 
 declare class DropdownItem<
+  // Need to use BsPrefixComponentClass to get proper type checking.
   As extends React.ElementType = BsPrefixComponentClass<'a', SafeAnchorProps>
 > extends BsPrefixComponent<As, DropdownItemProps> {}
 

--- a/types/components/DropdownToggle.d.ts
+++ b/types/components/DropdownToggle.d.ts
@@ -11,6 +11,7 @@ export interface DropdownToggleProps {
 }
 
 declare class DropdownToggle<
+  // Need to use BsPrefixComponentClass to get proper type checking.
   As extends React.ElementType = BsPrefixComponentClass<'button', ButtonProps>
 > extends BsPrefixComponent<As, DropdownToggleProps> {}
 

--- a/types/components/DropdownToggle.d.ts
+++ b/types/components/DropdownToggle.d.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-import Button from './Button';
+import Button, { ButtonProps } from './Button';
 
-import { BsPrefixComponent } from './helpers';
+import { BsPrefixComponent, BsPrefixComponentClass } from './helpers';
 
 export interface DropdownToggleProps {
   id: string;
@@ -11,7 +11,7 @@ export interface DropdownToggleProps {
 }
 
 declare class DropdownToggle<
-  As extends React.ElementType = typeof Button
+  As extends React.ElementType = BsPrefixComponentClass<'button', ButtonProps>
 > extends BsPrefixComponent<As, DropdownToggleProps> {}
 
 export default DropdownToggle;

--- a/types/components/NavLink.d.ts
+++ b/types/components/NavLink.d.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-import SafeAnchor from './SafeAnchor';
+import SafeAnchor, { SafeAnchorProps } from './SafeAnchor';
 
-import { BsPrefixComponent, SelectCallback } from './helpers';
+import { BsPrefixComponent, SelectCallback, BsPrefixComponentClass } from './helpers';
 
 export interface NavLinkProps {
   active?: boolean;
@@ -14,7 +14,7 @@ export interface NavLinkProps {
 }
 
 declare class NavLink<
-  As extends React.ElementType = typeof SafeAnchor
+  As extends React.ElementType = BsPrefixComponentClass<'a', SafeAnchorProps>
 > extends BsPrefixComponent<As, NavLinkProps> {}
 
 export default NavLink;

--- a/types/components/NavLink.d.ts
+++ b/types/components/NavLink.d.ts
@@ -2,7 +2,11 @@ import * as React from 'react';
 
 import SafeAnchor, { SafeAnchorProps } from './SafeAnchor';
 
-import { BsPrefixComponent, SelectCallback, BsPrefixComponentClass } from './helpers';
+import {
+  BsPrefixComponent,
+  SelectCallback,
+  BsPrefixComponentClass,
+} from './helpers';
 
 export interface NavLinkProps {
   active?: boolean;

--- a/types/components/NavLink.d.ts
+++ b/types/components/NavLink.d.ts
@@ -18,6 +18,7 @@ export interface NavLinkProps {
 }
 
 declare class NavLink<
+  // Need to use BsPrefixComponentClass to get proper type checking.
   As extends React.ElementType = BsPrefixComponentClass<'a', SafeAnchorProps>
 > extends BsPrefixComponent<As, NavLinkProps> {}
 

--- a/types/components/SafeAnchor.d.ts
+++ b/types/components/SafeAnchor.d.ts
@@ -8,7 +8,7 @@ export interface SafeAnchorProps {
   onKeyDown?: React.KeyboardEventHandler<this>;
   disabled?: boolean;
   role?: string;
-  tabIndex: number | string;
+  tabIndex?: number | string;
 }
 
 declare class SafeAnchor<

--- a/types/components/Spinner.d.ts
+++ b/types/components/Spinner.d.ts
@@ -19,7 +19,7 @@ export interface SpinnerProps {
 }
 
 declare class Spinner<
-  As extends React.ElementType = typeof Spinner
+  As extends React.ElementType = 'div'
 > extends BsPrefixComponent<As, SpinnerProps> {}
 
 export default Spinner;

--- a/types/components/Tabs.d.ts
+++ b/types/components/Tabs.d.ts
@@ -1,8 +1,12 @@
 import * as React from 'react';
 
-import Nav from './Nav';
+import Nav, { NavProps } from './Nav';
 
-import { BsPrefixComponent, SelectCallback } from './helpers';
+import {
+  BsPrefixComponent,
+  SelectCallback,
+  BsPrefixComponentClass,
+} from './helpers';
 
 export interface TabsProps {
   activeKey?: unknown;
@@ -16,7 +20,7 @@ export interface TabsProps {
 }
 
 declare class Tabs<
-  As extends React.ElementType = typeof Nav
+  As extends React.ElementType = BsPrefixComponentClass<'div', NavProps>
 > extends BsPrefixComponent<As, TabsProps> {}
 
 export default Tabs;

--- a/types/components/Tabs.d.ts
+++ b/types/components/Tabs.d.ts
@@ -20,6 +20,7 @@ export interface TabsProps {
 }
 
 declare class Tabs<
+  // Need to use BsPrefixComponentClass to get proper type checking.
   As extends React.ElementType = BsPrefixComponentClass<'div', NavProps>
 > extends BsPrefixComponent<As, TabsProps> {}
 

--- a/types/components/ToggleButton.d.ts
+++ b/types/components/ToggleButton.d.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-import Button from './Button';
+import Button, { ButtonProps } from './Button';
 
-import { BsPrefixComponent } from './helpers';
+import { BsPrefixComponent, BsPrefixComponentClass } from './helpers';
 
 export interface ToggleButtonProps {
   type?: 'checkbox' | 'radio';
@@ -16,7 +16,7 @@ export interface ToggleButtonProps {
 }
 
 declare class ToggleButton<
-  As extends React.ElementType = typeof Button
+  As extends React.ElementType = BsPrefixComponentClass<'button', ButtonProps>
 > extends BsPrefixComponent<As, ToggleButtonProps> {}
 
 export default ToggleButton;

--- a/types/components/ToggleButton.d.ts
+++ b/types/components/ToggleButton.d.ts
@@ -16,6 +16,7 @@ export interface ToggleButtonProps {
 }
 
 declare class ToggleButton<
+  // Need to use BsPrefixComponentClass to get proper type checking.
   As extends React.ElementType = BsPrefixComponentClass<'button', ButtonProps>
 > extends BsPrefixComponent<As, ToggleButtonProps> {}
 

--- a/types/components/ToggleButtonGroup.d.ts
+++ b/types/components/ToggleButtonGroup.d.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 
-import ButtonGroup from './ButtonGroup';
+import ButtonGroup, { ButtonGroupProps } from './ButtonGroup';
 
-import { BsPrefixComponent } from './helpers';
+import { BsPrefixComponent, BsPrefixComponentClass } from './helpers';
 
 export interface ToggleButtonRadioProps<T> {
   type?: 'radio';
@@ -25,7 +25,7 @@ export type ToggleButtonGroupProps<T> =
 
 declare class ToggleButtonGroup<
   T,
-  As extends React.ElementType = typeof ButtonGroup
+  As extends React.ElementType = BsPrefixComponentClass<'a', ButtonGroupProps>
 > extends BsPrefixComponent<As, ToggleButtonGroupProps<T>> {}
 
 export default ToggleButtonGroup;

--- a/types/components/ToggleButtonGroup.d.ts
+++ b/types/components/ToggleButtonGroup.d.ts
@@ -25,6 +25,7 @@ export type ToggleButtonGroupProps<T> =
 
 declare class ToggleButtonGroup<
   T,
+  // Need to use BsPrefixComponentClass to get proper type checking.
   As extends React.ElementType = BsPrefixComponentClass<'a', ButtonGroupProps>
 > extends BsPrefixComponent<As, ToggleButtonGroupProps<T>> {}
 

--- a/types/components/helpers.d.ts
+++ b/types/components/helpers.d.ts
@@ -18,6 +18,7 @@ export class BsPrefixComponent<
   P = {}
 > extends React.Component<ReplaceProps<As, BsPrefixProps<As> & P>> {}
 
+// Need to use this instead of typeof Component to get proper type checking.
 export type BsPrefixComponentClass<
   As extends React.ElementType,
   P = {}

--- a/types/components/helpers.d.ts
+++ b/types/components/helpers.d.ts
@@ -21,7 +21,7 @@ export class BsPrefixComponent<
 export type BsPrefixComponentClass<
   As extends React.ElementType,
   P = {}
-  > = React.ComponentClass<ReplaceProps<As, BsPrefixProps<As> & P>>;
+> = React.ComponentClass<ReplaceProps<As, BsPrefixProps<As> & P>>;
 
 export type SelectCallback = (
   eventKey: string,

--- a/types/components/helpers.d.ts
+++ b/types/components/helpers.d.ts
@@ -18,6 +18,11 @@ export class BsPrefixComponent<
   P = {}
 > extends React.Component<ReplaceProps<As, BsPrefixProps<As> & P>> {}
 
+export type BsPrefixComponentClass<
+  As extends React.ElementType,
+  P = {}
+  > = React.ComponentClass<ReplaceProps<As, BsPrefixProps<As> & P>>;
+
 export type SelectCallback = (
   eventKey: string,
   e: React.SyntheticEvent<unknown>,

--- a/types/simple.test.tsx
+++ b/types/simple.test.tsx
@@ -392,7 +392,7 @@ import {
 <AlerLink invalidProp="2" />; // $ExpectError
 <DropdownItem invalidProp="2" />; // $ExpectError
 <NavLink invalidProp="2" />; // $ExpectError
-<Spinner invalidProp="2" />; // $ExpectError
+<Spinner invalidProp="2" animation="border" />; // $ExpectError
 <ToggleButton invalidProp="2" />; // $ExpectError
 <ToggleButtonGroup invalidProp="2" />; // $ExpectError
 
@@ -400,3 +400,11 @@ import {
 <Button invalidProp="2" />; // $ExpectError
 <Alert invalidProp="2" />; // $ExpectError
 <Badge invalidProp="2" />; // $ExpectError
+
+// AS = ComponentClass
+<Spinner as={Button} colSpan="secondary" />; // $ExpectError
+<Spinner as={Button} active animation="border" />;
+
+// As = Intrinsic
+<Button<'img'> as="img" bla="foo" />; // $ExpectError
+<Button as="img" src="bla" />;

--- a/types/simple.test.tsx
+++ b/types/simple.test.tsx
@@ -389,9 +389,9 @@ import {
 
 // As = ComponentClass
 <Tabs invalidProp="2" />; // $ExpectError
-<AlerLink invalidProp="2" />; // $ExpectError
-<DropdownItem invalidProp="2" />; // $ExpectError
-<NavLink invalidProp="2" />; // $ExpectError
+<Alert.Link invalidProp="2" />; // $ExpectError
+<Dropdown.Item invalidProp="2" />; // $ExpectError
+<Nav.Link invalidProp="2" />; // $ExpectError
 <Spinner invalidProp="2" animation="border" />; // $ExpectError
 <ToggleButton invalidProp="2" />; // $ExpectError
 <ToggleButtonGroup invalidProp="2" />; // $ExpectError

--- a/types/simple.test.tsx
+++ b/types/simple.test.tsx
@@ -386,3 +386,17 @@ import {
   <ToggleButton value={2}>Radio 2</ToggleButton>
   <ToggleButton value={3}>Radio 3</ToggleButton>
 </ToggleButtonGroup>;
+
+// As = ComponentClass
+<Tabs invalidProp="2" />; // $ExpectError
+<AlerLink invalidProp="2" />; // $ExpectError
+<DropdownItem invalidProp="2" />; // $ExpectError
+<NavLink invalidProp="2" />; // $ExpectError
+<Spinner invalidProp="2" />; // $ExpectError
+<ToggleButton invalidProp="2" />; // $ExpectError
+<ToggleButtonGroup invalidProp="2" />; // $ExpectError
+
+// As = intrinsic
+<Button invalidProp="2" />; // $ExpectError
+<Alert invalidProp="2" />; // $ExpectError
+<Badge invalidProp="2" />; // $ExpectError


### PR DESCRIPTION
This is the real solution to solve the problem in https://github.com/react-bootstrap/react-bootstrap/pull/4512. 

With this change the `As` generic argument and the dependent props are correctly inferred for both Intrinsics ('div', 'a', ...) that where already working as well as other react-bootstrap Components ('SafeAnchor',  'Button') **new fix!!**

Here is a playground snippet comparing the two solutions. 

http://www.typescriptlang.org/play/?jsx=2#code/JYWwDg9gTgLgBAKjgQwM5wEoFNkGN4BmUEIcA5FDvmQNwBQdWAHpLHDAJ5hZwDyIwGAB4AKgBo4AVQB8cALxwACsFwBrURICiTXABsArgBMsQ1Vg4QCccXDMWrM6fUYto8Tt0xYwuvFkXEYKhCAJIAdmFYUHDMMFhhhujYeDAAdJq6WCDxMCJcWBKKsgr8gkJ0cF4pqQDCJJCRYTABEEEA6oIAFtgEoRFR0mIVSnSyAGTDis7MrPDATVEEfnAAQqgBWATATC1BQgCC6LHxiVX46ZnZTXncsgDew2gA-ABccIf0lQBG65RbTK84KgYFB5gBzegAXwYMzccD0aHQaw2-zq4AgjWEw0OMSYcQSSSoaQyWRyNwKk3kcDu0MqsmOBLOaTRDRyQmwPj8u2ChwkyL+225B1Q4yU0nucGhLlm7Hyq1+m22LIxORqvlQwWxRzxJ0J1RJV1y+SGlUUVJpw2KTNq9RVTTViPZ3l8uH8gR5qD5Cv+QsOoqKEqlsLY8ziUCWrrgADlkAA3bnU4ZhONfZBQfmKgFvYGgsIQ4a4NOGAASOGM6e920BOfBnzgsbTwGQTUBZBgyB+ZDgAB9yGBgLpdKhaI98MBY1gANLmQH6MKqMIQADuYTrxiW+l0MH2Y4n044s-ni5Xda2g8BXwgEEyzbrACt9MDgAQD29L9ecKvhsRMtWQbWkxTNMLyvG8v0qDF9wAEWXMJAWSc590vItNAnJpi2bQxMigIQYE6YARShBhjARSh4XVdAY1jcpKhxBlTgQ4lLjJOUFDIQxxzIS1cXxU4M1RW1MWFCQqO5e46CDVwQwWcNlhEDtfladAHkqFJxynGc3jnBdYLXTZkE3bddw0184G049wPrRtmxgVt207Hs+wHIcR0qEFm1QQRgAxQEliHHhe0Yi5SWufI62AQxs3-PM6xACA5xgXgwk0GSQI-W9hjnOKEqS7RBDSsCiLoEjfDIhENWsBS2mIPMaPebVeL1c4DRYzwFA8LBLGjONuPopFKyYZUhN5SqfjE6lJWIrBSJ4cr0Hkn4MGAMFOixWiGt1a0WtCtr5RRJVBNVCihHYziRLjMTep1Rl+IO9Fhs9UbFKCQMGDoBtomQKlRCqmqwTgCK5AAImQIG4AIK9gdTKAgYAeicOBYYQCGICBTp4t0QwYigYhPvQRd4HXeYsEMBBYfetM4C+b6FtQJaVrmQxgdB8HIaB6G4YRpGUbgMBiEMfRXSOHHoBQbVuHwEmyaAA

I've checked with a relatively big codebase and works ok. 