### PR TITLE
types(Overlay): fixed type for `ref`

### DIFF
--- a/types/components/Overlay.d.ts
+++ b/types/components/Overlay.d.ts
@@ -4,7 +4,7 @@ import * as BaseOverlay from 'react-overlays/Overlay';
 export type Placement = import('react-overlays/usePopper').Placement;
 
 export interface OverlayInjectedProps {
-  ref: (instance: HTMLElement) => void;
+  ref: React.RefCallback<HTMLElement>;
   style: React.CSSProperties;
   'aria-labelledby'?: string;
 


### PR DESCRIPTION
The upstream `react-overlays` type for the injected `ref` is actually `React.RefCallback<HTMLElement>` (see https://github.com/react-bootstrap/react-overlays/blob/3646ef243f95c6b91ce05da63b39ce5ee612f465/src/Overlay.tsx#L37). 

That type expands to `(instance: T | null) => void`, not the previous `(instance: T) => void`, so these types were naturally incompatible...

I think the longer-term fix would be to actually expose `OverlayInjectedProps` from `react-overlays` ([this bit](https://github.com/react-bootstrap/react-overlays/blob/3646ef243f95c6b91ce05da63b39ce5ee612f465/src/Overlay.tsx#L31-L45)) and use it here.

Before this is released, a client code fix is e.g.

```patch
 {({
   placement,
   scheduleUpdate,
   arrowProps,
   outOfBoundaries,
   show: _show,
+  ref,
   ...props
 }) => (
-  <div {...props}>
+  <div ref={e => e && ref(e)} {...props}>
```