### PR TITLE
#5111 Set flip to true if placement is auto in OverlayTrigger.js

### DIFF
--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -92,6 +92,27 @@ const propTypes = {
    * @private
    */
   show: PropTypes.oneOf([null]),
+
+  /**
+   * The placement of the Overlay in relation to it's `target`.
+   */
+  placement: PropTypes.oneOf([
+    'auto-start',
+    'auto',
+    'auto-end',
+    'top-start',
+    'top',
+    'top-end',
+    'right-start',
+    'right',
+    'right-end',
+    'bottom-end',
+    'bottom',
+    'bottom-start',
+    'left-end',
+    'left',
+    'left-start',
+  ]),
 };
 
 const defaultProps = {
@@ -106,6 +127,8 @@ function OverlayTrigger({
   popperConfig = {},
   defaultShow,
   delay: propsDelay,
+  placement,
+  flip = placement === 'auto',
   ...props
 }) {
   const triggerNodeRef = useRef(null);
@@ -247,6 +270,8 @@ function OverlayTrigger({
         show={show}
         onHide={handleHide}
         target={getTarget}
+        placement={placement}
+        flip={flip}
       >
         {overlay}
       </Overlay>

--- a/src/OverlayTrigger.js
+++ b/src/OverlayTrigger.js
@@ -128,7 +128,7 @@ function OverlayTrigger({
   defaultShow,
   delay: propsDelay,
   placement,
-  flip = placement === 'auto',
+  flip = placement && placement.indexOf('auto') !== -1,
   ...props
 }) {
   const triggerNodeRef = useRef(null);

--- a/test/OverlayTriggerSpec.js
+++ b/test/OverlayTriggerSpec.js
@@ -208,6 +208,21 @@ describe('<OverlayTrigger>', () => {
     contextSpy.calledWith('value').should.be.true;
   });
 
+  it('Should have flip set to true if placement is auto', () => {
+    const wrapper = mount(
+      <OverlayTrigger
+        overlay={<Div>test</Div>}
+        trigger="click"
+        placement="auto"
+      >
+        <button type="button">button</button>
+      </OverlayTrigger>,
+    );
+    wrapper.find('button').simulate('click');
+
+    expect(wrapper.update().find(Overlay).props().flip).to.equal(true);
+  });
+
   describe('overlay types', () => {
     [
       {


### PR DESCRIPTION
Sets flip to true if placement is auto. Discussed in #5111. As an added bonus the possible placements are now displayed on the OverlayTrigger API in the docs.