### PR TITLE
Fix typo in Col layout docs

### DIFF
--- a/src/Col.js
+++ b/src/Col.js
@@ -35,7 +35,7 @@ const propTypes = {
   as: PropTypes.elementType,
 
   /**
-   * The number of columns to span on sxtra small devices (<576px)
+   * The number of columns to span on extra small devices (<576px)
    *
    * @type {(true|"auto"|number|{ span: true|"auto"|number, offset: number, order: number })}
    */


### PR DESCRIPTION
Minor typo fix which appears in the layout component documentation