### PR TITLE
#5056 fix types for FormLabel

### DIFF
--- a/types/components/FormLabel.d.ts
+++ b/types/components/FormLabel.d.ts
@@ -15,7 +15,7 @@ export interface FormLabelOwnProps extends FormLabelBaseProps {
 }
 
 export interface FormLabelWithColProps extends FormLabelBaseProps, ColProps {
-  column: true;
+  column: true | 'sm' | 'lg';
 }
 
 export type FormLabelProps = FormLabelWithColProps | FormLabelOwnProps;

--- a/types/simple.test.tsx
+++ b/types/simple.test.tsx
@@ -224,6 +224,14 @@ import {
       <Form.Control type="text" placeholder="Hoizontal" />
     </Col>
   </Form.Group>
+  <Form.Group as={Row} controlId="exampleForm.HorizontalControl">
+    <Form.Label column="sm" sm={2}>
+      Horizontal
+    </Form.Label>
+    <Col sm={10}>
+      <Form.Control type="text" placeholder="Hoizontal" />
+    </Col>
+  </Form.Group>
   <Form.File id="custom-file" label="Custom file input" custom />
   <Form.File
     ref={React.createRef<HTMLInputElement & FormFile>()}


### PR DESCRIPTION
Fixes #5056 and adds 'sm' and 'lg' as types for FormLabel column