### PR TITLE
Add Comment to AccordionCollapse.js

### DIFF
--- a/src/AccordionCollapse.js
+++ b/src/AccordionCollapse.js
@@ -9,7 +9,7 @@ const propTypes = {
    * A key that corresponds to the toggler that triggers this collapse's expand or collapse.
    */
   eventKey: PropTypes.string.isRequired,
-  
+
   /** Children prop should only contain a single child, and  is enforced as such */
   children: PropTypes.element.isRequired,
 };

--- a/src/AccordionCollapse.js
+++ b/src/AccordionCollapse.js
@@ -10,7 +10,7 @@ const propTypes = {
    */
   eventKey: PropTypes.string.isRequired,
 
-  /** Children prop should only contain a single child, and  is enforced as such */
+  /** Children prop should only contain a single child, and is enforced as such */
   children: PropTypes.element.isRequired,
 };
 

--- a/src/AccordionCollapse.js
+++ b/src/AccordionCollapse.js
@@ -9,7 +9,8 @@ const propTypes = {
    * A key that corresponds to the toggler that triggers this collapse's expand or collapse.
    */
   eventKey: PropTypes.string.isRequired,
-
+  
+  /** Children prop should only contain a single child, and  is enforced as such */
   children: PropTypes.element.isRequired,
 };
 


### PR DESCRIPTION
Accordion.Collapse cannot have more than one child else the application will crash with the error `Unhandled Rejection (Error): React.Children.only expected to receive a single React element child.` Added a comment to reflect that.