### PR TITLE
Enable to install react-bootstrap from GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format": "eslint . --fix && npm run prettier -- --write",
     "lint": "eslint . && npm run prettier -- -l",
     "postrelease": "yarn --cwd www deploy",
-    "prepublishOnly": "npm run build",
+    "prepare": "npm run build",
     "prettier": "prettier \"types/**/*.{ts,tsx}\"",
     "release": "rollout",
     "start": "yarn --cwd www develop",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "sideEffects": false,
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
+  "types": "lib/index.d.ts",
   "scripts": {
     "bootstrap": "yarn && yarn --cwd www",
     "build": "node tools/build.js",


### PR DESCRIPTION
Enables to install react-bootstrap by typing the following command
```
npm install react-bootstrap/react-bootstrap#master
```