### PR TITLE
docs: makes link to react-overlays open in a new tab

### DIFF
--- a/www/src/pages/utilities/react-overlays.js
+++ b/www/src/pages/utilities/react-overlays.js
@@ -17,7 +17,11 @@ export default withLayout(function ReactOverlaysSection() {
         Often times you may need a more generic or low-level version of a
         Bootstrap component. Many of the <code>react-bootstrap</code> components
         are built on top of components from{' '}
-        <a href="https://react-bootstrap.github.io/react-overlays/">
+        <a
+          href="https://react-bootstrap.github.io/react-overlays/"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
           react-overlays
         </a>
         , if you find yourself at the limit of a Bootstrap component, consider


### PR DESCRIPTION
This PR aims to address #4455, where the link to the `react-overlays` documentation page isn't working because of a conflict with Gatsby/React's internal routing (and throws an invisible 404 in the console). To fix this, I've added `target="_blank"` and `rel="noreferrer noopener"` to the anchor tag, so it opens in a new tab (and will look for the site rooted at `https://react-bootstrap.github.io/react-overlays/` rather than using the SPA router).