### PR TITLE
#3508 fix duplicate class "carousel-item"

### DIFF
--- a/src/Carousel.js
+++ b/src/Carousel.js
@@ -506,7 +506,6 @@ class Carousel extends React.Component {
             return cloneElement(child, {
               className: classNames(
                 child.props.className,
-                `${bsPrefix}-item`,
                 current && currentClasses,
                 previous && prevClasses,
               ),


### PR DESCRIPTION
Regarding issue #3508.

The class "carousel-item" is duplicated because it gets passed from the parent as well as the carousel item itself:

`export default createWithBsPrefix('carousel-item');`

We fix this by no longer passing the class from the parent.

![](https://user-images.githubusercontent.com/5240653/53549092-29d29100-3ae8-11e9-8d56-d05947aa9b9b.png)
