### PR TITLE
Fix useAccordionToggle type

### DIFF
--- a/types/components/AccordionToggle.d.ts
+++ b/types/components/AccordionToggle.d.ts
@@ -7,11 +7,10 @@ export interface AccordionToggleProps {
   onClick?: (event?: React.SyntheticEvent) => void;
 }
 
-export interface useAccordionToggle {
-  (eventKey: string, onClick: (event?: React.SyntheticEvent) => void): (
-    event?: React.SyntheticEvent,
-  ) => void;
-}
+export function useAccordionToggle(
+  eventKey: string,
+  onClick: (event?: React.SyntheticEvent) => void,
+): (event?: React.SyntheticEvent) => void;
 
 declare class AccordionToggle<
   As extends React.ElementType = 'button'


### PR DESCRIPTION
Change the type definition for the useAccordionToggle hook to avoid errors with typescript.


*Related Issue:*
https://github.com/react-bootstrap/react-bootstrap/issues/4792