### PR TITLE
feat(Modal): Add modal static backdrop animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "invariant": "^2.2.4",
     "prop-types": "^15.7.2",
     "prop-types-extra": "^1.1.0",
-    "react-overlays": "^3.1.3",
+    "react-overlays": "^3.2.0",
     "react-transition-group": "^4.0.0",
     "uncontrollable": "^7.0.0",
     "warning": "^4.0.3"

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -441,7 +441,7 @@ const Modal = React.forwardRef(
         className={classNames(
           className,
           bsPrefix,
-          animateStaticModal && 'modal-static',
+          animateStaticModal && `${bsPrefix}-static`,
         )}
         onClick={
           backdrop === true || backdrop === 'static' ? handleClick : undefined

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -328,9 +328,6 @@ const Modal = React.forwardRef(
       removeStaticModalAnimationRef.current = transitionEnd(
         modal.dialog,
         () => {
-          if (removeStaticModalAnimationRef.current) {
-            removeStaticModalAnimationRef.current();
-          }
           setAnimateStaticModal(false);
         },
       );
@@ -432,9 +429,7 @@ const Modal = React.forwardRef(
           bsPrefix,
           animateStaticModal && `${bsPrefix}-static`,
         )}
-        onClick={
-          backdrop === true || backdrop === 'static' ? handleClick : undefined
-        }
+        onClick={backdrop ? handleClick : undefined}
         onMouseUp={handleMouseUp}
         aria-labelledby={ariaLabelledby}
       >

--- a/src/Modal.js
+++ b/src/Modal.js
@@ -307,6 +307,10 @@ const Modal = React.forwardRef(
 
     useWillUnmount(() => {
       removeEventListener(window, 'resize', handleWindowResize);
+
+      if (removeStaticModalAnimationRef.current) {
+        removeStaticModalAnimationRef.current();
+      }
     });
 
     // We prevent the modal from closing during a drag by detecting where the

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -312,4 +312,39 @@ describe('<Modal>', () => {
       'div.modal.show[role="dialog"][aria-labelledby="modal-title"]',
     );
   });
+
+  it('Should call onEscapeKeyDown when keyboard is true', () => {
+    const noOp = () => {};
+    const onEscapeKeyDownSpy = sinon.spy();
+    mount(
+      <Modal show onHide={noOp} keyboard onEscapeKeyDown={onEscapeKeyDownSpy}>
+        <strong>Message</strong>
+      </Modal>,
+    );
+
+    const event = new KeyboardEvent('keydown', { keyCode: 27 });
+    document.dispatchEvent(event);
+
+    expect(onEscapeKeyDownSpy).to.have.been.called;
+  });
+
+  it('Should not call onEscapeKeyDown when keyboard is false', () => {
+    const noOp = () => {};
+    const onEscapeKeyDownSpy = sinon.spy();
+    mount(
+      <Modal
+        show
+        onHide={noOp}
+        keyboard={false}
+        onEscapeKeyDown={onEscapeKeyDownSpy}
+      >
+        <strong>Message</strong>
+      </Modal>,
+    );
+
+    const event = new KeyboardEvent('keydown', { keyCode: 27 });
+    document.dispatchEvent(event);
+
+    expect(onEscapeKeyDownSpy).to.not.have.been.called;
+  });
 });

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -60,6 +60,64 @@ describe('<Modal>', () => {
     expect(onHideSpy).to.not.have.been.called;
   });
 
