### PR TITLE
fix(Collapse): allow passed in refs to be properly forwarded 

### DIFF
--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -125,7 +125,6 @@ const defaultProps = {
   mountOnEnter: false,
   unmountOnExit: false,
   appear: false,
-
   dimension: 'height',
   getDimensionValue,
 };
@@ -142,10 +141,11 @@ const Collapse = React.forwardRef((props, ref) => {
     ...otherProps
   } = props;
 
+  delete otherProps.dimension;
+  delete otherProps.getDimensionValue;
+
   const getDimension = () =>
-    typeof otherProps.dimension === 'function'
-      ? otherProps.dimension()
-      : otherProps.dimension;
+    typeof props.dimension === 'function' ? props.dimension() : props.dimension;
 
   // for testing
   const _getScrollDimensionValue = (elem, dimension) => {
@@ -170,10 +170,7 @@ const Collapse = React.forwardRef((props, ref) => {
   /* -- Collapsing -- */
   const _handleExit = elem => {
     const dimension = getDimension();
-    elem.style[dimension] = `${otherProps.getDimensionValue(
-      dimension,
-      elem,
-    )}px`;
+    elem.style[dimension] = `${props.getDimensionValue(dimension, elem)}px`;
     triggerBrowserReflow(elem);
   };
 
@@ -191,7 +188,7 @@ const Collapse = React.forwardRef((props, ref) => {
     <Transition
       ref={ref}
       {...otherProps}
-      aria-expanded={otherProps.role ? otherProps.in : null}
+      aria-expanded={props.role ? props.in : null}
       addEndListener={onEnd}
       onEnter={handleEnter}
       onEntering={handleEntering}

--- a/src/Collapse.js
+++ b/src/Collapse.js
@@ -130,97 +130,89 @@ const defaultProps = {
   getDimensionValue,
 };
 
-class Collapse extends React.Component {
-  getDimension() {
-    return typeof this.props.dimension === 'function'
-      ? this.props.dimension()
-      : this.props.dimension;
-  }
+const Collapse = React.forwardRef((props, ref) => {
+  const {
+    onEnter,
+    onEntering,
+    onEntered,
+    onExit,
+    onExiting,
+    children,
+    className,
+    ...otherProps
+  } = props;
+
+  const getDimension = () =>
+    typeof otherProps.dimension === 'function'
+      ? otherProps.dimension()
+      : otherProps.dimension;
+
+  // for testing
+  const _getScrollDimensionValue = (elem, dimension) => {
+    const scroll = `scroll${dimension[0].toUpperCase()}${dimension.slice(1)}`;
+    return `${elem[scroll]}px`;
+  };
 
   /* -- Expanding -- */
-  handleEnter = elem => {
-    elem.style[this.getDimension()] = '0';
+  const _handleEnter = elem => {
+    elem.style[getDimension()] = '0';
   };
 
-  handleEntering = elem => {
-    const dimension = this.getDimension();
-    elem.style[dimension] = this._getScrollDimensionValue(elem, dimension);
+  const _handleEntering = elem => {
+    const dimension = getDimension();
+    elem.style[dimension] = _getScrollDimensionValue(elem, dimension);
   };
 
-  handleEntered = elem => {
-    elem.style[this.getDimension()] = null;
+  const _handleEntered = elem => {
+    elem.style[getDimension()] = null;
   };
 
   /* -- Collapsing -- */
-  handleExit = elem => {
-    const dimension = this.getDimension();
-    elem.style[dimension] = `${this.props.getDimensionValue(
+  const _handleExit = elem => {
+    const dimension = getDimension();
+    elem.style[dimension] = `${otherProps.getDimensionValue(
       dimension,
       elem,
     )}px`;
     triggerBrowserReflow(elem);
   };
 
-  handleExiting = elem => {
-    elem.style[this.getDimension()] = null;
+  const _handleExiting = elem => {
+    elem.style[getDimension()] = null;
   };
 
-  // for testing
-  _getScrollDimensionValue(elem, dimension) {
-    const scroll = `scroll${dimension[0].toUpperCase()}${dimension.slice(1)}`;
-    return `${elem[scroll]}px`;
-  }
+  const handleEnter = createChainedFunction(_handleEnter, onEnter);
+  const handleEntering = createChainedFunction(_handleEntering, onEntering);
+  const handleEntered = createChainedFunction(_handleEntered, onEntered);
+  const handleExit = createChainedFunction(_handleExit, onExit);
+  const handleExiting = createChainedFunction(_handleExiting, onExiting);
 
-  render() {
-    const {
-      onEnter,
-      onEntering,
-      onEntered,
-      onExit,
-      onExiting,
-      className,
-      children,
-      ...props
-    } = this.props;
-
-    delete props.dimension;
-    delete props.getDimensionValue;
-
-    const handleEnter = createChainedFunction(this.handleEnter, onEnter);
-    const handleEntering = createChainedFunction(
-      this.handleEntering,
-      onEntering,
-    );
-    const handleEntered = createChainedFunction(this.handleEntered, onEntered);
-    const handleExit = createChainedFunction(this.handleExit, onExit);
-    const handleExiting = createChainedFunction(this.handleExiting, onExiting);
-
-    return (
-      <Transition
-        addEndListener={onEnd}
-        {...props}
-        aria-expanded={props.role ? props.in : null}
-        onEnter={handleEnter}
-        onEntering={handleEntering}
-        onEntered={handleEntered}
-        onExit={handleExit}
-        onExiting={handleExiting}
-      >
-        {(state, innerProps) =>
-          React.cloneElement(children, {
-            ...innerProps,
-            className: classNames(
-              className,
-              children.props.className,
-              collapseStyles[state],
-              this.getDimension() === 'width' && 'width',
-            ),
-          })
-        }
-      </Transition>
-    );
-  }
-}
+  return (
+    <Transition
+      ref={ref}
+      {...otherProps}
+      aria-expanded={otherProps.role ? otherProps.in : null}
+      addEndListener={onEnd}
+      onEnter={handleEnter}
+      onEntering={handleEntering}
+      onEntered={handleEntered}
+      onExit={handleExit}
+      onExiting={handleExiting}
+    >
+      {(state, innerProps) =>
+        React.cloneElement(children, {
+          ...innerProps,
+          className: classNames(
+            className,
+            children.props.className,
+            collapseStyles[state],
+            getDimension() === 'width' && 'width',
+          ),
+        })
+      }
+    </Transition>
+  );
+});
 
 Collapse.propTypes = propTypes;
 Collapse.defaultProps = defaultProps;


### PR DESCRIPTION
My PR for Collapse forward ref. I am getting an error on the `AccordinCollapse` test without any idea on how to fix it. Help would be much appreciated.

Below is the error:
```
Error: Warning: React does not recognize the `getDimensionValue` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `getdimensionvalue` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
        in div (at AccordionCollapse.js:22)
        in Transition (at Collapse.js:191)
```

Thanks in advance to anyone who can point me in the right direction. 😄 