### PR TITLE
docs: updating example in overlay-trigger documentation

### DIFF
--- a/www/src/examples/Overlays/OverlayTrigger.js
+++ b/www/src/examples/Overlays/OverlayTrigger.js
@@ -1,28 +1,10 @@
-const renderTooltip = ({
-  placement,
-  scheduleUpdate,
-  arrowProps,
-  outOfBoundaries,
-  show,
-  ...props
-}) => (
-  <div
-    {...props}
-    style={{
-      backgroundColor: 'rgba(0, 0, 0, 0.85)',
-      padding: '2px 10px',
-      color: 'white',
-      borderRadius: 3,
-      ...props.style,
-    }}
-  >
-    Simple tooltip
-  </div>
-);
+function renderTooltip(props) {
+  return <Tooltip {...props}>Simple tooltip</Tooltip>;
+}
 
 const Example = () => (
   <OverlayTrigger
-    placement="right-start"
+    placement="right"
     delay={{ show: 250, hide: 400 }}
     overlay={renderTooltip}
   >

--- a/www/src/examples/Overlays/OverlayTrigger.js
+++ b/www/src/examples/Overlays/OverlayTrigger.js
@@ -1,4 +1,11 @@
-const renderTooltip = props => (
+const renderTooltip = ({
+  placement,
+  scheduleUpdate,
+  arrowProps,
+  outOfBoundaries,
+  show,
+  ...props
+}) => (
   <div
     {...props}
     style={{

--- a/www/src/pages/utilities/react-overlays.js
+++ b/www/src/pages/utilities/react-overlays.js
@@ -17,7 +17,11 @@ export default withLayout(function ReactOverlaysSection() {
         Often times you may need a more generic or low-level version of a
         Bootstrap component. Many of the <code>react-bootstrap</code> components
         are built on top of components from{' '}
-        <a href="https://react-bootstrap.github.io/react-overlays/">
+        <a
+          href="https://react-bootstrap.github.io/react-overlays/"
+          target="_blank"
+          rel="noreferrer noopener"
+        >
           react-overlays
         </a>
         , if you find yourself at the limit of a Bootstrap component, consider


### PR DESCRIPTION
Hey there! This is a super quick PR that implements a fix for the problem in [react-bootstrap/react-overlays#312](https://github.com/react-bootstrap/react-overlays/issues/312). It now uses the `Tooltip` component, which properly handles down the props that were causing problems!