### PR TITLE
feat(OverlayTrigger): expose `show` for manually controlling visibility

### DIFF
--- a/src/ToggleButtonGroup.tsx
+++ b/src/ToggleButtonGroup.tsx
@@ -60,7 +60,7 @@ const propTypes = {
    * is `'radio'` or `'checkbox'`, `onChange` will be called with the value or
    * array of active values
    *
-   * @controllable values
+   * @controllable value
    */
   onChange: PropTypes.func,
 

--- a/test/OverlayTriggerSpec.js
+++ b/test/OverlayTriggerSpec.js
@@ -55,6 +55,27 @@ describe('<OverlayTrigger>', () => {
     callback.should.have.been.called;
   });
 
+  it('Should be controllable', () => {
+    const callback = sinon.spy();
+
+    const wrapper = mount(
+      <OverlayTrigger
+        show
+        trigger="click"
+        onToggle={callback}
+        overlay={<Div className="test" />}
+      >
+        <button type="button">button</button>
+      </OverlayTrigger>,
+    );
+
+    wrapper.assertSingle('div.test');
+
+    wrapper.find('button').simulate('click');
+
+    callback.should.have.been.calledOnce.and.calledWith(false);
+  });
+
   it('Should show after click trigger', () => {
     const wrapper = mount(
       <OverlayTrigger trigger="click" overlay={<Div className="test" />}>


### PR DESCRIPTION
resolves a slew of requests I haven't looked up yet