### PR TITLE
v5: Refactor file control and drop file from FormControl

### DIFF
--- a/src/FormControl.tsx
+++ b/src/FormControl.tsx
@@ -129,8 +129,6 @@ const FormControl: BsPrefixRefForwardingComponent<
     let classes;
     if (plaintext) {
       classes = { [`${bsPrefix}-plaintext`]: true };
-    } else if (type === 'file') {
-      classes = { [`${bsPrefix}-file`]: true };
     } else {
       classes = {
         [bsPrefix]: true,

--- a/src/FormFile.tsx
+++ b/src/FormFile.tsx
@@ -110,7 +110,7 @@ const FormFile: FormFile = (React.forwardRef(
       isInvalid = false,
       feedbackTooltip = false,
       feedback,
-      buttonText,
+      button,
       className,
       style,
       label,
@@ -153,7 +153,7 @@ const FormFile: FormFile = (React.forwardRef(
                 disabled={disabled}
                 as={inputAs}
               />
-              <FormFileLabel label={label} buttonText={buttonText} />
+              <FormFileLabel label={label} button={button} />
               {(isValid || isInvalid) && (
                 <Feedback
                   type={isValid ? 'valid' : 'invalid'}

--- a/src/FormFile.tsx
+++ b/src/FormFile.tsx
@@ -1,38 +1,38 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useContext, useMemo } from 'react';
-import all from 'prop-types-extra/lib/all';
 import Feedback from './Feedback';
+import FormFileButton from './FormFileButton';
 import FormFileInput from './FormFileInput';
 import FormFileLabel from './FormFileLabel';
+import FormFileText from './FormFileText';
 import FormContext from './FormContext';
 import { useBootstrapPrefix } from './ThemeProvider';
 import {
-  BsCustomPrefixProps,
   BsPrefixPropsWithChildren,
   BsPrefixRefForwardingComponent,
 } from './helpers';
 
 export interface FormFileProps
   extends BsPrefixPropsWithChildren,
-    BsCustomPrefixProps,
     Pick<React.HTMLAttributes<HTMLElement>, 'style'> {
   inputAs?: React.ElementType;
   id?: string;
   disabled?: boolean;
   label?: React.ReactNode;
-  custom?: boolean;
+  button?: React.ReactNode;
   isValid?: boolean;
   isInvalid?: boolean;
   feedback?: React.ReactNode;
   feedbackTooltip?: boolean;
-  lang?: string;
-  'data-browse'?: any; // ???
+  size?: 'sm' | 'lg';
 }
 
 type FormFile = BsPrefixRefForwardingComponent<'input', FormFileProps> & {
+  Button: typeof FormFileButton;
   Input: typeof FormFileInput;
   Label: typeof FormFileLabel;
+  Text: typeof FormFileText;
 };
 
 const propTypes = {
@@ -40,13 +40,6 @@ const propTypes = {
    * @default 'form-file'
    */
   bsPrefix: PropTypes.string,
-
-  /**
-   * A seperate bsPrefix used for custom controls
-   *
-   * @default 'custom-file'
-   */
-  bsCustomPrefix: PropTypes.string,
 
   /**
    * The wrapping HTML element to use when rendering the FormFile.
@@ -66,33 +59,30 @@ const propTypes = {
   id: PropTypes.string,
 
   /**
-   * Provide a function child to manually handle the layout of the FormFile's inner components.
+   * Provide a function child to manually handle the layout of the FormFile's
+   * inner components.
    *
-   * If not using the custom prop <code>FormFile.Label></code> should be before <code><FormFile.Input isInvalid /></code>
    * ```jsx
    * <FormFile>
-   *   <FormFile.Label>Allow us to contact you?</FormFile.Label>
    *   <FormFile.Input isInvalid />
-   *   <Feedback type="invalid">Yo this is required</Feedback>
-   * </FormFile>
-   * ```
-   *
-   * If using the custom prop <code><FormFile.Input isInvalid /></code> should be before <code>FormFile.Label></code>
-   * ```jsx
-   * <FormFile custom>
-   *   <FormFile.Input isInvalid />
-   *   <FormFile.Label>Allow us to contact you?</FormFile.Label>
+   *   <FormFile.Label>
+   *     <FormFile.Text>Select file</FormFile.Text>
+   *     <FormFile.Button>Browse</FormFile.Button>
+   *   </FormFile.Label>
    *   <Feedback type="invalid">Yo this is required</Feedback>
    * </FormFile>
    * ```
    */
   children: PropTypes.node,
 
+  /** Make the control disabled */
   disabled: PropTypes.bool,
+
+  /** The node for the input text */
   label: PropTypes.node,
 
-  /** Use Bootstrap's custom form elements to replace the browser defaults */
-  custom: PropTypes.bool,
+  /** The node for the "Browse" button label */
+  button: PropTypes.node,
 
   /** Manually style the input as valid */
   isValid: PropTypes.bool,
@@ -106,27 +96,8 @@ const propTypes = {
   /** A message to display when the input is in a validation state */
   feedback: PropTypes.node,
 
-  /**
-   * The string for the "Browse" text label when using custom file input
-   *
-   * @type string
-   */
-  'data-browse': all(
-    PropTypes.string,
-    ({ custom, 'data-browse': dataBrowse }) =>
-      dataBrowse && !custom
-        ? Error(
-            '`data-browse` attribute value will only be used when custom is `true`',
-          )
-        : null,
-  ),
-
-  /** The language for the button when using custom file input and SCSS based strings */
-  lang: all(PropTypes.string, ({ custom, lang }) =>
-    lang && !custom
-      ? Error('`lang` can only be set when custom is `true`')
-      : null,
-  ),
+  /** Size of the input */
+  size: PropTypes.string,
 };
 
 const FormFile: FormFile = (React.forwardRef(
@@ -134,19 +105,17 @@ const FormFile: FormFile = (React.forwardRef(
     {
       id,
       bsPrefix,
-      bsCustomPrefix,
       disabled = false,
       isValid = false,
       isInvalid = false,
       feedbackTooltip = false,
       feedback,
+      buttonText,
       className,
       style,
       label,
+      size,
       children,
-      custom,
-      lang,
-      'data-browse': dataBrowse,
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
       inputAs = 'input',
@@ -154,34 +123,14 @@ const FormFile: FormFile = (React.forwardRef(
     }: FormFileProps,
     ref,
   ) => {
-    const [prefix, defaultPrefix] = custom
-      ? [bsCustomPrefix, 'custom']
-      : [bsPrefix, 'form-file'];
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'form-file');
 
-    bsPrefix = useBootstrapPrefix(prefix, defaultPrefix);
-
-    const type = 'file';
     const { controlId } = useContext(FormContext);
     const innerFormContext = useMemo(
       () => ({
         controlId: id || controlId,
-        custom,
       }),
-      [controlId, custom, id],
-    );
-
-    const hasLabel = label != null && label !== false && !children;
-
-    const input = (
-      <FormFileInput
-        {...props}
-        ref={ref}
-        isValid={isValid}
-        isInvalid={isInvalid}
-        disabled={disabled}
-        as={inputAs}
-        lang={lang}
-      />
+      [controlId, id],
     );
 
     return (
@@ -191,26 +140,20 @@ const FormFile: FormFile = (React.forwardRef(
           className={classNames(
             className,
             bsPrefix,
-            custom && `custom-${type}`,
+            size && `${bsPrefix}-${size}`,
           )}
         >
           {children || (
             <>
-              {custom ? (
-                <>
-                  {input}
-                  {hasLabel && (
-                    <FormFileLabel data-browse={dataBrowse}>
-                      {label}
-                    </FormFileLabel>
-                  )}
-                </>
-              ) : (
-                <>
-                  {hasLabel && <FormFileLabel>{label}</FormFileLabel>}
-                  {input}
-                </>
-              )}
+              <FormFileInput
+                {...props}
+                ref={ref}
+                isValid={isValid}
+                isInvalid={isInvalid}
+                disabled={disabled}
+                as={inputAs}
+              />
+              <FormFileLabel label={label} buttonText={buttonText} />
               {(isValid || isInvalid) && (
                 <Feedback
                   type={isValid ? 'valid' : 'invalid'}
@@ -230,7 +173,9 @@ const FormFile: FormFile = (React.forwardRef(
 FormFile.displayName = 'FormFile';
 FormFile.propTypes = propTypes;
 
+FormFile.Button = FormFileButton;
 FormFile.Input = FormFileInput;
 FormFile.Label = FormFileLabel;
+FormFile.Text = FormFileText;
 
 export default FormFile;

--- a/src/FormFileButton.tsx
+++ b/src/FormFileButton.tsx
@@ -1,0 +1,5 @@
+import createWithBsPrefix from './createWithBsPrefix';
+
+export default createWithBsPrefix('form-file-button', {
+  Component: 'span',
+});

--- a/src/FormFileInput.tsx
+++ b/src/FormFileInput.tsx
@@ -3,18 +3,12 @@ import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import FormContext from './FormContext';
 import { useBootstrapPrefix } from './ThemeProvider';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-import {
-  BsCustomPrefixProps,
-  BsPrefixProps,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
-
-export interface FormFileInputProps extends BsPrefixProps, BsCustomPrefixProps {
+export interface FormFileInputProps extends BsPrefixProps {
   id?: string;
   isValid?: boolean;
   isInvalid?: boolean;
-  lang?: string;
 }
 type FormFileInput = BsPrefixRefForwardingComponent<
   'input',
@@ -49,9 +43,6 @@ const propTypes = {
 
   /** Manually style the input as invalid */
   isInvalid: PropTypes.bool,
-
-  /** The language for the button when using custom file input and SCSS based strings */
-  lang: PropTypes.string,
 };
 
 const FormFileInput: FormFileInput = React.forwardRef(
@@ -59,33 +50,24 @@ const FormFileInput: FormFileInput = React.forwardRef(
     {
       id,
       bsPrefix,
-      bsCustomPrefix,
       className,
       isValid,
       isInvalid,
-      lang,
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'input',
       ...props
     },
     ref,
   ) => {
-    const { controlId, custom } = useContext(FormContext);
-    const type = 'file';
-
-    const [prefix, defaultPrefix] = custom
-      ? [bsCustomPrefix, 'custom-file-input']
-      : [bsPrefix, 'form-control-file'];
-
-    bsPrefix = useBootstrapPrefix(prefix, defaultPrefix);
+    const { controlId } = useContext(FormContext);
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'form-file-input');
 
     return (
       <Component
         {...props}
         ref={ref}
         id={id || controlId}
-        type={type}
-        lang={lang}
+        type="file"
         className={classNames(
           className,
           bsPrefix,

--- a/src/FormFileLabel.tsx
+++ b/src/FormFileLabel.tsx
@@ -2,16 +2,18 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import FormContext from './FormContext';
+import FormFileButton from './FormFileButton';
+import FormFileText from './FormFileText';
 import { useBootstrapPrefix } from './ThemeProvider';
-
 import {
-  BsCustomPrefixProps,
-  BsPrefixProps,
+  BsPrefixAndClassNameOnlyProps,
   BsPrefixRefForwardingComponent,
 } from './helpers';
 
-export interface FormFileLabelProps extends BsPrefixProps, BsCustomPrefixProps {
+export interface FormFileLabelProps extends BsPrefixAndClassNameOnlyProps {
   htmlFor?: string;
+  label?: React.ReactNode;
+  button?: React.ReactNode;
 }
 type FormFileLabel = BsPrefixRefForwardingComponent<
   'label',
@@ -20,45 +22,56 @@ type FormFileLabel = BsPrefixRefForwardingComponent<
 
 const propTypes = {
   /**
-   * @default 'form-file-input'
+   * @default 'form-file-label'
    */
   bsPrefix: PropTypes.string,
-
-  /**
-   * A seperate bsPrefix used for custom controls
-   *
-   * @default 'custom-file-label'
-   */
-  bsCustomPrefix: PropTypes.string,
 
   /** The HTML for attribute for associating the label with an input */
   htmlFor: PropTypes.string,
 
-  /** The string for the "Browse" text label when using custom file input */
-  'data-browse': PropTypes.string,
+  /** The node for the "Choose file..." label */
+  label: PropTypes.node,
+
+  /** The node for the "Browse" label */
+  button: PropTypes.node,
 };
 
 const FormFileLabel: FormFileLabel = React.forwardRef<
   HTMLLabelElement,
   FormFileLabelProps
->(({ bsPrefix, bsCustomPrefix, className, htmlFor, ...props }, ref) => {
-  const { controlId, custom } = useContext(FormContext);
-  const [prefix, defaultPrefix] = custom
-    ? [bsCustomPrefix, 'custom-file-label']
-    : [bsPrefix, 'form-file-label'];
+>(
+  (
+    {
+      bsPrefix,
+      className,
+      htmlFor,
+      label = 'Choose file...',
+      button = 'Browse',
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const { controlId } = useContext(FormContext);
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'form-file-label');
 
-  bsPrefix = useBootstrapPrefix(prefix, defaultPrefix);
-
-  return (
-    <label // eslint-disable-line jsx-a11y/label-has-associated-control
-      {...props}
-      ref={ref}
-      htmlFor={htmlFor || controlId}
-      className={classNames(className, bsPrefix)}
-      data-browse={props['data-browse']}
-    />
-  );
-});
+    return (
+      <label // eslint-disable-line jsx-a11y/label-has-associated-control
+        {...props}
+        ref={ref}
+        htmlFor={htmlFor || controlId}
+        className={classNames(className, bsPrefix)}
+      >
+        {children || (
+          <>
+            <FormFileText>{label}</FormFileText>
+            <FormFileButton>{button}</FormFileButton>
+          </>
+        )}
+      </label>
+    );
+  },
+);
 
 FormFileLabel.displayName = 'FormFileLabel';
 FormFileLabel.propTypes = propTypes;

--- a/src/FormFileText.tsx
+++ b/src/FormFileText.tsx
@@ -1,0 +1,5 @@
+import createWithBsPrefix from './createWithBsPrefix';
+
+export default createWithBsPrefix('form-file-text', {
+  Component: 'span',
+});

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -13,10 +13,6 @@ export interface BsPrefixAndClassNameOnlyProps {
   className?: string;
 }
 
-export interface BsCustomPrefixProps {
-  bsCustomPrefix?: string;
-}
-
 export interface BsPrefixProps<
   As extends React.ElementType = React.ElementType
 > extends BsPrefixAndClassNameOnlyProps {

--- a/test/FormControlSpec.js
+++ b/test/FormControlSpec.js
@@ -17,12 +17,6 @@ describe('<FormControl>', () => {
     mount(<FormControl as="textarea" />).assertSingle('textarea.form-control');
   });
 
-  it('should support type=file', () => {
-    mount(<FormControl type="file" />)
-      .assertSingle('[type="file"].form-control-file')
-      .assertNone('.form-control');
-  });
-
   it('should support plaintext inputs', () => {
     mount(<FormControl plaintext />).assertSingle(
       'input.form-control-plaintext',

--- a/test/FormFileSpec.js
+++ b/test/FormFileSpec.js
@@ -9,7 +9,7 @@ describe('<FormFile>', () => {
         id="foo"
         name="foo"
         label="My label"
-        buttonText="My browse"
+        button="My browse"
         className="my-file"
       />,
     );

--- a/test/FormFileSpec.js
+++ b/test/FormFileSpec.js
@@ -5,17 +5,30 @@ import FormFile from '../src/FormFile';
 describe('<FormFile>', () => {
   it('should render correctly', () => {
     let wrapper = mount(
-      <FormFile id="foo" name="foo" label="My label" className="my-file" />,
+      <FormFile
+        id="foo"
+        name="foo"
+        label="My label"
+        buttonText="My browse"
+        className="my-file"
+      />,
     );
 
     wrapper
       .assertSingle('div.form-file.my-file')
       .assertSingle('input[type="file"][name="foo"]');
 
+    wrapper.assertSingle('label.form-file-label[htmlFor="foo"]');
+
+    wrapper.assertSingle('span.form-file-text').text().should.equal('My label');
     wrapper
-      .assertSingle('label.form-file-label[htmlFor="foo"]')
+      .assertSingle('span.form-file-button')
       .text()
-      .should.equal('My label');
+      .should.equal('My browse');
+  });
+
+  it('should support size', () => {
+    mount(<FormFile size="sm" />).assertSingle('.form-file-sm');
   });
 
   it('should support isValid', () => {
@@ -42,30 +55,6 @@ describe('<FormFile>', () => {
     const instance = mount(<Container />).instance();
 
     expect(instance.input.tagName).to.equal('INPUT');
-  });
-
-  it('should supports custom', () => {
-    const wrapper = mount(<FormFile custom label="My label" />);
-
-    wrapper
-      .assertSingle('div.custom-file')
-      .assertSingle('input.custom-file-input');
-
-    wrapper.assertSingle('label.custom-file-label');
-  });
-
-  it('should supports lang when custom', () => {
-    const wrapper = mount(<FormFile custom lang="en" label="My label" />);
-
-    expect(wrapper.prop('lang')).to.equal('en');
-  });
-
-  it('should supports data-browse when custom', () => {
-    const wrapper = mount(
-      <FormFile custom data-browse="foo" label="My label" />,
-    );
-
-    expect(wrapper.prop('data-browse')).to.equal('foo');
   });
 
   it('should support "inputAs"', () => {

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -500,34 +500,24 @@ const MegaComponent = () => (
         as="div"
         id="custom-file"
         label="Custom file input"
-        custom
-        data-browse="browse"
+        button="Browse custom"
         disabled
         feedback="feedback"
         feedbackTooltip
         inputAs="input"
         isInvalid
         isValid
-        lang="lang"
         bsPrefix="formfile"
-        bsCustomPrefix="formfilecustom"
+        size="sm"
         style={style}
       >
-        <Form.File.Label
-          data-browse="browse"
-          htmlFor="id"
-          bsPrefix="formfilelabel"
-          bsCustomPrefix="formfilelabelcustom"
-          style={style}
-        />
+        <Form.File.Label htmlFor="id" bsPrefix="formfilelabel" style={style} />
         <Form.File.Input
           as="input"
           id="id"
           isInvalid
           isValid
-          lang="en"
           bsPrefix="formfileinput"
-          bsCustomPrefix="formfileinputcustom"
           style={style}
         />
       </Form.File>
@@ -535,7 +525,6 @@ const MegaComponent = () => (
         ref={React.createRef<HTMLInputElement & FormFile>()}
         id="custom-file-ref"
         label="Custom file input"
-        custom
       />
 
       <Form.Switch label="Switch" disabled />

--- a/www/src/examples/Form/File.js
+++ b/www/src/examples/Form/File.js
@@ -1,7 +1,0 @@
-<Form>
-  <Form.File // prettier-ignore
-    id="custom-file"
-    label="Custom file input"
-    custom
-  />
-</Form>;

--- a/www/src/examples/Form/FileApi.js
+++ b/www/src/examples/Form/FileApi.js
@@ -2,15 +2,19 @@
   <div className="mb-3">
     <Form.File id="formcheck-api-custom" custom>
       <Form.File.Input isValid />
-      <Form.File.Label data-browse="Button text">
-        Custom file input
+      <Form.File.Label>
+        <Form.File.Text>Custom file input</Form.File.Text>
+        <Form.File.Button>Button text</Form.File.Button>
       </Form.File.Label>
       <Form.Control.Feedback type="valid">You did it!</Form.Control.Feedback>
     </Form.File>
   </div>
   <div className="mb-3">
     <Form.File id="formcheck-api-regular">
-      <Form.File.Label>Regular file input</Form.File.Label>
+      <Form.File.Label>
+        <Form.File.Text>Regular file input</Form.File.Text>
+        <Form.File.Button>Browse</Form.File.Button>
+      </Form.File.Label>
       <Form.File.Input />
     </Form.File>
   </div>

--- a/www/src/examples/Form/FileButtonTextHTML.js
+++ b/www/src/examples/Form/FileButtonTextHTML.js
@@ -1,8 +1,0 @@
-<Form>
-  <Form.File // prettier-ignore
-    id="custom-file-translate-html"
-    label="Voeg je document toe"
-    data-browse="Bestand kiezen"
-    custom
-  />
-</Form>;

--- a/www/src/examples/Form/FileButtonTextScss.js
+++ b/www/src/examples/Form/FileButtonTextScss.js
@@ -1,8 +1,0 @@
-<Form>
-  <Form.File // prettier-ignore
-    id="custom-file-translate-scss"
-    label="Custom file input"
-    lang="en"
-    custom
-  />
-</Form>;

--- a/www/src/examples/Form/FormFile.js
+++ b/www/src/examples/Form/FormFile.js
@@ -1,5 +1,1 @@
-<Form>
-  <Form.Group>
-    <Form.File id="exampleFormControlFile1" label="Example file input" />
-  </Form.Group>
-</Form>;
+<Form.File id="exampleFormControlFile1" label="Example file input" />;

--- a/www/src/examples/Form/FormFileSizes.js
+++ b/www/src/examples/Form/FormFileSizes.js
@@ -1,0 +1,4 @@
+<>
+  <Form.File size="lg" className="mb-3" />
+  <Form.File size="sm" className="mb-3" />
+</>;

--- a/www/src/examples/Form/ValidationTooltips.js
+++ b/www/src/examples/Form/ValidationTooltips.js
@@ -124,10 +124,8 @@ function FormExample() {
           </Form.Row>
           <Form.Group>
             <Form.File
-              className="position-relative"
               required
               name="file"
-              label="File"
               onChange={handleChange}
               isInvalid={!!errors.file}
               feedback={errors.file}

--- a/www/src/pages/components/forms.js
+++ b/www/src/pages/components/forms.js
@@ -9,6 +9,7 @@ import Check from '../../examples/Form/Check';
 import CheckApi from '../../examples/Form/CheckApi';
 import CheckInline from '../../examples/Form/CheckInline';
 import FormFile from '../../examples/Form/FormFile';
+import FormFileSizes from '../../examples/Form/FormFileSizes';
 import FormDisabled from '../../examples/Form/FormDisabled';
 import FormDisabledInputs from '../../examples/Form/FormDisabledInputs';
 import FormGroup from '../../examples/Form/FormGroup';
@@ -32,9 +33,6 @@ import Switch from '../../examples/Form/Switch';
 import Range from '../../examples/Form/Range';
 import SelectBasic from '../../examples/Form/SelectBasic';
 import SelectSizes from '../../examples/Form/SelectSizes';
-import File from '../../examples/Form/File';
-import FileButtonTextHTML from '../../examples/Form/FileButtonTextHTML';
-import FileButtonTextScss from '../../examples/Form/FileButtonTextScss';
 import FileApi from '../../examples/Form/FileApi';
 import FormTextControls from '../../examples/Form/TextControls';
 import ValidationFormik from '../../examples/Form/ValidationFormik';
@@ -84,10 +82,6 @@ export default withLayout(function FormControlsSection({ data }) {
         state, sizing, and more.
       </p>
       <ReactPlayground codeText={FormTextControls} />
-      <p>
-        For file inputs, use <code>Form.File</code>.
-      </p>
-      <ReactPlayground codeText={FormFile} />
       <LinkedHeading h="3" id="forms-input-sizes">
         Sizing
       </LinkedHeading>
@@ -166,6 +160,31 @@ export default withLayout(function FormControlsSection({ data }) {
         <code>FormGroup</code> and have it propagate to the label and input).
       </p>
       <ReactPlayground codeText={CheckApi} />
+      <LinkedHeading h="2" id="forms-file">
+        File
+      </LinkedHeading>
+      <ReactPlayground codeText={FormFile} />
+      <LinkedHeading h="3" id="forms-file-sizes">
+        Sizing
+      </LinkedHeading>
+      <p>
+        You may also choose from small and large file inputs to match our
+        similarly sized text inputs.
+      </p>
+      <ReactPlayground codeText={FormFileSizes} />
+      <h4>Customizing FormFile rendering</h4>
+      <p>
+        When you need tighter control, or want to customize how the{' '}
+        <code>FormFile</code> component renders, it may be better to use its
+        constituent parts directly.
+      </p>
+      <p>
+        By providing <code>children</code> to the <code>FormFile</code> and{' '}
+        <code>FormFileLabel</code> you can forgo the default rendering and
+        handle it yourself. (You can still provide an <code>id</code> to the{' '}
+        <code>FormFile</code> and have it propagate to the label and input).
+      </p>
+      <ReactPlayground codeText={FileApi} />
       <LinkedHeading h="2" id="forms-range">
         Range
       </LinkedHeading>
@@ -475,71 +494,6 @@ export default withLayout(function FormControlsSection({ data }) {
         You can also use the <code>{'<Form.Switch>'}</code> alias which
         encapsulates the above, in a very small component wrapper.
       </Callout>
-      <LinkedHeading h="3" id="forms-custom-file">
-        File
-      </LinkedHeading>
-      <p>A custom styled File uploader.</p>
-      <Callout>
-        The custom <code>FormFile</code> will by default not visibly display
-        your selected file. This requires additional JS. The recommended plugin
-        to animate custom file input is{' '}
-        <a href="https://www.npmjs.com/package/bs-custom-file-input">
-          bs-custom-file-input
-        </a>
-        .
-      </Callout>
-      <ReactPlayground codeText={File} />
-      <h4>Translating or customizing the strings with HTML</h4>
-      <p>
-        Bootstrap also provides a way to translate the “Browse” text in HTML
-        with the <code>data-browse</code> attribute which can be added to the
-        custom input label (example in Dutch):
-      </p>
-      <Callout>
-        Note that the <code>data-browse</code> attribute does not to anything
-        unless the <code>custom</code> prop is set.
-      </Callout>
-      <ReactPlayground codeText={FileButtonTextHTML} />
-      <h4>Translating or customizing the strings with SCSS</h4>
-      <p>
-        Please refer to the official{' '}
-        <a href="https://getbootstrap.com/docs/4.4/components/forms/#translating-or-customizing-the-strings-with-scss">
-          Bootstrap documentation for translating via SCSS
-        </a>
-        . The <code>lang</code> prop can be used to pass the language.
-      </p>
-      <ReactPlayground codeText={FileButtonTextScss} />
-      <h4>Customizing FormFile rendering</h4>
-      <p>
-        When you need tighter control, or want to customize how the{' '}
-        <code>FormFile</code> component renders, it may be better to use it's
-        constituent parts directly.
-      </p>
-      <p>
-        By providing <code>children</code> to the <code>FormFile</code> you can
-        forgo the default rendering and handle it yourself. (You can still
-        provide an <code>id</code> to the <code>FormFile</code> and have it
-        propagate to the label and input).
-      </p>
-      <Callout>
-        <p>
-          When customizing the <code>FormFile</code> rendering it is important
-          to note the order of the <code>label</code> and <code>input</code>{' '}
-          elements.
-        </p>
-        <ul>
-          <li>
-            If you are not setting the <code>custom</code> prop the
-            <code>label</code> should be before the <code>input</code>.
-          </li>
-          <li>
-            If you are setting the custom prop the <code>input</code> element
-            has to be placed before the <code>label</code> or the{' '}
-            <code>buttonText</code> prop will not work.
-          </li>
-        </ul>
-      </Callout>
-      <ReactPlayground codeText={FileApi} />
       <LinkedHeading h="2" id="forms-api">
         API
       </LinkedHeading>


### PR DESCRIPTION
https://v5.getbootstrap.com/docs/5.0/forms/file/
https://v5.getbootstrap.com/docs/5.0/migration/#forms

Changes:

- Dropped file from `FormControl` - v5 removed native file support
- Dropped `custom` and `bsCustomPrefix` props from `FormFile` - custom file input is the new norm
- Added `button` prop - To support custom nodes placed in the Browse button span
- Added `FormFileText` and `FormFileButton` components - The markup for the file input has changed and these were added to support those.  
- Dropped `lang` and `data-browse` - translations and button text are now controlled in html so lang isn't needed.  `data-browse` is replaced by the `button` prop, which allows you to place a node into `FormFileButton`
- Added `size` prop
- Tests, docs, example changes
