### PR TITLE
fix: added eslint pragma for ignoring dangerouslySetInnerHTML

### DIFF
--- a/www/src/components/ComponentApi.js
+++ b/www/src/components/ComponentApi.js
@@ -37,6 +37,7 @@ function ComponentApi({ heading, metadata, exportedBy }) {
 
       <ImportApi name={importName} />
       {/* use composes here */}
+      {/* eslint-disable-next-line react/no-danger */}
       {descHtml && <div dangerouslySetInnerHTML={{ __html: descHtml }} />}
       <PropTable metadata={metadata} />
     </>


### PR DESCRIPTION
Seems like GitHub is extracting the warnings, so better to exclude it that we now have no warnings anymore.

![image](https://user-images.githubusercontent.com/17984549/66736485-90cf6b00-ee69-11e9-943f-58f0593fa15c.png)
