### PR TITLE
docs(Form): Added missing Form.Text API and more docs/examples

### DIFF
--- a/www/src/examples/Form/FormDisabled.js
+++ b/www/src/examples/Form/FormDisabled.js
@@ -1,0 +1,22 @@
+<Form>
+  <fieldset disabled>
+    <Form.Group>
+      <Form.Label for="disabledTextInput">Disabled input</Form.Label>
+      <Form.Control id="disabledTextInput" placeholder="Disabled input" />
+    </Form.Group>
+    <Form.Group>
+      <Form.Label for="disabledSelect">Disabled select menu</Form.Label>
+      <Form.Control as="select" id="disabledSelect">
+        <option>Disabled select</option>
+      </Form.Control>
+    </Form.Group>
+    <Form.Group>
+      <Form.Check
+        type="checkbox"
+        id="disabledFieldsetCheck"
+        label="Can't check this"
+      />
+    </Form.Group>
+    <Button type="submit">Submit</Button>
+  </fieldset>
+</Form>;

--- a/www/src/examples/Form/FormDisabledInputs.js
+++ b/www/src/examples/Form/FormDisabledInputs.js
@@ -1,0 +1,15 @@
+<>
+  <Form.Group>
+    <Form.Label>Disabled input</Form.Label>
+    <Form.Control placeholder="Disabled input" disabled />
+  </Form.Group>
+  <Form.Group>
+    <Form.Label>Disabled select menu</Form.Label>
+    <Form.Control as="select" disabled>
+      <option>Disabled select</option>
+    </Form.Control>
+  </Form.Group>
+  <Form.Group>
+    <Form.Check type="checkbox" label="Can't check this" disabled />
+  </Form.Group>
+</>;

--- a/www/src/examples/Form/FormFile.js
+++ b/www/src/examples/Form/FormFile.js
@@ -1,0 +1,5 @@
+<Form>
+  <Form.Group>
+    <Form.File id="exampleFormControlFile1" label="Example file input" />
+  </Form.Group>
+</Form>;

--- a/www/src/examples/Form/FormText.js
+++ b/www/src/examples/Form/FormText.js
@@ -1,0 +1,12 @@
+<>
+  <Form.Label for="inputPassword5">Password</Form.Label>
+  <Form.Control
+    type="password"
+    id="inputPassword5"
+    aria-describedby="passwordHelpBlock"
+  />
+  <Form.Text id="passwordHelpBlock" muted>
+    Your password must be 8-20 characters long, contain letters and numbers, and
+    must not contain spaces, special characters, or emoji.
+  </Form.Text>
+</>;

--- a/www/src/examples/Form/FormTextInline.js
+++ b/www/src/examples/Form/FormTextInline.js
@@ -1,0 +1,14 @@
+<Form inline>
+  <Form.Group>
+    <Form.Label for="inputPassword6">Password</Form.Label>
+    <Form.Control
+      type="password"
+      className="mx-sm-3"
+      id="inputPassword6"
+      aria-describedby="passwordHelpInline"
+    />
+    <Form.Text id="passwordHelpBlock" muted>
+      Must be 8-20 characters long.
+    </Form.Text>
+  </Form.Group>
+</Form>;

--- a/www/src/examples/Form/GridAutoSizing.js
+++ b/www/src/examples/Form/GridAutoSizing.js
@@ -1,0 +1,38 @@
+<Form>
+  <Form.Row className="align-items-center">
+    <Col xs="auto">
+      <Form.Label for="inlineFormInput" srOnly>
+        Name
+      </Form.Label>
+      <Form.Control
+        className="mb-2"
+        id="inlineFormInput"
+        placeholder="Jane Doe"
+      />
+    </Col>
+    <Col xs="auto">
+      <Form.Label for="inlineFormInputGroup" srOnly>
+        Username
+      </Form.Label>
+      <InputGroup className="mb-2">
+        <InputGroup.Prepend>
+          <InputGroup.Text>@</InputGroup.Text>
+        </InputGroup.Prepend>
+        <FormControl id="inlineFormInputGroup" placeholder="Username" />
+      </InputGroup>
+    </Col>
+    <Col xs="auto">
+      <Form.Check
+        type="checkbox"
+        id="autoSizingCheck"
+        className="mb-2"
+        label="Remember me"
+      />
+    </Col>
+    <Col xs="auto">
+      <Button type="submit" className="mb-2">
+        Submit
+      </Button>
+    </Col>
+  </Form.Row>
+</Form>;

