### PR TITLE
Remove Role Attribute From SafeAnchor Component

### DIFF
--- a/src/SafeAnchor.tsx
+++ b/src/SafeAnchor.tsx
@@ -29,7 +29,7 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-function isTrivialHref(href) {
+function isTrivialHref(href?: string) {
   return !href || href.trim() === '#';
 }
 
@@ -75,11 +75,10 @@ const SafeAnchor: SafeAnchor = React.forwardRef(
       }
     };
 
-    if (isTrivialHref(props.href)) {
-      props.role = props.role || 'button';
+    if (!props.href) {
       // we want to make sure there is a href attribute on the node
-      // otherwise, the cursor incorrectly styled (except with role='button')
-      props.href = props.href || '#';
+      // otherwise, the cursor incorrectly styled
+      props.href = '#';
     }
 
     if (disabled) {


### PR DESCRIPTION
Added a type definition to the "isTrivialHref" method's argument.

Removed the use of the "isTrivialHref" in some conditional logic and replaced it with a falsy value detection for the "href" prop.

Removed the assignment of the "role" prop from this conditional logic and simplified the remaining statement to not include a falsy dedection since it will now be redundant.