### PR TITLE
Passing event to onClose prop

### DIFF
--- a/src/ToastHeader.js
+++ b/src/ToastHeader.js
@@ -37,9 +37,9 @@ const ToastHeader = React.forwardRef(
 
     const context = useContext(ToastContext);
 
-    const handleClick = useEventCallback(() => {
+    const handleClick = useEventCallback((e) => {
       if (context) {
-        context.onClose();
+        context.onClose(e);
       }
     });
 


### PR DESCRIPTION
When I'm passing `onClose` event to `Toast` - this method doesn't receive `event` prop and it's not possible for example to call `event.stopPropagation()` to prevent firing `Toast.onClick` method