### PR TITLE
[#4194] - ref forwarding for ToggleButton

### DIFF
--- a/src/ToggleButton.js
+++ b/src/ToggleButton.js
@@ -65,13 +65,9 @@ const ToggleButton = React.forwardRef(
   ) => {
     const [focused, setFocused] = useState(false);
 
-    const handleFocus = e => {
-      if (e.target.tagName === 'INPUT') setFocused(true);
-    };
-
-    const handleBlur = e => {
-      if (e.target.tagName === 'INPUT') setFocused(false);
-    };
+    const toggleFocus = useCallback(e => {
+      if (e.target.tagName === 'INPUT') setFocused(!focused);
+    }, []);
 
     return (
       <Button
@@ -94,8 +90,8 @@ const ToggleButton = React.forwardRef(
           autoComplete="off"
           checked={!!checked}
           disabled={!!disabled}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
+          onFocus={toggleFocus}
+          onBlur={toggleFocus}
           onChange={onChange || noop}
         />
 

--- a/src/ToggleButton.js
+++ b/src/ToggleButton.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 
 import Button from './Button';
 

--- a/src/ToggleButton.js
+++ b/src/ToggleButton.js
@@ -29,20 +29,10 @@ const propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * The focused state of the input
-   */
-  focused: PropTypes.bool,
-
-  /**
    * A callback fired when the underlying input element changes. This is passed
    * directly to the `<input>` so shares the same signature as a native `onChange` event.
    */
   onChange: PropTypes.func,
-
-  /**
-   * A callback fired when the underlying input element is focused or blurred.
-   */
-  toggleFocus: PropTypes.func,
 
   /**
    * The value of the input, should be unique amongst it's siblings when nested in a
@@ -66,22 +56,21 @@ const ToggleButton = React.forwardRef(
       checked,
       type,
       onChange,
-      toggleFocus,
       value,
       disabled,
-      focused,
       inputRef,
       ...props
     },
     ref,
   ) => {
+    const [focused, setFocus] = useState(false);
 
     const handleFocus = e => {
-      if (e.target.tagName === 'INPUT') toggleFocus(true);
+      if (e.target.tagName === 'INPUT') setFocus(true);
     };
 
     const handleBlur = e => {
-      if (e.target.tagName === 'INPUT') toggleFocus(false);
+      if (e.target.tagName === 'INPUT') setFocus(false);
     };
 
     return (

--- a/src/ToggleButton.js
+++ b/src/ToggleButton.js
@@ -106,5 +106,6 @@ const ToggleButton = React.forwardRef(
 );
 
 ToggleButton.propTypes = propTypes;
+ToggleButton.displayName = 'ToggleButton';
 
 export default ToggleButton;

--- a/src/ToggleButton.js
+++ b/src/ToggleButton.js
@@ -65,8 +65,12 @@ const ToggleButton = React.forwardRef(
   ) => {
     const [focused, setFocused] = useState(false);
 
-    const toggleFocus = useCallback(e => {
-      if (e.target.tagName === 'INPUT') setFocused(!focused);
+    const handleFocus = useCallback(e => {
+      if (e.target.tagName === 'INPUT') setFocused(true);
+    }, []);
+
+    const handleBlur = useCallback(e => {
+      if (e.target.tagName === 'INPUT') setFocused(false);
     }, []);
 
     return (
@@ -90,8 +94,8 @@ const ToggleButton = React.forwardRef(
           autoComplete="off"
           checked={!!checked}
           disabled={!!disabled}
-          onFocus={toggleFocus}
-          onBlur={toggleFocus}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
           onChange={onChange || noop}
         />
 

--- a/src/ToggleButton.js
+++ b/src/ToggleButton.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 
 import Button from './Button';
 

--- a/src/ToggleButton.js
+++ b/src/ToggleButton.js
@@ -66,7 +66,7 @@ const ToggleButton = React.forwardRef(
       checked,
       type,
       onChange,
-      onFocus,
+      toggleFocus,
       value,
       disabled,
       focused,

--- a/src/ToggleButton.js
+++ b/src/ToggleButton.js
@@ -98,7 +98,7 @@ const ToggleButton = React.forwardRef(
         {children}
       </Button>
     );
-  }
+  },
 );
 
 ToggleButton.propTypes = propTypes;

--- a/src/ToggleButton.js
+++ b/src/ToggleButton.js
@@ -44,7 +44,6 @@ const propTypes = {
    * @type {ReactRef}
    */
   inputRef: PropTypes.any,
-
 };
 
 const ToggleButton = React.forwardRef(
@@ -59,10 +58,9 @@ const ToggleButton = React.forwardRef(
       value,
       disabled,
       inputRef,
-      innerRef,
       ...props
     },
-    ref
+    ref,
   ) => {
     const { focused } = this.state;
 

--- a/src/ToggleButton.js
+++ b/src/ToggleButton.js
@@ -63,14 +63,14 @@ const ToggleButton = React.forwardRef(
     },
     ref,
   ) => {
-    const [focused, setFocus] = useState(false);
+    const [focused, setFocused] = useState(false);
 
     const handleFocus = e => {
-      if (e.target.tagName === 'INPUT') setFocus(true);
+      if (e.target.tagName === 'INPUT') setFocused(true);
     };
 
     const handleBlur = e => {
-      if (e.target.tagName === 'INPUT') setFocus(false);
+      if (e.target.tagName === 'INPUT') setFocused(false);
     };
 
     return (

--- a/src/ToggleButton.js
+++ b/src/ToggleButton.js
@@ -45,23 +45,11 @@ const propTypes = {
    */
   inputRef: PropTypes.any,
 
-  /** @ignore */
-  innerRef: PropTypes.any,
 };
 
-class ToggleButton extends React.Component {
-  state = { focused: false };
-
-  handleFocus = e => {
-    if (e.target.tagName === 'INPUT') this.setState({ focused: true });
-  };
-
-  handleBlur = e => {
-    if (e.target.tagName === 'INPUT') this.setState({ focused: false });
-  };
-
-  render() {
-    const {
+const ToggleButton = React.forwardRef(
+  (
+    {
       children,
       name,
       className,
@@ -73,13 +61,23 @@ class ToggleButton extends React.Component {
       inputRef,
       innerRef,
       ...props
-    } = this.props;
+    },
+    ref
+  ) => {
     const { focused } = this.state;
+
+    const handleFocus = e => {
+      if (e.target.tagName === 'INPUT') this.setState({ focused: true });
+    };
+
+    const handleBlur = e => {
+      if (e.target.tagName === 'INPUT') this.setState({ focused: false });
+    };
 
     return (
       <Button
         {...props}
-        ref={innerRef}
+        ref={ref}
         className={classNames(
           className,
           focused && 'focus',
@@ -97,19 +95,16 @@ class ToggleButton extends React.Component {
           autoComplete="off"
           checked={!!checked}
           disabled={!!disabled}
-          onFocus={this.handleFocus}
-          onBlur={this.handleBlur}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
           onChange={onChange || noop}
         />
-
         {children}
       </Button>
     );
   }
-}
+);
 
 ToggleButton.propTypes = propTypes;
 
-export default React.forwardRef((props, ref) => (
-  <ToggleButton innerRef={ref} {...props} />
-));
+export default ToggleButton;

--- a/src/ToggleButton.js
+++ b/src/ToggleButton.js
@@ -29,10 +29,21 @@ const propTypes = {
   disabled: PropTypes.bool,
 
   /**
+   * The focused state of the input
+   */
+  focused: PropTypes.bool,
+
+  /**
    * A callback fired when the underlying input element changes. This is passed
    * directly to the `<input>` so shares the same signature as a native `onChange` event.
    */
   onChange: PropTypes.func,
+
+  /**
+   * A callback fired when the underlying input element is focused or blurred.
+   */
+  toggleFocus: PropTypes.func,
+
   /**
    * The value of the input, should be unique amongst it's siblings when nested in a
    * `ToggleButtonGroup`.
@@ -55,21 +66,22 @@ const ToggleButton = React.forwardRef(
       checked,
       type,
       onChange,
+      onFocus,
       value,
       disabled,
+      focused,
       inputRef,
       ...props
     },
     ref,
   ) => {
-    const { focused } = this.state;
 
     const handleFocus = e => {
-      if (e.target.tagName === 'INPUT') this.setState({ focused: true });
+      if (e.target.tagName === 'INPUT') toggleFocus(true);
     };
 
     const handleBlur = e => {
-      if (e.target.tagName === 'INPUT') this.setState({ focused: false });
+      if (e.target.tagName === 'INPUT') toggleFocus(false);
     };
 
     return (
@@ -97,6 +109,7 @@ const ToggleButton = React.forwardRef(
           onBlur={handleBlur}
           onChange={onChange || noop}
         />
+
         {children}
       </Button>
     );

--- a/types/components/ToggleButton.d.ts
+++ b/types/components/ToggleButton.d.ts
@@ -12,7 +12,6 @@ export interface ToggleButtonProps {
   onChange?: React.ChangeEventHandler<this>;
   value: unknown;
   inputRef?: React.LegacyRef<this>;
-  innerRef?: React.LegacyRef<this>;
 }
 
 declare class ToggleButton<

--- a/types/components/ToggleButton.d.ts
+++ b/types/components/ToggleButton.d.ts
@@ -9,7 +9,9 @@ export interface ToggleButtonProps {
   name?: string;
   checked?: boolean;
   disabled?: boolean;
+  focused?: boolean;
   onChange?: React.ChangeEventHandler<this>;
+  onFocus?: React.FocusEventHandler<this>;
   value: unknown;
   inputRef?: React.LegacyRef<this>;
 }

--- a/types/components/ToggleButton.d.ts
+++ b/types/components/ToggleButton.d.ts
@@ -9,9 +9,7 @@ export interface ToggleButtonProps {
   name?: string;
   checked?: boolean;
   disabled?: boolean;
-  focused?: boolean;
   onChange?: React.ChangeEventHandler<this>;
-  onFocus?: React.FocusEventHandler<this>;
   value: unknown;
   inputRef?: React.LegacyRef<this>;
 }


### PR DESCRIPTION
This is a first pass at handling the ref forwarding work for the ToggleButton.

# Related issue:
https://github.com/react-bootstrap/react-bootstrap/issues/4194

# Note:
- I think that `innerRef` can be removed for this component, as well as the previously added "wrapping ref" that was exported. I'm new to this project so that could totally be wrong.