### PR TITLE
ci(v5): add configuration for pushes and pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - master
       - bs3-dev
+      - bs5-dev
   pull_request:
     branches:
       - master
       - bs3-dev
+      - bs5-dev
 jobs:
   ci:
     name: CI


### PR DESCRIPTION
Adds the configuration necessary for triggering our ci builds on
pushes and pull requests to the bs5-dev branch.