### PR TITLE
Fix type of Overlay's onHide prop

### DIFF
--- a/types/components/Overlay.d.ts
+++ b/types/components/Overlay.d.ts
@@ -27,7 +27,7 @@ export interface OverlayProps extends TransitionCallbacks {
   popperConfig?: object;
   rootClose?: boolean;
   rootCloseEvent?: 'click' | 'mousedown';
-  onHide?: () => void;
+  onHide?: (event: React.SyntheticEvent) => void;
   transition?: boolean | React.ElementType;
   placement?: Placement;
 }


### PR DESCRIPTION
The type is incorrect, and is a regression from v0.x; react-overlays supplies the event to the `onHide` callback.

Reference:
- `onHide` is called from the `useRootClose` hook: https://github.com/react-bootstrap/react-overlays/blob/master/src/Overlay.js#L74
- `useRootClose` passes the event to the `onClose` function: https://github.com/react-bootstrap/react-overlays/blob/master/src/useRootClose.js#L59