### PR TITLE
#4887 Add support for setting columns in <Row>

### DIFF
--- a/src/Row.js
+++ b/src/Row.js
@@ -66,14 +66,19 @@ const defaultProps = {
 };
 
 const Row = React.forwardRef(
-  // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
   (
-    { bsPrefix, className, noGutters, as: Component = 'div', ...props },
+    {
+      bsPrefix,
+      className,
+      noGutters,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
+      as: Component = 'div',
+      ...props
+    },
     ref,
   ) => {
     const decoratedBsPrefix = useBootstrapPrefix(bsPrefix, 'row');
     const sizePrefix = `${decoratedBsPrefix}-cols`;
-    const rowCols = [];
     const classes = [];
 
     DEVICE_SIZES.forEach(brkPoint => {
@@ -89,11 +94,11 @@ const Row = React.forwardRef(
 
       let infix = brkPoint !== 'xs' ? `-${brkPoint}` : '';
 
-      if (cols != null) rowCols.push(`${sizePrefix}${infix}-${cols}`);
+      if (cols != null) classes.push(`${sizePrefix}${infix}-${cols}`);
     });
 
-    if (!rowCols.length) {
-      rowCols.push(decoratedBsPrefix); // plain 'row'
+    if (!classes.length) {
+      classes.push(decoratedBsPrefix); // plain 'row'
     }
 
     return (
@@ -104,7 +109,6 @@ const Row = React.forwardRef(
           className,
           decoratedBsPrefix,
           noGutters && 'no-gutters',
-          ...rowCols,
           ...classes,
         )}
       />

--- a/src/Row.js
+++ b/src/Row.js
@@ -5,6 +5,16 @@ import React from 'react';
 
 import { useBootstrapPrefix } from './ThemeProvider';
 
+const DEVICE_SIZES = ['xl', 'lg', 'md', 'sm', 'xs'];
+const colSize = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+
+const column = PropTypes.oneOfType([
+  colSize,
+  PropTypes.shape({
+    size: colSize,
+  }),
+]);
+
 const propTypes = {
   /**
    * @default 'row'
@@ -14,36 +24,101 @@ const propTypes = {
   /** Removes the gutter spacing between `Col`s as well as any added negative margins. */
   noGutters: PropTypes.bool.isRequired,
   as: PropTypes.elementType,
+
+  /**
+   * The number of columns each column will span on extra small devices (<576px)
+   *
+   * @type {(number)}
+   */
+  xs: column,
+
+  /**
+   * The number of columns each column will span on small devices (≥576px)
+   *
+   * @type {(number)}
+   */
+  sm: column,
+
+  /**
+   * The number of columns each column will span on medium devices (≥768px)
+   *
+   * @type {(number)}
+   */
+  md: column,
+
+  /**
+   * The number of columns each column will span on large devices (≥992px)
+   *
+   * @type {(number)}
+   */
+  lg: column,
+
+  /**
+   * The number of columns each column will span on extra large devices (≥1200px)
+   *
+   * @type {(number)}
+   */
+  xl: column,
 };
 
 const defaultProps = {
   noGutters: false,
 };
 
-const Row = React.forwardRef((props, ref) => {
-  const {
-    bsPrefix,
-    noGutters,
-    // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
-    as: Component = 'div',
-    className,
-    ...otherProps
-  } = props;
+const Row = React.forwardRef(
+  // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
+  (
+    { bsPrefix, className, noGutters, as: Component = 'div', ...props },
+    ref,
+  ) => {
+    const decoratedBsPrefix = useBootstrapPrefix(bsPrefix, 'row');
+    const sizePrefix = useBootstrapPrefix(
+      `${decoratedBsPrefix}-cols`,
+      'row-cols',
+    );
+    const spans = [];
+    const classes = [];
 
-  const decoratedBsPrefix = useBootstrapPrefix(bsPrefix, 'row');
+    DEVICE_SIZES.forEach(brkPoint => {
+      let propValue = props[brkPoint];
+      delete props[brkPoint];
 
-  return (
-    <Component
-      ref={ref}
-      {...otherProps}
-      className={classNames(
-        className,
-        decoratedBsPrefix,
-        noGutters && 'no-gutters',
-      )}
-    />
-  );
-});
+      let span;
+      if (propValue != null && typeof propValue === 'object') {
+        ({ span = true } = propValue);
+      } else {
+        span = propValue;
+      }
+
+      let infix = brkPoint !== 'xs' ? `-${brkPoint}` : '';
+
+      if (span != null)
+        spans.push(
+          span === true
+            ? `${sizePrefix}${infix}`
+            : `${sizePrefix}${infix}-${span}`,
+        );
+    });
+
+    if (!spans.length) {
+      spans.push(decoratedBsPrefix); // plain 'row'
+    }
+
+    return (
+      <Component
+        ref={ref}
+        {...props}
+        className={classNames(
+          className,
+          decoratedBsPrefix,
+          noGutters && 'no-gutters',
+          ...spans,
+          ...classes,
+        )}
+      />
+    );
+  },
+);
 
 Row.propTypes = propTypes;
 Row.defaultProps = defaultProps;

--- a/src/Row.js
+++ b/src/Row.js
@@ -28,35 +28,35 @@ const propTypes = {
   /**
    * The number of columns that will fit next to each other on extra small devices (<576px)
    *
-   * @type {(number)}
+   * @type {(number|{ cols: number })}
    */
   xs: rowColumns,
 
   /**
    * The number of columns that will fit next to each other on small devices (≥576px)
    *
-   * @type {(number)}
+   * @type {(number|{ cols: number })}
    */
   sm: rowColumns,
 
   /**
    * The number of columns that will fit next to each other on medium devices (≥768px)
    *
-   * @type {(number)}
+   * @type {(number|{ cols: number })}
    */
   md: rowColumns,
 
   /**
    * The number of columns that will fit next to each other on large devices (≥992px)
    *
-   * @type {(number)}
+   * @type {(number|{ cols: number })}
    */
   lg: rowColumns,
 
   /**
    * The number of columns that will fit next to each other on extra large devices (≥1200px)
    *
-   * @type {(number)}
+   * @type {(number|{ cols: number })}
    */
   xl: rowColumns,
 };
@@ -76,32 +76,32 @@ const Row = React.forwardRef(
       `${decoratedBsPrefix}-cols`,
       'row-cols',
     );
-    const cols = [];
+    const rowCols = [];
     const classes = [];
 
     DEVICE_SIZES.forEach(brkPoint => {
       let propValue = props[brkPoint];
       delete props[brkPoint];
 
-      let col;
+      let cols;
       if (propValue != null && typeof propValue === 'object') {
-        ({ col = true } = propValue);
+        ({ cols = true } = propValue);
       } else {
-        col = propValue;
+        cols = propValue;
       }
 
       let infix = brkPoint !== 'xs' ? `-${brkPoint}` : '';
 
-      if (col != null)
-        cols.push(
-          col === true
+      if (cols != null)
+        rowCols.push(
+          cols === true
             ? `${sizePrefix}${infix}`
-            : `${sizePrefix}${infix}-${col}`,
+            : `${sizePrefix}${infix}-${cols}`,
         );
     });
 
-    if (!cols.length) {
-      cols.push(decoratedBsPrefix); // plain 'row'
+    if (!rowCols.length) {
+      rowCols.push(decoratedBsPrefix); // plain 'row'
     }
 
     return (
@@ -112,7 +112,7 @@ const Row = React.forwardRef(
           className,
           decoratedBsPrefix,
           noGutters && 'no-gutters',
-          ...cols,
+          ...rowCols,
           ...classes,
         )}
       />

--- a/src/Row.js
+++ b/src/Row.js
@@ -97,10 +97,6 @@ const Row = React.forwardRef(
       if (cols != null) classes.push(`${sizePrefix}${infix}-${cols}`);
     });
 
-    if (!classes.length) {
-      classes.push(decoratedBsPrefix); // plain 'row'
-    }
-
     return (
       <Component
         ref={ref}

--- a/src/Row.js
+++ b/src/Row.js
@@ -82,7 +82,7 @@ const Row = React.forwardRef(
     const classes = [];
 
     DEVICE_SIZES.forEach(brkPoint => {
-      let propValue = props[brkPoint];
+      const propValue = props[brkPoint];
       delete props[brkPoint];
 
       let cols;

--- a/src/Row.js
+++ b/src/Row.js
@@ -6,12 +6,12 @@ import React from 'react';
 import { useBootstrapPrefix } from './ThemeProvider';
 
 const DEVICE_SIZES = ['xl', 'lg', 'md', 'sm', 'xs'];
-const colSize = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
+const rowColWidth = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
 
-const column = PropTypes.oneOfType([
-  colSize,
+const rowColumns = PropTypes.oneOfType([
+  rowColWidth,
   PropTypes.shape({
-    size: colSize,
+    size: rowColWidth,
   }),
 ]);
 
@@ -26,39 +26,39 @@ const propTypes = {
   as: PropTypes.elementType,
 
   /**
-   * The number of columns each column will span on extra small devices (<576px)
+   * The number of columns that will fit next to each other on extra small devices (<576px)
    *
    * @type {(number)}
    */
-  xs: column,
+  xs: rowColumns,
 
   /**
-   * The number of columns each column will span on small devices (≥576px)
+   * The number of columns that will fit next to each other on small devices (≥576px)
    *
    * @type {(number)}
    */
-  sm: column,
+  sm: rowColumns,
 
   /**
-   * The number of columns each column will span on medium devices (≥768px)
+   * The number of columns that will fit next to each other on medium devices (≥768px)
    *
    * @type {(number)}
    */
-  md: column,
+  md: rowColumns,
 
   /**
-   * The number of columns each column will span on large devices (≥992px)
+   * The number of columns that will fit next to each other on large devices (≥992px)
    *
    * @type {(number)}
    */
-  lg: column,
+  lg: rowColumns,
 
   /**
-   * The number of columns each column will span on extra large devices (≥1200px)
+   * The number of columns that will fit next to each other on extra large devices (≥1200px)
    *
    * @type {(number)}
    */
-  xl: column,
+  xl: rowColumns,
 };
 
 const defaultProps = {
@@ -76,32 +76,32 @@ const Row = React.forwardRef(
       `${decoratedBsPrefix}-cols`,
       'row-cols',
     );
-    const spans = [];
+    const cols = [];
     const classes = [];
 
     DEVICE_SIZES.forEach(brkPoint => {
       let propValue = props[brkPoint];
       delete props[brkPoint];
 
-      let span;
+      let col;
       if (propValue != null && typeof propValue === 'object') {
-        ({ span = true } = propValue);
+        ({ col = true } = propValue);
       } else {
-        span = propValue;
+        col = propValue;
       }
 
       let infix = brkPoint !== 'xs' ? `-${brkPoint}` : '';
 
-      if (span != null)
-        spans.push(
-          span === true
+      if (col != null)
+        cols.push(
+          col === true
             ? `${sizePrefix}${infix}`
-            : `${sizePrefix}${infix}-${span}`,
+            : `${sizePrefix}${infix}-${col}`,
         );
     });
 
-    if (!spans.length) {
-      spans.push(decoratedBsPrefix); // plain 'row'
+    if (!cols.length) {
+      cols.push(decoratedBsPrefix); // plain 'row'
     }
 
     return (
@@ -112,7 +112,7 @@ const Row = React.forwardRef(
           className,
           decoratedBsPrefix,
           noGutters && 'no-gutters',
-          ...spans,
+          ...cols,
           ...classes,
         )}
       />

--- a/src/Row.js
+++ b/src/Row.js
@@ -11,7 +11,7 @@ const rowColWidth = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
 const rowColumns = PropTypes.oneOfType([
   rowColWidth,
   PropTypes.shape({
-    size: rowColWidth,
+    cols: rowColWidth,
   }),
 ]);
 
@@ -72,10 +72,7 @@ const Row = React.forwardRef(
     ref,
   ) => {
     const decoratedBsPrefix = useBootstrapPrefix(bsPrefix, 'row');
-    const sizePrefix = useBootstrapPrefix(
-      `${decoratedBsPrefix}-cols`,
-      'row-cols',
-    );
+    const sizePrefix = `${decoratedBsPrefix}-cols`;
     const rowCols = [];
     const classes = [];
 
@@ -85,19 +82,14 @@ const Row = React.forwardRef(
 
       let cols;
       if (propValue != null && typeof propValue === 'object') {
-        ({ cols = true } = propValue);
+        ({ cols } = propValue);
       } else {
         cols = propValue;
       }
 
       let infix = brkPoint !== 'xs' ? `-${brkPoint}` : '';
 
-      if (cols != null)
-        rowCols.push(
-          cols === true
-            ? `${sizePrefix}${infix}`
-            : `${sizePrefix}${infix}-${cols}`,
-        );
+      if (cols != null) rowCols.push(`${sizePrefix}${infix}-${cols}`);
     });
 
     if (!rowCols.length) {

--- a/test/RowSpec.js
+++ b/test/RowSpec.js
@@ -4,6 +4,14 @@ import { mount } from 'enzyme';
 import Row from '../src/Row';
 
 describe('Row', () => {
+  it('Should include "row" when there are no sizes', () => {
+    mount(<Row />).assertSingle('.row');
+  });
+
+  it('Should include sizes', () => {
+    mount(<Row xs={4} md={8} />).assertSingle('.row-cols-md-8.row-cols-4');
+  });
+
   it('uses "div" by default', () => {
     mount(
       <Row className="custom-class">

--- a/types/components/Row.d.ts
+++ b/types/components/Row.d.ts
@@ -2,8 +2,29 @@ import * as React from 'react';
 
 import { BsPrefixComponent } from './helpers';
 
+type NumberAttr =
+  | number
+  | '1'
+  | '2'
+  | '3'
+  | '4'
+  | '5'
+  | '6'
+  | '7'
+  | '8'
+  | '9'
+  | '10'
+  | '11'
+  | '12';
+type RowColSpec = NumberAttr | { cols?: NumberAttr };
+
 export interface RowProps {
   noGutters?: boolean;
+  xs?: RowColSpec;
+  sm?: RowColSpec;
+  md?: RowColSpec;
+  lg?: RowColSpec;
+  xl?: RowColSpec;
 }
 
 declare class Row<

--- a/types/components/Row.d.ts
+++ b/types/components/Row.d.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { BsPrefixComponent } from './helpers';
 
-type NumberAttr =
+type RowColWidth =
   | number
   | '1'
   | '2'
@@ -16,15 +16,15 @@ type NumberAttr =
   | '10'
   | '11'
   | '12';
-type RowColSpec = NumberAttr | { cols?: NumberAttr };
+type RowColumns = RowColWidth | { cols?: RowColWidth };
 
 export interface RowProps {
   noGutters?: boolean;
-  xs?: RowColSpec;
-  sm?: RowColSpec;
-  md?: RowColSpec;
-  lg?: RowColSpec;
-  xl?: RowColSpec;
+  xs?: RowColumns;
+  sm?: RowColumns;
+  md?: RowColumns;
+  lg?: RowColumns;
+  xl?: RowColumns;
 }
 
 declare class Row<

--- a/www/src/examples/Grid/RowColLayout.js
+++ b/www/src/examples/Grid/RowColLayout.js
@@ -1,0 +1,11 @@
+<Container>
+  <Row xs={2} md={4} lg={6}>
+    <Col>1 of 2</Col>
+    <Col>2 of 2</Col>
+  </Row>
+  <Row xs={1} md={2}>
+    <Col>1 of 3</Col>
+    <Col>2 of 3</Col>
+    <Col>3 of 3</Col>
+  </Row>
+</Container>;

--- a/www/src/examples/Grid/RowColLayoutColWidth.js
+++ b/www/src/examples/Grid/RowColLayoutColWidth.js
@@ -1,7 +1,0 @@
-<Container>
-  <Row xs="2" sm="3" md="4" lg="5" xl="6">
-    <Col>1 of 3</Col>
-    <Col>2 of 3</Col>
-    <Col>3 of 3</Col>
-  </Row>
-</Container>;

--- a/www/src/examples/Grid/RowColLayoutColWidth.js
+++ b/www/src/examples/Grid/RowColLayoutColWidth.js
@@ -1,5 +1,5 @@
 <Container>
-  <Row xs={3}>
+  <Row xs="2" sm="3" md="4" lg="5" xl="6">
     <Col>1 of 3</Col>
     <Col>2 of 3</Col>
     <Col>3 of 3</Col>

--- a/www/src/examples/Grid/RowColLayoutColWidth.js
+++ b/www/src/examples/Grid/RowColLayoutColWidth.js
@@ -1,0 +1,7 @@
+<Container>
+  <Row xs={3}>
+    <Col>1 of 3</Col>
+    <Col>2 of 3</Col>
+    <Col>3 of 3</Col>
+  </Row>
+</Container>;

--- a/www/src/examples/Grid/RowColLayoutColWidthBreakpoint.js
+++ b/www/src/examples/Grid/RowColLayoutColWidthBreakpoint.js
@@ -1,0 +1,7 @@
+<Container>
+  <Row md={4}>
+    <Col>1 of 3</Col>
+    <Col xs={6}>2 of 3</Col>
+    <Col>3 of 3</Col>
+  </Row>
+</Container>;

--- a/www/src/pages/layout/grid.js
+++ b/www/src/pages/layout/grid.js
@@ -7,8 +7,7 @@ import ComponentApi from '../../components/ComponentApi';
 import ReactPlayground from '../../components/ReactPlayground';
 import GridAutoLayout from '../../examples/Grid/AutoLayout';
 import GridRowColLayout from '../../examples/Grid/RowColLayout';
-import RowColLayoutColWidth from '../../examples/Grid/RowColLayoutColWidth';
-import RowColLayoutColWidthBreakpoint from '../../examples/Grid/RowColLayoutColWidthBreakpoint';
+import GridRowColLayoutColWidthBreakpoint from '../../examples/Grid/RowColLayoutColWidthBreakpoint';
 import GridAutoLayoutSizing from '../../examples/Grid/AutoLayoutSizing';
 import GridAutoLayoutVariable from '../../examples/Grid/AutoLayoutVariable';
 import GridOffsetting from '../../examples/Grid/Offsetting';
@@ -156,30 +155,14 @@ export default withLayout(function GridSection({ data }) {
         codeText={GridRowColLayout}
         exampleClassName={styles.example}
       />
-
-      <LinkedHeading h="4" id="row-layout-col-width-sizing">
-        Setting column widths using Row
-      </LinkedHeading>
-
       <p>
-        You can define the column widths on the <code>Row</code> instead of on
-        each <code>Col</code>. You can use the same breakpoints (xs, sm, md,
-        large, and xl) on the <code>Row</code> to specify different widths for
-        the columns on each breakpoint.
-      </p>
-      <ReactPlayground
-        codeText={RowColLayoutColWidth}
-        exampleClassName={styles.example}
-      />
-
-      <p>
-        Note that <code>Row</code> column widths will override <code>Col</code>
-        widths set on lower breakpoints when viewed on larger screens. The
-        <code>{'<Col xs={6} />'}</code> size will be overriden by
+        Note that <code>Row</code> column widths will override <code>Col</code>{' '}
+        widths set on lower breakpoints when viewed on larger screens. The{' '}
+        <code>{'<Col xs={6} />'}</code> size will be overriden by{' '}
         <code>{'<Row md={4} />'}</code> on medium and larger screens.
       </p>
       <ReactPlayground
-        codeText={RowColLayoutColWidthBreakpoint}
+        codeText={GridRowColLayoutColWidthBreakpoint}
         exampleClassName={styles.example}
       />
 

--- a/www/src/pages/layout/grid.js
+++ b/www/src/pages/layout/grid.js
@@ -6,6 +6,9 @@ import LinkedHeading from '../../components/LinkedHeading';
 import ComponentApi from '../../components/ComponentApi';
 import ReactPlayground from '../../components/ReactPlayground';
 import GridAutoLayout from '../../examples/Grid/AutoLayout';
+import GridRowColLayout from '../../examples/Grid/RowColLayout';
+import RowColLayoutColWidth from '../../examples/Grid/RowColLayoutColWidth';
+import RowColLayoutColWidthBreakpoint from '../../examples/Grid/RowColLayoutColWidthBreakpoint';
 import GridAutoLayoutSizing from '../../examples/Grid/AutoLayoutSizing';
 import GridAutoLayoutVariable from '../../examples/Grid/AutoLayoutVariable';
 import GridOffsetting from '../../examples/Grid/Offsetting';
@@ -139,6 +142,45 @@ export default withLayout(function GridSection({ data }) {
         codeText={GridOffsetting}
         exampleClassName={styles.example}
       />
+
+      <LinkedHeading h="3" id="row-layout-col-sizing">
+        Setting column widths in Row
+      </LinkedHeading>
+
+      <p>
+        The <code>Row</code> lets you specify column widths across 5 breakpoint
+        sizes (xs, sm, md, large, and xl). For every breakpoint, you can specify
+        the amount of columns that will fit next to each other.
+      </p>
+      <ReactPlayground
+        codeText={GridRowColLayout}
+        exampleClassName={styles.example}
+      />
+
+      <LinkedHeading h="4" id="row-layout-col-width-sizing">
+        Setting column widths in Row and column widths
+      </LinkedHeading>
+
+      <p>
+        You can combine the <code>Row</code> column width with a specified width
+        for one or several <code>Col</code>.
+      </p>
+      <ReactPlayground
+        codeText={RowColLayoutColWidth}
+        exampleClassName={styles.example}
+      />
+
+      <p>
+        Note that <code>Row</code> column widths will override <code>Col</code>
+        widths set on lower breakpoints when viewed on larger screens. The
+        <code>{'<Col xs={6} />'}</code> size will be overriden by
+        <code>{'<Row md={4} />'}</code> on medium and larger screens.
+      </p>
+      <ReactPlayground
+        codeText={RowColLayoutColWidthBreakpoint}
+        exampleClassName={styles.example}
+      />
+
       <LinkedHeading h="2" id="grid-props">
         API
       </LinkedHeading>

--- a/www/src/pages/layout/grid.js
+++ b/www/src/pages/layout/grid.js
@@ -158,12 +158,14 @@ export default withLayout(function GridSection({ data }) {
       />
 
       <LinkedHeading h="4" id="row-layout-col-width-sizing">
-        Setting column widths in Row and column widths
+        Setting column widths using Row
       </LinkedHeading>
 
       <p>
-        You can combine the <code>Row</code> column width with a specified width
-        for one or several <code>Col</code>.
+        You can define the column widths on the <code>Row</code> instead of on
+        each <code>Col</code>. You can use the same breakpoints (xs, sm, md,
+        large, and xl) on the <code>Row</code> to specify different widths for
+        the columns on each breakpoint.
       </p>
       <ReactPlayground
         codeText={RowColLayoutColWidth}


### PR DESCRIPTION
This PR extends <Row> to accept sizing prop similar to how <Col> does it.

I created an issue for this, #4887 , and here is my attempt at an PR for it.

- Extends Row.js with logic from Col.js
- Updated RowSpec.js with what it should handle with the above changes
- Updated docs with some examples and text that (hopefully) explains how it works

There are some gotcha's I found while creating this:
- The sizing prop into `<Row>` doesn't set the column widths, rather it sets the number of columns that should fit next to each other
- Setting `<Row md={4}>` will override `<Col xs={6}>` on medium devices (Row-sizing props takes precedence based on breakpoint as it does in Bootstrap)
- Setting `<Row md={4}>` will NOT override `<Col md={6}>` on medium devices

I'm unsure if this is clear enough in the docs.

I am sure that you can propose better names for a few of the files and headings I added for the docs.