+  it('Should show "static" dialog animation when backdrop is clicked', () => {
+    const noOp = () => {};
+    const wrapper = mount(
+      <Modal show onHide={noOp} backdrop="static">
+        <strong>Message</strong>
+      </Modal>,
+    );
+
+    const modal = wrapper.find('.modal');
+    modal.simulate('click');
+
+    expect(wrapper.find('.modal-static').length).to.equal(1);
+  });
+
+  it('Should show "static" dialog animation when esc pressed and keyboard is false', () => {
+    const noOp = () => {};
+    const wrapper = mount(
+      <Modal show onHide={noOp} backdrop="static" keyboard={false}>
+        <strong>Message</strong>
+      </Modal>,
+    );
+
+    const event = new KeyboardEvent('keydown', { keyCode: 27 });
+    document.dispatchEvent(event);
+    wrapper.update();
+
+    expect(wrapper.find('.modal-static').length).to.equal(1);
+  });
+
+  it('Should not show "static" dialog animation when esc pressed and keyboard is true', () => {
+    const noOp = () => {};
+    const wrapper = mount(
+      <Modal show onHide={noOp} backdrop="static" keyboard>
+        <strong>Message</strong>
+      </Modal>,
+    );
+
+    const event = new KeyboardEvent('keydown', { keyCode: 27 });
+    document.dispatchEvent(event);
+    wrapper.update();
+
+    expect(wrapper.find('.modal-static').length).to.equal(0);
+  });
+
+  it('Should not show "static" dialog animation modal backdrop is not "static"', () => {
+    const noOp = () => {};
+    const wrapper = mount(
+      <Modal show onHide={noOp} backdrop>
+        <strong>Message</strong>
+      </Modal>,
+    );
+
+    const modal = wrapper.find('.modal');
+    modal.simulate('click');
+
+    expect(wrapper.find('.modal-static').length).to.equal(0);
+  });
+
   it('Should close the modal when the modal close button is clicked', (done) => {
     const doneOp = () => {
       done();

--- a/www/src/examples/Modal/StaticBackdrop.js
+++ b/www/src/examples/Modal/StaticBackdrop.js
@@ -1,0 +1,37 @@
+function Example() {
+  const [show, setShow] = useState(false);
+
+  const handleClose = () => setShow(false);
+  const handleShow = () => setShow(true);
+
+  return (
+    <>
+      <Button variant="primary" onClick={handleShow}>
+        Launch static backdrop modal
+      </Button>
+
+      <Modal
+        show={show}
+        onHide={handleClose}
+        backdrop="static"
+        keyboard={false}
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>Modal title</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          I will not close if you click outside me. Don't even try to press
+          escape key.
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="secondary" onClick={handleClose}>
+            Close
+          </Button>
+          <Button variant="primary">Understood</Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+}
+
+render(<Example />);

--- a/www/src/pages/components/modal.js
+++ b/www/src/pages/components/modal.js
@@ -8,6 +8,7 @@ import ReactPlayground from '../../components/ReactPlayground';
 
 import ModalStatic from '../../examples/Modal/Static';
 import ModalBasic from '../../examples/Modal/Basic';
+import ModalStaticBackdrop from '../../examples/Modal/StaticBackdrop';
 import ModalDefaultSizing from '../../examples/Modal/DefaultSizing';
 import ModalCustomSizing from '../../examples/Modal/CustomSizing';
 import ModalVerticallyCentered from '../../examples/Modal/VerticallyCentered';
@@ -86,6 +87,14 @@ export default withLayout(function ModalSection({ data }) {
         content.
       </p>
       <ReactPlayground codeText={ModalBasic} />
+      <LinkedHeading h="3" id="static-backdrop">
+        Static backdrop
+      </LinkedHeading>
+      <p>
+        When backdrop is set to static, the modal will not close when clicking
+        outside it. Click the button below to try it.
+      </p>
+      <ReactPlayground codeText={ModalStaticBackdrop} />
       <LinkedHeading h="3" id="without-animation">
         Without Animation
       </LinkedHeading>

--- a/yarn.lock
+++ b/yarn.lock
@@ -7339,10 +7339,10 @@ react-lifecycles-compat@^3.0.4:
   resolved "https://registry.yarnpkg.com/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz#4f1a273afdfc8f3488a8c516bfda78f872352362"
   integrity sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==
 
-react-overlays@^3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-3.1.3.tgz#e6ac2b43fd2179924491bd794508072399940128"
-  integrity sha512-FH82W0R9lFJm/YCTDeSvEKQxXyTaZmjMEQlAjRhgjQhknTkyMsft+X4Wep5l95QveqdxGVxl/P41WUOzTGJUcw==
+react-overlays@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-3.2.0.tgz#ed8335adb0871e701b0fc8396c44dfd2467e7a55"
+  integrity sha512-YTgCmw6l4uBOYylSnc3V8WLX+A0EoGnzDrqkYz0K7MUKbMBZFpaxLXH4EF9eZbspd+syZHQ5XAABI7n/zak1EA==
   dependencies:
     "@babel/runtime" "^7.4.5"
     "@popperjs/core" "^2.0.0"


### PR DESCRIPTION
Resolves #5163 

This adds the animation using the bootstrap class `modal-static`. The animation will appear on static backdrop modals when clicking the backdrop or pressing escape when `keyboard` is set to `false`.