### PR TITLE
docs: Remove link to nonexistent popover docs page

### DIFF
--- a/www/src/components/SideNav.js
+++ b/www/src/components/SideNav.js
@@ -128,7 +128,6 @@ const components = [
   'navbar',
   'overlays',
   'pagination',
-  'popovers',
   'progress',
   'spinners',
   'table',

--- a/www/src/components/SideNav.js
+++ b/www/src/components/SideNav.js
@@ -132,7 +132,6 @@ const components = [
   'spinners',
   'table',
   'tabs',
-  'tooltips',
   'toasts',
 ];
 


### PR DESCRIPTION
Fixes https://github.com/react-bootstrap/react-bootstrap/issues/5214