### PR TITLE
docs: Added copy to clipboard option for import statements in API doc…

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -19,6 +19,7 @@
     "bootstrap": "^4.3.1",
     "classnames": "^2.2.6",
     "common-tags": "^1.8.0",
+    "copy-text-to-clipboard": "^2.1.1",
     "docsearch.js": "^2.6.3",
     "dom-helpers": "^3.4.0",
     "formik": "^1.5.8",

--- a/www/src/components/ComponentApi.js
+++ b/www/src/components/ComponentApi.js
@@ -1,32 +1,13 @@
 import { graphql } from 'gatsby';
 import kebabCase from 'lodash/kebabCase';
 import React from 'react';
-import styled from 'astroturf';
-
-import Heading from './Heading';
 import Anchor from './Anchor';
+import Heading from './Heading';
+import ImportApi from './ImportApi';
 import LinkToSource from './LinkToSource';
 import PropTable from './PropTable';
 
-const Keyword = styled('span')`
-  color: #a626a4;
-`;
-const Code = styled('code')`
-  padding: 0;
-  display: block;
-  color: #50a14f;
-  background-color: transparent;
-  margin-bottom: 1rem;
-`;
-
 const propTypes = {};
-
-const Import = ({ name }) => (
-  <Code aria-label={`Import code for the ${name} component`}>
-    <Keyword>import</Keyword> {name} <Keyword>from</Keyword> 'react-bootstrap/
-    {name}'
-  </Code>
-);
 
 function ComponentApi({ heading, metadata, exportedBy }) {
   let { description, displayName: name } = metadata;
@@ -54,7 +35,7 @@ function ComponentApi({ heading, metadata, exportedBy }) {
         </div>
       </Heading>
 
-      <Import name={importName} />
+      <ImportApi name={importName} />
       {/* use composes here */}
       {descHtml && <div dangerouslySetInnerHTML={{ __html: descHtml }} />}
       <PropTable metadata={metadata} />

--- a/www/src/components/ImportApi.js
+++ b/www/src/components/ImportApi.js
@@ -1,0 +1,63 @@
+import { faCopy } from '@fortawesome/free-solid-svg-icons/faCopy';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import styled from 'astroturf';
+import copy from 'copy-text-to-clipboard';
+import React, { useCallback, useMemo, useState } from 'react';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+
+const Link = styled('span')`
+  font-size: 1rem;
+  padding: 0 0.5rem;
+  cursor: pointer;
+`;
+
+const Keyword = styled('span')`
+  color: #a626a4;
+`;
+
+const Code = styled('code')`
+  padding: 0;
+  display: inline-block;
+  color: #50a14f;
+  background-color: transparent;
+  margin-bottom: 1rem;
+`;
+
+const COPY_IMPORT_TEXT = 'Copy import code';
+const COPIED_IMPORT_TEXT = 'Copied!';
+
+const CopyImport = ({ name }) => {
+  const [text, setText] = useState(COPY_IMPORT_TEXT);
+  const textToCopy = useMemo(
+    () => `import ${name} from 'react-bootstrap/${name}'`,
+    [name],
+  );
+
+  const handleCopy = useCallback(() => {
+    copy(textToCopy);
+    setText(COPIED_IMPORT_TEXT);
+    setTimeout(() => setText(COPY_IMPORT_TEXT), 2000);
+  }, [textToCopy]);
+
+  return (
+    <OverlayTrigger
+      overlay={<Tooltip id={`copy-${name}-import-tooltip`}>{text}</Tooltip>}
+    >
+      <Link onClick={handleCopy} className="js-search-exclude">
+        <FontAwesomeIcon icon={faCopy} />
+        <span className="sr-only">{`Copy import code for the ${name} component`}</span>
+      </Link>
+    </OverlayTrigger>
+  );
+};
+
+export default ({ name }) => (
+  <>
+    <Code aria-label={`Import code for the ${name} component`}>
+      <Keyword>import</Keyword> {name} <Keyword>from</Keyword> 'react-bootstrap/
+      {name}'
+    </Code>
+    <CopyImport name={name} />
+  </>
+);

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -3103,6 +3103,11 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-text-to-clipboard@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/copy-text-to-clipboard/-/copy-text-to-clipboard-2.1.1.tgz#5340e8620976d2dd9de0ff11493d13a80d600fd2"
+  integrity sha512-oSuMj4ArDGSLcLPsDhzWOhalzOVV0ErCHNfZNNr+spC+iWJ6PVSLzPPrJw/rcdFZyOhugn8iw6O0nrpY/ZrEMg==
+
 copyfiles@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-1.2.0.tgz#a8da3ac41aa2220ae29bd3c58b6984294f2c593c"


### PR DESCRIPTION
This PR aims to implement the requested feature in #4502. This is what I did:

- Added `copy-text-to-clipboard` lib as a dependency in `www` folder
- Created a new `CopyImport` component which displays a copy icon that performs the mentioned functionality
- Added `CopyImport` to `ComponentApi` next to the import statement `code` section.

This is how it looks:

![imagen](https://user-images.githubusercontent.com/1621557/65845901-970a0700-e301-11e9-9efb-4210211e8f0e.png)

Please let me know if you need something else.