### PR TITLE
Fix whitespace on homepage

### DIFF
--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -152,9 +152,9 @@ export default withLayout(
                   ecosystem.
                 </p>
                 <p>
-                  By relying entirely on the Bootstrap stylesheet, React-
-                  Bootstrap just works with the thousands of bootstrap themes
-                  you already love.
+                  By relying entirely on the Bootstrap stylesheet,
+                  React-Bootstrap just works with the thousands of bootstrap
+                  themes you already love.
                 </p>
                 <p />
               </FeatureCard>

--- a/www/src/pages/index.js
+++ b/www/src/pages/index.js
@@ -153,7 +153,7 @@ export default withLayout(
                 </p>
                 <p>
                   By relying entirely on the Bootstrap stylesheet,
-                  React-Bootstrap just works with the thousands of bootstrap
+                  React-Bootstrap just works with the thousands of Bootstrap
                   themes you already love.
                 </p>
                 <p />


### PR DESCRIPTION
Previously, the hyphen at the end of the line caused whitespace to appear between `React-` and `Bootstrap` on the homepage