### PR TITLE
fix(docs): type mismatch with environment variable

### DIFF
--- a/www/src/components/DocsAlert.js
+++ b/www/src/components/DocsAlert.js
@@ -11,7 +11,7 @@ export default function DocsAlert() {
         <Row>
           <Alert variant="warning" className="w-100">
             You are currently viewing the auto-generated docs from{' '}
-            {netlify.pullRequest ? (
+            {netlify.pullRequest === 'true' ? (
               <span>
                 a{' '}
                 <Alert.Link
@@ -21,7 +21,9 @@ export default function DocsAlert() {
                 </Alert.Link>
               </span>
             ) : (
-              <span>the {netlify.branch} branch</span>
+              <span>
+                the <b>{netlify.branch}</b> branch
+              </span>
             )}
             . The docs for the current release are available at{' '}
             <Alert.Link href="https://react-bootstrap.github.io/">


### PR DESCRIPTION
The classic issue of checking a string as if it was a boolean
value.

Also comes with a styling change to put more of an emphasis on
the branch name (when it is being specified).