### PR TITLE
#4913: add support for defaultChecked in <ToggleButton>

### DIFF
--- a/src/ToggleButton.js
+++ b/src/ToggleButton.js
@@ -2,9 +2,8 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useState, useCallback } from 'react';
 
+import { useUncontrolled } from 'uncontrollable';
 import Button from './Button';
-
-const noop = () => {};
 
 const propTypes = {
   /**
@@ -20,6 +19,8 @@ const propTypes = {
 
   /**
    * The checked state of the input, managed by `<ToggleButtonGroup>` automatically
+   *
+   * @controllable onChange
    */
   checked: PropTypes.bool,
 
@@ -31,6 +32,8 @@ const propTypes = {
   /**
    * A callback fired when the underlying input element changes. This is passed
    * directly to the `<input>` so shares the same signature as a native `onChange` event.
+   *
+   * @controllable  checked
    */
   onChange: PropTypes.func,
 
@@ -45,65 +48,69 @@ const propTypes = {
    * @type {ReactRef}
    */
   inputRef: PropTypes.any,
+
+  /**
+   * The defaultChecked state of the input
+   */
+  defaultChecked: PropTypes.bool,
 };
 
-const ToggleButton = React.forwardRef(
-  (
-    {
-      children,
-      name,
-      className,
-      checked,
-      type,
-      onChange,
-      value,
-      disabled,
-      inputRef,
-      ...props
-    },
-    ref,
-  ) => {
-    const [focused, setFocused] = useState(false);
+const ToggleButton = React.forwardRef((props, ref) => {
+  let {
+    children,
+    name,
+    className,
+    checked,
+    type,
+    onChange,
+    value,
+    disabled,
+    inputRef,
+    ...controlledProps
+  } = useUncontrolled(props, {
+    checked: 'onChange',
+  });
 
-    const handleFocus = useCallback(e => {
-      if (e.target.tagName === 'INPUT') setFocused(true);
-    }, []);
+  const [focused, setFocused] = useState(false);
 
-    const handleBlur = useCallback(e => {
-      if (e.target.tagName === 'INPUT') setFocused(false);
-    }, []);
+  const handleFocus = useCallback(e => {
+    if (e.target.tagName === 'INPUT') setFocused(true);
+  }, []);
 
-    return (
-      <Button
-        {...props}
-        ref={ref}
-        className={classNames(
-          className,
-          focused && 'focus',
-          disabled && 'disabled',
-        )}
-        type={null}
-        active={!!checked}
-        as="label"
-      >
-        <input
-          name={name}
-          type={type}
-          value={value}
-          ref={inputRef}
-          autoComplete="off"
-          checked={!!checked}
-          disabled={!!disabled}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
-          onChange={onChange || noop}
-        />
+  const handleBlur = useCallback(e => {
+    if (e.target.tagName === 'INPUT') setFocused(false);
+  }, []);
 
-        {children}
-      </Button>
-    );
-  },
-);
+  return (
+    <Button
+      {...controlledProps}
+      ref={ref}
+      className={classNames(
+        className,
+        focused && 'focus',
+        disabled && 'disabled',
+      )}
+      type={null}
+      active={!!checked}
+      as="label"
+    >
+      <input
+        name={name}
+        type={type}
+        value={value}
+        ref={inputRef}
+        autoComplete="off"
+        checked={!!checked}
+        disabled={!!disabled}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        onChange={onChange}
+      />
+
+      {children}
+    </Button>
+  );
+});
 
 ToggleButton.propTypes = propTypes;
 ToggleButton.displayName = 'ToggleButton';

--- a/test/ToggleButtonGroupSpec.js
+++ b/test/ToggleButtonGroupSpec.js
@@ -2,6 +2,8 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import ToggleButtonGroup from '../src/ToggleButtonGroup';
+import ToggleButton from '../src/ToggleButton';
+import ButtonGroup from '../src/ButtonGroup';
 
 describe('ToggleButton', () => {
   it('should forward refs to the label', () => {
@@ -49,6 +51,21 @@ describe('ToggleButton', () => {
       .find('Button')
       .hasClass('focus')
       .should.equal(false);
+  });
+
+  it('should be active when defaultChecked is true', () => {
+    const wrapper = mount(
+      <ButtonGroup toggle>
+        <ToggleButton type="checkbox" defaultChecked value="1">
+          Checked
+        </ToggleButton>
+      </ButtonGroup>,
+    );
+
+    wrapper
+      .find('label')
+      .hasClass('active')
+      .should.equal(true);
   });
 });
 

--- a/types/components/ToggleButton.d.ts
+++ b/types/components/ToggleButton.d.ts
@@ -12,6 +12,7 @@ export interface ToggleButtonProps {
   onChange?: React.ChangeEventHandler<this>;
   value: unknown;
   inputRef?: React.LegacyRef<this>;
+  defaultChecked?: boolean;
 }
 
 declare class ToggleButton<


### PR DESCRIPTION
#### What does this PR do?
Adds support for defaultChecked in `<ToggleButton>`

#### Description of tasks completed.
- add defaultChecked prop to the ToggleButtonProps interface
- use defaultChecked as value for active prop for the Button element
- write a test for this to make sure it is working fine

#### What is the related issue?
[#4913](https://github.com/react-bootstrap/react-bootstrap/issues/4913)

#### Screenshots

Before:
<img width="909" alt="Screenshot 2020-01-13 at 00 40 39" src="https://user-images.githubusercontent.com/40595048/72239264-7ab08280-35f1-11ea-8326-07f24255d3b5.png">

After:
<img width="891" alt="Screenshot 2020-01-13 at 00 40 31" src="https://user-images.githubusercontent.com/40595048/72239270-83a15400-35f1-11ea-84b5-8947b4b3af73.png">
