### PR TITLE
Allow type to be set for SplitButton non-toggle Button

### DIFF
--- a/src/SplitButton.js
+++ b/src/SplitButton.js
@@ -30,6 +30,9 @@ const propTypes = {
   /** The content of the non-toggle Button.  */
   title: PropTypes.node.isRequired,
 
+  /** A `type` passed to the non-toggle Button */
+  type: PropTypes.string,
+
   /** Disables both Buttons  */
   disabled: PropTypes.bool,
 
@@ -52,6 +55,7 @@ const propTypes = {
 
 const defaultProps = {
   toggleLabel: 'Toggle dropdown',
+  type: 'button',
 };
 
 const SplitButton = React.forwardRef(
@@ -62,6 +66,7 @@ const SplitButton = React.forwardRef(
       size,
       variant,
       title,
+      type,
       toggleLabel,
       children,
       onClick,
@@ -82,6 +87,7 @@ const SplitButton = React.forwardRef(
         href={href}
         target={target}
         onClick={onClick}
+        type={type}
       >
         {title}
       </Button>

--- a/test/SplitButtonSpec.js
+++ b/test/SplitButtonSpec.js
@@ -104,4 +104,12 @@ describe('<SplitButton>', () => {
       .text()
       .should.equal('Label');
   });
+
+  it('should set type attribute from type', () => {
+    mount(
+      <SplitButton title="Title" id="test-id" type="submit">
+        <DropdownItem>Item 1</DropdownItem>
+      </SplitButton>,
+    ).assertSingle('button[type="submit"]');
+  });
 });


### PR DESCRIPTION
https://github.com/react-bootstrap/react-bootstrap/issues/5008