### PR TITLE
v5: Add fullscreen modal support

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -39,7 +39,7 @@ export interface ModalProps
     | 'backdropTransition'
   > {
   size?: 'sm' | 'lg' | 'xl';
-  fullScreen?: true | 'sm' | 'md' | 'lg' | 'xl';
+  fullscreen?: true | 'sm-down' | 'md-down' | 'lg-down' | 'xl-down';
   bsPrefix?: string;
   centered?: boolean;
   backdropClassName?: string;
@@ -78,9 +78,9 @@ const propTypes = {
    * Renders a fullscreen modal. Specifying a breakpoint will render the modal
    * as fullscreen __below__ the breakpoint size.
    *
-   * @type (true|'sm'|'md'|'lg'|'xl')
+   * @type (true|'sm-down'|'md-down'|'lg-down'|'xl-down')
    */
-  fullScreen: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  fullscreen: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 
   /**
    * vertically center the Dialog in the window

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -39,6 +39,7 @@ export interface ModalProps
     | 'backdropTransition'
   > {
   size?: 'sm' | 'lg' | 'xl';
+  fullScreen?: true | 'sm' | 'md' | 'lg' | 'xl';
   bsPrefix?: string;
   centered?: boolean;
   backdropClassName?: string;
@@ -69,9 +70,17 @@ const propTypes = {
   /**
    * Render a large, extra large or small modal.
    *
-   * @type ('sm'|'lg','xl')
+   * @type ('sm'|'lg'|'xl')
    */
   size: PropTypes.string,
+
+  /**
+   * Renders a fullscreen modal. Specifying a breakpoint will render the modal
+   * as fullscreen __below__ the breakpoint size.
+   *
+   * @type (true|'sm'|'md'|'lg'|'xl')
+   */
+  fullScreen: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 
   /**
    * vertically center the Dialog in the window

--- a/src/ModalDialog.tsx
+++ b/src/ModalDialog.tsx
@@ -10,7 +10,7 @@ export interface ModalDialogProps
   extends React.HTMLAttributes<HTMLDivElement>,
     BsPrefixPropsWithChildren {
   size?: 'sm' | 'lg' | 'xl';
-  fullScreen?: true | 'sm' | 'md' | 'lg' | 'xl';
+  fullscreen?: true | 'sm-down' | 'md-down' | 'lg-down' | 'xl-down';
   centered?: boolean;
   scrollable?: boolean;
 }
@@ -30,9 +30,9 @@ const propTypes = {
    * Renders a fullscreen modal. Specifying a breakpoint will render the modal
    * as fullscreen __below__ the breakpoint size.
    *
-   * @type (true|'sm'|'md'|'lg'|'xl')
+   * @type (true|'sm-down'|'md-down'|'lg-down'|'xl-down')
    */
-  fullScreen: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
+  fullscreen: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 
   /**
    * Specify whether the Component should be vertically centered
@@ -52,7 +52,7 @@ const ModalDialog = React.forwardRef<HTMLDivElement, ModalDialogProps>(
       className,
       centered,
       size,
-      fullScreen,
+      fullscreen,
       children,
       scrollable,
       ...props
@@ -62,13 +62,10 @@ const ModalDialog = React.forwardRef<HTMLDivElement, ModalDialogProps>(
     bsPrefix = useBootstrapPrefix(bsPrefix, 'modal');
     const dialogClass = `${bsPrefix}-dialog`;
 
-    let fullScreenClass: string | undefined;
-    if (fullScreen) {
-      fullScreenClass =
-        fullScreen === true
-          ? `${bsPrefix}-fullscreen`
-          : `${bsPrefix}-fullscreen-${fullScreen}-down`;
-    }
+    const fullScreenClass =
+      typeof fullscreen === 'string'
+        ? `${bsPrefix}-fullscreen-${fullscreen}`
+        : `${bsPrefix}-fullscreen`;
 
     return (
       <div
@@ -80,7 +77,7 @@ const ModalDialog = React.forwardRef<HTMLDivElement, ModalDialogProps>(
           size && `${bsPrefix}-${size}`,
           centered && `${dialogClass}-centered`,
           scrollable && `${dialogClass}-scrollable`,
-          fullScreenClass,
+          fullscreen && fullScreenClass,
         )}
       >
         <div className={`${bsPrefix}-content`}>{children}</div>

--- a/src/ModalDialog.tsx
+++ b/src/ModalDialog.tsx
@@ -10,6 +10,7 @@ export interface ModalDialogProps
   extends React.HTMLAttributes<HTMLDivElement>,
     BsPrefixPropsWithChildren {
   size?: 'sm' | 'lg' | 'xl';
+  fullScreen?: true | 'sm' | 'md' | 'lg' | 'xl';
   centered?: boolean;
   scrollable?: boolean;
 }
@@ -24,6 +25,14 @@ const propTypes = {
    * @type ('sm'|'lg','xl')
    */
   size: PropTypes.string,
+
+  /**
+   * Renders a fullscreen modal. Specifying a breakpoint will render the modal
+   * as fullscreen __below__ the breakpoint size.
+   *
+   * @type (true|'sm'|'md'|'lg'|'xl')
+   */
+  fullScreen: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 
   /**
    * Specify whether the Component should be vertically centered
@@ -43,6 +52,7 @@ const ModalDialog = React.forwardRef<HTMLDivElement, ModalDialogProps>(
       className,
       centered,
       size,
+      fullScreen,
       children,
       scrollable,
       ...props
@@ -51,6 +61,14 @@ const ModalDialog = React.forwardRef<HTMLDivElement, ModalDialogProps>(
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'modal');
     const dialogClass = `${bsPrefix}-dialog`;
+
+    let fullScreenClass: string | undefined;
+    if (fullScreen) {
+      fullScreenClass =
+        fullScreen === true
+          ? `${bsPrefix}-fullscreen`
+          : `${bsPrefix}-fullscreen-${fullScreen}-down`;
+    }
 
     return (
       <div
@@ -62,6 +80,7 @@ const ModalDialog = React.forwardRef<HTMLDivElement, ModalDialogProps>(
           size && `${bsPrefix}-${size}`,
           centered && `${dialogClass}-centered`,
           scrollable && `${dialogClass}-scrollable`,
+          fullScreenClass,
         )}
       >
         <div className={`${bsPrefix}-content`}>{children}</div>

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -161,6 +161,22 @@ describe('<Modal>', () => {
     ).find('.modal-dialog.modal-sm');
   });
 
+  it('Should pass fullScreen as bool to the dialog', () => {
+    mount(
+      <Modal show fullScreen>
+        <strong>Message</strong>
+      </Modal>,
+    ).assertSingle('.modal-dialog.modal-fullscreen');
+  });
+
+  it('Should pass fullScreen as string to the dialog', () => {
+    mount(
+      <Modal show fullScreen="sm">
+        <strong>Message</strong>
+      </Modal>,
+    ).assertSingle('.modal-dialog.modal-fullscreen-sm-down');
+  });
+
   it('Should pass dialog style to the dialog', () => {
     const noOp = () => {};
     const dialog = mount(

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -161,17 +161,17 @@ describe('<Modal>', () => {
     ).find('.modal-dialog.modal-sm');
   });
 
-  it('Should pass fullScreen as bool to the dialog', () => {
+  it('Should pass fullscreen as bool to the dialog', () => {
     mount(
-      <Modal show fullScreen>
+      <Modal show fullscreen>
         <strong>Message</strong>
       </Modal>,
     ).assertSingle('.modal-dialog.modal-fullscreen');
   });
 
-  it('Should pass fullScreen as string to the dialog', () => {
+  it('Should pass fullscreen as string to the dialog', () => {
     mount(
-      <Modal show fullScreen="sm">
+      <Modal show fullscreen="sm-down">
         <strong>Message</strong>
       </Modal>,
     ).assertSingle('.modal-dialog.modal-fullscreen-sm-down');

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -685,16 +685,16 @@ const MegaComponent = () => (
         <Button variant="primary">Save Changes</Button>
       </Modal.Footer>
     </Modal>
-    <Modal fullScreen />
-    <Modal fullScreen="sm" />
-    <Modal fullScreen="md" />
-    <Modal fullScreen="lg" />
-    <Modal fullScreen="xl" />
-    <Modal.Dialog fullScreen />
-    <Modal.Dialog fullScreen="sm" />
-    <Modal.Dialog fullScreen="md" />
-    <Modal.Dialog fullScreen="lg" />
-    <Modal.Dialog fullScreen="xl" />
+    <Modal fullscreen />
+    <Modal fullscreen="sm-down" />
+    <Modal fullscreen="md-down" />
+    <Modal fullscreen="lg-down" />
+    <Modal fullscreen="xl-down" />
+    <Modal.Dialog fullscreen />
+    <Modal.Dialog fullscreen="sm-down" />
+    <Modal.Dialog fullscreen="md-down" />
+    <Modal.Dialog fullscreen="lg-down" />
+    <Modal.Dialog fullscreen="xl-down" />
     <Modal.Dialog
       centered
       scrollable

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -685,6 +685,16 @@ const MegaComponent = () => (
         <Button variant="primary">Save Changes</Button>
       </Modal.Footer>
     </Modal>
+    <Modal fullScreen />
+    <Modal fullScreen="sm" />
+    <Modal fullScreen="md" />
+    <Modal fullScreen="lg" />
+    <Modal fullScreen="xl" />
+    <Modal.Dialog fullScreen />
+    <Modal.Dialog fullScreen="sm" />
+    <Modal.Dialog fullScreen="md" />
+    <Modal.Dialog fullScreen="lg" />
+    <Modal.Dialog fullScreen="xl" />
     <Modal.Dialog
       centered
       scrollable

--- a/www/src/examples/Modal/FullScreen.js
+++ b/www/src/examples/Modal/FullScreen.js
@@ -1,10 +1,10 @@
 function Example() {
-  const values = [true, 'sm', 'md', 'lg', 'xl'];
-  const [fullScreen, setFullScreen] = useState(true);
+  const values = [true, 'sm-down', 'md-down', 'lg-down', 'xl-down'];
+  const [fullscreen, setFullscreen] = useState(true);
   const [show, setShow] = useState(false);
 
   function handleShow(breakpoint) {
-    setFullScreen(breakpoint);
+    setFullscreen(breakpoint);
     setShow(true);
   }
 
@@ -13,10 +13,10 @@ function Example() {
       {values.map((v, idx) => (
         <Button key={idx} className="mr-2" onClick={() => handleShow(v)}>
           Full screen
-          {typeof v === 'string' && `below ${v}`}
+          {typeof v === 'string' && `below ${v.split('-')[0]}`}
         </Button>
       ))}
-      <Modal show={show} fullScreen={fullScreen} onHide={() => setShow(false)}>
+      <Modal show={show} fullscreen={fullscreen} onHide={() => setShow(false)}>
         <Modal.Header closeButton>
           <Modal.Title>Modal</Modal.Title>
         </Modal.Header>

--- a/www/src/examples/Modal/FullScreen.js
+++ b/www/src/examples/Modal/FullScreen.js
@@ -1,0 +1,29 @@
+function Example() {
+  const values = [true, 'sm', 'md', 'lg', 'xl'];
+  const [fullScreen, setFullScreen] = useState(true);
+  const [show, setShow] = useState(false);
+
+  function handleShow(breakpoint) {
+    setFullScreen(breakpoint);
+    setShow(true);
+  }
+
+  return (
+    <>
+      {values.map((v, idx) => (
+        <Button key={idx} className="mr-2" onClick={() => handleShow(v)}>
+          Full screen
+          {typeof v === 'string' && `below ${v}`}
+        </Button>
+      ))}
+      <Modal show={show} fullScreen={fullScreen} onHide={() => setShow(false)}>
+        <Modal.Header closeButton>
+          <Modal.Title>Modal</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>Modal body content</Modal.Body>
+      </Modal>
+    </>
+  );
+}
+
+render(<Example />);

--- a/www/src/pages/components/modal.js
+++ b/www/src/pages/components/modal.js
@@ -10,6 +10,7 @@ import ModalStatic from '../../examples/Modal/Static';
 import ModalBasic from '../../examples/Modal/Basic';
 import ModalStaticBackdrop from '../../examples/Modal/StaticBackdrop';
 import ModalDefaultSizing from '../../examples/Modal/DefaultSizing';
+import ModalFullScreen from '../../examples/Modal/FullScreen';
 import ModalCustomSizing from '../../examples/Modal/CustomSizing';
 import ModalVerticallyCentered from '../../examples/Modal/VerticallyCentered';
 import ModalWithoutAnimation from '../../examples/Modal/WithoutAnimation';
@@ -131,10 +132,20 @@ export default withLayout(function ModalSection({ data }) {
         Optional Sizes
       </LinkedHeading>
       <p>
-        You can specify a bootstrap large or small modal by using the "size"
-        prop.
+        You can specify a bootstrap large or small modal by using the{' '}
+        <code>size</code> prop.
       </p>
       <ReactPlayground codeText={ModalDefaultSizing} />
+
+      <LinkedHeading h="3" id="modal-fullscreen">
+        Fullscreen Modal
+      </LinkedHeading>
+      <p>
+        You can use the <code>fullScreen</code> prop to make the modal
+        fullscreen. Specifying a breakpoint will only set the modal as
+        fullscreen <b>below</b> the breakpoint size.
+      </p>
+      <ReactPlayground codeText={ModalFullScreen} />
 
       <LinkedHeading h="3" id="modal-custom-sizing">
         Sizing modals using custom CSS

--- a/www/src/pages/components/modal.js
+++ b/www/src/pages/components/modal.js
@@ -141,7 +141,7 @@ export default withLayout(function ModalSection({ data }) {
         Fullscreen Modal
       </LinkedHeading>
       <p>
-        You can use the <code>fullScreen</code> prop to make the modal
+        You can use the <code>fullscreen</code> prop to make the modal
         fullscreen. Specifying a breakpoint will only set the modal as
         fullscreen <b>below</b> the breakpoint size.
       </p>


### PR DESCRIPTION
Adds prop `fullScreen` which supports `true` or breakpoints `sm` and up.

https://v5.getbootstrap.com/docs/5.0/components/modal/#fullscreen-modal