--- a/www/src/examples/Form/GridAutoSizingColMix.js
+++ b/www/src/examples/Form/GridAutoSizingColMix.js
@@ -1,0 +1,27 @@
+<Form>
+  <Form.Row className="align-items-center">
+    <Col sm={3} className="my-1">
+      <Form.Label for="inlineFormInputName" srOnly>
+        Name
+      </Form.Label>
+      <Form.Control id="inlineFormInputName" placeholder="Jane Doe" />
+    </Col>
+    <Col sm={3} className="my-1">
+      <Form.Label for="inlineFormInputGroupUsername" srOnly>
+        Username
+      </Form.Label>
+      <InputGroup>
+        <InputGroup.Prepend>
+          <InputGroup.Text>@</InputGroup.Text>
+        </InputGroup.Prepend>
+        <FormControl id="inlineFormInputGroupUsername" placeholder="Username" />
+      </InputGroup>
+    </Col>
+    <Col xs="auto" className="my-1">
+      <Form.Check type="checkbox" id="autoSizingCheck2" label="Remember me" />
+    </Col>
+    <Col xs="auto" className="my-1">
+      <Button type="submit">Submit</Button>
+    </Col>
+  </Form.Row>
+</Form>;

--- a/www/src/examples/Form/GridAutoSizingCustom.js
+++ b/www/src/examples/Form/GridAutoSizingCustom.js
@@ -1,0 +1,31 @@
+<Form>
+  <Form.Row className="align-items-center">
+    <Col xs="auto" className="my-1">
+      <Form.Label className="mr-sm-2" for="inlineFormCustomSelect" srOnly>
+        Preference
+      </Form.Label>
+      <Form.Control
+        as="select"
+        className="mr-sm-2"
+        id="inlineFormCustomSelect"
+        custom
+      >
+        <option selected>Choose...</option>
+        <option value="1">One</option>
+        <option value="2">Two</option>
+        <option value="3">Three</option>
+      </Form.Control>
+    </Col>
+    <Col xs="auto" className="my-1">
+      <Form.Check
+        type="checkbox"
+        id="customControlAutosizing"
+        label="Remember my preference"
+        custom
+      />
+    </Col>
+    <Col xs="auto" className="my-1">
+      <Button type="submit">Submit</Button>
+    </Col>
+  </Form.Row>
+</Form>;

--- a/www/src/examples/Form/GridColSizes.js
+++ b/www/src/examples/Form/GridColSizes.js
@@ -1,0 +1,13 @@
+<Form>
+  <Form.Row>
+    <Col xs={7}>
+      <Form.Control placeholder="City" />
+    </Col>
+    <Col>
+      <Form.Control placeholder="State" />
+    </Col>
+    <Col>
+      <Form.Control placeholder="Zip" />
+    </Col>
+  </Form.Row>
+</Form>;

--- a/www/src/examples/Form/Inline.js
+++ b/www/src/examples/Form/Inline.js
@@ -1,11 +1,28 @@
 <Form inline>
