### PR TITLE
Add 'as' prop to Form.Check

### DIFF
--- a/src/FormCheck.js
+++ b/src/FormCheck.js
@@ -30,6 +30,13 @@ const propTypes = {
    */
   _ref: PropTypes.any,
 
+  /**
+   * The underlying HTML element to use when rendering the FormCheck.
+   *
+   * @type {('input'|elementType)}
+   */
+  as: PropTypes.elementType,
+
   /** A HTML id attribute, necessary for proper form accessibility. */
   id: PropTypes.string,
 
@@ -103,6 +110,8 @@ const FormCheck = React.forwardRef(
       label,
       children,
       custom: propCustom,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
+      as = 'input',
       ...props
     },
     ref,
@@ -133,6 +142,7 @@ const FormCheck = React.forwardRef(
         isInvalid={isInvalid}
         isStatic={!hasLabel}
         disabled={disabled}
+        as={as}
       />
     );
 

--- a/src/FormCheckInput.js
+++ b/src/FormCheckInput.js
@@ -17,6 +17,13 @@ const propTypes = {
    */
   bsCustomPrefix: PropTypes.string,
 
+  /**
+   * The underlying HTML element to use when rendering the FormCheckInput.
+   *
+   * @type {('input'|elementType)}
+   */
+  as: PropTypes.elementType,
+
   /** A HTML id attribute, necessary for proper form accessibility. */
   id: PropTypes.string,
 
@@ -50,6 +57,8 @@ const FormCheckInput = React.forwardRef(
       isValid,
       isInvalid,
       isStatic,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
+      as: Component = 'input',
       ...props
     },
     ref,
@@ -60,7 +69,7 @@ const FormCheckInput = React.forwardRef(
       : useBootstrapPrefix(bsPrefix, 'form-check-input');
 
     return (
-      <input
+      <Component
         {...props}
         ref={ref}
         id={id || controlId}

--- a/test/FormCheckSpec.js
+++ b/test/FormCheckSpec.js
@@ -117,4 +117,12 @@ describe('<FormCheck>', () => {
 
     wrapper.assertSingle('label.custom-control-label');
   });
+
+  it('should support "as"', () => {
+    const Surrogate = ({ className = '', ...rest }) => (
+      <input className={`extraClass ${className}'`} {...rest} />
+    );
+    const wrapper = mount(<FormCheck as={Surrogate} />);
+    wrapper.assertSingle('input.extraClass[type="checkbox"]');
+  });
 });

--- a/types/components/FormCheckInput.d.ts
+++ b/types/components/FormCheckInput.d.ts
@@ -11,9 +11,8 @@ export interface FormCheckInputProps {
   innerRef?: React.LegacyRef<this>;
 }
 
-declare class FormCheckInput extends BsPrefixComponent<
-  'input',
-  FormCheckInputProps
-> {}
+declare class FormCheckInput<
+  As extends React.ElementType = 'input'
+> extends BsPrefixComponent<As, FormCheckInputProps> {}
 
 export default FormCheckInput;


### PR DESCRIPTION
Addresses react-bootstrap/react-bootstrap#4565

I haven't written tests yet:

- I won't spend the time unless a maintainer says this feature could be accepted
- I can't write tests unless I can run them:
  - `npm test` returns a billion errors before I have even made any changes
  - Following the guidelines in CONTRIBUTING.md leads me to try `npm run tdd FormCheckInput` which fails (cannot find module), or `npm run tdd src/FormCheckInput` which also fails (syntax error: unexpected identifier classNames in `import classNames from 'classnames';`, which I haven't touched)