### PR TITLE
Toast uses opacity 0 instead of display none

### DIFF
--- a/src/Toast.js
+++ b/src/Toast.js
@@ -1,4 +1,10 @@
-import React, { useEffect, useRef, useMemo, useCallback } from 'react';
+import React, {
+  useEffect,
+  useRef,
+  useMemo,
+  useCallback,
+  useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
@@ -73,6 +79,13 @@ const Toast = React.forwardRef(
     bsPrefix = useBootstrapPrefix('toast');
     const delayRef = useRef(delay);
     const onCloseRef = useRef(onClose);
+    const [transitionComplete, setTransitionComplete] = useState(false);
+
+    useEffect(() => {
+      if (show && transitionComplete) {
+        setTransitionComplete(false);
+      }
+    }, [show, transitionComplete]);
 
     useEffect(() => {
       // We use refs for these, because we don't want to restart the autohide
@@ -96,6 +109,10 @@ const Toast = React.forwardRef(
       animation,
     ]);
 
+    const handleTransitionEnd = () => {
+      setTransitionComplete(true);
+    };
+
     const toast = (
       <div
         {...props}
@@ -104,6 +121,8 @@ const Toast = React.forwardRef(
           bsPrefix,
           className,
           !useAnimation && show && 'show',
+          !useAnimation && !show && 'hide',
+          !show && transitionComplete && 'hide',
         )}
         role="alert"
         aria-live="assertive"
@@ -117,9 +136,15 @@ const Toast = React.forwardRef(
       onClose,
     };
 
+    const toastWithTransition = (
+      <Transition in={show} onExited={handleTransitionEnd}>
+        {toast}
+      </Transition>
+    );
+
     return (
       <ToastContext.Provider value={toastContext}>
-        {useAnimation ? <Transition in={show}>{toast}</Transition> : toast}
+        {useAnimation ? toastWithTransition : toast}
       </ToastContext.Provider>
     );
   },

--- a/src/Toast.js
+++ b/src/Toast.js
@@ -142,6 +142,10 @@ const Toast = React.forwardRef(
       </Transition>
     );
 
+    if ((!useAnimation && !show) || (!show && transitionComplete)) {
+      return null;
+    }
+
     return (
       <ToastContext.Provider value={toastContext}>
         {useAnimation ? toastWithTransition : toast}

--- a/src/Toast.js
+++ b/src/Toast.js
@@ -121,8 +121,6 @@ const Toast = React.forwardRef(
           bsPrefix,
           className,
           !useAnimation && show && 'show',
-          !useAnimation && !show && 'hide',
-          !show && transitionComplete && 'hide',
         )}
         role="alert"
         aria-live="assertive"

--- a/src/ToastHeader.js
+++ b/src/ToastHeader.js
@@ -38,7 +38,7 @@ const ToastHeader = React.forwardRef(
     const context = useContext(ToastContext);
 
     const handleClick = useEventCallback(() => {
-      if (context) {
+      if (context && context.onClose) {
         context.onClose();
       }
     });


### PR DESCRIPTION
Added class hide when the toast is manually closed or autoclosed. If the toast uses fade transition then the hide class gets added after completion of the transition