### PR TITLE
docs(Navs): mentions that vertical navs styled as tabs are unsupported by Bootstrap

### DIFF
--- a/www/src/pages/components/navs.mdx
+++ b/www/src/pages/components/navs.mdx
@@ -84,7 +84,9 @@ responsive versions to stack in some viewports but not others (e.g.
 ## Tabs
 
 Visually represent nav items as "tabs". This style pairs nicely with
-tabbable regions created by our [Tab components](../tabs/)
+tabbable regions created by our [Tab components](../tabs/).
+
+Note: creating a vertical nav (`.flex-column`) with tabs styling is unsupported by Bootstrap's default stylesheet.
 
 <ReactPlayground codeText={Tabs} />
 


### PR DESCRIPTION
Hey there! This is a very small PR that follows up on #4314, which is that vertical navs (created by `class="flex-column"` are not styled properly when used on Tabs (`variant="tabs"`), which is an issue core to Bootstrap's stylesheet.

Let me know if I should change the language of the docs!