### PR TITLE
[types/helpers] add 'this : void' to SelectCallback

### DIFF
--- a/types/components/helpers.d.ts
+++ b/types/components/helpers.d.ts
@@ -39,6 +39,7 @@ export type BsPrefixComponentClass<
 > = React.ComponentClass<ReplaceProps<As, BsPrefixProps<As> & P>>;
 
 export type SelectCallback = (
+  this : void,
   eventKey: string,
   e: React.SyntheticEvent<unknown>,
 ) => void;


### PR DESCRIPTION
Add a 'this : void' parameter to the SelectCallback, indicating to TypeScript
that this callback will overwrite the 'this' context. See [1].

[1]: https://www.typescriptlang.org/docs/handbook/functions.html#this-parameters-in-callbacks