-  <Form.Group controlId="formInlineName">
-    <Form.Label>Name</Form.Label>{' '}
-    <Form.Control type="text" placeholder="Jane Doe" />
-  </Form.Group>{' '}
-  <Form.Group controlId="formInlineEmail">
-    <Form.Label>Email</Form.Label>{' '}
-    <Form.Control type="email" placeholder="jane.doe@example.com" />
-  </Form.Group>{' '}
-  <Button type="submit">Send invitation</Button>
+  <Form.Label for="inlineFormInputName2" srOnly>
+    Name
+  </Form.Label>
+  <Form.Control
+    className="mb-2 mr-sm-2"
+    id="inlineFormInputName2"
+    placeholder="Jane Doe"
+  />
+  <Form.Label for="inlineFormInputGroupUsername2" srOnly>
+    Username
+  </Form.Label>
+  <InputGroup className="mb-2 mr-sm-2">
+    <InputGroup.Prepend>
+      <InputGroup.Text>@</InputGroup.Text>
+    </InputGroup.Prepend>
+    <FormControl id="inlineFormInputGroupUsername2" placeholder="Username" />
+  </InputGroup>
+  <Form.Check
+    type="checkbox"
+    className="mb-2 mr-sm-2"
+    id="inlineFormCheck"
+    label="Remember me"
+  />
+  <Button type="submit" className="mb-2">
+    Submit
+  </Button>
 </Form>;

--- a/www/src/examples/Form/InlineCustom.js
+++ b/www/src/examples/Form/InlineCustom.js
@@ -1,0 +1,26 @@
+<Form inline>
+  <Form.Label className="my-1 mr-2" for="inlineFormCustomSelectPref">
+    Preference
+  </Form.Label>
+  <Form.Control
+    as="select"
+    className="my-1 mr-sm-2"
+    id="inlineFormCustomSelectPref"
+    custom
+  >
+    <option selected>Choose...</option>
+    <option value="1">One</option>
+    <option value="2">Two</option>
+    <option value="3">Three</option>
+  </Form.Control>
+  <Form.Check
+    type="checkbox"
+    className="my-1 mr-sm-2"
+    id="customControlInline"
+    label="Remember my preference"
+    custom
+  />
+  <Button type="submit" className="my-1">
+    Submit
+  </Button>
+</Form>;

--- a/www/src/examples/Form/InputReadOnly.js
+++ b/www/src/examples/Form/InputReadOnly.js
@@ -1,0 +1,1 @@
+<Form.Control type="text" placeholder="Readonly input here..." readOnly />;

--- a/www/src/examples/Form/SelectSizes.js
+++ b/www/src/examples/Form/SelectSizes.js
@@ -1,0 +1,13 @@
+<Form.Group>
+  <Form.Control as="select" size="lg">
+    <option>Large select</option>
+  </Form.Control>
+  <br />
+  <Form.Control as="select">
+    <option>Default select</option>
+  </Form.Control>
+  <br />
+  <Form.Control size="sm" as="select">
+    <option>Small select</option>
+  </Form.Control>
+</Form.Group>;

--- a/www/src/pages/components/forms.js
+++ b/www/src/pages/components/forms.js
@@ -10,12 +10,24 @@ import CheckApi from '../../examples/Form/CheckApi';
 import CheckCustom from '../../examples/Form/CheckCustom';
 import CheckCustomInline from '../../examples/Form/CheckCustomInline';
 import CheckInline from '../../examples/Form/CheckInline';
+import FormFile from '../../examples/Form/FormFile';
+import FormDisabled from '../../examples/Form/FormDisabled';
+import FormDisabledInputs from '../../examples/Form/FormDisabledInputs';
 import FormGroup from '../../examples/Form/FormGroup';
 import FormRow from '../../examples/Form/FormRow';
+import FormText from '../../examples/Form/FormText';
+import FormTextInline from '../../examples/Form/FormTextInline';
 import FormLabelSizing from '../../examples/Form/FormLabelSizing';
+import GridAutoSizing from '../../examples/Form/GridAutoSizing';
+import GridAutoSizingCustom from '../../examples/Form/GridAutoSizingCustom';
+import GridAutoSizingColMix from '../../examples/Form/GridAutoSizingColMix';
 import GridBasic from '../../examples/Form/GridBasic';
+import GridColSizes from '../../examples/Form/GridColSizes';
 import GridComplex from '../../examples/Form/GridComplex';
 import Horizontal from '../../examples/Form/Horizontal';
+import Inline from '../../examples/Form/Inline';
+import InlineCustom from '../../examples/Form/InlineCustom';
+import InputReadOnly from '../../examples/Form/InputReadOnly';
 import FormInputSizes from '../../examples/Form/InputSizes';
 import NoLabels from '../../examples/Form/NoLabels';
 import Plaintext from '../../examples/Form/Plaintext';
