### PR TITLE
docs: List.Item to ListGroup.Item

### DIFF
--- a/www/src/pages/components/list-group.mdx
+++ b/www/src/pages/components/list-group.mdx
@@ -43,7 +43,7 @@ Set the `active` prop to indicate the list groups current active selection.
 
 ### Disabled items
 
-Set the `disabled` prop to prevent actions on a `<List.Item>`. For elements
+Set the `disabled` prop to prevent actions on a `<ListGroup.Item>`. For elements
 that aren't naturally disable-able (like anchors) `onClick` handlers are added
 that call `preventDefault` to mimick disabled behavior.
 
@@ -80,7 +80,7 @@ edge-to-edge in a parent container [such as a `Card`](/components/cards/#list-gr
 
 ### Contextual classes
 
-Use contextual variants on `<List.Item>`s to style them with a stateful background and color.
+Use contextual variants on `<ListGroup.Item>`s to style them with a stateful background and color.
 
 <ReactPlayground
   codeText={ListGroupStyle}


### PR DESCRIPTION
Fixed a small typo in the docs of ListGroup component where it says `List.Item` instead of `ListGroup.Item`.