### PR TITLE
Fix NavDropdown alignRight failing typescript check.

### DIFF
--- a/src/NavDropdown.tsx
+++ b/src/NavDropdown.tsx
@@ -5,12 +5,10 @@ import Dropdown, { DropdownProps } from './Dropdown';
 import NavItem from './NavItem';
 import NavLink from './NavLink';
 import { BsPrefixRefForwardingComponent } from './helpers';
-import { PropsFromToggle } from './DropdownToggle';
 
 export interface NavDropdownProps
   extends DropdownProps,
-    Omit<React.HTMLAttributes<HTMLElement>, 'onSelect' | 'title'>,
-    React.PropsWithChildren<PropsFromToggle> {
+    Omit<React.HTMLAttributes<HTMLElement>, 'onSelect' | 'title'> {
   id: string;
   title: React.ReactNode;
   disabled?: boolean;
@@ -76,9 +74,6 @@ const NavDropdown: NavDropdown = (React.forwardRef(
       disabled,
       active,
       renderMenuOnMount,
-      href,
-      size,
-      variant,
       ...props
     }: NavDropdownProps,
     ref,
@@ -91,9 +86,6 @@ const NavDropdown: NavDropdown = (React.forwardRef(
         disabled={disabled}
         childBsPrefix={bsPrefix}
         as={NavLink}
-        href={href}
-        size={size}
-        variant={variant}
       >
         {title}
       </Dropdown.Toggle>

--- a/src/NavDropdown.tsx
+++ b/src/NavDropdown.tsx
@@ -1,15 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Dropdown from './Dropdown';
+import Dropdown, { DropdownProps } from './Dropdown';
 import NavItem from './NavItem';
 import NavLink from './NavLink';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixRefForwardingComponent } from './helpers';
 
-export interface NavDropdownProps extends BsPrefixPropsWithChildren {
+export interface NavDropdownProps extends DropdownProps {
   id: string;
   title: React.ReactNode;
   disabled?: boolean;

--- a/src/NavDropdown.tsx
+++ b/src/NavDropdown.tsx
@@ -5,8 +5,12 @@ import Dropdown, { DropdownProps } from './Dropdown';
 import NavItem from './NavItem';
 import NavLink from './NavLink';
 import { BsPrefixRefForwardingComponent } from './helpers';
+import { PropsFromToggle } from './DropdownToggle';
 
-export interface NavDropdownProps extends DropdownProps {
+export interface NavDropdownProps
+  extends DropdownProps,
+    Omit<React.HTMLAttributes<HTMLElement>, 'onSelect' | 'title'>,
+    React.PropsWithChildren<PropsFromToggle> {
   id: string;
   title: React.ReactNode;
   disabled?: boolean;
@@ -72,6 +76,9 @@ const NavDropdown: NavDropdown = (React.forwardRef(
       disabled,
       active,
       renderMenuOnMount,
+      href,
+      size,
+      variant,
       ...props
     }: NavDropdownProps,
     ref,
@@ -84,6 +91,9 @@ const NavDropdown: NavDropdown = (React.forwardRef(
         disabled={disabled}
         childBsPrefix={bsPrefix}
         as={NavLink}
+        href={href}
+        size={size}
+        variant={variant}
       >
         {title}
       </Dropdown.Toggle>

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -754,9 +754,6 @@ const MegaComponent = () => (
         onSelect={noop}
         focusFirstItemOnShow
         navbar
-        href="#"
-        size="sm"
-        variant="light"
       >
         <NavDropdown.Item eventKey="4.1">Action</NavDropdown.Item>
         <NavDropdown.Item eventKey="4.2">Another action</NavDropdown.Item>

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -754,6 +754,9 @@ const MegaComponent = () => (
         onSelect={noop}
         focusFirstItemOnShow
         navbar
+        href="#"
+        size="sm"
+        variant="light"
       >
         <NavDropdown.Item eventKey="4.1">Action</NavDropdown.Item>
         <NavDropdown.Item eventKey="4.2">Another action</NavDropdown.Item>

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -746,6 +746,14 @@ const MegaComponent = () => (
         id="nav-dropdown"
         bsPrefix="prefix"
         style={style}
+        drop="up"
+        alignRight
+        show
+        flip={false}
+        onToggle={noop}
+        onSelect={noop}
+        focusFirstItemOnShow
+        navbar
       >
         <NavDropdown.Item eventKey="4.1">Action</NavDropdown.Item>
         <NavDropdown.Item eventKey="4.2">Another action</NavDropdown.Item>


### PR DESCRIPTION
Fixes issue #5339 
I changed the `NavDropdownProps` to extends from `DropdownProps` instead of `BsPrefixPropsWithChildren`. This way it will include all of Dropdown's props.