### PR TITLE
v5: Add FormRange component

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -6,6 +6,7 @@ import FormFile from './FormFile';
 import FormControl from './FormControl';
 import FormGroup from './FormGroup';
 import FormLabel from './FormLabel';
+import FormRange from './FormRange';
 import FormSelect from './FormSelect';
 import FormText from './FormText';
 import Switch from './Switch';
@@ -31,6 +32,7 @@ type Form = BsPrefixRefForwardingComponent<'form', FormProps> & {
   Switch: typeof Switch;
   Label: typeof FormLabel;
   Text: typeof FormText;
+  Range: typeof FormRange;
   Select: typeof FormSelect;
 };
 
@@ -108,6 +110,7 @@ FormImpl.File = FormFile;
 FormImpl.Switch = Switch;
 FormImpl.Label = FormLabel;
 FormImpl.Text = FormText;
+FormImpl.Range = FormRange;
 FormImpl.Select = FormSelect;
 
 export default FormImpl;

--- a/src/FormControl.tsx
+++ b/src/FormControl.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import all from 'prop-types-extra/lib/all';
 import React, { useContext } from 'react';
 import warning from 'warning';
 import Feedback from './Feedback';
@@ -11,7 +10,6 @@ import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 type FormControlElement = HTMLInputElement | HTMLTextAreaElement;
 
 export interface FormControlProps extends BsPrefixProps {
-  bsCustomPrefix?: string;
   htmlSize?: number;
   size?: 'sm' | 'lg';
   plaintext?: boolean;
@@ -19,7 +17,6 @@ export interface FormControlProps extends BsPrefixProps {
   disabled?: boolean;
   value?: string | string[] | number;
   onChange?: React.ChangeEventHandler<FormControlElement>;
-  custom?: boolean;
   type?: string;
   id?: string;
   isValid?: boolean;
@@ -31,13 +28,6 @@ const propTypes = {
    * @default {'form-control'}
    */
   bsPrefix: PropTypes.string,
-
-  /**
-   * A seperate bsPrefix used for custom controls
-   *
-   * @default 'custom'
-   */
-  bsCustomPrefix: PropTypes.string,
 
   /**
    * The FormControl `ref` will be forwarded to the underlying input element,
@@ -94,18 +84,6 @@ const propTypes = {
   onChange: PropTypes.func,
 
   /**
-   * Use Bootstrap's custom form elements to replace the browser defaults
-   * @type boolean
-   */
-  custom: all(PropTypes.bool, ({ type, custom }) =>
-    custom === true && type !== 'range'
-      ? Error(
-          '`custom` can only be set to `true` when the input type is `range`',
-        )
-      : null,
-  ),
-
-  /**
    * The HTML input `type`, which is only relevant if `as` is `'input'` (the default).
    */
   type: PropTypes.string,
@@ -129,7 +107,6 @@ const FormControl: BsPrefixRefForwardingComponent<
   (
     {
       bsPrefix,
-      bsCustomPrefix,
       type,
       size,
       htmlSize,
@@ -139,7 +116,6 @@ const FormControl: BsPrefixRefForwardingComponent<
       isInvalid = false,
       plaintext,
       readOnly,
-      custom,
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'input',
       ...props
@@ -147,19 +123,14 @@ const FormControl: BsPrefixRefForwardingComponent<
     ref,
   ) => {
     const { controlId } = useContext(FormContext);
-    const [prefix, defaultPrefix] = custom
-      ? [bsCustomPrefix, 'custom']
-      : [bsPrefix, 'form-control'];
 
-    bsPrefix = useBootstrapPrefix(prefix, defaultPrefix);
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'form-control');
 
     let classes;
     if (plaintext) {
       classes = { [`${bsPrefix}-plaintext`]: true };
     } else if (type === 'file') {
       classes = { [`${bsPrefix}-file`]: true };
-    } else if (type === 'range') {
-      classes = { [`${bsPrefix}-range`]: true };
     } else {
       classes = {
         [bsPrefix]: true,

--- a/src/FormRange.tsx
+++ b/src/FormRange.tsx
@@ -1,0 +1,59 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { useBootstrapPrefix } from './ThemeProvider';
+import {
+  BsPrefixAndClassNameOnlyProps,
+  BsPrefixRefForwardingComponent,
+} from './helpers';
+
+export interface FormRangeProps
+  extends BsPrefixAndClassNameOnlyProps,
+    React.InputHTMLAttributes<HTMLInputElement> {}
+
+const propTypes = {
+  /**
+   * @default {'form-range'}
+   */
+  bsPrefix: PropTypes.string,
+
+  /** Make the control disabled */
+  disabled: PropTypes.bool,
+
+  /**
+   * The `value` attribute of underlying input
+   *
+   * @controllable onChange
+   * */
+  value: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.number,
+  ]),
+
+  /** A callback fired when the `value` prop changes */
+  onChange: PropTypes.func,
+};
+
+const FormRange: BsPrefixRefForwardingComponent<
+  'input',
+  FormRangeProps
+> = React.forwardRef<HTMLInputElement, FormRangeProps>(
+  ({ bsPrefix, className, ...props }, ref) => {
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'form-range');
+
+    return (
+      <input
+        {...props}
+        type="range"
+        ref={ref}
+        className={classNames(className, bsPrefix)}
+      />
+    );
+  },
+);
+
+FormRange.displayName = 'FormRange';
+FormRange.propTypes = propTypes;
+
+export default FormRange;

--- a/test/FormControlSpec.js
+++ b/test/FormControlSpec.js
@@ -23,18 +23,6 @@ describe('<FormControl>', () => {
       .assertNone('.form-control');
   });
 
-  it('should support type=range', () => {
-    mount(<FormControl type="range" />)
-      .assertSingle('[type="range"].form-control-range')
-      .assertNone('.form-control');
-  });
-
-  it('should support custom type=range', () => {
-    mount(<FormControl type="range" custom />)
-      .assertSingle('[type="range"].custom-range')
-      .assertNone('.form-control-range')
-      .assertNone('.form-control');
-  });
   it('should support plaintext inputs', () => {
     mount(<FormControl plaintext />).assertSingle(
       'input.form-control-plaintext',

--- a/test/FormRangeSpec.js
+++ b/test/FormRangeSpec.js
@@ -1,0 +1,12 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import FormRange from '../src/FormRange';
+
+describe('<FormRange>', () => {
+  it('should render correctly', () => {
+    mount(
+      <FormRange id="foo" name="bar" className="my-control" />,
+    ).assertSingle('input#foo.form-range.my-control[type="range"][name="bar"]');
+  });
+});

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -393,7 +393,6 @@ const MegaComponent = () => (
         />
         <Form.Control
           as="input"
-          custom
           disabled
           htmlSize={1}
           id="id"
@@ -442,6 +441,15 @@ const MegaComponent = () => (
           />
           <Form.Check.Label htmlFor="for" bsPrefix="formlabel" style={style} />
         </Form.Check>
+        <Form.Range
+          bsPrefix="prefix"
+          ref={React.createRef<HTMLInputElement>()}
+          min={0}
+          max={100}
+          value={50}
+          className="class"
+          style={style}
+        />
       </Form.Group>
       <Form.Group controlId="exampleForm.ControlSelect1">
         <Form.Label>Example select</Form.Label>

--- a/www/src/examples/Form/Range.js
+++ b/www/src/examples/Form/Range.js
@@ -1,6 +1,4 @@
-<Form>
-  <Form.Group controlId="formBasicRange">
-    <Form.Label>Range</Form.Label>
-    <Form.Control type="range" />
-  </Form.Group>
-</Form>;
+<>
+  <Form.Label>Range</Form.Label>
+  <Form.Range />
+</>;

--- a/www/src/examples/Form/RangeCustom.js
+++ b/www/src/examples/Form/RangeCustom.js
@@ -1,6 +1,0 @@
-<Form>
-  <Form.Group controlId="formBasicRangeCustom">
-    <Form.Label>Range</Form.Label>
-    <Form.Control type="range" custom />
-  </Form.Group>
-</Form>;

--- a/www/src/pages/components/forms.js
+++ b/www/src/pages/components/forms.js
@@ -30,7 +30,6 @@ import NoLabels from '../../examples/Form/NoLabels';
 import Plaintext from '../../examples/Form/Plaintext';
 import Switch from '../../examples/Form/Switch';
 import Range from '../../examples/Form/Range';
-import RangeCustom from '../../examples/Form/RangeCustom';
 import SelectBasic from '../../examples/Form/SelectBasic';
 import SelectSizes from '../../examples/Form/SelectSizes';
 import File from '../../examples/Form/File';
@@ -116,10 +115,6 @@ export default withLayout(function FormControlsSection({ data }) {
         default form field styling and preserve the correct margin and padding.
       </p>
       <ReactPlayground codeText={Plaintext} />
-      <LinkedHeading h="2" id="forms-range">
-        Range Inputs
-      </LinkedHeading>
-      <ReactPlayground codeText={Range} />
       <LinkedHeading h="2" id="forms-form-check">
         Checkboxes and Radios
       </LinkedHeading>
@@ -156,11 +151,9 @@ export default withLayout(function FormControlsSection({ data }) {
         </strong>
       </p>
       <ReactPlayground codeText={NoLabels} />
-
       <LinkedHeading h="3" id="forms-check-api">
         Customizing FormCheck rendering
       </LinkedHeading>
-
       <p>
         When you need tighter control, or want to customize how the{' '}
         <code>FormCheck</code> component renders, it may better to use it's
@@ -173,7 +166,15 @@ export default withLayout(function FormControlsSection({ data }) {
         <code>FormGroup</code> and have it propagate to the label and input).
       </p>
       <ReactPlayground codeText={CheckApi} />
-
+      <LinkedHeading h="2" id="forms-range">
+        Range
+      </LinkedHeading>
+      Create custom <code>{'<input type="range">'}</code> controls with
+      <code>{'<FormRange>'}</code>. The track (the background) and thumb (the
+      value) are both styled to appear the same across browsers. As only Firefox
+      supports “filling” their track from the left or right of the thumb as a
+      means to visually indicate progress, we do not currently support it.
+      <ReactPlayground codeText={Range} />
       <LinkedHeading h="2" id="forms-select">
         Select
       </LinkedHeading>
@@ -186,7 +187,6 @@ export default withLayout(function FormControlsSection({ data }) {
         similarly sized text inputs.
       </p>
       <ReactPlayground codeText={SelectSizes} />
-
       <LinkedHeading h="2" id="forms-layout">
         Layout
       </LinkedHeading>
@@ -427,7 +427,6 @@ export default withLayout(function FormControlsSection({ data }) {
         <code>{'<form>'}</code> element.
       </Callout>
       <ReactPlayground codeText={ValidationNative} />
-
       <LinkedHeading h="3" id="forms-validation-libraries">
         Form libraries and server-rendered styles
       </LinkedHeading>
@@ -440,7 +439,6 @@ export default withLayout(function FormControlsSection({ data }) {
         <a href="https://github.com/jaredpalmer/formik">Formik</a>.
       </p>
       <ReactPlayground codeText={ValidationFormik} />
-
       <LinkedHeading h="3" id="forms-validation-tooltips">
         Tooltips
       </LinkedHeading>
@@ -452,11 +450,9 @@ export default withLayout(function FormControlsSection({ data }) {
         but your project may require an alternative setup.
       </p>
       <ReactPlayground codeText={ValidationTooltips} />
-
       <LinkedHeading h="3" id="forms-validation-examples">
         Examples
       </LinkedHeading>
-
       <LinkedHeading h="2" id="forms-custom">
         Custom forms
       </LinkedHeading>
@@ -466,7 +462,6 @@ export default withLayout(function FormControlsSection({ data }) {
         built on top of semantic and accessible markup, so they’re solid
         replacements for any default form control.
       </p>
-
       <LinkedHeading h="3" id="forms-custom-switch">
         Switches
       </LinkedHeading>
@@ -475,26 +470,11 @@ export default withLayout(function FormControlsSection({ data }) {
         <code>type="switch"</code> to render a toggle switch. Switches also
         support the same customizable children as <code>{'<FormCheck>'}</code>.
       </p>
-
       <ReactPlayground codeText={Switch} />
       <Callout>
         You can also use the <code>{'<Form.Switch>'}</code> alias which
         encapsulates the above, in a very small component wrapper.
       </Callout>
-
-      <LinkedHeading h="3" id="forms-custom-range">
-        Range
-      </LinkedHeading>
-      <p>
-        For the <code>range</code> form control you can pass the{' '}
-        <code>custom</code> prop to get custom styling of the select element.
-        The track (the background) and thumb (the value) are both styled to
-        appear the same across browsers. As only IE and Firefox support
-        “filling” their track from the left or right of the thumb as a means to
-        visually indicate progress, we do not currently support it.
-      </p>
-      <ReactPlayground codeText={RangeCustom} />
-
       <LinkedHeading h="3" id="forms-custom-file">
         File
       </LinkedHeading>
@@ -509,7 +489,6 @@ export default withLayout(function FormControlsSection({ data }) {
         .
       </Callout>
       <ReactPlayground codeText={File} />
-
       <h4>Translating or customizing the strings with HTML</h4>
       <p>
         Bootstrap also provides a way to translate the “Browse” text in HTML
@@ -521,7 +500,6 @@ export default withLayout(function FormControlsSection({ data }) {
         unless the <code>custom</code> prop is set.
       </Callout>
       <ReactPlayground codeText={FileButtonTextHTML} />
-
       <h4>Translating or customizing the strings with SCSS</h4>
       <p>
         Please refer to the official{' '}
@@ -531,7 +509,6 @@ export default withLayout(function FormControlsSection({ data }) {
         . The <code>lang</code> prop can be used to pass the language.
       </p>
       <ReactPlayground codeText={FileButtonTextScss} />
-
       <h4>Customizing FormFile rendering</h4>
       <p>
         When you need tighter control, or want to customize how the{' '}
@@ -563,7 +540,6 @@ export default withLayout(function FormControlsSection({ data }) {
         </ul>
       </Callout>
       <ReactPlayground codeText={FileApi} />
-
       <LinkedHeading h="2" id="forms-api">
         API
       </LinkedHeading>
@@ -586,6 +562,7 @@ export default withLayout(function FormControlsSection({ data }) {
       <ComponentApi metadata={data.FormFile} exportedBy={data.Form} />
       <ComponentApi metadata={data.FormFileInput} exportedBy={data.FormFile} />
       <ComponentApi metadata={data.FormFileLabel} exportedBy={data.FormFile} />
+      <ComponentApi metadata={data.FormRange} exportedBy={data.Form} />
       <ComponentApi metadata={data.FormSelect} exportedBy={data.Form} />
     </>
   );
@@ -630,6 +607,9 @@ export const query = graphql`
       ...ComponentApi_metadata
     }
     FormFileLabel: componentMetadata(displayName: { eq: "FormFileLabel" }) {
+      ...ComponentApi_metadata
+    }
+    FormRange: componentMetadata(displayName: { eq: "FormRange" }) {
       ...ComponentApi_metadata
     }
     FormSelect: componentMetadata(displayName: { eq: "FormSelect" }) {


### PR DESCRIPTION
V5 combines native and custom ranges.

Changes:

- Create new `FormRange` component - v5 no longer uses the .form-control class and instead uses its own `.form-range` class
- Remove `custom` and `bsCustomPrefix` props from `FormControl` - This is the last control to break out of form control, so it's not needed anymore
- Add associated docs and tests