### PR TITLE
tests: reworked sometimes failing tests

### DIFF
--- a/test/BreadcrumbItemSpec.js
+++ b/test/BreadcrumbItemSpec.js
@@ -53,7 +53,7 @@ describe('<Breadcrumb.Item>', () => {
 
     instance.find('a').simulate('click');
 
-    expect(handleClick).to.have.property('callCount', 1);
+    expect(handleClick.callCount).to.equal(1);
   });
 
   it('Should apply id onto the anchor', () => {

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -141,10 +141,7 @@ describe('<Modal>', () => {
   });
 
   it('Should pass transition callbacks to Transition', done => {
-    let count = 0;
-    const increment = () => {
-      ++count;
-    };
+    const increment = sinon.spy();
 
     const instance = mount(
       <Modal
@@ -154,7 +151,7 @@ describe('<Modal>', () => {
         onExiting={increment}
         onExited={() => {
           increment();
-          expect(count).to.equal(6);
+          expect(increment.callCount).to.equal(6);
           done();
         }}
         onEnter={increment}

--- a/test/OverlayTriggerSpec.js
+++ b/test/OverlayTriggerSpec.js
@@ -126,8 +126,7 @@ describe('<OverlayTrigger>', () => {
   });
 
   it('Should pass transition callbacks to Transition', done => {
-    let count = 0;
-    const increment = () => count++;
+    const increment = sinon.spy();
 
     const wrapper = mount(
       <OverlayTrigger
@@ -137,7 +136,7 @@ describe('<OverlayTrigger>', () => {
         onExiting={increment}
         onExited={() => {
           increment();
-          expect(count).to.equal(6);
+          expect(increment.callCount).to.equal(6);
           done();
         }}
         onEnter={increment}

--- a/test/SplitButtonSpec.js
+++ b/test/SplitButtonSpec.js
@@ -50,21 +50,18 @@ describe('<SplitButton>', () => {
       .simulate('click');
   });
 
-  it('should not invoke onClick when SplitButton.Toggle is clicked (prop)', done => {
+  it('should not invoke onClick when SplitButton.Toggle is clicked (prop)', () => {
     let onClickSpy = sinon.spy();
 
     const wrapper = mount(
-      <SplitButton title="Title" id="test-id" onClick={() => done()}>
+      <SplitButton title="Title" id="test-id" onClick={onClickSpy}>
         <DropdownItem>Item 1</DropdownItem>
       </SplitButton>,
     );
 
     wrapper.find('button.dropdown-toggle').simulate('click');
 
-    setTimeout(() => {
-      onClickSpy.should.not.have.been.called;
-      done();
-    }, 10);
+    expect(onClickSpy.callCount).to.equal(0);
   });
 
   it('Should pass disabled to both buttons', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -5,8 +5,8 @@ import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-const assertLength = length =>
-  function $assertLength(selector) {
+function assertLength(length) {
+  return function $assertLength(selector) {
     let result = this.find(selector);
     expect(
       result,
@@ -16,6 +16,7 @@ const assertLength = length =>
     ).to.have.length(length);
     return result;
   };
+}
 
 ReactWrapper.prototype.assertSingle = assertLength(1);
 ShallowWrapper.prototype.assertSingle = assertLength(1);

--- a/test/index.js
+++ b/test/index.js
@@ -5,8 +5,8 @@ import Adapter from 'enzyme-adapter-react-16';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-function assertLength(length) {
-  return function $assertLength(selector) {
+const assertLength = length =>
+  function $assertLength(selector) {
     let result = this.find(selector);
     expect(
       result,
@@ -16,24 +16,12 @@ function assertLength(length) {
     ).to.have.length(length);
     return result;
   };
-}
-
-function print() {
-  return this.tap(f => console.log(f.debug()));
-}
 
 ReactWrapper.prototype.assertSingle = assertLength(1);
 ShallowWrapper.prototype.assertSingle = assertLength(1);
 
 ReactWrapper.prototype.assertNone = assertLength(0);
 ShallowWrapper.prototype.assertNone = assertLength(0);
-
-ReactWrapper.prototype.print = print;
-ReactWrapper.prototype.printDOM = function printDOM() {
-  return this.tap(f => console.log(f.html()));
-};
-
-ShallowWrapper.prototype.print = print;
 
 beforeEach(() => {
   sinon.stub(console, 'error').callsFake((msg, ...args) => {


### PR DESCRIPTION
Sometimes the following tests are failing:

https://github.com/react-bootstrap/react-bootstrap/runs/248586391#step:8:591

```
  <OverlayTrigger>
    ✖ Should pass transition callbacks to Transition
      Firefox 69.0.0 (Mac OS X 10.14.0)
    uncaught exception: AssertionError: expected 'next' to equal 'prev' (:0)

  ✖ "after each" hook for "allows only ProgressBar in children"
    Firefox 69.0.0 (Mac OS X 10.14.0)
  console.error.expected is undefined
  ./test/index.js/<@webpack:///test/index.js:63:1 <- test/index.js:227223:7
  

  ✖ "after each" hook for "should contain `embed-responsive` class"
    Firefox 69.0.0 (Mac OS X 10.14.0)
  console.error.expected is undefined
  ./test/index.js/<@webpack:///test/index.js:63:1 <- test/index.js:227223:7
```

https://github.com/react-bootstrap/react-bootstrap/runs/248886920#step:8:483

```
  <Modal>
    × Should pass transition callbacks to Transition
      Firefox 69.0.0 (Windows 10.0.0)
    uncaught exception: AssertionError: expected 2 to equal 0 (:0)
```

https://github.com/react-bootstrap/react-bootstrap/runs/248600092#step:8:620

```
  <SplitButton>
    ✖ should not invoke onClick when SplitButton.Toggle is clicked (prop)
      HeadlessChrome 77.0.3865 (Mac OS X 10.14.6)
    Error: Uncaught AssertionError: expected 'next' to equal 'prev' (node_modules/chai/chai.js:239)

  ✖ "after each" hook for "Should pass disabled to both buttons"
    HeadlessChrome 77.0.3865 (Mac OS X 10.14.6)
  TypeError: Cannot read property 'length' of undefined
      at Context.<anonymous> (webpack:///test/index.js:63:1 <- test/index.js:227223:54)
```
