### PR TITLE
Fix type error in overlay example

### DIFF
--- a/www/src/examples/Overlays/Overlay.js
+++ b/www/src/examples/Overlays/Overlay.js
@@ -4,7 +4,7 @@ function Example() {
 
   return (
     <>
-      <Button variant="danger" ref={target} onClick={() => setShow(!show)}>
+      <Button variant="danger" ref={target || undefined} onClick={() => setShow(!show)}>
         Click me to see
       </Button>
       <Overlay target={target.current} show={show} placement="right">


### PR DESCRIPTION
`Overlay.target` does not accept `null`; it does accept `undefined` though, which is the default for `useRef`.