### PR TITLE
fix(Modal): TypeScript manager typings

### DIFF
--- a/types/components/Modal.d.ts
+++ b/types/components/Modal.d.ts
@@ -27,7 +27,7 @@ export interface ModalProps extends TransitionCallbacks {
   container?: any;
   scrollable?: boolean;
   onEscapeKeyDown?: () => void;
-  manager: any;
+  manager?: any;
 }
 
 declare class Modal<

--- a/types/components/Modal.d.ts
+++ b/types/components/Modal.d.ts
@@ -27,6 +27,7 @@ export interface ModalProps extends TransitionCallbacks {
   container?: any;
   scrollable?: boolean;
   onEscapeKeyDown?: () => void;
+  manager: any;
 }
 
 declare class Modal<


### PR DESCRIPTION
The docs have a manager property but it's missing from the types