### PR TITLE
Fix(Bs3): Remove unsafe lifecycles by upgrading uncontrollable to ^7.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "react-overlays": "^0.8.0",
     "react-prop-types": "^0.4.0",
     "react-transition-group": "^2.0.0",
-    "uncontrollable": "^5.0.0",
+    "uncontrollable": "^7.0.2",
     "warning": "^3.0.0"
   },
   "release-script": {

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -8,7 +8,7 @@ import ReactDOM from 'react-dom';
 import all from 'prop-types-extra/lib/all';
 import elementType from 'prop-types-extra/lib/elementType';
 import isRequiredForA11y from 'prop-types-extra/lib/isRequiredForA11y';
-import uncontrollable from 'uncontrollable';
+import { uncontrollable } from 'uncontrollable';
 import warning from 'warning';
 
 import ButtonGroup from './ButtonGroup';

--- a/src/Navbar.js
+++ b/src/Navbar.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import elementType from 'prop-types-extra/lib/elementType';
-import uncontrollable from 'uncontrollable';
+import { uncontrollable } from 'uncontrollable';
 
 import Grid from './Grid';
 import NavbarBrand from './NavbarBrand';
@@ -259,8 +259,6 @@ UncontrollableNavbar.Text = createSimpleWrapper('p', 'text', 'NavbarText');
 UncontrollableNavbar.Link = createSimpleWrapper('a', 'link', 'NavbarLink');
 
 // Set bsStyles here so they can be overridden.
-export default bsStyles(
-  [Style.DEFAULT, Style.INVERSE],
-  Style.DEFAULT,
+export default bsStyles([Style.DEFAULT, Style.INVERSE], Style.DEFAULT)(
   UncontrollableNavbar
 );

--- a/src/Panel.js
+++ b/src/Panel.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import uncontrollable from 'uncontrollable';
+import { uncontrollable } from 'uncontrollable';
 import warning from 'warning';
 
 import {

--- a/src/PanelGroup.js
+++ b/src/PanelGroup.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { cloneElement } from 'react';
-import uncontrollable from 'uncontrollable';
+import { uncontrollable } from 'uncontrollable';
 
 import {
   bsClass,

--- a/src/TabContainer.js
+++ b/src/TabContainer.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import uncontrollable from 'uncontrollable';
+import { uncontrollable } from 'uncontrollable';
 
 const TAB = 'tab';
 const PANE = 'pane';

--- a/src/Tabs.js
+++ b/src/Tabs.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import requiredForA11y from 'prop-types-extra/lib/isRequiredForA11y';
-import uncontrollable from 'uncontrollable';
+import { uncontrollable } from 'uncontrollable';
 import elementType from 'prop-types-extra/lib/elementType';
 
 import Nav from './Nav';

--- a/src/ToggleButtonGroup.js
+++ b/src/ToggleButtonGroup.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import invariant from 'invariant';
-import uncontrollable from 'uncontrollable';
+import { uncontrollable } from 'uncontrollable';
 
 import chainFunction from './utils/createChainedFunction';
 import ValidChildren from './utils/ValidComponentChildren';

--- a/src/utils/bootstrapUtils.js
+++ b/src/utils/bootstrapUtils.js
@@ -178,7 +178,7 @@ export function splitBsPropsAndOmit(props, omittedPropNames) {
  * in order to validate the new variant.
  */
 export function addStyle(Component, ...styleVariant) {
-  bsStyles(styleVariant, Component);
+  bsStyles(styleVariant)(Component);
 }
 
 export const _curry = curry;

--- a/test/DropdownButtonSpec.js
+++ b/test/DropdownButtonSpec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
+import { mount } from 'enzyme';
 
 import Dropdown from '../src/Dropdown';
 import DropdownButton from '../src/DropdownButton';
@@ -224,30 +225,24 @@ describe('<DropdownButton>', () => {
   });
 
   it('should pass defaultOpen to `<Dropdown>`', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <DropdownButton id="test-id" title="title" defaultOpen>
         <MenuItem eventKey="1">MenuItem 1 content</MenuItem>
       </DropdownButton>
     );
 
-    const dropdown = ReactTestUtils.findRenderedComponentWithType(
-      instance,
-      Dropdown
-    );
-    const toggle = ReactTestUtils.findRenderedComponentWithType(
-      instance,
-      DropdownToggle
-    );
+    const dropdown = wrapper.find(Dropdown).first();
+    const toggle = wrapper.find(DropdownToggle).first();
 
-    expect(dropdown.props.defaultOpen).to.equal(true);
-    expect(toggle.props.defaultOpen).to.not.exist;
+    expect(dropdown.props().defaultOpen).to.equal(true);
+    expect(toggle.props().defaultOpen).to.not.exist;
   });
 
   it('should pass onMouseEnter and onMouseLeave to `<Dropdown>`', () => {
     const onMouseEnter = () => {};
     const onMouseLeave = () => {};
 
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <DropdownButton
         id="test-id"
         title="title"
@@ -258,19 +253,13 @@ describe('<DropdownButton>', () => {
       </DropdownButton>
     );
 
-    const dropdown = ReactTestUtils.findRenderedComponentWithType(
-      instance,
-      Dropdown
-    );
-    const toggle = ReactTestUtils.findRenderedComponentWithType(
-      instance,
-      DropdownToggle
-    );
+    const dropdown = wrapper.find(Dropdown).first();
+    const toggle = wrapper.find(DropdownToggle).first();
 
-    expect(dropdown.props.onMouseEnter).to.equal(onMouseEnter);
-    expect(dropdown.props.onMouseLeave).to.equal(onMouseLeave);
+    expect(dropdown.props().onMouseEnter).to.equal(onMouseEnter);
+    expect(dropdown.props().onMouseLeave).to.equal(onMouseLeave);
 
-    expect(toggle.props.onMouseEnter).to.not.exist;
-    expect(toggle.props.onMouseLeave).to.not.exist;
+    expect(toggle.props().onMouseEnter).to.not.exist;
+    expect(toggle.props().onMouseLeave).to.not.exist;
   });
 });

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -33,8 +33,8 @@ describe('<Dropdown>', () => {
   const simpleDropdown = <Dropdown id="test-id">{dropdownChildren}</Dropdown>;
 
   it('renders div with dropdown class', () => {
-    const instance = ReactTestUtils.renderIntoDocument(simpleDropdown);
-    const node = ReactDOM.findDOMNode(instance);
+    const wrapper = mount(simpleDropdown);
+    const node = wrapper.getDOMNode();
 
     node.tagName.should.equal('DIV');
     node.className.should.match(/\bdropdown\b/);
@@ -42,12 +42,12 @@ describe('<Dropdown>', () => {
   });
 
   it('renders div with dropup class', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Dropdown title="Dropup" dropup id="test-id">
         {dropdownChildren}
       </Dropdown>
     );
-    const node = ReactDOM.findDOMNode(instance);
+    const node = wrapper.getDOMNode();
 
     node.tagName.should.equal('DIV');
     node.className.should.not.match(/\bdropdown\b/);
@@ -55,12 +55,8 @@ describe('<Dropdown>', () => {
   });
 
   it('renders toggle with Dropdown.Toggle', () => {
-    const instance = ReactTestUtils.renderIntoDocument(simpleDropdown);
-
-    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-      instance,
-      'BUTTON'
-    );
+    const wrapper = mount(simpleDropdown);
+    const buttonNode = wrapper.find('button').getDOMNode();
 
     buttonNode.textContent.should.match(/Child Title/);
 
@@ -74,11 +70,8 @@ describe('<Dropdown>', () => {
   });
 
   it('renders dropdown toggle button caret', () => {
-    const instance = ReactTestUtils.renderIntoDocument(simpleDropdown);
-    const caretNode = ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'caret'
-    );
+    const wrapper = mount(simpleDropdown);
+    const caretNode = wrapper.find('.caret').getDOMNode();
 
     caretNode.tagName.should.equal('SPAN');
   });
@@ -96,7 +89,7 @@ describe('<Dropdown>', () => {
   });
 
   it('renders custom menu', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Dropdown title="Single child" id="test-id">
         <Dropdown.Toggle>Child Text</Dropdown.Toggle>
 
@@ -106,14 +99,8 @@ describe('<Dropdown>', () => {
       </Dropdown>
     );
 
-    ReactTestUtils.scryRenderedComponentsWithType(
-      instance,
-      DropdownMenu
-    ).length.should.equal(0);
-    ReactTestUtils.scryRenderedComponentsWithType(
-      instance,
-      CustomMenu
-    ).length.should.equal(1);
+    expect(wrapper.find(DropdownMenu)).to.have.lengthOf(0);
+    expect(wrapper.find(CustomMenu)).to.have.lengthOf(1);
   });
 
   it('prop validation with multiple menus', () => {
@@ -139,29 +126,23 @@ describe('<Dropdown>', () => {
   });
 
   it('forwards pullRight to menu', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Dropdown pullRight id="test-id">
         {dropdownChildren}
       </Dropdown>
     );
-    const menu = ReactTestUtils.findRenderedComponentWithType(
-      instance,
-      DropdownMenu
-    );
+    const menu = wrapper.find(DropdownMenu);
 
-    menu.props.pullRight.should.be.true;
+    expect(menu.props().pullRight).to.be.true;
   });
 
   // NOTE: The onClick event handler is invoked for both the Enter and Space
   // keys as well since the component is a button. I cannot figure out how to
   // get ReactTestUtils to simulate such though.
   it('toggles open/closed when clicked', () => {
-    const instance = ReactTestUtils.renderIntoDocument(simpleDropdown);
-    const node = ReactDOM.findDOMNode(instance);
-    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-      instance,
-      'BUTTON'
-    );
+    const wrapper = mount(simpleDropdown);
+    const node = wrapper.getDOMNode();
+    const buttonNode = wrapper.find('button').getDOMNode();
 
     node.className.should.not.match(/\bopen\b/);
     buttonNode.getAttribute('aria-expanded').should.equal('false');
@@ -178,12 +159,9 @@ describe('<Dropdown>', () => {
   });
 
   it('closes when clicked outside', () => {
-    const instance = ReactTestUtils.renderIntoDocument(simpleDropdown);
-    const node = ReactDOM.findDOMNode(instance);
-    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-      instance,
-      'BUTTON'
-    );
+    const wrapper = mount(simpleDropdown);
+    const node = wrapper.getDOMNode();
+    const buttonNode = wrapper.find('button').getDOMNode();
 
     node.className.should.not.match(/\bopen\b/);
     buttonNode.getAttribute('aria-expanded').should.equal('false');
@@ -202,16 +180,13 @@ describe('<Dropdown>', () => {
   });
 
   it('closes when mousedown outside if rootCloseEvent set', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Dropdown id="test-id" rootCloseEvent="mousedown">
         {dropdownChildren}
       </Dropdown>
     );
-    const node = ReactDOM.findDOMNode(instance);
-    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-      instance,
-      'BUTTON'
-    );
+    const node = wrapper.getDOMNode();
+    const buttonNode = wrapper.find('button').getDOMNode();
 
     node.className.should.not.match(/\bopen\b/);
     buttonNode.getAttribute('aria-expanded').should.equal('false');
@@ -230,7 +205,7 @@ describe('<Dropdown>', () => {
   });
 
   it('opens if dropdown contains no focusable menu item', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Dropdown title="custom child" id="dropdown">
         <Dropdown.Toggle>Toggle</Dropdown.Toggle>
         <Dropdown.Menu>
@@ -238,22 +213,16 @@ describe('<Dropdown>', () => {
         </Dropdown.Menu>
       </Dropdown>
     );
-    const node = ReactDOM.findDOMNode(instance);
-    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-      instance,
-      'BUTTON'
-    );
+    const node = wrapper.getDOMNode();
+    const buttonNode = wrapper.find('button').getDOMNode();
     ReactTestUtils.Simulate.click(buttonNode);
     node.className.should.match(/\bopen\b/);
   });
 
   it('when focused and closed toggles open when the key "down" is pressed', () => {
-    const instance = ReactTestUtils.renderIntoDocument(simpleDropdown);
-    const node = ReactDOM.findDOMNode(instance);
-    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-      instance,
-      'BUTTON'
-    );
+    const wrapper = mount(simpleDropdown);
+    const node = wrapper.getDOMNode();
+    const buttonNode = wrapper.find('button').getDOMNode();
 
     ReactTestUtils.Simulate.keyDown(buttonNode, { keyCode: keycode('down') });
 
@@ -262,11 +231,8 @@ describe('<Dropdown>', () => {
   });
 
   it('button has aria-haspopup attribute (As per W3C WAI-ARIA Spec)', () => {
-    const instance = ReactTestUtils.renderIntoDocument(simpleDropdown);
-    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-      instance,
-      'BUTTON'
-    );
+    const wrapper = mount(simpleDropdown);
+    const buttonNode = wrapper.find('button').getDOMNode();
 
     buttonNode.getAttribute('aria-haspopup').should.equal('true');
   });
@@ -279,21 +245,17 @@ describe('<Dropdown>', () => {
   });
 
   it('closes when child MenuItem is selected', () => {
-    const instance = ReactTestUtils.renderIntoDocument(simpleDropdown);
+    const wrapper = mount(simpleDropdown);
+    const node = wrapper.getDOMNode();
 
-    const node = ReactDOM.findDOMNode(instance);
-
-    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-      instance,
-      'BUTTON'
-    );
+    const buttonNode = wrapper.find('button').getDOMNode();
     ReactTestUtils.Simulate.click(buttonNode);
     node.className.should.match(/\bopen\b/);
 
-    const menuItem = ReactTestUtils.scryRenderedDOMComponentsWithTag(
-      instance,
-      'A'
-    )[0];
+    const menuItem = wrapper
+      .find('a')
+      .first()
+      .getDOMNode();
     ReactTestUtils.Simulate.click(menuItem);
     node.className.should.not.match(/\bopen\b/);
   });
@@ -301,22 +263,17 @@ describe('<Dropdown>', () => {
   it('does not close when onToggle is controlled', () => {
     const handleSelect = () => {};
 
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Dropdown open onToggle={handleSelect} id="test-id">
         {dropdownChildren}
       </Dropdown>
     );
-
-    const node = ReactDOM.findDOMNode(instance);
-    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-      instance,
-      'BUTTON'
-    );
-
-    const menuItem = ReactTestUtils.scryRenderedDOMComponentsWithTag(
-      instance,
-      'A'
-    )[0];
+    const node = wrapper.getDOMNode();
+    const buttonNode = wrapper.find('button').getDOMNode();
+    const menuItem = wrapper
+      .find('a')
+      .first()
+      .getDOMNode();
 
     ReactTestUtils.Simulate.click(buttonNode);
     node.className.should.match(/\bopen\b/);
@@ -375,12 +332,9 @@ describe('<Dropdown>', () => {
   });
 
   it('has aria-labelledby same id as toggle button', () => {
-    const instance = ReactTestUtils.renderIntoDocument(simpleDropdown);
-    const node = ReactDOM.findDOMNode(instance);
-    const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-      instance,
-      'BUTTON'
-    );
+    const wrapper = mount(simpleDropdown);
+    const node = wrapper.getDOMNode();
+    const buttonNode = wrapper.find('button').getDOMNode();
     const menuNode = node.children[1];
 
     buttonNode
@@ -444,10 +398,7 @@ describe('<Dropdown>', () => {
     class RefDropdown extends React.Component {
       render() {
         return (
-          <Dropdown
-            ref={dropdown => (this.dropdown = dropdown.inner)}
-            id="test"
-          >
+          <Dropdown ref={dropdown => (this.dropdown = dropdown)} id="test">
             <Dropdown.Toggle ref={toggle => (this.toggle = toggle)} />
             <Dropdown.Menu ref={menu => (this.menu = menu)} />
           </Dropdown>
@@ -495,31 +446,22 @@ describe('<Dropdown>', () => {
     });
 
     it('when focused and closed sets focus on first menu item when the key "down" is pressed', () => {
-      const instance = ReactDOM.render(simpleDropdown, focusableContainer);
-      const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-        instance,
-        'BUTTON'
-      );
-
+      const wrapper = mount(simpleDropdown, { attachTo: focusableContainer });
+      const buttonNode = wrapper.find('button').getDOMNode();
       buttonNode.focus();
-
       ReactTestUtils.Simulate.keyDown(buttonNode, { keyCode: keycode('down') });
 
-      const firstMenuItemAnchor = ReactTestUtils.scryRenderedDOMComponentsWithTag(
-        instance,
-        'A'
-      )[0];
-
+      const firstMenuItemAnchor = wrapper
+        .find('a')
+        .first()
+        .getDOMNode();
       document.activeElement.should.equal(firstMenuItemAnchor);
     });
 
     it('when focused and open does not toggle closed when the key "down" is pressed', () => {
-      const instance = ReactTestUtils.renderIntoDocument(simpleDropdown);
-      const node = ReactDOM.findDOMNode(instance);
-      const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-        instance,
-        'BUTTON'
-      );
+      const wrapper = mount(simpleDropdown);
+      const node = wrapper.getDOMNode();
+      const buttonNode = wrapper.find('button').getDOMNode();
 
       ReactTestUtils.Simulate.click(buttonNode);
       ReactTestUtils.Simulate.keyDown(buttonNode, { keyCode: keycode('down') });
@@ -530,25 +472,22 @@ describe('<Dropdown>', () => {
 
     // This test is more complicated then it appears to need. This is
     // because there was an intermittent failure of the test when not structured this way
-    // The failure occured when all tests in the suite were run together, but not a subset of the tests.
+    // The failure occurred when all tests in the suite were run together, but not a subset of the tests.
     //
     // I am fairly confident that the failure is due to a test specific conflict and not an actual bug.
     it('when open and the key "esc" is pressed the menu is closed and focus is returned to the button', () => {
-      const instance = ReactDOM.render(
+      const wrapper = mount(
         <Dropdown defaultOpen role="menuitem" id="test-id">
           {dropdownChildren}
         </Dropdown>,
-        focusableContainer
+        { attachTo: focusableContainer }
       );
 
-      const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-        instance,
-        'BUTTON'
-      );
-      const firstMenuItemAnchor = ReactTestUtils.scryRenderedDOMComponentsWithTag(
-        instance,
-        'A'
-      )[0];
+      const buttonNode = wrapper.find('button').getDOMNode();
+      const firstMenuItemAnchor = wrapper
+        .find('a')
+        .first()
+        .getDOMNode();
 
       document.activeElement.should.equal(firstMenuItemAnchor);
 
@@ -561,25 +500,15 @@ describe('<Dropdown>', () => {
     });
 
     it('when open and the key "tab" is pressed the menu is closed and focus is progress to the next focusable element', done => {
-      const instance = ReactDOM.render(
+      const wrapper = mount(
         <Grid>
           {simpleDropdown}
           <input type="text" id="next-focusable" />
         </Grid>,
-        focusableContainer
+        { attachTo: focusableContainer }
       );
-
-      // Need to use Grid instead of div above to make instance a composite
-      // element, to make this call legal.
-      const node = ReactTestUtils.findRenderedComponentWithType(
-        instance,
-        Dropdown
-      );
-
-      const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-        node,
-        'BUTTON'
-      );
+      const node = wrapper.find(Dropdown);
+      const buttonNode = node.find('button').getDOMNode();
 
       ReactTestUtils.Simulate.click(buttonNode);
       buttonNode.getAttribute('aria-expanded').should.equal('true');
@@ -615,15 +544,12 @@ describe('<Dropdown>', () => {
 
     it('passes open, event, and source correctly when opened with click', () => {
       const spy = sinon.spy();
-      const instance = ReactTestUtils.renderIntoDocument(
+      const wrapper = mount(
         <Dropdown id="test-id" onToggle={spy}>
           {dropdownChildren}
         </Dropdown>
       );
-      const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-        instance,
-        'BUTTON'
-      );
+      const buttonNode = wrapper.find('button').getDOMNode();
 
       expect(spy).to.not.have.been.called;
 
@@ -638,15 +564,12 @@ describe('<Dropdown>', () => {
 
     it('passes open, event, and source correctly when closed with click', () => {
       const spy = sinon.spy();
-      const instance = ReactTestUtils.renderIntoDocument(
+      const wrapper = mount(
         <Dropdown id="test-id" onToggle={spy}>
           {dropdownChildren}
         </Dropdown>
       );
-      const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-        instance,
-        'BUTTON'
-      );
+      const buttonNode = wrapper.find('button').getDOMNode();
 
       expect(spy).to.not.have.been.called;
       ReactTestUtils.Simulate.click(buttonNode);
@@ -662,7 +585,7 @@ describe('<Dropdown>', () => {
 
     it('passes open, event, and source correctly when child selected', () => {
       const spy = sinon.spy();
-      const instance = ReactTestUtils.renderIntoDocument(
+      const wrapper = mount(
         <Dropdown id="test-id" onToggle={spy}>
           <Dropdown.Toggle key="toggle">Child Title</Dropdown.Toggle>
           <Dropdown.Menu key="menu">
@@ -670,14 +593,8 @@ describe('<Dropdown>', () => {
           </Dropdown.Menu>
         </Dropdown>
       );
-      const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-        instance,
-        'BUTTON'
-      );
-      const childNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-        instance,
-        'A'
-      );
+      const buttonNode = wrapper.find('button').getDOMNode();
+      const childNode = wrapper.find('a').getDOMNode();
 
       expect(spy).to.not.have.been.called;
       ReactTestUtils.Simulate.click(buttonNode);
@@ -694,15 +611,12 @@ describe('<Dropdown>', () => {
 
     it('passes open, event, and source correctly when opened with keydown', () => {
       const spy = sinon.spy();
-      const instance = ReactTestUtils.renderIntoDocument(
+      const wrapper = mount(
         <Dropdown id="test-id" onToggle={spy}>
           {dropdownChildren}
         </Dropdown>
       );
-      const buttonNode = ReactTestUtils.findRenderedDOMComponentWithTag(
-        instance,
-        'BUTTON'
-      );
+      const buttonNode = wrapper.find('button').getDOMNode();
 
       ReactTestUtils.Simulate.keyDown(buttonNode, {
         key: 'Down Arrow',
@@ -719,7 +633,7 @@ describe('<Dropdown>', () => {
   });
 
   it('should derive bsClass from parent', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Dropdown bsClass="my-dropdown" id="test-id">
         <Dropdown.Toggle bsClass="my-toggle">Child Title</Dropdown.Toggle>
         <Dropdown.Menu bsClass="my-menu">
@@ -728,26 +642,10 @@ describe('<Dropdown>', () => {
       </Dropdown>
     );
 
-    assert.ok(
-      ReactTestUtils.findRenderedDOMComponentWithClass(
-        instance,
-        'my-dropdown-toggle'
-      )
-    );
-    assert.ok(
-      ReactTestUtils.findRenderedDOMComponentWithClass(
-        instance,
-        'my-dropdown-menu'
-      )
-    );
+    expect(wrapper.exists('.my-dropdown-toggle')).to.be.true;
+    expect(wrapper.exists('.my-dropdown-menu')).to.be.true;
 
-    assert.lengthOf(
-      ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'my-toggle'),
-      0
-    );
-    assert.lengthOf(
-      ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'my-menu'),
-      0
-    );
+    expect(wrapper.find('.my-toggle')).to.have.lengthOf(0);
+    expect(wrapper.find('.my-menu')).to.have.lengthOf(0);
   });
 });

--- a/test/NavbarSpec.js
+++ b/test/NavbarSpec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
+import { mount } from 'enzyme';
 
 import Nav from '../src/Nav';
 import Navbar from '../src/Navbar';
@@ -12,103 +13,65 @@ import { getOne } from './helpers';
 
 describe('<Navbar>', () => {
   it('Should create nav element', () => {
-    const instance = ReactTestUtils.renderIntoDocument(<Navbar />);
-    const nav = ReactDOM.findDOMNode(instance);
+    const wrapper = mount(<Navbar />);
+    const nav = wrapper.getDOMNode();
     assert.equal(nav.nodeName, 'NAV');
     assert.ok(nav.className.match(/\bnavbar\b/));
     assert.notOk(nav.getAttribute('role'));
   });
 
   it('Should add "navigation" role when not using a `<nav>`', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
-      <Navbar componentClass="div" />
-    );
-    const nav = ReactDOM.findDOMNode(instance);
+    const wrapper = mount(<Navbar componentClass="div" />);
+    const nav = wrapper.getDOMNode();
     assert.equal(nav.nodeName, 'DIV');
     assert.ok(nav.getAttribute('role') === 'navigation');
   });
 
   it('Should add fixedTop variation class', () => {
-    const instance = ReactTestUtils.renderIntoDocument(<Navbar fixedTop />);
-    assert.ok(
-      ReactTestUtils.findRenderedDOMComponentWithClass(
-        instance,
-        'navbar-fixed-top'
-      )
-    );
+    const wrapper = mount(<Navbar fixedTop />);
+    assert.ok(wrapper.find('.navbar-fixed-top').exists());
   });
 
   it('Should add fixedBottom variation class', () => {
-    const instance = ReactTestUtils.renderIntoDocument(<Navbar fixedBottom />);
-    assert.ok(
-      ReactTestUtils.findRenderedDOMComponentWithClass(
-        instance,
-        'navbar-fixed-bottom'
-      )
-    );
+    const wrapper = mount(<Navbar fixedBottom />);
+    assert.ok(wrapper.find('.navbar-fixed-bottom').exists());
   });
 
   it('Should add staticTop variation class', () => {
-    const instance = ReactTestUtils.renderIntoDocument(<Navbar staticTop />);
-    assert.ok(
-      ReactTestUtils.findRenderedDOMComponentWithClass(
-        instance,
-        'navbar-static-top'
-      )
-    );
+    const wrapper = mount(<Navbar staticTop />);
+    assert.ok(wrapper.find('.navbar-static-top').exists());
   });
 
   it('Should add inverse variation class', () => {
-    const instance = ReactTestUtils.renderIntoDocument(<Navbar inverse />);
-    assert.ok(
-      ReactTestUtils.findRenderedDOMComponentWithClass(
-        instance,
-        'navbar-inverse'
-      )
-    );
+    const wrapper = mount(<Navbar inverse />);
+    assert.ok(wrapper.find('.navbar-inverse').exists());
   });
 
   it('Should not add default class along with custom styles', () => {
     addStyle(Navbar, 'custom');
 
-    const instance = ReactTestUtils.renderIntoDocument(
-      <Navbar bsStyle="custom" />
-    );
+    const wrapper = mount(<Navbar bsStyle="custom" />);
 
-    expect(() =>
-      ReactTestUtils.findRenderedDOMComponentWithClass(
-        instance,
-        'navbar-default'
-      )
-    ).to.throw();
+    expect(() => wrapper.find('.navbar-default').getDOMNode()).to.throw();
   });
 
   it('Should add fluid variation class', () => {
-    const instance = ReactTestUtils.renderIntoDocument(<Navbar fluid />);
-    assert.ok(
-      ReactTestUtils.findRenderedDOMComponentWithClass(
-        instance,
-        'container-fluid'
-      )
-    );
+    const wrapper = mount(<Navbar fluid />);
+    assert.ok(wrapper.find('.container-fluid').exists());
   });
 
   it('Should override role attribute', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
-      <Navbar role="banner" />
-    );
-    assert.ok(ReactDOM.findDOMNode(instance).getAttribute('role'), 'banner');
+    const wrapper = mount(<Navbar role="banner" />);
+    assert.ok(wrapper.getDOMNode().getAttribute('role'), 'banner');
   });
 
   it('Should override node class', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
-      <Navbar componentClass="header" />
-    );
-    assert.equal(ReactDOM.findDOMNode(instance).nodeName, 'HEADER');
+    const wrapper = mount(<Navbar componentClass="header" />);
+    assert.equal(wrapper.getDOMNode().nodeName, 'HEADER');
   });
 
   it('Should add header with brand', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar>
         <Navbar.Header>
           <Navbar.Brand>Brand</Navbar.Brand>
@@ -116,10 +79,7 @@ describe('<Navbar>', () => {
       </Navbar>
     );
 
-    const header = ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'navbar-header'
-    );
+    const header = wrapper.find('.navbar-header').getDOMNode();
 
     const brand = getOne(header.getElementsByClassName('navbar-brand'));
 
@@ -129,7 +89,7 @@ describe('<Navbar>', () => {
   });
 
   it('Should add link element with navbar-brand class using NavBrand Component', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar>
         <Navbar.Header>
           <Navbar.Brand>
@@ -139,10 +99,7 @@ describe('<Navbar>', () => {
       </Navbar>
     );
 
-    const brand = ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'navbar-brand'
-    );
+    const brand = wrapper.find('.navbar-brand').getDOMNode();
 
     assert.ok(brand);
     assert.equal(brand.nodeName, 'A');
@@ -150,19 +107,19 @@ describe('<Navbar>', () => {
   });
 
   it('Should pass navbar context to navs', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar>
         <Nav />
       </Navbar>
     );
 
-    const nav = ReactTestUtils.findRenderedComponentWithType(instance, Nav);
+    const nav = wrapper.find(Nav).instance();
 
     assert.ok(nav.context.$bs_navbar);
   });
 
   it('Should add default toggle', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar>
         <Navbar.Header>
           <Navbar.Toggle />
@@ -170,12 +127,12 @@ describe('<Navbar>', () => {
       </Navbar>
     );
 
-    ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'navbar-toggle');
-    ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'icon-bar');
+    wrapper.find('.navbar-toggle').getDOMNode();
+    expect(wrapper.find('.icon-bar').exists()).to.be.true;
   });
 
   it('Should add custom toggle', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar>
         <Navbar.Header>
           <Navbar.Toggle>
@@ -185,13 +142,13 @@ describe('<Navbar>', () => {
       </Navbar>
     );
 
-    ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'navbar-toggle');
-    ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'test');
+    wrapper.find('.navbar-toggle').getDOMNode();
+    wrapper.find('.test').getDOMNode();
   });
 
   it('Should trigger onToggle', () => {
     const toggleSpy = sinon.spy();
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar onToggle={toggleSpy}>
         <Navbar.Header>
           <Navbar.Toggle />
@@ -199,10 +156,7 @@ describe('<Navbar>', () => {
       </Navbar>
     );
 
-    const toggle = ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'navbar-toggle'
-    );
+    const toggle = wrapper.find('.navbar-toggle').getDOMNode();
 
     ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(toggle));
 
@@ -213,7 +167,7 @@ describe('<Navbar>', () => {
   it('Should support custom props', () => {
     const clickSpy = sinon.spy();
 
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar>
         <Navbar.Header>
           <Navbar.Toggle
@@ -225,10 +179,7 @@ describe('<Navbar>', () => {
       </Navbar>
     );
 
-    const toggle = ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'navbar-toggle'
-    );
+    const toggle = wrapper.find('.navbar-toggle').getDOMNode();
 
     expect(toggle.className).to.match(/foo bar/);
     expect(toggle.style.height).to.equal('100px');
@@ -238,35 +189,29 @@ describe('<Navbar>', () => {
   });
 
   it('Should render collapse', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar>
         <Navbar.Collapse>hello</Navbar.Collapse>
       </Navbar>
     );
 
-    ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'navbar-collapse'
-    );
+    assert.ok(wrapper.find('.navbar-collapse').exists());
   });
 
   it('Should pass expanded to Collapse', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar defaultExpanded>
         <Navbar.Collapse>hello</Navbar.Collapse>
       </Navbar>
     );
 
-    const collapse = ReactTestUtils.findRenderedComponentWithType(
-      instance,
-      Navbar.Collapse
-    );
+    const collapse = wrapper.find(Navbar.Collapse).instance();
 
     expect(collapse.context.$bs_navbar.expanded).to.equal(true);
   });
 
   it('Should wire the toggle to the collapse', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar>
         <Navbar.Header>
           <Navbar.Toggle />
@@ -275,14 +220,8 @@ describe('<Navbar>', () => {
       </Navbar>
     );
 
-    const toggle = ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'navbar-toggle'
-    );
-    const collapse = ReactTestUtils.findRenderedComponentWithType(
-      instance,
-      Navbar.Collapse
-    );
+    const toggle = wrapper.find('.navbar-toggle').getDOMNode();
+    const collapse = wrapper.find(Navbar.Collapse).instance();
 
     expect(collapse.context.$bs_navbar.expanded).to.not.be.ok;
     expect(toggle.className).to.match(/collapsed/);
@@ -296,7 +235,7 @@ describe('<Navbar>', () => {
   it('Should open external href link in collapseOnSelect', () => {
     const selectSpy = sinon.spy();
     const navItemOnClick = sinon.stub();
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar onSelect={selectSpy}>
         <Navbar.Header>
           <Navbar.Toggle />
@@ -313,7 +252,7 @@ describe('<Navbar>', () => {
       </Navbar>
     );
 
-    const link = ReactTestUtils.findRenderedDOMComponentWithTag(instance, 'A');
+    const link = wrapper.find('a').getDOMNode();
 
     ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link));
 
@@ -330,7 +269,7 @@ describe('<Navbar>', () => {
 
   it('Should fire external href click', () => {
     const navItemSpy = sinon.spy();
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar defaultExpanded>
         <Navbar.Header>
           <Navbar.Toggle />
@@ -349,12 +288,9 @@ describe('<Navbar>', () => {
       </Navbar>
     );
 
-    const link = ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'link-text'
-    );
+    const link = wrapper.find('.link-text').getDOMNode();
 
-    ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link));
+    ReactTestUtils.Simulate.click(link);
 
     expect(navItemSpy.getCall(0).args[0].isDefaultPrevented()).to.be.false;
   });
@@ -362,7 +298,7 @@ describe('<Navbar>', () => {
   it('Should collapseOnSelect & fire Nav subcomponent onSelect event if expanded', () => {
     const toggleSpy = sinon.spy();
     const navItemSpy = sinon.spy();
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar collapseOnSelect onToggle={toggleSpy} defaultExpanded>
         <Navbar.Header>
           <Navbar.Toggle />
@@ -377,10 +313,7 @@ describe('<Navbar>', () => {
       </Navbar>
     );
 
-    const link = ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'link-text'
-    );
+    const link = wrapper.find('.link-text').getDOMNode();
 
     ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link));
 
@@ -392,7 +325,7 @@ describe('<Navbar>', () => {
   it('Should fire onSelect with eventKey for nav children', () => {
     const selectSpy = sinon.spy();
     const navItemSpy = sinon.spy();
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar onSelect={selectSpy}>
         <Navbar.Header>
           <Navbar.Toggle />
@@ -407,10 +340,7 @@ describe('<Navbar>', () => {
       </Navbar>
     );
 
-    const link = ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'onselect-text'
-    );
+    const link = wrapper.find('.onselect-text').getDOMNode();
 
     ReactTestUtils.Simulate.click(ReactDOM.findDOMNode(link));
 
@@ -420,7 +350,7 @@ describe('<Navbar>', () => {
   });
 
   it('Should pass `bsClass` down to sub components', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar bsClass="my-navbar">
         <Navbar.Header>
           <Navbar.Brand />
@@ -435,51 +365,30 @@ describe('<Navbar>', () => {
       </Navbar>
     );
 
-    ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'my-navbar');
-    ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'my-navbar-header'
-    );
-    ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'my-navbar-brand'
-    );
-    ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'my-navbar-toggle'
-    );
-    ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'my-navbar-text'
-    );
-    ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'my-navbar-link'
-    );
-    ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'my-navbar-form'
-    );
-    ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'my-navbar-collapse'
-    );
-    ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'my-navbar-nav');
-    ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'my-navbar-right'
-    );
+    wrapper.find('.my-navbar').getDOMNode();
+    wrapper.find('.my-navbar-header').getDOMNode();
+    wrapper.find('.my-navbar-brand').getDOMNode();
+    wrapper.find('.my-navbar-toggle').getDOMNode();
+    wrapper.find('.my-navbar-text').getDOMNode();
+    wrapper.find('.my-navbar-link').getDOMNode();
+    wrapper.find('.my-navbar-form').getDOMNode();
+    wrapper.find('.my-navbar-collapse').getDOMNode();
+    wrapper.find('.my-navbar-nav').getDOMNode();
+    wrapper.find('.my-navbar-right').getDOMNode();
   });
 
   it('Should add custom className to header', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Navbar>
-        <Navbar.Header className="test">
+        <Navbar.Header className="my-test">
           <Navbar.Brand />
         </Navbar.Header>
       </Navbar>
     );
 
-    ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'test');
+    wrapper
+      .find('.my-test')
+      .hostNodes()
+      .getDOMNode();
   });
 });

--- a/test/PanelGroupSpec.js
+++ b/test/PanelGroupSpec.js
@@ -1,6 +1,4 @@
 import React from 'react';
-import ReactTestUtils from 'react-dom/test-utils';
-
 import { mount } from 'enzyme';
 
 import Panel from '../src/Panel';
@@ -10,7 +8,7 @@ import { shouldWarn } from './helpers';
 
 describe('<PanelGroup>', () => {
   it('Should pass bsStyle to Panels', () => {
-    let instance = ReactTestUtils.renderIntoDocument(
+    let wrapper = mount(
       <PanelGroup bsStyle="default" id="panel">
         <Panel>
           <Panel.Body>Panel 1</Panel.Body>
@@ -18,13 +16,13 @@ describe('<PanelGroup>', () => {
       </PanelGroup>
     );
 
-    let panel = ReactTestUtils.findRenderedComponentWithType(instance, Panel);
+    let panel = wrapper.find(Panel);
 
-    assert.equal(panel.props.bsStyle, 'default');
+    assert.equal(panel.props().bsStyle, 'default');
   });
 
   it('Should not override bsStyle on Panel', () => {
-    let instance = ReactTestUtils.renderIntoDocument(
+    let wrapper = mount(
       <PanelGroup bsStyle="default" id="panel">
         <Panel bsStyle="primary">
           <Panel.Body>Panel 1</Panel.Body>
@@ -32,9 +30,9 @@ describe('<PanelGroup>', () => {
       </PanelGroup>
     );
 
-    let panel = ReactTestUtils.findRenderedComponentWithType(instance, Panel);
+    let panel = wrapper.find(Panel);
 
-    assert.equal(panel.props.bsStyle, 'primary');
+    assert.equal(panel.props().bsStyle, 'primary');
   });
 
   describe('accordion', () => {

--- a/test/PanelSpec.js
+++ b/test/PanelSpec.js
@@ -160,7 +160,7 @@ describe('<Panel>', () => {
   });
 
   it('Should toggle when uncontrolled', () => {
-    const inst = mount(
+    const wrapper = mount(
       <Panel defaultExpanded={false}>
         <Panel.Heading>
           <Panel.Title toggle>foo</Panel.Title>
@@ -170,12 +170,11 @@ describe('<Panel>', () => {
       </Panel>
     );
 
-    inst.assertSingle('a').simulate('click');
+    wrapper.find('a').simulate('click');
 
-    inst
-      .children() // get pass controlled wrapper
-      .prop('expanded')
-      .should.equal(true);
+    expect(wrapper.find(Panel.ControlledComponent).props().expanded).to.equal(
+      true
+    );
   });
 
   describe('Web Accessibility', () => {

--- a/test/TabsSpec.js
+++ b/test/TabsSpec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
+import { mount } from 'enzyme';
 
 import Nav from '../src/Nav';
 import NavItem from '../src/NavItem';
@@ -9,11 +10,9 @@ import TabPane from '../src/TabPane';
 import Tabs from '../src/Tabs';
 import ValidComponentChildren from '../src/utils/ValidComponentChildren';
 
-import { render } from './helpers';
-
 describe('<Tabs>', () => {
   it('Should show the correct tab', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" defaultActiveKey={1}>
         <Tab title="Tab 1" eventKey={1}>
           Tab 1 content
@@ -24,20 +23,27 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    const panes = ReactTestUtils.scryRenderedComponentsWithType(
-      instance,
-      TabPane
+    const panes = wrapper.find(TabPane);
+
+    assert.ok(
+      panes
+        .at(0)
+        .getDOMNode()
+        .className.match(/\bactive\b/)
+    );
+    assert.ok(
+      !panes
+        .at(1)
+        .getDOMNode()
+        .className.match(/\bactive\b/)
     );
 
-    assert.ok(ReactDOM.findDOMNode(panes[0]).className.match(/\bactive\b/));
-    assert.ok(!ReactDOM.findDOMNode(panes[1]).className.match(/\bactive\b/));
-
-    const nav = ReactTestUtils.findRenderedComponentWithType(instance, Nav);
+    const nav = wrapper.find(Nav).instance();
     assert.equal(nav.context.$bs_tabContainer.activeKey, 1);
   });
 
   it('Should only show the tabs with `Tab.props.title` set', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" defaultActiveKey={3}>
         <Tab title="Tab 1" eventKey={1}>
           Tab 1 content
@@ -49,13 +55,13 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    const nav = ReactTestUtils.findRenderedComponentWithType(instance, Nav);
+    const nav = wrapper.find(Nav).instance();
     assert.equal(ValidComponentChildren.count(nav.props.children), 2);
   });
 
   it('Should allow tab to have React components', () => {
     const tabTitle = <strong className="special-tab">Tab 2</strong>;
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" defaultActiveKey={2}>
         <Tab title="Tab 1" eventKey={1}>
           Tab 1 content
@@ -66,7 +72,7 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    const nav = ReactTestUtils.findRenderedComponentWithType(instance, Nav);
+    const nav = wrapper.find(Nav).instance();
     assert.ok(
       ReactTestUtils.findRenderedDOMComponentWithClass(nav, 'special-tab')
     );
@@ -79,7 +85,7 @@ describe('<Tabs>', () => {
     }
 
     const tab2 = <span className="tab2">Tab2</span>;
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" onSelect={onSelect} activeKey={1}>
         <Tab title="Tab 1" eventKey="1">
           Tab 1 content
@@ -90,13 +96,11 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    ReactTestUtils.Simulate.click(
-      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'tab2')
-    );
+    ReactTestUtils.Simulate.click(wrapper.find('.tab2').getDOMNode());
   });
 
   it('Should have children with the correct DOM properties', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" defaultActiveKey={1}>
         <Tab title="Tab 1" className="custom" eventKey={1}>
           Tab 1 content
@@ -107,19 +111,26 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    const panes = ReactTestUtils.scryRenderedComponentsWithType(instance, Tab);
-    const navs = ReactTestUtils.scryRenderedComponentsWithType(
-      instance,
-      NavItem
-    );
+    const panes = wrapper.find(Tab);
+    const navs = wrapper.find(NavItem);
 
-    assert.ok(ReactDOM.findDOMNode(panes[0]).className.match(/\bcustom\b/));
-    assert.ok(ReactDOM.findDOMNode(navs[1]).className.match(/\btcustom\b/));
-    assert.equal(ReactDOM.findDOMNode(panes[0]).id, 'test-pane-1');
+    assert.ok(
+      panes
+        .at(0)
+        .getDOMNode()
+        .className.match(/\bcustom\b/)
+    );
+    assert.ok(
+      navs
+        .at(1)
+        .getDOMNode()
+        .className.match(/\btcustom\b/)
+    );
+    assert.equal(panes.at(0).getDOMNode().id, 'test-pane-1');
   });
 
   it('Should show the correct first tab with no active key value', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test">
         <Tab title="Tab 1" eventKey={1}>
           Tab 1 content
@@ -130,14 +141,21 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    const panes = ReactTestUtils.scryRenderedComponentsWithType(
-      instance,
-      TabPane
+    const panes = wrapper.find(TabPane);
+    assert.ok(
+      panes
+        .at(0)
+        .getDOMNode()
+        .className.match(/\bactive\b/)
     );
-    assert.ok(ReactDOM.findDOMNode(panes[0]).className.match(/\bactive\b/));
-    assert.ok(!ReactDOM.findDOMNode(panes[1]).className.match(/\bactive\b/));
+    assert.ok(
+      !panes
+        .at(1)
+        .getDOMNode()
+        .className.match(/\bactive\b/)
+    );
 
-    const nav = ReactTestUtils.findRenderedComponentWithType(instance, Nav);
+    const nav = wrapper.find(Nav).instance();
     assert.equal(nav.context.$bs_tabContainer.activeKey, 1);
   });
 
@@ -148,20 +166,20 @@ describe('<Tabs>', () => {
       </Tab>
     ));
 
-    let instance = ReactTestUtils.renderIntoDocument(
+    let wrapper = mount(
       <Tabs id="test">
         {panes}
         {null}
       </Tabs>
     );
 
-    const nav = ReactTestUtils.findRenderedComponentWithType(instance, Nav);
+    const nav = wrapper.find(Nav).instance();
     assert.equal(nav.context.$bs_tabContainer.activeKey, 0);
   });
 
   it('Should show the correct tab when selected', () => {
     const tab1 = <span className="tab1">Tab 1</span>;
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" defaultActiveKey={2} animation={false}>
         <Tab title={tab1} eventKey={1}>
           Tab 1 content
@@ -172,25 +190,30 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    const panes = ReactTestUtils.scryRenderedComponentsWithType(
-      instance,
-      TabPane
+    const panes = wrapper.find(TabPane);
+
+    ReactTestUtils.Simulate.click(wrapper.find('.tab1').getDOMNode());
+
+    assert.ok(
+      panes
+        .at(0)
+        .getDOMNode()
+        .className.match(/\bactive\b/)
+    );
+    assert.ok(
+      !panes
+        .at(1)
+        .getDOMNode()
+        .className.match(/\bactive\b/)
     );
 
-    ReactTestUtils.Simulate.click(
-      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'tab1')
-    );
-
-    assert.ok(ReactDOM.findDOMNode(panes[0]).className.match(/\bactive\b/));
-    assert.ok(!ReactDOM.findDOMNode(panes[1]).className.match(/\bactive\b/));
-
-    const nav = ReactTestUtils.findRenderedComponentWithType(instance, Nav);
+    const nav = wrapper.find(Nav).instance();
     assert.equal(nav.context.$bs_tabContainer.activeKey, 1);
   });
 
   it('Should mount initial tab and no others when unmountOnExit is true and animation is false', () => {
     const tab1 = <span className="tab1">Tab 1</span>;
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" defaultActiveKey={1} animation={false} unmountOnExit>
         <Tab title={tab1} eventKey={1}>
           Tab 1 content
@@ -204,18 +227,15 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    const panes = ReactTestUtils.scryRenderedComponentsWithType(
-      instance,
-      TabPane
-    );
-    expect(ReactDOM.findDOMNode(panes[0])).to.exist;
-    expect(ReactDOM.findDOMNode(panes[1])).to.not.exist;
-    expect(ReactDOM.findDOMNode(panes[2])).to.not.exist;
+    const panes = wrapper.find(TabPane);
+    expect(panes.at(0).getDOMNode()).to.exist;
+    expect(panes.at(1).getDOMNode()).to.not.exist;
+    expect(panes.at(2).getDOMNode()).to.not.exist;
   });
 
   it('Should mount the correct tab when selected and unmount the previous when unmountOnExit is true and animation is false', () => {
     const tab1 = <span className="tab1">Tab 1</span>;
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" defaultActiveKey={2} animation={false} unmountOnExit>
         <Tab title={tab1} eventKey={1}>
           Tab 1 content
@@ -226,24 +246,19 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    const panes = ReactTestUtils.scryRenderedComponentsWithType(
-      instance,
-      TabPane
-    );
+    const panes = wrapper.find(TabPane);
 
-    ReactTestUtils.Simulate.click(
-      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'tab1')
-    );
+    ReactTestUtils.Simulate.click(wrapper.find('.tab1').getDOMNode());
 
-    expect(ReactDOM.findDOMNode(panes[0])).to.exist;
-    expect(ReactDOM.findDOMNode(panes[1])).to.not.exist;
+    expect(panes.at(0).getDOMNode()).to.exist;
+    expect(panes.at(1).getDOMNode()).to.not.exist;
 
-    const nav = ReactTestUtils.findRenderedComponentWithType(instance, Nav);
+    const nav = wrapper.find(Nav).instance();
     assert.equal(nav.context.$bs_tabContainer.activeKey, 1);
   });
 
   it('Should treat active key of null as nothing selected', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" activeKey={null} onSelect={() => {}}>
         <Tab title="Tab 1" eventKey={1}>
           Tab 1 content
@@ -254,12 +269,12 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    const nav = ReactTestUtils.findRenderedComponentWithType(instance, Nav);
+    const nav = wrapper.find(Nav).instance();
     expect(nav.context.$bs_tabContainer.activeKey).to.not.exist;
   });
 
   it('Should pass default bsStyle (of "tabs") to Nav', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" defaultActiveKey={1} animation={false}>
         <Tab title="Tab 1" eventKey={1}>
           Tab 1 content
@@ -270,13 +285,11 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    assert.ok(
-      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'nav-tabs')
-    );
+    assert.ok(wrapper.find('.nav-tabs').getDOMNode());
   });
 
   it('Should pass bsStyle to Nav', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" bsStyle="pills" defaultActiveKey={1} animation={false}>
         <Tab title="Tab 1" eventKey={1}>
           Tab 1 content
@@ -287,13 +300,11 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    assert.ok(
-      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'nav-pills')
-    );
+    assert.ok(wrapper.find('.nav-pills').getDOMNode());
   });
 
   it('Should pass disabled to Nav', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" defaultActiveKey={1}>
         <Tab title="Tab 1" eventKey={1}>
           Tab 1 content
@@ -304,14 +315,12 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    assert.ok(
-      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'disabled')
-    );
+    assert.ok(wrapper.find('.disabled').getDOMNode());
   });
 
   it('Should not show content when clicking disabled tab', () => {
     const tab1 = <span className="tab1">Tab 1</span>;
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" defaultActiveKey={2} animation={false}>
         <Tab title={tab1} eventKey={1} disabled>
           Tab 1 content
@@ -322,19 +331,24 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    const panes = ReactTestUtils.scryRenderedComponentsWithType(
-      instance,
-      TabPane
+    const panes = wrapper.find(TabPane);
+
+    ReactTestUtils.Simulate.click(wrapper.find('.tab1').getDOMNode());
+
+    assert.ok(
+      !panes
+        .at(0)
+        .getDOMNode()
+        .className.match(/\bactive\b/)
+    );
+    assert.ok(
+      panes
+        .at(1)
+        .getDOMNode()
+        .className.match(/\bactive\b/)
     );
 
-    ReactTestUtils.Simulate.click(
-      ReactTestUtils.findRenderedDOMComponentWithClass(instance, 'tab1')
-    );
-
-    assert.ok(!ReactDOM.findDOMNode(panes[0]).className.match(/\bactive\b/));
-    assert.ok(ReactDOM.findDOMNode(panes[1]).className.match(/\bactive\b/));
-
-    const nav = ReactTestUtils.findRenderedComponentWithType(instance, Nav);
+    const nav = wrapper.find(Nav).instance();
     assert.equal(nav.context.$bs_tabContainer.activeKey, 2);
   });
 
@@ -353,7 +367,7 @@ describe('<Tabs>', () => {
 
     [true, false].forEach(animation => {
       it(`should correctly set "active" after Tab is removed with "animation=${animation}"`, () => {
-        const instance = render(
+        let wrapper = mount(
           <Tabs
             id="test"
             activeKey={2}
@@ -367,21 +381,26 @@ describe('<Tabs>', () => {
               Tab 2 content
             </Tab>
           </Tabs>,
-          mountPoint
+          { attachTo: mountPoint }
         );
 
-        const panes = ReactTestUtils.scryRenderedComponentsWithType(
-          instance,
-          TabPane
-        );
+        let panes = wrapper.find(TabPane);
 
         assert.ok(
-          !ReactDOM.findDOMNode(panes[0]).className.match(/\bactive\b/)
+          !panes
+            .at(0)
+            .getDOMNode()
+            .className.match(/\bactive\b/)
         );
-        assert.ok(ReactDOM.findDOMNode(panes[1]).className.match(/\bactive\b/));
+        assert.ok(
+          panes
+            .at(1)
+            .getDOMNode()
+            .className.match(/\bactive\b/)
+        );
 
         // second tab has been removed
-        render(
+        wrapper = mount(
           <Tabs
             id="test"
             activeKey={1}
@@ -392,19 +411,25 @@ describe('<Tabs>', () => {
               Tab 1 content
             </Tab>
           </Tabs>,
-          mountPoint
-        ).inner;
+          { attachTo: mountPoint }
+        );
 
-        assert.ok(ReactDOM.findDOMNode(panes[0]).className.match(/\bactive\b/));
+        panes = wrapper.find(TabPane);
+        assert.ok(
+          panes
+            .at(0)
+            .getDOMNode()
+            .className.match(/\bactive\b/)
+        );
       });
     });
   });
 
   describe('Web Accessibility', () => {
-    let instance;
+    let wrapper;
 
     beforeEach(() => {
-      instance = ReactTestUtils.renderIntoDocument(
+      wrapper = mount(
         <Tabs defaultActiveKey={2} id="test">
           <Tab title="Tab 1" eventKey={1}>
             Tab 1 content
@@ -417,53 +442,53 @@ describe('<Tabs>', () => {
     });
 
     it('Should generate ids from parent id', () => {
-      const tabs = ReactTestUtils.scryRenderedComponentsWithType(
-        instance,
-        NavItem
-      );
+      const tabs = wrapper.find(NavItem);
 
-      tabs.every(tab => assert.ok(tab.props['aria-controls'] && tab.props.id));
+      tabs.every(tab => assert.ok(tab.prop('aria-controls') && tab.prop('id')));
     });
 
     it('Should add aria-labelledby', () => {
-      const panes = ReactTestUtils.scryRenderedDOMComponentsWithClass(
-        instance,
-        'tab-pane'
-      );
+      const panes = wrapper.find('.tab-pane');
 
-      assert.equal(panes[0].getAttribute('aria-labelledby'), 'test-tab-1');
-      assert.equal(panes[1].getAttribute('aria-labelledby'), 'test-tab-2');
+      assert.equal(
+        panes
+          .at(0)
+          .getDOMNode()
+          .getAttribute('aria-labelledby'),
+        'test-tab-1'
+      );
+      assert.equal(
+        panes
+          .at(1)
+          .getDOMNode()
+          .getAttribute('aria-labelledby'),
+        'test-tab-2'
+      );
     });
 
     it('Should add aria-controls', () => {
-      const tabs = ReactTestUtils.scryRenderedComponentsWithType(
-        instance,
-        NavItem
-      );
+      const tabs = wrapper.find(NavItem);
 
-      assert.equal(tabs[0].props['aria-controls'], 'test-pane-1');
-      assert.equal(tabs[1].props['aria-controls'], 'test-pane-2');
+      assert.equal(tabs.at(0).prop('aria-controls'), 'test-pane-1');
+      assert.equal(tabs.at(1).prop('aria-controls'), 'test-pane-2');
     });
 
     it('Should add role=tablist to the nav', () => {
-      const nav = ReactTestUtils.findRenderedComponentWithType(instance, Nav);
+      const nav = wrapper.find(Nav).instance();
 
       assert.equal(nav.props.role, 'tablist');
     });
 
     it('Should add aria-selected to the nav item for the selected tab', () => {
-      const tabs = ReactTestUtils.scryRenderedComponentsWithType(
-        instance,
-        NavItem
-      );
-      const link1 = ReactTestUtils.findRenderedDOMComponentWithTag(
-        tabs[0],
-        'a'
-      );
-      const link2 = ReactTestUtils.findRenderedDOMComponentWithTag(
-        tabs[1],
-        'a'
-      );
+      const tabs = wrapper.find(NavItem);
+      const link1 = tabs
+        .at(0)
+        .find('a')
+        .getDOMNode();
+      const link2 = tabs
+        .at(1)
+        .find('a')
+        .getDOMNode();
 
       assert.equal(link1.getAttribute('aria-selected'), 'false');
       assert.equal(link2.getAttribute('aria-selected'), 'true');
@@ -471,7 +496,7 @@ describe('<Tabs>', () => {
   });
 
   it('Should not pass className to Nav', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" bsStyle="pills" defaultActiveKey={1} animation={false}>
         <Tab title="Tab 1" eventKey={1} className="my-tab-class">
           Tab 1 content
@@ -482,20 +507,20 @@ describe('<Tabs>', () => {
       </Tabs>
     );
 
-    const myTabClass = ReactTestUtils.findRenderedDOMComponentWithClass(
-      instance,
-      'my-tab-class'
-    );
-    const myNavItem = ReactTestUtils.scryRenderedDOMComponentsWithClass(
-      instance,
-      'nav-pills'
-    )[0];
+    const myTabClass = wrapper
+      .find('.my-tab-class')
+      .hostNodes()
+      .getDOMNode();
+    const myNavItem = wrapper
+      .find('.nav-pills')
+      .first()
+      .getDOMNode();
 
     assert.notDeepEqual(myTabClass, myNavItem);
   });
 
   it('Should pass className, Id, and style to Tabs', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs
         bsStyle="pills"
         defaultActiveKey={1}
@@ -506,36 +531,21 @@ describe('<Tabs>', () => {
       />
     );
 
-    assert.equal(
-      ReactDOM.findDOMNode(instance).getAttribute('class'),
-      'my-tabs-class'
-    );
-    assert.equal(
-      ReactDOM.findDOMNode(instance).getAttribute('id'),
-      'my-tabs-id'
-    );
+    assert.equal(wrapper.getDOMNode().getAttribute('class'), 'my-tabs-class');
+    assert.equal(wrapper.getDOMNode().getAttribute('id'), 'my-tabs-id');
     // Decimal point string depends on locale
-    assert.equal(parseFloat(ReactDOM.findDOMNode(instance).style.opacity), 0.5);
+    assert.equal(parseFloat(wrapper.getDOMNode().style.opacity), 0.5);
   });
 
   it('should derive bsClass from parent', () => {
-    const instance = ReactTestUtils.renderIntoDocument(
+    const wrapper = mount(
       <Tabs id="test" bsClass="my-tabs">
         <Tab eventKey={1} title="Tab 1" />
         <Tab eventKey={2} title="Tab 2" bsClass="my-pane" />
       </Tabs>
     );
 
-    assert.lengthOf(
-      ReactTestUtils.scryRenderedDOMComponentsWithClass(
-        instance,
-        'my-tabs-pane'
-      ),
-      2
-    );
-    assert.lengthOf(
-      ReactTestUtils.scryRenderedDOMComponentsWithClass(instance, 'my-pane'),
-      0
-    );
+    assert.lengthOf(wrapper.find('.my-tabs-pane'), 2);
+    assert.lengthOf(wrapper.find('.my-pane'), 0);
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -679,6 +679,13 @@
     core-js "^2.5.7"
     regenerator-runtime "^0.12.0"
 
+"@babel/runtime@^7.4.5":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.6.2.tgz#c3d6e41b304ef10dcf13777a33e7694ec4a9a6dd"
+  integrity sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@7.0.0-beta.51":
   version "7.0.0-beta.51"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.51.tgz#9602a40aebcf357ae9677e2532ef5fc810f5fbff"
@@ -5315,6 +5322,11 @@ regenerator-runtime@^0.12.0:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 
+regenerator-runtime@^0.13.2:
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
+  integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
+
 regenerator-transform@^0.13.3:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.13.3.tgz#264bd9ff38a8ce24b06e0636496b2c856b57bcbb"
@@ -6234,11 +6246,14 @@ ultron@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.1.1.tgz#9fe1536a10a664a65266a1e3ccf85fd36302bc9c"
 
-uncontrollable@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-5.1.0.tgz#7e9a1c50ea24e3c78b625e52d21ff3f758c7bd59"
+uncontrollable@^7.0.2:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-7.0.2.tgz#8c8fc4d04c2c13a8cb463991838ca3016945475f"
+  integrity sha512-7fa8OBQ5+X4VAcp0os6BD74bCeUPQSHmr4Rqy75Me98NnlD5kNShCqqx4xWo4OmlAMiT2/YSMklLFC4FCuoGYg==
   dependencies:
+    "@babel/runtime" "^7.4.5"
     invariant "^2.2.4"
+    react-lifecycles-compat "^3.0.4"
 
 underscore@~1.4.4:
   version "1.4.4"


### PR DESCRIPTION
Fixes #4398 for [`uncontrollable`](https://github.com/jquense/uncontrollable) components:
* Dropdown
* Navbar
* Panel
* PanelGroup
* TabContainer
* Tabs
* ToggleButtonGroup

In conjunction with https://github.com/react-bootstrap/react-bootstrap/pull/4244, this stops most of the warnings. The only warnings that remain are from [`react-overlays ^0.8.0`](https://github.com/react-bootstrap/react-overlays/tree/v0.8.3).

Also fixes the tests that broke since `uncontrollable` may now return `forwardRef()` components, which cannot be inspected with ReactTestUtils. (See https://github.com/facebook/react/issues/13455 for details.)