### PR TITLE
increase test coverage with minor refactor

### DIFF
--- a/test/TabContainerSpec.js
+++ b/test/TabContainerSpec.js
@@ -41,6 +41,52 @@ describe('<TabContainer>', () => {
     onSelect.should.have.been.calledOnce;
   });
 
+  it('should let generateChildId function create id', () => {
+    const generateChildIdSpy = sinon.spy(() => 'test-id');
+
+    let instance = mount(
+      <TabContainer generateChildId={generateChildIdSpy}>
+        <div>
+          <Nav>
+            <Nav.Item>
+              <Nav.Link eventKey="1">One</Nav.Link>
+            </Nav.Item>
+          </Nav>
+          <TabContent>
+            <TabPane eventKey="1" />
+          </TabContent>
+        </div>
+      </TabContainer>,
+    );
+
+    instance.assertSingle(`SafeAnchor[id="test-id"]`);
+  });
+
+  it('should throw an error if id is not set', () => {
+    try {
+      mount(
+        <TabContainer>
+          <div>
+            <Nav>
+              <Nav.Item>
+                <Nav.Link eventKey="1">One</Nav.Link>
+              </Nav.Item>
+            </Nav>
+            <TabContent>
+              <TabPane eventKey="1" />
+            </TabContent>
+          </div>
+        </TabContainer>,
+      );
+    } catch (error) {
+      expect(error.message).to.contain(
+        'In order to properly initialize Tabs in a way that is accessible ' +
+          'to assistive technologies (such as screen readers) an `id` or a ' +
+          '`generateChildId` prop to TabContainer is required',
+      );
+    }
+  });
+
   it('should match up ids', () => {
     let instance = mount(
       <TabContainer id="custom-id">

--- a/test/ToastSpec.js
+++ b/test/ToastSpec.js
@@ -11,7 +11,18 @@ describe('<Toast>', () => {
         <Toast.Body />
       </Toast>,
     ).assertSingle(
-      'div.toast[role="alert"][aria-live="assertive"][aria-atomic="true"]',
+      'div.toast[className="fade toast show"][role="alert"][aria-live="assertive"][aria-atomic="true"]',
+    );
+  });
+
+  it('should render without transition if animation is false', () => {
+    mount(
+      <Toast animation={false}>
+        <Toast.Header />
+        <Toast.Body />
+      </Toast>,
+    ).assertSingle(
+      'div.toast[className="toast show"][role="alert"][aria-live="assertive"][aria-atomic="true"]',
     );
   });
 
@@ -45,6 +56,24 @@ describe('<Toast>', () => {
       );
       clock.tick(1000);
       expect(onCloseSpy).to.have.been.calledOnce;
+    } finally {
+      clock.restore();
+    }
+  });
+
+  it('should not trigger the onClose event if autohide is not set', () => {
+    const clock = sinon.useFakeTimers();
+
+    try {
+      const onCloseSpy = sinon.spy();
+      mount(
+        <Toast onClose={onCloseSpy}>
+          <Toast.Header>header-content</Toast.Header>
+          <Toast.Body>body-content</Toast.Body>
+        </Toast>,
+      );
+      clock.tick(3000);
+      expect(onCloseSpy).not.to.have.been.called;
     } finally {
       clock.restore();
     }


### PR DESCRIPTION
- I wrote test cases to increase coverage for Toast.js and TabContainer.js
- I removed a fallback for id in Tabcontainer.js since there was no way (I could think of) that can happen. Please let me know if I should revert the refactoring.

related #3889

