### PR TITLE
feat(FormControl): Add support for html size attribute

### DIFF
--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -37,6 +37,13 @@ const propTypes = {
   size: PropTypes.string,
 
   /**
+   * The size attribute of the underlying HTML element.
+   * Specifies the visible width in characters if `as` is `'input'`.
+   * Specifies the number of visible options if `as` is `'select'`.
+   */
+  htmlSize: PropTypes.number,
+
+  /**
    * The underlying HTML element to use when rendering the FormControl.
    *
    * @type {('input'|'textarea'|'select'|elementType)}
@@ -104,6 +111,7 @@ const FormControl = React.forwardRef(
       bsCustomPrefix,
       type,
       size,
+      htmlSize,
       id,
       className,
       isValid,
@@ -152,6 +160,7 @@ const FormControl = React.forwardRef(
       <Component
         {...props}
         type={type}
+        size={htmlSize}
         ref={ref}
         readOnly={readOnly}
         id={id || controlId}

--- a/test/FormControlSpec.js
+++ b/test/FormControlSpec.js
@@ -95,6 +95,12 @@ describe('<FormControl>', () => {
     );
   });
 
+  it('should properly display html size of FormControl', () => {
+    const wrapper = mount(<FormControl type="text" htmlSize={42} />);
+
+    expect(wrapper.find('input').props().size).to.eq(42);
+  });
+
   it('Should have input as default component', () => {
     mount(<FormControl />).assertSingle('input');
   });

--- a/types/components/FormControl.d.ts
+++ b/types/components/FormControl.d.ts
@@ -9,6 +9,7 @@ type FormControlElement =
 
 export interface FormControlProps {
   size?: 'sm' | 'lg';
+  htmlSize?: number;
   plaintext?: boolean;
   readOnly?: boolean;
   disabled?: boolean;

--- a/www/src/examples/Form/SelectCustomHtmlSize.js
+++ b/www/src/examples/Form/SelectCustomHtmlSize.js
@@ -1,0 +1,12 @@
+<Form>
+  <Form.Group controlId="exampleForm.SelectCustomHtmlSize">
+    <Form.Label>Select with three visible options</Form.Label>
+    <Form.Control as="select" htmlSize={3} custom>
+      <option>1</option>
+      <option>2</option>
+      <option>3</option>
+      <option>4</option>
+      <option>5</option>
+    </Form.Control>
+  </Form.Group>
+</Form>;

--- a/www/src/pages/components/forms.js
+++ b/www/src/pages/components/forms.js
@@ -24,6 +24,7 @@ import Range from '../../examples/Form/Range';
 import RangeCustom from '../../examples/Form/RangeCustom';
 import SelectCustom from '../../examples/Form/SelectCustom';
 import SelectCustomSize from '../../examples/Form/SelectCustomSize';
+import SelectCustomHtmlSize from '../../examples/Form/SelectCustomHtmlSize';
 import File from '../../examples/Form/File';
 import FileButtonTextHTML from '../../examples/Form/FileButtonTextHTML';
 import FileButtonTextScss from '../../examples/Form/FileButtonTextScss';
@@ -320,6 +321,12 @@ export default withLayout(function FormControlsSection({ data }) {
         The custom <code>select</code> element supports sizing.
       </p>
       <ReactPlayground codeText={SelectCustomSize} />
+      <h4>HTML size</h4>
+      <p>
+        You can also specify the visible options of your <code>select</code>{' '}
+        element.
+      </p>
+      <ReactPlayground codeText={SelectCustomHtmlSize} />
 
       <LinkedHeading h="3" id="forms-custom-range">
         Range


### PR DESCRIPTION
**Description**
The commit of this PR adds support for the size attribute of select and input elements. This is especially useful in case someone wants to create a select table with multiple visible options. (Check https://www.w3schools.com/tags/att_select_size.asp for details.)

**Changes**
- [x] Added htmlSize prop to _FormControl.js_ and linked it to the size attribute of the underlaying component.
- [x] Created a new test case in _FormControlSpec.js_ to check if the html size attribute is properly set.
- [x] Updated forms doc and added an html size example to the "Select" section.

**Related issue**
#4499