### PR TITLE
Added type string to ListGroupProps horizontal prop

### DIFF
--- a/types/components/ListGroup.d.ts
+++ b/types/components/ListGroup.d.ts
@@ -6,7 +6,7 @@ import { BsPrefixComponent, SelectCallback } from './helpers';
 
 export interface ListGroupProps {
   variant?: 'flush';
-  horizontal?: boolean;
+  horizontal?: boolean | string;
   activeKey?: unknown;
   defaultActiveKey?: unknown;
   onSelect?: SelectCallback;

--- a/types/components/ListGroup.d.ts
+++ b/types/components/ListGroup.d.ts
@@ -6,7 +6,7 @@ import { BsPrefixComponent, SelectCallback } from './helpers';
 
 export interface ListGroupProps {
   variant?: 'flush';
-  horizontal?: boolean | string;
+  horizontal?: boolean | 'sm' | 'md' | 'lg' | 'xl';
   activeKey?: unknown;
   defaultActiveKey?: unknown;
   onSelect?: SelectCallback;


### PR DESCRIPTION
Hi,

This PR fixes a minor oversight with PR #4864 - the ListGroup component has a horizontal prop which is either a boolean (makes it horizontal) or a string (this makes the ListGroup horizontal at a given breakpoint) - PR #4864 only covers the boolean use case.

Thanks!