### PR TITLE
[docs] Fix FontAwesome icons' flash when press F5

### DIFF
--- a/www/gatsby-browser.js
+++ b/www/gatsby-browser.js
@@ -1,3 +1,10 @@
 require('./src/css/global.scss');
 
+// prevent FontAwesome icons' flash from a very large one down to a properly sized one
+require('@fortawesome/fontawesome-svg-core/styles.css');
+// Prevent fontawesome from adding its CSS since we did it manually above
+const { config } = require('@fortawesome/fontawesome-svg-core');
+
+config.autoAddCss = false;
+
 exports.wrapPageElement = require(`./src/wrap-page`);

--- a/www/gatsby-ssr.js
+++ b/www/gatsby-ssr.js
@@ -1,1 +1,4 @@
+// prevent FontAwesome icons' flash from a very large one down to a properly sized one
+require('@fortawesome/fontawesome-svg-core/styles.css');
+
 exports.wrapPageElement = require('./src/wrap-page');


### PR DESCRIPTION
fix #5159 FontAwesome icons flash from a large one down to a proper one