### PR TITLE
feat: can customize BreadcrumbItem's inner link

### DIFF
--- a/src/BreadcrumbItem.js
+++ b/src/BreadcrumbItem.js
@@ -5,6 +5,35 @@ import PropTypes from 'prop-types';
 import SafeAnchor from './SafeAnchor';
 import { useBootstrapPrefix } from './ThemeProvider';
 
+const linkPropTypes = {
+  active: PropTypes.bool,
+  as: PropTypes.elementType,
+  href: PropTypes.string,
+  target: PropTypes.string,
+  title: PropTypes.node,
+};
+
+const linkDefaultProps = {};
+
+const BreadcrumbItemLink = ({ active, as: Component, ...props }) => {
+  const { href, title, target, ...elementProps } = props;
+  const linkProps = { href, title, target };
+
+  if (active) {
+    return <span {...elementProps} className={classNames({ active })} />;
+  }
+
+  if (Component) {
+    return <Component {...elementProps} {...linkProps} />;
+  }
+
+  return <SafeAnchor {...elementProps} {...linkProps} />;
+};
+
+BreadcrumbItemLink.displayName = 'BreadcrumbItemLink';
+BreadcrumbItemLink.propTypes = linkPropTypes;
+BreadcrumbItemLink.defaultProps = linkDefaultProps;
+
 const propTypes = {
   /**
    * @default 'breadcrumb-item'
@@ -15,6 +44,10 @@ const propTypes = {
    * Item and disables the link.
    */
   active: PropTypes.bool,
+  /**
+   * You can use a custom element type for this component's inner link.
+   */
+  linkAs: PropTypes.elementType,
   /**
    * `href` attribute for the inner `a` element
    */
@@ -37,11 +70,11 @@ const defaultProps = {
 
 const BreadcrumbItem = React.forwardRef(
   // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
-  ({ bsPrefix, active, className, as: Component = 'li', ...props }, ref) => {
+  (
+    { bsPrefix, active, className, as: Component = 'li', linkAs, ...props },
+    ref,
+  ) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'breadcrumb-item');
-
-    const { href, title, target, ...elementProps } = props;
-    const linkProps = { href, title, target };
 
     return (
       <Component
@@ -49,11 +82,7 @@ const BreadcrumbItem = React.forwardRef(
         className={classNames(prefix, className, { active })}
         aria-current={active ? 'page' : undefined}
       >
-        {active ? (
-          <span {...elementProps} className={classNames({ active })} />
-        ) : (
-          <SafeAnchor {...elementProps} {...linkProps} />
-        )}
+        <BreadcrumbItemLink active={active} as={linkAs} {...props} />
       </Component>
     );
   },

--- a/test/BreadcrumbItemSpec.js
+++ b/test/BreadcrumbItemSpec.js
@@ -3,6 +3,7 @@ import sinon from 'sinon';
 import { mount } from 'enzyme';
 
 import Breadcrumb from '../src/Breadcrumb';
+import Button from '../src/Button';
 
 describe('<Breadcrumb.Item>', () => {
   it('Should render `a` as inner element when is not active', () => {
@@ -122,5 +123,11 @@ describe('<Breadcrumb.Item>', () => {
 
   it('Should have li as default component', () => {
     mount(<Breadcrumb.Item />).assertSingle('li');
+  });
+
+  it('Should be able to customize inner link element', () => {
+    const instance = mount(<Breadcrumb.Item linkAs={Button} />);
+    instance.find('a').should.have.length(0);
+    instance.find('button').should.have.length(1);
   });
 });


### PR DESCRIPTION
I propose the following change to be able to customize BreadcrumbItem's inner link.

The new property is `linkAs` as suggested.

I split the inner component in a new function because making two ternary comparisons is ugly, and forbidden by the linter anyway. However I don't know the project's good practices regarding naming and visibility.

Fixes #4472.