### PR TITLE
Fix issue with OverlayTrigger, hover and disabled child element

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -110,6 +110,14 @@ class OverlayTrigger extends React.Component {
     };
   }
 
+  componentDidUpdate(prevProps) {
+    const disabled = React.Children.only(this.props.children).props.disabled;
+    const prevDisabled = React.Children.only(prevProps.children).props.disabled;
+    if (disabled === true && disabled !== prevDisabled && this.state.show) {
+      this.hide();
+    }
+  }
+
   componentWillUnmount() {
     clearTimeout(this._timeout);
   }


### PR DESCRIPTION
This pull request fixes an issue with the fact that `onMouseOut` does not trigger when the mouse leaves a disabled element (In Chrome and Safari). This causes the `show` state to still be `true` when leaving the element and the overlay will re-appear when the button is enabled again even if the mouse no longer is above the element.

The fix is to always set the `show` state to `false` if the childs `disabled` property has changed to `true` and the `show` state is still `true`. If you prefer to solve this issue in another way just let me know but it would be nice if this bug is fixed in some way. :)