### PR TITLE
Create master docs alert

### DIFF
--- a/www/src/components/MasterDocsAlert.js
+++ b/www/src/components/MasterDocsAlert.js
@@ -1,18 +1,24 @@
 import React from 'react';
 import Alert from 'react-bootstrap/Alert';
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
 
 function MasterDocsAlert() {
   return (
     typeof window !== 'undefined' &&
     window.location.host.substr(window.location.host.indexOf('.') + 1) ===
       'netlify.com' && (
-      <Alert variant="warning">
-        You are currently viewing the auto-generated docs from the
-        master-branch. The docs for the current release are available at{' '}
-        <Alert.Link href="https://react-bootstrap.github.io/">
-          https://react-bootstrap.github.io/
-        </Alert.Link>
-      </Alert>
+      <Container fluid>
+        <Row>
+          <Alert variant="warning" className="w-100">
+            You are currently viewing the auto-generated docs from the
+            master-branch. The docs for the current release are available at{' '}
+            <Alert.Link href="https://react-bootstrap.github.io/">
+              https://react-bootstrap.github.io/
+            </Alert.Link>
+          </Alert>
+        </Row>
+      </Container>
     )
   );
 }

--- a/www/src/components/MasterDocsAlert.js
+++ b/www/src/components/MasterDocsAlert.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import Alert from 'react-bootstrap/Alert';
+
+function MasterDocsAlert() {
+  return (
+    typeof window !== 'undefined' &&
+    window.location.host.substr(window.location.host.indexOf('.') + 1) ===
+      'netlify.com' && (
+      <Alert variant="warning">
+        You are currently viewing the auto-generated docs from the
+        master-branch. The docs for the current release are available at{' '}
+        <Alert.Link href="https://react-bootstrap.github.io/">
+          https://react-bootstrap.github.io/
+        </Alert.Link>
+      </Alert>
+    )
+  );
+}
+
+export default MasterDocsAlert;

--- a/www/src/layouts/index.js
+++ b/www/src/layouts/index.js
@@ -6,6 +6,7 @@ import NavMain from '../components/NavMain';
 import Heading from '../components/Heading';
 import CodeBlock from '../components/CodeBlock';
 import LinkedHeading from '../components/LinkedHeading';
+import MasterDocsAlert from '../components/MasterDocsAlert';
 
 const getMode = (className = '') => {
   const [, mode] = className.match(/language-(\w+)/) || [];
@@ -38,6 +39,7 @@ function DefaultLayout({ children, location }) {
   return (
     <div>
       <NavMain activePage={location.pathname} />
+      <MasterDocsAlert />
       <MDXProvider components={components}>{children}</MDXProvider>
     </div>
   );


### PR DESCRIPTION
This PR adds a simple component that checks if the current window.location.host contains "netlify.com" and if so shows the following Alert (not sticky):

![Screenshot 2020-03-28 at 01 03 40](https://user-images.githubusercontent.com/322759/77809701-26b22780-7091-11ea-8fb3-babc65dbca87.png)

I got no idea if it's running SSR or similar on Netlify so I added a check to check that window is not undefined.

Any improvements or better ideas how to do this is welcome. I took the fast and easy route here :)

This issue with the Netlify docs display features not yet in a release was raised in #5057.