### PR TITLE
#4884 add responsive containers

### DIFF
--- a/src/Container.js
+++ b/src/Container.js
@@ -4,8 +4,8 @@ import PropTypes from 'prop-types';
 
 import { useBootstrapPrefix } from './ThemeProvider';
 
-const brkPoints = PropTypes.oneOfType([
-  PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
+const sizes = PropTypes.oneOfType([
+  PropTypes.oneOf(['sm', 'md', 'lg', 'xl', 'fluid']),
 ]);
 
 const propTypes = {
@@ -26,7 +26,7 @@ const propTypes = {
    * You can set responsive container width.
    * @type {("sm"|"md"|"lg"|"xl")}
    */
-  breakpoint: brkPoints,
+  size: sizes,
 };
 
 const defaultProps = {
@@ -36,11 +36,11 @@ const defaultProps = {
 const Container = React.forwardRef(
   // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
   (
-    { bsPrefix, fluid, breakpoint, as: Component = 'div', className, ...props },
+    { bsPrefix, fluid, size, as: Component = 'div', className, ...props },
     ref,
   ) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'container');
-    let suffix = breakpoint != null ? `-${breakpoint}` : '';
+    let suffix = size != null ? `-${size}` : '';
     return (
       <Component
         ref={ref}

--- a/src/Container.js
+++ b/src/Container.js
@@ -24,6 +24,7 @@ const propTypes = {
   as: PropTypes.elementType,
   /**
    * You can set responsive container width.
+   * @type {("sm"|"md"|"lg"|"xl")}
    */
   breakpoint: brkPoints,
 };

--- a/src/Container.js
+++ b/src/Container.js
@@ -50,7 +50,7 @@ const Container = React.forwardRef(
         {...props}
         className={classNames(
           className,
-          fluid === true ? `${prefix}-fluid` : `${prefix}${suffix}`,
+          fluid ? `${prefix}${suffix}` : prefix,
         )}
       />
     );

--- a/src/Container.js
+++ b/src/Container.js
@@ -4,8 +4,9 @@ import PropTypes from 'prop-types';
 
 import { useBootstrapPrefix } from './ThemeProvider';
 
-const sizes = PropTypes.oneOfType([
-  PropTypes.oneOf(['sm', 'md', 'lg', 'xl', 'fluid']),
+const containerSizes = PropTypes.oneOfType([
+  PropTypes.bool,
+  PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
 ]);
 
 const propTypes = {
@@ -16,17 +17,13 @@ const propTypes = {
 
   /**
    * Allow the Container to fill all of its available horizontal space.
+   * @type {(true|"sm"|"md"|"lg"|"xl")}
    */
-  fluid: PropTypes.bool,
+  fluid: containerSizes,
   /**
    * You can use a custom element for this component
    */
   as: PropTypes.elementType,
-  /**
-   * You can set responsive container width.
-   * @type {("sm"|"md"|"lg"|"xl")}
-   */
-  size: sizes,
 };
 
 const defaultProps = {
@@ -34,20 +31,26 @@ const defaultProps = {
 };
 
 const Container = React.forwardRef(
-  // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
   (
-    { bsPrefix, fluid, size, as: Component = 'div', className, ...props },
+    {
+      bsPrefix,
+      fluid,
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
+      as: Component = 'div',
+      className,
+      ...props
+    },
     ref,
   ) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'container');
-    let suffix = size != null ? `-${size}` : '';
+    let suffix = fluid === false ? '' : `-${fluid}`;
     return (
       <Component
         ref={ref}
         {...props}
         className={classNames(
           className,
-          fluid ? `${prefix}-fluid` : `${prefix}${suffix}`,
+          fluid === true ? `${prefix}-fluid` : `${prefix}${suffix}`,
         )}
       />
     );

--- a/src/Container.js
+++ b/src/Container.js
@@ -4,6 +4,10 @@ import PropTypes from 'prop-types';
 
 import { useBootstrapPrefix } from './ThemeProvider';
 
+const brkPoints = PropTypes.oneOfType([
+  PropTypes.oneOf(['sm', 'md', 'lg', 'xl']),
+]);
+
 const propTypes = {
   /**
    * @default 'container'
@@ -18,6 +22,10 @@ const propTypes = {
    * You can use a custom element for this component
    */
   as: PropTypes.elementType,
+  /**
+   * You can set responsive container width.
+   */
+  breakpoint: brkPoints,
 };
 
 const defaultProps = {
@@ -26,13 +34,20 @@ const defaultProps = {
 
 const Container = React.forwardRef(
   // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
-  ({ bsPrefix, fluid, as: Component = 'div', className, ...props }, ref) => {
+  (
+    { bsPrefix, fluid, breakpoint, as: Component = 'div', className, ...props },
+    ref,
+  ) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'container');
+    let suffix = breakpoint != null ? `-${breakpoint}` : '';
     return (
       <Component
         ref={ref}
         {...props}
-        className={classNames(className, fluid ? `${prefix}-fluid` : prefix)}
+        className={classNames(
+          className,
+          fluid ? `${prefix}-fluid` : `${prefix}${suffix}`,
+        )}
       />
     );
   },

--- a/src/Container.js
+++ b/src/Container.js
@@ -48,10 +48,7 @@ const Container = React.forwardRef(
       <Component
         ref={ref}
         {...props}
-        className={classNames(
-          className,
-          fluid ? `${prefix}${suffix}` : prefix,
-        )}
+        className={classNames(className, fluid ? `${prefix}${suffix}` : prefix)}
       />
     );
   },

--- a/src/Container.js
+++ b/src/Container.js
@@ -43,7 +43,7 @@ const Container = React.forwardRef(
     ref,
   ) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'container');
-    let suffix = fluid === false ? '' : `-${fluid}`;
+    const suffix = typeof fluid === 'string' ? `-${fluid}` : '-fluid';
     return (
       <Component
         ref={ref}

--- a/test/ContainerSpec.js
+++ b/test/ContainerSpec.js
@@ -14,12 +14,16 @@ describe('<Container>', () => {
     mount(<Container fluid />).assertSingle('.container-fluid');
   });
 
+  it('turns grid into "full-width" layout via size="fluid" property set', () => {
+    mount(<Container size="fluid" />).assertSingle('.container-fluid');
+  });
+
   it('allows custom elements instead of "div"', () => {
     mount(<Container as="section" />).assertSingle('section.container');
   });
 
-  it('Should include breakpoint when breakpoint is set', () => {
-    mount(<Container breakpoint="sm" />).assertSingle('.container-sm');
+  it('Should include size breakpoint class when size is set', () => {
+    mount(<Container size="sm" />).assertSingle('.container-sm');
   });
 
   it('Should have div as default component', () => {

--- a/test/ContainerSpec.js
+++ b/test/ContainerSpec.js
@@ -18,6 +18,10 @@ describe('<Container>', () => {
     mount(<Container as="section" />).assertSingle('section.container');
   });
 
+  it('Should include breakpoint when breakpoint is set', () => {
+    mount(<Container breakpoint="sm" />).assertSingle('.container-sm');
+  });
+
   it('Should have div as default component', () => {
     mount(<Container />).assertSingle('div');
   });

--- a/test/ContainerSpec.js
+++ b/test/ContainerSpec.js
@@ -14,16 +14,12 @@ describe('<Container>', () => {
     mount(<Container fluid />).assertSingle('.container-fluid');
   });
 
-  it('turns grid into "full-width" layout via size="fluid" property set', () => {
-    mount(<Container size="fluid" />).assertSingle('.container-fluid');
+  it('Should include size breakpoint class when fluid is set to sm, md, lg or xl', () => {
+    mount(<Container fluid="sm" />).assertSingle('.container-sm');
   });
 
   it('allows custom elements instead of "div"', () => {
     mount(<Container as="section" />).assertSingle('section.container');
-  });
-
-  it('Should include size breakpoint class when size is set', () => {
-    mount(<Container size="sm" />).assertSingle('.container-sm');
   });
 
   it('Should have div as default component', () => {

--- a/www/src/examples/Grid/Container.js
+++ b/www/src/examples/Grid/Container.js
@@ -1,0 +1,5 @@
+<Container>
+  <Row>
+    <Col>1 of 1</Col>
+  </Row>
+</Container>;

--- a/www/src/examples/Grid/ContainerFluid.js
+++ b/www/src/examples/Grid/ContainerFluid.js
@@ -1,0 +1,5 @@
+<Container fluid>
+  <Row>
+    <Col>1 of 1</Col>
+  </Row>
+</Container>;

--- a/www/src/examples/Grid/ContainerFluidBreakpoint.js
+++ b/www/src/examples/Grid/ContainerFluidBreakpoint.js
@@ -1,0 +1,5 @@
+<Container fluid="md">
+  <Row>
+    <Col>1 of 1</Col>
+  </Row>
+</Container>;

--- a/www/src/pages/layout/grid.js
+++ b/www/src/pages/layout/grid.js
@@ -5,6 +5,9 @@ import { css } from 'astroturf';
 import LinkedHeading from '../../components/LinkedHeading';
 import ComponentApi from '../../components/ComponentApi';
 import ReactPlayground from '../../components/ReactPlayground';
+import GridContainer from '../../examples/Grid/Container';
+import GridContainerFluid from '../../examples/Grid/ContainerFluid';
+import GridContainerFluidBreakpoint from '../../examples/Grid/ContainerFluidBreakpoint';
 import GridAutoLayout from '../../examples/Grid/AutoLayout';
 import GridAutoLayoutSizing from '../../examples/Grid/AutoLayoutSizing';
 import GridAutoLayoutVariable from '../../examples/Grid/AutoLayoutVariable';
@@ -56,6 +59,38 @@ export default withLayout(function GridSection({ data }) {
         </a>{' '}
         for background, terminology, guidelines, and code snippets.
       </p>
+      <LinkedHeading h="2" id="container">
+        Container
+      </LinkedHeading>
+      <p>
+        Containers provide a means to center and horizontally pad your site’s
+        contents. Use <code>Container</code> for a responsive pixel width.
+      </p>
+      <ReactPlayground
+        codeText={GridContainer}
+        exampleClassName={styles.example}
+      />
+      <LinkedHeading h="3" id="container-fluid">
+        Fluid Container
+      </LinkedHeading>
+      <p>
+        You can use <code>{'<Container fluid />'}</code> for width: 100% across
+        all viewport and device sizes.
+      </p>
+      <ReactPlayground
+        codeText={GridContainerFluid}
+        exampleClassName={styles.example}
+      />
+      <p>
+        You can set breakpoints for the <code>fluid</code> prop. Setting it to a
+        breakpoint (<code>sm, md, lg, xl</code>) will set the{' '}
+        <code>Container</code> as fluid until the specified breakpoint.
+      </p>
+      <ReactPlayground
+        codeText={GridContainerFluidBreakpoint}
+        exampleClassName={styles.example}
+      />
+
       <LinkedHeading h="2" id="auto-layout">
         Auto-layout columns
       </LinkedHeading>


### PR DESCRIPTION
An attempt at extending `<Container>` with breakpoints as in #4884

**I have not updated docs yet since I want to make sure we find consensus about how this prop should work for the Container component.** I will add docs once we have decided if this is a good idea or not.

- Adds "breakpoint" prop to `<Container>`
- Permits only "sm", "md", "lg" and "xl" (same as Bootstrap classes)
- if fluid is set it takes precedence since fluid and container-[breakpoint] should not be combined
- updated test for `<Container>` to include breakpoint

I first considered setting sm, md, lg and xl as booleans, but realised that would allow for all kinds of fails since then you could set more than one as true at the same time (not good).

And since we already have fluid I left that prop alone and extended on it.

**Regarding docs**
I'm a bit unsure where to add them. Comparing to the regular Bootstrap docs we do not have their Overview section. Should we add it and place the Container documentation in it like they do?