### PR TITLE
#3047 Range input and allow for custom prop for select and range input

### DIFF
--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -75,7 +75,7 @@ const propTypes = {
   custom: all(PropTypes.bool, ({ as, type, custom }) =>
     custom === true && type !== 'range' && as !== 'select'
       ? Error(
-          '`custom` can only be set to `true` when the type is `range` or if as is `select`',
+          '`custom` can only be set to `true` when the input type is `range`, or  `select`',
         )
       : null,
   ),

--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -38,16 +38,8 @@ const propTypes = {
 
   /**
    * The underlying HTML element to use when rendering the FormControl.
-   *
-   * @type {('input'|'textarea'|'select'|elementType)}
    */
-  as: all(PropTypes.elementType, ({ as, custom }) =>
-    as !== 'input' && as !== 'select' && custom === true
-      ? Error(
-          '`custom` can only be set to `true` when the as is `input` or `select`',
-        )
-      : null,
-  ),
+  as: PropTypes.elementType,
 
   /**
    * Render the input as plain text. Generally used along side `readOnly`.
@@ -74,20 +66,22 @@ const propTypes = {
   /** A callback fired when the `value` prop changes */
   onChange: PropTypes.func,
 
-  /** Use Bootstrap's custom form elements to replace the browser defaults */
-  custom: PropTypes.bool,
-
   /**
-   * The HTML input `type`, which is only relevant if `as` is `'input'` (the default).
-   * @type string
+   * Use Bootstrap's custom form elements to replace the browser defaults
+   * @type boolean
    */
-  type: all(PropTypes.string, ({ type, custom }) =>
-    type !== 'range' && custom === true
+  custom: all(PropTypes.bool, ({ as, type, custom }) =>
+    custom === true && type !== 'range' && as !== 'select'
       ? Error(
-          '`custom` can only be set to `true` when the as is `input` and type is `range` or as is `select`',
+          '`custom` can only be set to `true` when the type is `range` or if as is `select`',
         )
       : null,
   ),
+
+  /**
+   * The HTML input `type`, which is only relevant if `as` is `'input'` (the default).
+   */
+  type: PropTypes.string,
 
   /**
    * Uses `controlId` from `<FormGroup>` if not explicitly specified.

--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -41,7 +41,6 @@ const propTypes = {
    *
    * @type {('input'|'textarea'|'select'|elementType)}
    */
-  // as: PropTypes.elementType,
   as: all(PropTypes.elementType, ({ as, custom }) =>
     as !== 'input' && as !== 'select' && custom === true
       ? Error(
@@ -82,7 +81,6 @@ const propTypes = {
    * The HTML input `type`, which is only relevant if `as` is `'input'` (the default).
    * @type string
    */
-  // type: PropTypes.string,
   type: all(PropTypes.string, ({ type, custom }) =>
     type !== 'range' && custom === true
       ? Error(

--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -16,7 +16,7 @@ const propTypes = {
   /**
    * A seperate bsPrefix used for custom controls
    *
-   * @default 'custom-control'
+   * @default 'custom'
    */
   bsCustomPrefix: PropTypes.string,
 

--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -38,6 +38,8 @@ const propTypes = {
 
   /**
    * The underlying HTML element to use when rendering the FormControl.
+   *
+   * @type {('input'|'textarea'|'select'|elementType)}
    */
   as: PropTypes.elementType,
 

--- a/test/FormControlSpec.js
+++ b/test/FormControlSpec.js
@@ -21,12 +21,30 @@ describe('<FormControl>', () => {
     mount(<FormControl as="select" />).assertSingle('select.form-control');
   });
 
+  it('should support custom select', () => {
+    mount(<FormControl as="select" custom />)
+      .assertSingle('select.custom-select')
+      .assertNone('.form-control');
+  });
+
   it('should support type=file', () => {
     mount(<FormControl type="file" />)
       .assertSingle('[type="file"].form-control-file')
       .assertNone('.form-control');
   });
 
+  it('should support type=range', () => {
+    mount(<FormControl type="range" />)
+      .assertSingle('[type="range"].form-control-range')
+      .assertNone('.form-control');
+  });
+
+  it('should support custom type=range', () => {
+    mount(<FormControl type="range" custom />)
+      .assertSingle('[type="range"].custom-range')
+      .assertNone('.form-control-range')
+      .assertNone('.form-control');
+  });
   it('should support plaintext inputs', () => {
     mount(<FormControl plaintext />).assertSingle(
       'input.form-control-plaintext',

--- a/types/components/FormControl.d.ts
+++ b/types/components/FormControl.d.ts
@@ -15,6 +15,7 @@ export interface FormControlProps {
   disabled?: boolean;
   value?: string | string[] | number;
   onChange?: React.FormEventHandler<FormControlElement>;
+  custom?: boolean;
   type?: string;
   id?: string;
   isValid?: boolean;

--- a/www/src/examples/Form/Range.js
+++ b/www/src/examples/Form/Range.js
@@ -1,0 +1,6 @@
+<Form>
+  <Form.Group controlId="formBasicRange">
+    <Form.Label>Range</Form.Label>
+    <Form.Control type="range" />
+  </Form.Group>
+</Form>;

--- a/www/src/examples/Form/RangeCustom.js
+++ b/www/src/examples/Form/RangeCustom.js
@@ -1,0 +1,6 @@
+<Form>
+  <Form.Group controlId="formBasicRangeCustom">
+    <Form.Label>Range</Form.Label>
+    <Form.Control type="range" custom />
+  </Form.Group>
+</Form>;

--- a/www/src/examples/Form/SelectCustom.js
+++ b/www/src/examples/Form/SelectCustom.js
@@ -1,0 +1,12 @@
+<Form>
+  <Form.Group controlId="exampleForm.SelectCustom">
+    <Form.Label>Custom select</Form.Label>
+    <Form.Control as="select" custom>
+      <option>1</option>
+      <option>2</option>
+      <option>3</option>
+      <option>4</option>
+      <option>5</option>
+    </Form.Control>
+  </Form.Group>
+</Form>;

--- a/www/src/examples/Form/SelectCustomSize.js
+++ b/www/src/examples/Form/SelectCustomSize.js
@@ -1,0 +1,22 @@
+<Form>
+  <Form.Group controlId="exampleForm.SelectCustomSizeSm">
+    <Form.Label>Custom select Small</Form.Label>
+    <Form.Control as="select" size="sm" custom>
+      <option>1</option>
+      <option>2</option>
+      <option>3</option>
+      <option>4</option>
+      <option>5</option>
+    </Form.Control>
+  </Form.Group>
+  <Form.Group controlId="exampleForm.SelectCustomSizeLg">
+    <Form.Label>Custom select Large</Form.Label>
+    <Form.Control as="select" size="lg" custom>
+      <option>1</option>
+      <option>2</option>
+      <option>3</option>
+      <option>4</option>
+      <option>5</option>
+    </Form.Control>
+  </Form.Group>
+</Form>;

--- a/www/src/pages/components/forms.js
+++ b/www/src/pages/components/forms.js
@@ -20,6 +20,10 @@ import FormInputSizes from '../../examples/Form/InputSizes';
 import NoLabels from '../../examples/Form/NoLabels';
 import Plaintext from '../../examples/Form/Plaintext';
 import Switch from '../../examples/Form/Switch';
+import Range from '../../examples/Form/Range';
+import RangeCustom from '../../examples/Form/RangeCustom';
+import SelectCustom from '../../examples/Form/SelectCustom';
+import SelectCustomSize from '../../examples/Form/SelectCustomSize';
 import FormTextControls from '../../examples/Form/TextControls';
 import ValidationFormik from '../../examples/Form/ValidationFormik';
 import ValidationNative from '../../examples/Form/ValidationNative';
@@ -85,6 +89,10 @@ export default withLayout(function FormControlsSection({ data }) {
         field styling and preserve the correct margin and padding.
       </p>
       <ReactPlayground codeText={Plaintext} />
+      <LinkedHeading h="2" id="forms-range">
+        Range Inputs
+      </LinkedHeading>
+      <ReactPlayground codeText={Range} />
       <LinkedHeading h="2" id="forms-form-check">
         Checkboxes and Radios
       </LinkedHeading>
@@ -291,6 +299,36 @@ export default withLayout(function FormControlsSection({ data }) {
 
       <h3>Inline</h3>
       <ReactPlayground codeText={CheckCustomInline} />
+
+      <LinkedHeading h="3" id="forms-custom-select">
+        Select
+      </LinkedHeading>
+      <p>
+        For the <code>select</code> form control you can pass the{' '}
+        <code>custom</code> prop to get custom styling of the select element.
+        Custom styles are limited to the <code>select</code> initial appearance
+        and cannot modify the <code>option</code> styling due to browser
+        limitations.
+      </p>
+      <ReactPlayground codeText={SelectCustom} />
+      <h4>Sizing</h4>
+      <p>
+        The custom <code>select</code> element supports sizing.
+      </p>
+      <ReactPlayground codeText={SelectCustomSize} />
+
+      <LinkedHeading h="3" id="forms-custom-range">
+        Range
+      </LinkedHeading>
+      <p>
+        For the <code>range</code> form control you can pass the{' '}
+        <code>custom</code> prop to get custom styling of the select element.
+        The track (the background) and thumb (the value) are both styled to
+        appear the same across browsers. As only IE and Firefox support
+        “filling” their track from the left or right of the thumb as a means to
+        visually indicate progress, we do not currently support it.
+      </p>
+      <ReactPlayground codeText={RangeCustom} />
 
       <LinkedHeading h="2" id="forms-api">
         API


### PR DESCRIPTION
This PR adds the Range input to Form.Control.

It also adds the custom prop to Form.Control and is usable if type is set to range or if as is set to select. It also handles sizing of the select element if custom is set.

It has added tests as well as updated documentation.