### PR TITLE
#5084 sets aria-labelledby on correct element

### DIFF
--- a/src/Modal.js
+++ b/src/Modal.js
@@ -167,6 +167,8 @@ const propTypes = {
    * @private
    */
   container: PropTypes.any,
+
+  'aria-labelledby': PropTypes.any,
 };
 
 const defaultProps = {
@@ -317,6 +319,7 @@ class Modal extends React.Component {
       dialogClassName,
       children,
       dialogAs: Dialog,
+      'aria-labelledby': ariaLabelledby,
 
       /* BaseModal props */
       show,
@@ -382,6 +385,7 @@ class Modal extends React.Component {
             onEnter: this.handleEnter,
             onEntering: this.handleEntering,
             onExited: this.handleExited,
+            'aria-labelledby': ariaLabelledby,
           }}
         >
           <Dialog

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -224,4 +224,18 @@ describe('<Modal>', () => {
 
     expect(onHideSpy).to.not.have.been.called;
   });
+
+  it('Should set aria-labelledby to the role="dialog" element if aria-labelledby set', () => {
+    const noOp = () => {};
+    const wrapper = mount(
+      <Modal show onHide={noOp} aria-labelledby="modal-title">
+        <Modal.Header closeButton>
+          <Modal.Title id="modal-title">Modal heading</Modal.Title>
+        </Modal.Header>
+      </Modal>,
+    );
+    wrapper.assertSingle(
+      'div.modal.show[role="dialog"][aria-labelledby="modal-title"]',
+    );
+  });
 });


### PR DESCRIPTION
fixes #5084. Adds test to check that aria-labelledby is set on the Modal element.