### PR TITLE
Adjust type of FormControl to support numbers

### DIFF
--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -51,7 +51,11 @@ const propTypes = {
    *
    * @controllable onChange
    * */
-  value: PropTypes.string,
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.number,
+  ]),
 
   /** A callback fired when the `value` prop changes */
   onChange: PropTypes.func,

--- a/test/FormControlSpec.js
+++ b/test/FormControlSpec.js
@@ -80,4 +80,18 @@ describe('<FormControl>', () => {
   it('Should have input as default component', () => {
     mount(<FormControl />).assertSingle('input');
   });
+
+  it('should support numbers as values', () => {
+    const wrapper = mount(<FormControl value={10} onChange={() => {}} />);
+
+    expect(wrapper.find('input').props().value).to.eq(10);
+  });
+
+  it('should support an array of strings as values', () => {
+    const wrapper = mount(
+      <FormControl value={['hello', 'world']} onChange={() => {}} />,
+    );
+
+    expect(wrapper.find('input').props().value).to.eql(['hello', 'world']);
+  });
 });

--- a/types/components/FormControl.d.ts
+++ b/types/components/FormControl.d.ts
@@ -13,7 +13,7 @@ export interface FormControlProps {
   plaintext?: boolean;
   readOnly?: boolean;
   disabled?: boolean;
-  value?: string;
+  value?: string | string[] | number;
   onChange?: React.FormEventHandler<FormControlElement>;
   type?: string;
   id?: string;


### PR DESCRIPTION
The React Typescript definition for an input supports strings, an array
of strings, or numbers. I've adjusted the types and PropType of the
"value" prop to support this.

Reference:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react/index.d.ts#L2058
https://github.com/react-bootstrap/react-bootstrap/issues/5028

Fixes #5028 