### PR TITLE
(fix): remove associated aria on overlay hide

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -166,9 +166,11 @@ class OverlayTrigger extends React.Component {
 
   handleClick = e => {
     const { onClick } = this.getChildProps();
-
-    if (this.state.show) this.hide();
-    else this.show();
+    if (this.state.show) {
+      const target = e.currentTarget;
+      target.removeAttribute('aria-describedby');
+      this.hide();
+    } else this.show();
 
     if (onClick) onClick(e);
   };

--- a/test/OverlayTriggerSpec.js
+++ b/test/OverlayTriggerSpec.js
@@ -97,6 +97,24 @@ describe('<OverlayTrigger>', () => {
     });
   });
 
+  it('Should remove aria-describedby for tooltips if the state is hide', done => {
+    const wrapper = mount(
+      <OverlayTrigger trigger="click" overlay={<Div />}>
+        <button type="button">button</button>
+      </OverlayTrigger>,
+    );
+    wrapper.find('button').simulate('click');
+    wrapper.find('button').simulate('click');
+
+    setTimeout(() => {
+      wrapper
+        .find('button')
+        .getDOMNode()
+        .matches('[aria-describedby="test-tooltip"]')
+        .should.equal(false);
+      done();
+    });
+  });
   describe('trigger handlers', () => {
     let mountPoint;
 


### PR DESCRIPTION
fix for issue #4934 

solution:
-get target from element during onHide event and use removeAttribute

First PR for this repo and still need to dive more into react so please spot me on any mistakes or incorrect design patterns!
Any feedback and constructive critcism is always welcome!