### PR TITLE
Give displayName to NavContext

### DIFF
--- a/src/NavContext.tsx
+++ b/src/NavContext.tsx
@@ -9,5 +9,6 @@ interface NavContextType {
 }
 
 const NavContext = React.createContext<NavContextType | null>(null);
+NavContext.displayName = 'NavContext';
 
 export default NavContext;


### PR DESCRIPTION
This Merge Request adds `displayName` to `NavContext` to address issue when ParcelJS eliminates identical files when creating a production bundle, similar to #5089.

### The issue
The following `Navbar` doesn't work:
```
<Navbar bg="light" variant="light" className="header">
    <Navbar.Brand className="mr-auto">Alt. Pocket</Navbar.Brand>
    <Nav>
      <NavDropdown title="Actions" id="basic-nav-dropdown">
        {/* a few NavDropdown.Item items */}
      </NavDropdown>
    </Nav>
  </Navbar>
```
It produces an error:
```
react-dom.production.min.js:196 TypeError: x.getControllerId is not a function
    at AbstractNavItem.js:28
    at Si (react-dom.production.min.js:154)
    at lo (react-dom.production.min.js:172)
    at Bo (react-dom.production.min.js:263)
    at Qu (react-dom.production.min.js:230)
    at Bu (react-dom.production.min.js:229)
    at Iu (react-dom.production.min.js:223)
    at react-dom.production.min.js:121
    at exports.unstable_runWithPriority (scheduler.production.min.js:18)
    at ia (react-dom.production.min.js:120)
```
`AbstractNavItem` contains the following code:
```
const navContext = useContext(NavContext);
```
In the production bundle assembled by ParcelJS, `navContext` variable actually refers to an instance of `DropdownContext` from `react-overlays`.
This occurs that the following files are very similar (except for Typescript type definitions):
https://github.com/react-bootstrap/react-overlays/blob/master/src/DropdownContext.ts and https://github.com/react-bootstrap/react-bootstrap/blob/master/src/NavContext.tsx so Parcel leaves only `DropdownContext` and eliminates `NavContext` as a duplicate

### The solution
Similar to #5181 - make `NavContext` different from `DropdownContext`.
