### PR TITLE
Add Button `as` prop to typescript definition

### DIFF
--- a/types/components/Button.d.ts
+++ b/types/components/Button.d.ts
@@ -27,6 +27,7 @@ export interface ButtonProps {
   type?: 'button' | 'reset' | 'submit';
   href?: string;
   disabled?: boolean;
+  as?:  React.ReactType;
 }
 
 declare class Button<


### PR DESCRIPTION
The `as` prop was missing from typescript definition.