### PR TITLE
docs: Fix docs proptypes and console warnings

### DIFF
--- a/src/AccordionToggle.js
+++ b/src/AccordionToggle.js
@@ -15,9 +15,6 @@ const propTypes = {
 
   /** A callback function for when this component is clicked */
   onClick: PropTypes.func,
-
-  /** Children prop should only contain a single child, and  is enforced as such */
-  children: PropTypes.element,
 };
 
 export function useAccordionToggle(eventKey, onClick) {

--- a/src/FormCheck.js
+++ b/src/FormCheck.js
@@ -74,10 +74,10 @@ const propTypes = {
   ),
 
   /** Manually style the input as valid */
-  isValid: PropTypes.bool.isRequired,
+  isValid: PropTypes.bool,
 
   /** Manually style the input as invalid */
-  isInvalid: PropTypes.bool.isRequired,
+  isInvalid: PropTypes.bool,
 
   /** Display feedback as a tooltip. */
   feedbackTooltip: PropTypes.bool,

--- a/src/FormCheckInput.js
+++ b/src/FormCheckInput.js
@@ -37,14 +37,16 @@ const propTypes = {
   isStatic: PropTypes.bool,
 
   /** Manually style the input as valid */
-  isValid: PropTypes.bool.isRequired,
+  isValid: PropTypes.bool,
 
   /** Manually style the input as invalid */
-  isInvalid: PropTypes.bool.isRequired,
+  isInvalid: PropTypes.bool,
 };
 
 const defaultProps = {
   type: 'checkbox',
+  isValid: false,
+  isInvalid: false,
 };
 
 const FormCheckInput = React.forwardRef(

--- a/src/FormControl.js
+++ b/src/FormControl.js
@@ -104,6 +104,11 @@ const propTypes = {
   isInvalid: PropTypes.bool,
 };
 
+const defaultProps = {
+  isValid: false,
+  isInvalid: false,
+};
+
 const FormControl = React.forwardRef(
   (
     {
@@ -177,6 +182,7 @@ const FormControl = React.forwardRef(
 
 FormControl.displayName = 'FormControl';
 FormControl.propTypes = propTypes;
+FormControl.defaultProps = defaultProps;
 
 FormControl.Feedback = Feedback;
 

--- a/src/FormFile.js
+++ b/src/FormFile.js
@@ -68,10 +68,10 @@ const propTypes = {
   custom: PropTypes.bool,
 
   /** Manually style the input as valid */
-  isValid: PropTypes.bool.isRequired,
+  isValid: PropTypes.bool,
 
   /** Manually style the input as invalid */
-  isInvalid: PropTypes.bool.isRequired,
+  isInvalid: PropTypes.bool,
 
   /** Display feedback as a tooltip. */
   feedbackTooltip: PropTypes.bool,

--- a/src/FormFileInput.js
+++ b/src/FormFileInput.js
@@ -28,10 +28,10 @@ const propTypes = {
   id: PropTypes.string,
 
   /** Manually style the input as valid */
-  isValid: PropTypes.bool.isRequired,
+  isValid: PropTypes.bool,
 
   /** Manually style the input as invalid */
-  isInvalid: PropTypes.bool.isRequired,
+  isInvalid: PropTypes.bool,
 
   /** The language for the button when using custom file input and SCSS based strings */
   lang: PropTypes.string,

--- a/www/src/examples/Button/ToggleButton.js
+++ b/www/src/examples/Button/ToggleButton.js
@@ -1,19 +1,44 @@
-<>
-  <ButtonGroup toggle className="mb-2">
-    <ToggleButton type="checkbox" defaultChecked value="1">
-      Checked
-    </ToggleButton>
-  </ButtonGroup>
-  <br />
-  <ButtonGroup toggle>
-    <ToggleButton type="radio" name="radio" defaultChecked value="1">
-      Active
-    </ToggleButton>
-    <ToggleButton type="radio" name="radio" value="2">
-      Radio
-    </ToggleButton>
-    <ToggleButton type="radio" name="radio" value="3">
-      Radio
-    </ToggleButton>
-  </ButtonGroup>
-</>;
+function ToggleButtonExample() {
+  const [checked, setChecked] = useState(false);
+  const [radioValue, setRadioValue] = useState('1');
+
+  const radios = [
+    { name: 'Active', value: '1' },
+    { name: 'Radio', value: '2' },
+    { name: 'Radio', value: '3' },
+  ];
+
+  return (
+    <>
+      <ButtonGroup toggle className="mb-2">
+        <ToggleButton
+          type="checkbox"
+          variant="secondary"
+          checked={checked}
+          value="1"
+          onChange={(e) => setChecked(e.currentTarget.checked)}
+        >
+          Checked
+        </ToggleButton>
+      </ButtonGroup>
+      <br />
+      <ButtonGroup toggle>
+        {radios.map((radio, idx) => (
+          <ToggleButton
+            key={idx}
+            type="radio"
+            variant="secondary"
+            name="radio"
+            value={radio.value}
+            checked={radioValue === radio.value}
+            onChange={(e) => setRadioValue(e.currentTarget.value)}
+          >
+            {radio.name}
+          </ToggleButton>
+        ))}
+      </ButtonGroup>
+    </>
+  );
+}
+
+render(<ToggleButtonExample />);

--- a/www/src/examples/Card/BgColor.js
+++ b/www/src/examples/Card/BgColor.js
@@ -8,22 +8,20 @@
   'Light',
   'Dark',
 ].map((variant, idx) => (
-  <>
-    <Card
-      bg={variant.toLowerCase()}
-      key={idx}
-      text={variant.toLowerCase() === 'light' ? 'dark' : 'white'}
-      style={{ width: '18rem' }}
-    >
-      <Card.Header>Header</Card.Header>
-      <Card.Body>
-        <Card.Title>{variant} Card Title </Card.Title>
-        <Card.Text>
-          Some quick example text to build on the card title and make up the
-          bulk of the card's content.
-        </Card.Text>
-      </Card.Body>
-    </Card>
-    <br />
-  </>
+  <Card
+    bg={variant.toLowerCase()}
+    key={idx}
+    text={variant.toLowerCase() === 'light' ? 'dark' : 'white'}
+    style={{ width: '18rem' }}
+    className="mb-2"
+  >
+    <Card.Header>Header</Card.Header>
+    <Card.Body>
+      <Card.Title>{variant} Card Title </Card.Title>
+      <Card.Text>
+        Some quick example text to build on the card title and make up the bulk
+        of the card's content.
+      </Card.Text>
+    </Card.Body>
+  </Card>
 ));

--- a/www/src/examples/Dropdown/ButtonSizes.js
+++ b/www/src/examples/Dropdown/ButtonSizes.js
@@ -1,41 +1,37 @@
 <>
   <div className="mb-2">
     {[DropdownButton, SplitButton].map((DropdownType, idx) => (
-      <>
-        <DropdownType
-          as={ButtonGroup}
-          key={idx}
-          id={`dropdown-button-drop-${idx}`}
-          size="lg"
-          title="Drop large"
-        >
-          <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-          <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-          <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
-          <Dropdown.Divider />
-          <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-        </DropdownType>{' '}
-      </>
+      <DropdownType
+        as={ButtonGroup}
+        key={idx}
+        id={`dropdown-button-drop-${idx}`}
+        size="lg"
+        title="Drop large"
+      >
+        <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+        <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+        <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
+        <Dropdown.Divider />
+        <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+      </DropdownType>
     ))}
   </div>
   <div>
     {[DropdownButton, SplitButton].map((DropdownType, idx) => (
-      <>
-        <DropdownType
-          as={ButtonGroup}
-          key={idx}
-          id={`dropdown-button-drop-${idx}`}
-          size="sm"
-          variant="secondary"
-          title="Drop small"
-        >
-          <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-          <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-          <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
-          <Dropdown.Divider />
-          <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-        </DropdownType>{' '}
-      </>
+      <DropdownType
+        as={ButtonGroup}
+        key={idx}
+        id={`dropdown-button-drop-${idx}`}
+        size="sm"
+        variant="secondary"
+        title="Drop small"
+      >
+        <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+        <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+        <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
+        <Dropdown.Divider />
+        <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+      </DropdownType>
     ))}
   </div>
 </>;

--- a/www/src/examples/Dropdown/DropDirections.js
+++ b/www/src/examples/Dropdown/DropDirections.js
@@ -1,42 +1,38 @@
 <>
   <div className="mb-2">
     {['up', 'down', 'left', 'right'].map((direction) => (
-      <>
-        <DropdownButton
-          as={ButtonGroup}
-          key={direction}
-          id={`dropdown-button-drop-${direction}`}
-          drop={direction}
-          variant="secondary"
-          title={` Drop ${direction} `}
-        >
-          <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-          <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-          <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
-          <Dropdown.Divider />
-          <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-        </DropdownButton>{' '}
-      </>
+      <DropdownButton
+        as={ButtonGroup}
+        key={direction}
+        id={`dropdown-button-drop-${direction}`}
+        drop={direction}
+        variant="secondary"
+        title={` Drop ${direction} `}
+      >
+        <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+        <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+        <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
+        <Dropdown.Divider />
+        <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+      </DropdownButton>
     ))}
   </div>
 
   <div>
     {['up', 'down', 'left', 'right'].map((direction) => (
-      <>
-        <SplitButton
-          key={direction}
-          id={`dropdown-button-drop-${direction}`}
-          drop={direction}
-          variant="secondary"
-          title={`Drop ${direction}`}
-        >
-          <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-          <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-          <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
-          <Dropdown.Divider />
-          <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-        </SplitButton>{' '}
-      </>
+      <SplitButton
+        key={direction}
+        id={`dropdown-button-drop-${direction}`}
+        drop={direction}
+        variant="secondary"
+        title={`Drop ${direction}`}
+      >
+        <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+        <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+        <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
+        <Dropdown.Divider />
+        <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+      </SplitButton>
     ))}
   </div>
 </>;

--- a/www/src/examples/Dropdown/SplitVariants.js
+++ b/www/src/examples/Dropdown/SplitVariants.js
@@ -1,22 +1,20 @@
 <>
   {['Primary', 'Secondary', 'Success', 'Info', 'Warning', 'Danger'].map(
     (variant) => (
-      <>
-        <SplitButton
-          key={variant}
-          id={`dropdown-split-variants-${variant}`}
-          variant={variant.toLowerCase()}
-          title={variant}
-        >
-          <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-          <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-          <Dropdown.Item eventKey="3" active>
-            Active Item
-          </Dropdown.Item>
-          <Dropdown.Divider />
-          <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-        </SplitButton>{' '}
-      </>
+      <SplitButton
+        key={variant}
+        id={`dropdown-split-variants-${variant}`}
+        variant={variant.toLowerCase()}
+        title={variant}
+      >
+        <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+        <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+        <Dropdown.Item eventKey="3" active>
+          Active Item
+        </Dropdown.Item>
+        <Dropdown.Divider />
+        <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+      </SplitButton>
     ),
   )}
 </>;

--- a/www/src/examples/Dropdown/Variants.js
+++ b/www/src/examples/Dropdown/Variants.js
@@ -1,23 +1,21 @@
 <>
   {['Primary', 'Secondary', 'Success', 'Info', 'Warning', 'Danger'].map(
     (variant) => (
-      <>
-        <DropdownButton
-          as={ButtonGroup}
-          key={variant}
-          id={`dropdown-variants-${variant}`}
-          variant={variant.toLowerCase()}
-          title={variant}
-        >
-          <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-          <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-          <Dropdown.Item eventKey="3" active>
-            Active Item
-          </Dropdown.Item>
-          <Dropdown.Divider />
-          <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-        </DropdownButton>{' '}
-      </>
+      <DropdownButton
+        as={ButtonGroup}
+        key={variant}
+        id={`dropdown-variants-${variant}`}
+        variant={variant.toLowerCase()}
+        title={variant}
+      >
+        <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+        <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+        <Dropdown.Item eventKey="3" active>
+          Active Item
+        </Dropdown.Item>
+        <Dropdown.Divider />
+        <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+      </DropdownButton>
     ),
   )}
 </>;

--- a/www/src/examples/Form/FormDisabled.js
+++ b/www/src/examples/Form/FormDisabled.js
@@ -1,11 +1,11 @@
 <Form>
   <fieldset disabled>
     <Form.Group>
-      <Form.Label for="disabledTextInput">Disabled input</Form.Label>
+      <Form.Label htmlFor="disabledTextInput">Disabled input</Form.Label>
       <Form.Control id="disabledTextInput" placeholder="Disabled input" />
     </Form.Group>
     <Form.Group>
-      <Form.Label for="disabledSelect">Disabled select menu</Form.Label>
+      <Form.Label htmlFor="disabledSelect">Disabled select menu</Form.Label>
       <Form.Control as="select" id="disabledSelect">
         <option>Disabled select</option>
       </Form.Control>

--- a/www/src/examples/Form/FormText.js
+++ b/www/src/examples/Form/FormText.js
@@ -1,5 +1,5 @@
 <>
-  <Form.Label for="inputPassword5">Password</Form.Label>
+  <Form.Label htmlFor="inputPassword5">Password</Form.Label>
   <Form.Control
     type="password"
     id="inputPassword5"

--- a/www/src/examples/Form/FormTextInline.js
+++ b/www/src/examples/Form/FormTextInline.js
@@ -1,6 +1,6 @@
 <Form inline>
   <Form.Group>
-    <Form.Label for="inputPassword6">Password</Form.Label>
+    <Form.Label htmlFor="inputPassword6">Password</Form.Label>
     <Form.Control
       type="password"
       className="mx-sm-3"

--- a/www/src/examples/Form/GridAutoSizing.js
+++ b/www/src/examples/Form/GridAutoSizing.js
@@ -1,7 +1,7 @@
 <Form>
   <Form.Row className="align-items-center">
     <Col xs="auto">
-      <Form.Label for="inlineFormInput" srOnly>
+      <Form.Label htmlFor="inlineFormInput" srOnly>
         Name
       </Form.Label>
       <Form.Control
@@ -11,7 +11,7 @@
       />
     </Col>
     <Col xs="auto">
-      <Form.Label for="inlineFormInputGroup" srOnly>
+      <Form.Label htmlFor="inlineFormInputGroup" srOnly>
         Username
       </Form.Label>
       <InputGroup className="mb-2">

--- a/www/src/examples/Form/GridAutoSizingColMix.js
+++ b/www/src/examples/Form/GridAutoSizingColMix.js
@@ -1,13 +1,13 @@
 <Form>
   <Form.Row className="align-items-center">
     <Col sm={3} className="my-1">
-      <Form.Label for="inlineFormInputName" srOnly>
+      <Form.Label htmlFor="inlineFormInputName" srOnly>
         Name
       </Form.Label>
       <Form.Control id="inlineFormInputName" placeholder="Jane Doe" />
     </Col>
     <Col sm={3} className="my-1">
-      <Form.Label for="inlineFormInputGroupUsername" srOnly>
+      <Form.Label htmlFor="inlineFormInputGroupUsername" srOnly>
         Username
       </Form.Label>
       <InputGroup>

--- a/www/src/examples/Form/GridAutoSizingCustom.js
+++ b/www/src/examples/Form/GridAutoSizingCustom.js
@@ -1,7 +1,7 @@
 <Form>
   <Form.Row className="align-items-center">
     <Col xs="auto" className="my-1">
-      <Form.Label className="mr-sm-2" for="inlineFormCustomSelect" srOnly>
+      <Form.Label className="mr-sm-2" htmlFor="inlineFormCustomSelect" srOnly>
         Preference
       </Form.Label>
       <Form.Control
@@ -10,7 +10,7 @@
         id="inlineFormCustomSelect"
         custom
       >
-        <option selected>Choose...</option>
+        <option value="0">Choose...</option>
         <option value="1">One</option>
         <option value="2">Two</option>
         <option value="3">Three</option>

--- a/www/src/examples/Form/GridComplex.js
+++ b/www/src/examples/Form/GridComplex.js
@@ -29,7 +29,7 @@
 
     <Form.Group as={Col} controlId="formGridState">
       <Form.Label>State</Form.Label>
-      <Form.Control as="select" value="Choose...">
+      <Form.Control as="select" defaultValue="Choose...">
         <option>Choose...</option>
         <option>...</option>
       </Form.Control>

--- a/www/src/examples/Form/Inline.js
+++ b/www/src/examples/Form/Inline.js
@@ -1,5 +1,5 @@
 <Form inline>
-  <Form.Label for="inlineFormInputName2" srOnly>
+  <Form.Label htmlFor="inlineFormInputName2" srOnly>
     Name
   </Form.Label>
   <Form.Control
@@ -7,7 +7,7 @@
     id="inlineFormInputName2"
     placeholder="Jane Doe"
   />
-  <Form.Label for="inlineFormInputGroupUsername2" srOnly>
+  <Form.Label htmlFor="inlineFormInputGroupUsername2" srOnly>
     Username
   </Form.Label>
   <InputGroup className="mb-2 mr-sm-2">

--- a/www/src/examples/Form/InlineCustom.js
+++ b/www/src/examples/Form/InlineCustom.js
@@ -1,5 +1,5 @@
 <Form inline>
-  <Form.Label className="my-1 mr-2" for="inlineFormCustomSelectPref">
+  <Form.Label className="my-1 mr-2" htmlFor="inlineFormCustomSelectPref">
     Preference
   </Form.Label>
   <Form.Control
@@ -8,7 +8,7 @@
     id="inlineFormCustomSelectPref"
     custom
   >
-    <option selected>Choose...</option>
+    <option value="0">Choose...</option>
     <option value="1">One</option>
     <option value="2">Two</option>
     <option value="3">Three</option>

--- a/www/src/examples/Form/ValidationTooltips.js
+++ b/www/src/examples/Form/ValidationTooltips.js
@@ -32,7 +32,7 @@ function FormExample() {
       }) => (
         <Form noValidate onSubmit={handleSubmit}>
           <Form.Row>
-            <Form.Group as={Col} md="4" controlId="validationFormik01">
+            <Form.Group as={Col} md="4" controlId="validationFormik101">
               <Form.Label>First name</Form.Label>
               <Form.Control
                 type="text"
@@ -43,7 +43,7 @@ function FormExample() {
               />
               <Form.Control.Feedback tooltip>Looks good!</Form.Control.Feedback>
             </Form.Group>
-            <Form.Group as={Col} md="4" controlId="validationFormik02">
+            <Form.Group as={Col} md="4" controlId="validationFormik102">
               <Form.Label>Last name</Form.Label>
               <Form.Control
                 type="text"
@@ -55,7 +55,7 @@ function FormExample() {
 
               <Form.Control.Feedback tooltip>Looks good!</Form.Control.Feedback>
             </Form.Group>
-            <Form.Group as={Col} md="4" controlId="validationFormikUsername">
+            <Form.Group as={Col} md="4" controlId="validationFormikUsername2">
               <Form.Label>Username</Form.Label>
               <InputGroup>
                 <InputGroup.Prepend>
@@ -77,7 +77,7 @@ function FormExample() {
             </Form.Group>
           </Form.Row>
           <Form.Row>
-            <Form.Group as={Col} md="6" controlId="validationFormik03">
+            <Form.Group as={Col} md="6" controlId="validationFormik103">
               <Form.Label>City</Form.Label>
               <Form.Control
                 type="text"
@@ -92,7 +92,7 @@ function FormExample() {
                 {errors.city}
               </Form.Control.Feedback>
             </Form.Group>
-            <Form.Group as={Col} md="3" controlId="validationFormik04">
+            <Form.Group as={Col} md="3" controlId="validationFormik104">
               <Form.Label>State</Form.Label>
               <Form.Control
                 type="text"
@@ -106,7 +106,7 @@ function FormExample() {
                 {errors.state}
               </Form.Control.Feedback>
             </Form.Group>
-            <Form.Group as={Col} md="3" controlId="validationFormik05">
+            <Form.Group as={Col} md="3" controlId="validationFormik105">
               <Form.Label>Zip</Form.Label>
               <Form.Control
                 type="text"
@@ -131,7 +131,7 @@ function FormExample() {
               onChange={handleChange}
               isInvalid={!!errors.file}
               feedback={errors.file}
-              id="validationFormik07"
+              id="validationFormik107"
               feedbackTooltip
             />
           </Form.Group>
@@ -143,7 +143,7 @@ function FormExample() {
               onChange={handleChange}
               isInvalid={!!errors.terms}
               feedback={errors.terms}
-              id="validationFormik06"
+              id="validationFormik106"
               feedbackTooltip
             />
           </Form.Group>

--- a/www/src/examples/Overlays/PopoverPositioned.js
+++ b/www/src/examples/Overlays/PopoverPositioned.js
@@ -1,21 +1,19 @@
 <>
   {['top', 'right', 'bottom', 'left'].map((placement) => (
-    <>
-      <OverlayTrigger
-        trigger="click"
-        key={placement}
-        placement={placement}
-        overlay={
-          <Popover id={`popover-positioned-${placement}`}>
-            <Popover.Title as="h3">{`Popover ${placement}`}</Popover.Title>
-            <Popover.Content>
-              <strong>Holy guacamole!</strong> Check this info.
-            </Popover.Content>
-          </Popover>
-        }
-      >
-        <Button variant="secondary">Popover on {placement}</Button>
-      </OverlayTrigger>{' '}
-    </>
+    <OverlayTrigger
+      trigger="click"
+      key={placement}
+      placement={placement}
+      overlay={
+        <Popover id={`popover-positioned-${placement}`}>
+          <Popover.Title as="h3">{`Popover ${placement}`}</Popover.Title>
+          <Popover.Content>
+            <strong>Holy guacamole!</strong> Check this info.
+          </Popover.Content>
+        </Popover>
+      }
+    >
+      <Button variant="secondary">Popover on {placement}</Button>
+    </OverlayTrigger>
   ))}
 </>;

--- a/www/src/examples/Overlays/TooltipPositioned.js
+++ b/www/src/examples/Overlays/TooltipPositioned.js
@@ -1,17 +1,15 @@
 <>
   {['top', 'right', 'bottom', 'left'].map((placement) => (
-    <>
-      <OverlayTrigger
-        key={placement}
-        placement={placement}
-        overlay={
-          <Tooltip id={`tooltip-${placement}`}>
-            Tooltip on <strong>{placement}</strong>.
-          </Tooltip>
-        }
-      >
-        <Button variant="secondary">Tooltip on {placement}</Button>
-      </OverlayTrigger>{' '}
-    </>
+    <OverlayTrigger
+      key={placement}
+      placement={placement}
+      overlay={
+        <Tooltip id={`tooltip-${placement}`}>
+          Tooltip on <strong>{placement}</strong>.
+        </Tooltip>
+      }
+    >
+      <Button variant="secondary">Tooltip on {placement}</Button>
+    </OverlayTrigger>
   ))}
 </>;


### PR DESCRIPTION
This PR fixes a bunch of console warnings in the docs along with some prop types and doc examples.

Props changes are as follows:
Accordion `children` - Docs was wrong here about enforcing a single child and you can use any node, so I deleted this as it was not needed.

FormCheck, FormCheckInput, FormControl, FormFile, FormFileInput - Removed isRequired since some of the components default it to `false` anyway.
