### PR TITLE
Update min required React for UNSAFE_ lifecycles

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   "author": "Stephen J. Collings <stevoland@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.14.9 || >=15.3.0",
-    "react-dom": "^0.14.9 || >=15.3.0"
+    "react": "^16.3.0",
+    "react-dom": "^16.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
This PR updates the minimum react requirements for the "bootstrap 3" track. #4244 refactored the code to use the `UNSAFE_` methods. These methods were only introduced in [`react@16.3.0`](https://github.com/facebook/react/blob/master/CHANGELOG.md#1630-march-29-2018) so that version is going to be necessary for it to work.

Please let me know if you would like me to add version increment (0.33.0?) to this PR to support the release of a React 16.9 friendly version of the Bootstrap3 package. Happy to include that. Additionally let me know if there's anything else you'd like modified.