### PR TITLE
#5071 Update cards docs

### DIFF
--- a/www/src/pages/components/cards.mdx
+++ b/www/src/pages/components/cards.mdx
@@ -54,6 +54,9 @@ Using `<Card.Title>`, `<Card.Subtitle>`, and
 `<Card.Text>` inside the `<Card.Body>` will line them up nicely.
 `<Card.Link>`s are used to line up links next to each other.
 
+`<Card.Text>` outputs `<p>` tags around the content, so you can
+use multiple `<Card.Text>`s to create separate paragraphs.
+
 <ReactPlayground codeText={CardText} />
 
 ### List Groups


### PR DESCRIPTION
Add mention that `<Card.Text>` is a `<p>` tag and can be used multiple times.

This was requested in #5071 so I created this. I'll let you decide if it should be merged, we should do it another way or simple leave it as is.