### PR TITLE
fix(Modal): prevent closing if mouseup was outside

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -232,15 +232,15 @@ class Modal extends React.Component {
 
   handleDialogBackdropMouseDown = () => {
     this._waitingForMouseUp = true;
-  }
+  };
 
-  handleMouseUp = (ev) => {
+  handleMouseUp = ev => {
     const dialogNode = this._modal.getDialogElement();
     if (this._waitingForMouseUp && ev.target === dialogNode) {
       this._ignoreBackdropClick = true;
     }
     this._waitingForMouseUp = false;
-  }
+  };
 
   render() {
     const {

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -178,7 +178,8 @@ class Modal extends React.Component {
   }
 
   handleDialogClick(e) {
-    if (e.target !== e.currentTarget) {
+    if (this._ignoreBackdropClick || e.target !== e.currentTarget) {
+      this._ignoreBackdropClick = false;
       return;
     }
 
@@ -229,6 +230,18 @@ class Modal extends React.Component {
     });
   }
 
+  handleDialogBackdropMouseDown = () => {
+    this._waitingForMouseUp = true;
+  }
+
+  handleMouseUp = (ev) => {
+    const dialogNode = this._modal.getDialogElement();
+    if (this._waitingForMouseUp && ev.target === dialogNode) {
+      this._ignoreBackdropClick = true;
+    }
+    this._waitingForMouseUp = false;
+  }
+
   render() {
     const {
       backdrop,
@@ -264,12 +277,14 @@ class Modal extends React.Component {
         )}
         onEntering={createChainedFunction(onEntering, this.handleEntering)}
         onExited={createChainedFunction(onExited, this.handleExited)}
+        onMouseUp={this.handleMouseUp}
       >
         <Dialog
           {...dialogProps}
           style={{ ...this.state.style, ...style }}
           className={classNames(className, inClassName)}
           onClick={backdrop === true ? this.handleDialogClick : null}
+          onMouseDownDialog={this.handleDialogBackdropMouseDown}
         >
           {children}
         </Dialog>

--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -49,8 +49,11 @@ class ModalDialog extends React.Component {
         className={classNames(className, bsClassName)}
       >
         {
-          // eslint-disable-next-line jsx-a11y/no-static-element-interactions
-        }<div className={classNames(dialogClassName, dialogClasses)} onMouseDown={onMouseDownDialog}>
+          // eslint-disable-next-line jsx-a11y/no-static-element-interactions, prettier/prettier
+        }<div
+          className={classNames(dialogClassName, dialogClasses)}
+          onMouseDown={onMouseDownDialog}
+        >
           <div className={prefix(bsProps, 'content')} role="document">
             {children}
           </div>

--- a/src/ModalDialog.js
+++ b/src/ModalDialog.js
@@ -25,6 +25,7 @@ class ModalDialog extends React.Component {
       className,
       style,
       children,
+      onMouseDownDialog,
       ...props
     } = this.props;
     const [bsProps, elementProps] = splitBsProps(props);
@@ -47,7 +48,9 @@ class ModalDialog extends React.Component {
         style={modalStyle}
         className={classNames(className, bsClassName)}
       >
-        <div className={classNames(dialogClassName, dialogClasses)}>
+        {
+          // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+        }<div className={classNames(dialogClassName, dialogClasses)} onMouseDown={onMouseDownDialog}>
           <div className={prefix(bsProps, 'content')} role="document">
             {children}
           </div>


### PR DESCRIPTION
This PR applies the backport fix for (#3373 and #2666) which was already applied in PR #3187 for Bootstrap 4.
