### PR TITLE
test(Carousel): Set interval to null for indicator click tests

### DIFF
--- a/test/CarouselSpec.js
+++ b/test/CarouselSpec.js
@@ -57,7 +57,7 @@ describe('<Carousel>', () => {
     }
 
     const wrapper = mount(
-      <Carousel activeIndex={1} onSelect={onSelect}>
+      <Carousel activeIndex={1} onSelect={onSelect} interval={null}>
         {items}
       </Carousel>,
     );
@@ -106,7 +106,11 @@ describe('<Carousel>', () => {
       }
 
       const wrapper = mount(
-        <Carousel defaultActiveIndex={1} {...{ [eventName]: onEvent }}>
+        <Carousel
+          defaultActiveIndex={1}
+          interval={null}
+          {...{ [eventName]: onEvent }}
+        >
           {items}
         </Carousel>,
       );


### PR DESCRIPTION
This might fix all those random test failures we've been seeing with each PR:

AssertionError: expected 2 to equal 0
AssertionError: expected 1 to equal 0

I believe setting interval to null should be ok for these tests here since we are testing the carousel indicators clicks and we don't want it to automatically transition.