@@ -25,6 +37,7 @@ import RangeCustom from '../../examples/Form/RangeCustom';
 import SelectCustom from '../../examples/Form/SelectCustom';
 import SelectCustomSize from '../../examples/Form/SelectCustomSize';
 import SelectCustomHtmlSize from '../../examples/Form/SelectCustomHtmlSize';
+import SelectSizes from '../../examples/Form/SelectSizes';
 import File from '../../examples/Form/File';
 import FileButtonTextHTML from '../../examples/Form/FileButtonTextHTML';
 import FileButtonTextScss from '../../examples/Form/FileButtonTextScss';
@@ -77,6 +90,10 @@ export default withLayout(function FormControlsSection({ data }) {
         appearance, focus state, sizing, and more.
       </p>
       <ReactPlayground codeText={FormTextControls} />
+      <p>
+        For file inputs, use <code>Form.File</code>.
+      </p>
+      <ReactPlayground codeText={FormFile} />
       <LinkedHeading h="3" id="forms-input-sizes">
         Sizing
       </LinkedHeading>
@@ -86,13 +103,23 @@ export default withLayout(function FormControlsSection({ data }) {
         respectively.
       </p>
       <ReactPlayground codeText={FormInputSizes} />
-      <LinkedHeading h="3" id="forms-input-Plaintext">
-        Plaintext
+      <ReactPlayground codeText={SelectSizes} />
+      <LinkedHeading h="3" id="forms-input-readonly">
+        Readonly
       </LinkedHeading>
       <p>
-        If you want to have elements in your form styled as plain text, use the{' '}
-        <code>plaintext</code> prop on FormControls to remove the default form
-        field styling and preserve the correct margin and padding.
+        Add the <code>readOnly</code> prop on an input to prevent modification
+        of the input's value. Read-only inputs appear lighter (just like
+        disabled inputs), but retain the standard cursor.
+      </p>
+      <ReactPlayground codeText={InputReadOnly} />
+      <LinkedHeading h="3" id="forms-input-plaintext">
+        Readonly plain text
+      </LinkedHeading>
+      <p>
+        If you want to have readonly elements in your form styled as plain text,
+        use the <code>plaintext</code> prop on FormControls to remove the
+        default form field styling and preserve the correct margin and padding.
       </p>
       <ReactPlayground codeText={Plaintext} />
       <LinkedHeading h="2" id="forms-range">
@@ -124,7 +151,7 @@ export default withLayout(function FormControlsSection({ data }) {
         <code>inline</code> prop.
       </p>
       <ReactPlayground codeText={CheckInline} />
-      <LinkedHeading h="3" id="forms-check-inline">
+      <LinkedHeading h="3" id="forms-check-without-labels">
         Without labels
       </LinkedHeading>
       <p>
@@ -163,7 +190,7 @@ export default withLayout(function FormControlsSection({ data }) {
         layout on a per-form basis.
       </p>
       <LinkedHeading h="3" id="forms-layout-group">
-        Form group
+        Form groups
       </LinkedHeading>
       <p>
         The <code>FormGroup</code> component is the easiest way to add some
@@ -198,8 +225,8 @@ export default withLayout(function FormControlsSection({ data }) {
       <ReactPlayground codeText={FormRow} />
       <p>More complex layouts can also be created with the grid system.</p>
       <ReactPlayground codeText={GridComplex} />
-      <LinkedHeading h="3" id="horizontal-forms">
-        Horizontal forms
+      <LinkedHeading h="4" id="horizontal-forms">
+        Horizontal form
       </LinkedHeading>
       <p>
         You may also swap <code>{'<Row>'}</code> for <code>{'<Form.Row>'}</code>
@@ -208,14 +235,160 @@ export default withLayout(function FormControlsSection({ data }) {
       </p>
       <ReactPlayground codeText={Horizontal} />
       <LinkedHeading h="4" id="horizontal-forms-label-sizing">
-        Horizontal forms label sizing
+        Horizontal form label sizing
       </LinkedHeading>
       <p>
         You can size the <code>{'<FormLabel>'}</code> using the column prop as
         shown.
       </p>
       <ReactPlayground codeText={FormLabelSizing} />
-
+      <LinkedHeading h="4" id="forms-col-sizing">
+        Column sizing
+      </LinkedHeading>
+      <p>
+        As shown in the previous examples, our grid system allows you to place
+        any number of <code>{'<Col>'}</code>s within a <code>{'<Row>'}</code> or{' '}
+        <code>{'<Form.Row>'}</code>. They'll split the available width equally
+        between them. You may also pick a subset of your columns to take up more
+        or less space, while the remaining <code>{'<Col>'}</code>s equally split
+        the rest, with specific column classes like{' '}
+        <code>{'<Col xs={7}>'}</code>.
+      </p>
+      <ReactPlayground codeText={GridColSizes} />
+      <LinkedHeading h="4" id="forms-auto-sizing">
+        Auto-sizing
+      </LinkedHeading>
+      <p>
+        The example below uses a flexbox utility to vertically center the
+        contents and changes <code>{'<Col>'}</code> to{' '}
+        <code>{'<Col xs="auto">'}</code> so that your columns only take up as
+        much space as needed. Put another way, the column sizes itself based on
+        on the contents.
+      </p>
+      <ReactPlayground codeText={GridAutoSizing} />
+      <p>
+        You can then remix that once again with size-specific column classes.
+      </p>
+      <ReactPlayground codeText={GridAutoSizingColMix} />
+      <p>
+        And of course <a href="#forms-custom">custom form controls</a> are
+        supported.
+      </p>
+      <ReactPlayground codeText={GridAutoSizingCustom} />
+      <LinkedHeading h="3" id="forms-inline">
+        Inline forms
+      </LinkedHeading>
+      <p>
+        Use the <code>inline</code> prop to display a series of labels, form
+        controls, and buttons on a single horizontal row. Form controls within
+        forms vary slightly from their default states.
+      </p>
+      <ul>
+        <li>
+          Controls are <code>display: flex</code>, collapsing any HTML white
+          space and allowing you to provide alignment control with spacing and
+          utilities.
+        </li>
+        <li>
+          Controls and input groups receive <code>width: auto</code> to override
+          the Bootstrap default <code>width: 100%</code>.
+        </li>
+        <li>
+          Controls{' '}
+          <b>only appear inline in viewports that are at least 576px wide</b> to
+          account for narrow viewports on mobile devices.
+        </li>
+      </ul>
+      <p>
+        You may need to manually address the width and alignment of individual
+        form controls with spacing utilities (as shown below). Lastly, be sure
+        to always include a <code>{'<Form.Label>'}</code> with each form
+        control, even if you need to hide it from non-screenreader visitors with
+        the <code>srOnly</code> prop.
+      </p>
+      <ReactPlayground codeText={Inline} />
+      <p>Custom form controls and selects are also supported.</p>
+      <ReactPlayground codeText={InlineCustom} />
+      <Callout>
+        <h5>Alternatives to hidden labels</h5>
+        Assistive technologies such as screen readers will have trouble with
+        your forms if you don’t include a label for every input. For these
+        inline forms, you can hide the labels using the <code>srOnly</code>{' '}
+        prop. There are further alternative methods of providing a label for
+        assistive technologies, such as the <code>aria-label</code>,{' '}
+        <code>aria-labelledby</code> or <code>title</code> attribute. If none of
+        these are present, assistive technologies may resort to using the{' '}
+        <code>placeholder</code> attribute, if present, but note that use of{' '}
+        <code>placeholder</code> as a replacement for other labelling methods is
+        not advised.
+      </Callout>
+      <LinkedHeading h="2" id="forms-help-text">
+        Help text
+      </LinkedHeading>
+      <p>
+        Block-level help text in forms can be created using{' '}
+        <code>{'<Form.Text>'}</code>. Inline help text can be flexibly
+        implemented using any inline HTML element and utility classes like
+        <code>.text-muted</code>.
+      </p>
+      <Callout>
+        <h5>Associating help text with form controls</h5>
+        Help text should be explicitly associated with the form control it
+        relates to using the <code>aria-describedby</code> attribute. This will
+        ensure that assistive technologies—such as screen readers—will announce
+        this help text when the user focuses or enters the control.
+      </Callout>
+      <p>
+        Help text below inputs can be styled with <code>{'<Form.Text>'}</code>.
+        This component includes <code>display: block</code> and adds some top
+        margin for easy spacing from the inputs above.
+      </p>
+      <ReactPlayground codeText={FormText} />
+      <p>
+        Inline text can use any typical inline HTML element (be it a{' '}
+        <code>{'<small>'}</code>, <code>{'<span>'}</code>, or something else)
+        with nothing more than a utility class.
+      </p>
+      <ReactPlayground codeText={FormTextInline} />
+      <LinkedHeading h="2" id="forms-disabled">
+        Disabled forms
+      </LinkedHeading>
+      <p>
+        Add the <code>disabled</code> boolean attribute on an input to prevent
+        user interactions and make it appear lighter.
+      </p>
+      <ReactPlayground codeText={FormDisabledInputs} />
+      <p>
+        Add the <code>disabled</code> attribute to a <code>{'<fieldset>'}</code>{' '}
+        to disable all the controls within.
+      </p>
+      <ReactPlayground codeText={FormDisabled} />
+      <Callout>
+        <h5>Caveat with anchors</h5>
+        By default, browsers will treat all native form controls (
+        <code>{'<input>'}</code>, <code>{'<select>'}</code> and{' '}
+        <code>{'<button>'}</code> elements) inside a{' '}
+        <code>{'<fieldset disabled>'}</code> as disabled, preventing both
+        keyboard and mouse interactions on them. However, if your form also
+        includes <code>{'<a ... class="btn btn-*">'}</code> elements, these will
+        only be given a style of <code>pointer-events: none</code>. As noted in
+        the section about{' '}
+        <a href="/components/buttons/#disabled-state">
+          disabled state for buttons
+        </a>{' '}
+        (and specifically in the sub-section for anchor elements), this CSS
+        property is not yet standardized and isn’t fully supported in Internet
+        Explorer 10, and won’t prevent keyboard users from being able to focus
+        or activate these links. So to be safe, use custom JavaScript to disable
+        such links.
+      </Callout>
+      <Callout theme="danger">
+        <h4>Cross-browser compatibility</h4>
+        While Bootstrap will apply these styles in all browsers, Internet
+        Explorer 11 and below don’t fully support the <code>disabled</code>{' '}
+        attribute on a <code>{'<fieldset>'}</code>. Use custom JavaScript to
+        disable the fieldset in these browsers.
+      </Callout>
       <LinkedHeading h="2" id="forms-validation">
         Validation
       </LinkedHeading>
@@ -430,6 +603,7 @@ export default withLayout(function FormControlsSection({ data }) {
       <ComponentApi metadata={data.FormRow} exportedBy={data.Form} />
       <ComponentApi metadata={data.FormGroup} exportedBy={data.Form} />
       <ComponentApi metadata={data.FormLabel} exportedBy={data.Form} />
+      <ComponentApi metadata={data.FormText} exportedBy={data.Form} />
       <ComponentApi metadata={data.FormControl} exportedBy={data.Form} />
       <ComponentApi metadata={data.Feedback} exportedBy={data.FormControl} />
       <ComponentApi metadata={data.FormCheck} exportedBy={data.Form} />
@@ -463,6 +637,9 @@ export const query = graphql`
       ...ComponentApi_metadata
     }
     FormLabel: componentMetadata(displayName: { eq: "FormLabel" }) {
+      ...ComponentApi_metadata
+    }
+    FormText: componentMetadata(displayName: { eq: "FormText" }) {
       ...ComponentApi_metadata
     }
     FormCheck: componentMetadata(displayName: { eq: "FormCheck" }) {


### PR DESCRIPTION
Added missing Form.Text API into the docs.  Also added more docs/examples so the forms section is more in sync with official bootstrap docs.