### PR TITLE
Increase overlay trigger test coverage

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -72,7 +72,7 @@ const propTypes = {
 };
 
 const defaultProps = {
-  defaultOverlayShown: false,
+  defaultShow: false,
   trigger: ['hover', 'focus'],
 };
 
@@ -149,19 +149,18 @@ class OverlayTrigger extends React.Component {
 
   handleFocus = e => {
     const { onFocus } = this.getChildProps();
-    this.handleShow(e);
+    this.handleShow();
     if (onFocus) onFocus(e);
   };
 
   handleBlur = e => {
     const { onBlur } = this.getChildProps();
-    this.handleHide(e);
+    this.handleHide();
     if (onBlur) onBlur(e);
   };
 
   handleClick = e => {
     const { onClick } = this.getChildProps();
-
     if (this.state.show) this.hide();
     else this.show();
 
@@ -184,7 +183,7 @@ class OverlayTrigger extends React.Component {
     const related = e.relatedTarget || e.nativeEvent[relatedNative];
 
     if ((!related || related !== target) && !contains(target, related)) {
-      handler(e);
+      handler();
     }
   }
 
@@ -212,18 +211,18 @@ class OverlayTrigger extends React.Component {
 
     const triggerProps = {};
 
-    let triggers = trigger == null ? [] : [].concat(trigger);
+    let triggers = trigger ? [].concat(trigger) : [];
 
-    if (triggers.indexOf('click') !== -1) {
+    if (triggers.includes('click')) {
       triggerProps.onClick = this.handleClick;
     }
 
-    if (triggers.indexOf('focus') !== -1) {
-      triggerProps.onFocus = this.handleShow;
-      triggerProps.onBlur = this.handleHide;
+    if (triggers.includes('focus')) {
+      triggerProps.onFocus = this.handleFocus;
+      triggerProps.onBlur = this.handleBlur;
     }
 
-    if (triggers.indexOf('hover') !== -1) {
+    if (triggers.includes('hover')) {
       warning(
         triggers.length >= 1,
         '[react-bootstrap] Specifying only the `"hover"` trigger limits the ' +

--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -213,16 +213,16 @@ class OverlayTrigger extends React.Component {
 
     let triggers = trigger ? [].concat(trigger) : [];
 
-    if (triggers.includes('click')) {
+    if (triggers.indexOf('click') !== -1) {
       triggerProps.onClick = this.handleClick;
     }
 
-    if (triggers.includes('focus')) {
+    if (triggers.indexOf('focus') !== -1) {
       triggerProps.onFocus = this.handleFocus;
       triggerProps.onBlur = this.handleBlur;
     }
 
-    if (triggers.includes('hover')) {
+    if (triggers.indexOf('hover') !== -1) {
       warning(
         triggers.length >= 1,
         '[react-bootstrap] Specifying only the `"hover"` trigger limits the ' +

--- a/test/OverlayTriggerSpec.js
+++ b/test/OverlayTriggerSpec.js
@@ -39,18 +39,69 @@ describe('<OverlayTrigger>', () => {
     callback.should.have.been.called;
   });
 
-  it('Should show after click trigger', () => {
-    const wrapper = mount(
-      <OverlayTrigger trigger="click" overlay={<Div className="test" />}>
-        <button type="button">button</button>
-      </OverlayTrigger>,
-    );
+  describe('trigger handlers', () => {
+    [
+      {
+        trigger: 'click',
+        event: 'click',
+      },
+      {
+        trigger: 'hover',
+        event: 'mouseOver',
+      },
+      {
+        trigger: 'focus',
+        event: 'focus',
+      },
+    ].forEach(({ trigger, event }) => {
+      it(`Should show after ${trigger} trigger`, () => {
+        const wrapper = mount(
+          <OverlayTrigger trigger={trigger} overlay={<Div className="test" />}>
+            <button type="button">button</button>
+          </OverlayTrigger>,
+        );
 
-    wrapper.assertNone('.test');
+        wrapper.assertNone('div.test');
 
-    wrapper.find('button').simulate('click');
+        wrapper.find('button').simulate(event);
 
-    wrapper.assertSingle('div.test');
+        wrapper.assertSingle('div.test');
+      });
+    });
+
+    it('Should hide after blur for the focus trigger', () => {
+      const wrapper = mount(
+        <OverlayTrigger
+          defaultShow
+          trigger="focus"
+          overlay={<Div className="test" />}
+        >
+          <button type="button">button</button>
+        </OverlayTrigger>,
+      );
+      wrapper.assertSingle('div.test.show');
+
+      wrapper.find('button').simulate('blur');
+
+      wrapper.assertNone('div.test.show');
+    });
+
+    it('Should hide after mouseOut for the hover trigger', () => {
+      const wrapper = mount(
+        <OverlayTrigger
+          defaultShow
+          trigger="hover"
+          overlay={<Div className="test" />}
+        >
+          <button type="button">button</button>
+        </OverlayTrigger>,
+      );
+      wrapper.assertSingle('div.test.show');
+
+      wrapper.find('button').simulate('mouseOut');
+
+      wrapper.assertNone('div.test.show');
+    });
   });
 
   it('Should not set aria-describedby if the state is not show', () => {
@@ -82,7 +133,7 @@ describe('<OverlayTrigger>', () => {
     });
   });
 
-  describe('trigger handlers', () => {
+  describe('maintain trigger handlers', () => {
     let mountPoint;
 
     beforeEach(() => {
@@ -95,11 +146,12 @@ describe('<OverlayTrigger>', () => {
       document.body.removeChild(mountPoint);
     });
 
-    it('Should keep trigger handlers', done => {
+    it('Should keep trigger handlers', () => {
+      const triggerSpy = sinon.spy();
       mount(
         <div>
           <OverlayTrigger trigger="click" overlay={<Div>test</Div>}>
-            <button type="button" onClick={() => done()}>
+            <button type="button" onClick={triggerSpy}>
               button
             </button>
           </OverlayTrigger>
@@ -108,6 +160,8 @@ describe('<OverlayTrigger>', () => {
       )
         .find('button')
         .simulate('click');
+
+      triggerSpy.should.have.been.calledOnce;
     });
   });
 

--- a/test/OverlayTriggerSpec.js
+++ b/test/OverlayTriggerSpec.js
@@ -23,20 +23,54 @@ describe('<OverlayTrigger>', () => {
     ).assertSingle('button');
   });
 
-  it('Should call OverlayTrigger onClick prop to child', () => {
-    const callback = sinon.spy();
+  describe('forward triggers to child', () => {
+    it(`Should call child's onClick for the click trigger`, () => {
+      const callback = sinon.spy();
 
-    mount(
-      <OverlayTrigger overlay={<Div>test</Div>} trigger="click">
-        <button type="button" onClick={callback}>
-          button
-        </button>
-      </OverlayTrigger>,
-    )
-      .find('button')
-      .simulate('click');
+      mount(
+        <OverlayTrigger overlay={<Div>test</Div>} trigger="click">
+          <button type="button" onClick={callback}>
+            button
+          </button>
+        </OverlayTrigger>,
+      )
+        .find('button')
+        .simulate('click');
 
-    callback.should.have.been.called;
+      callback.should.have.been.called;
+    });
+
+    it(`Should call child's onFocus for the focus trigger`, () => {
+      const callback = sinon.spy();
+
+      mount(
+        <OverlayTrigger overlay={<Div>test</Div>} trigger="focus">
+          <button type="button" onFocus={callback}>
+            button
+          </button>
+        </OverlayTrigger>,
+      )
+        .find('button')
+        .simulate('focus');
+
+      callback.should.have.been.called;
+    });
+
+    it(`Should call child's onBlur for the focus trigger`, () => {
+      const callback = sinon.spy();
+
+      mount(
+        <OverlayTrigger overlay={<Div>test</Div>} trigger="focus">
+          <button type="button" onBlur={callback}>
+            button
+          </button>
+        </OverlayTrigger>,
+      )
+        .find('button')
+        .simulate('blur');
+
+      callback.should.have.been.called;
+    });
   });
 
   describe('trigger handlers', () => {
@@ -67,6 +101,29 @@ describe('<OverlayTrigger>', () => {
 
         wrapper.assertSingle('div.test');
       });
+    });
+
+    it('Should allow multiple triggers (click and focus)', () => {
+      const wrapper = mount(
+        <OverlayTrigger
+          trigger={['focus', 'click']}
+          overlay={<Div className="test" />}
+        >
+          <button type="button">button</button>
+        </OverlayTrigger>,
+      );
+
+      wrapper.assertNone('div.test.show');
+
+      wrapper.find('button').simulate('click');
+      wrapper.assertSingle('div.test.show');
+
+      // hide the element
+      wrapper.find('button').simulate('click');
+      wrapper.assertNone('div.test.show');
+
+      wrapper.find('button').simulate('focus');
+      wrapper.assertSingle('div.test.show');
     });
 
     it('Should hide after blur for the focus trigger', () => {


### PR DESCRIPTION
Increase test coverage of Overlay(Trigger) by checking all trigger events and their respective hide events (and small refactoring and bug fixing).

Issue: https://github.com/react-bootstrap/react-bootstrap/issues/3889

One thing I would have liked to do better (help/input appreciated):
I could not really get the tooltip element to vanish entirely. I think it has something to do with the transition, but I am not sure.
While the hidden state is triggered and the underlying Overlay element is updated the tooltip is not removed from the DOM.

I also had problems testing the delay case, which delayed the reaction, but actually never fired to the transition to the correct state :man_shrugging: 

The test I would have liked to write but does not work: 

```
  it('Delays the trigger event if the delay prop is passed', (done) => {
    const wrapper = mount(
      <OverlayTrigger
        defaultShow
        delay={1}
        trigger="hover"
        overlay={<Div className="test" />}
      >
        <button type="button">button</button>
      </OverlayTrigger>,
    );
    wrapper.assertSingle('div.test.show');

    wrapper.find('button').simulate('mouseOut');

    wrapper.assertSingle('div.test.show');

    setTimeout(() => {
      wrapper.assertNone('div.test.show');
      done()
    }, 2);
  });
```