### PR TITLE
feat(v5): Drop InputGroupPrepend and InputGroupAppend

### DIFF
--- a/src/InputGroup.tsx
+++ b/src/InputGroup.tsx
@@ -5,14 +5,11 @@ import React from 'react';
 
 import createWithBsPrefix from './createWithBsPrefix';
 import { useBootstrapPrefix } from './ThemeProvider';
+import FormCheckInput from './FormCheckInput';
 import {
   BsPrefixPropsWithChildren,
   BsPrefixRefForwardingComponent,
 } from './helpers';
-
-const InputGroupAppend = createWithBsPrefix('input-group-append');
-
-const InputGroupPrepend = createWithBsPrefix('input-group-prepend');
 
 const InputGroupText = createWithBsPrefix('input-group-text', {
   Component: 'span',
@@ -20,13 +17,13 @@ const InputGroupText = createWithBsPrefix('input-group-text', {
 
 const InputGroupCheckbox = (props) => (
   <InputGroupText>
-    <input type="checkbox" {...props} />
+    <FormCheckInput type="checkbox" {...props} />
   </InputGroupText>
 );
 
 const InputGroupRadio = (props) => (
   <InputGroupText>
-    <input type="radio" {...props} />
+    <FormCheckInput type="radio" {...props} />
   </InputGroupText>
 );
 
@@ -35,8 +32,6 @@ export interface InputGroupProps extends BsPrefixPropsWithChildren {
 }
 
 type InputGroupExtras = {
-  Append: typeof InputGroupAppend;
-  Prepend: typeof InputGroupPrepend;
   Text: typeof InputGroupText;
   Checkbox: typeof InputGroupCheckbox;
   Radio: typeof InputGroupRadio;
@@ -60,8 +55,6 @@ const propTypes = {
 
 /**
  *
- * @property {InputGroupAppend} Append
- * @property {InputGroupPrepend} Prepend
  * @property {InputGroupText} Text
  * @property {InputGroupRadio} Radio
  * @property {InputGroupCheckbox} Checkbox
@@ -102,8 +95,6 @@ const InputGroupWithExtras: InputGroup & InputGroupExtras = {
   Text: InputGroupText,
   Radio: InputGroupRadio,
   Checkbox: InputGroupCheckbox,
-  Append: InputGroupAppend,
-  Prepend: InputGroupPrepend,
 } as any;
 
 export default InputGroupWithExtras;

--- a/test/InputGroupSpec.js
+++ b/test/InputGroupSpec.js
@@ -17,7 +17,7 @@ describe('<InputGroup>', () => {
     it('Should forward props to underlying input element', () => {
       const name = 'foobar';
       const wrapper = mount(<InputGroup.Checkbox name={name} />);
-      const input = wrapper.find(`span>input[type="checkbox"]`);
+      const input = wrapper.find('FormCheckInput');
       expect(input.length).to.equal(1);
       expect(input.prop('name')).to.equal(name);
     });
@@ -27,7 +27,7 @@ describe('<InputGroup>', () => {
     it('Should forward props to underlying input element', () => {
       const name = 'foobar';
       const wrapper = mount(<InputGroup.Radio name={name} />);
-      const input = wrapper.find(`span>input[type="radio"]`);
+      const input = wrapper.find('FormCheckInput');
       expect(input.length).to.equal(1);
       expect(input.prop('name')).to.equal(name);
     });

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -537,9 +537,7 @@ const MegaComponent = () => (
         className="mb-3"
         style={style}
       >
-        <InputGroup.Prepend bsPrefix="inputgroupprepend" style={style}>
-          <InputGroup.Text id="basic-addon1">@</InputGroup.Text>
-        </InputGroup.Prepend>
+        <InputGroup.Text id="basic-addon1">@</InputGroup.Text>
         <FormControl
           placeholder="Username"
           aria-label="Username"
@@ -553,35 +551,25 @@ const MegaComponent = () => (
           aria-label="Recipient's username"
           aria-describedby="basic-addon2"
         />
-        <InputGroup.Append bsPrefix="inputgroupappend" style={style}>
-          <InputGroup.Text id="basic-addon2">@example.com</InputGroup.Text>
-        </InputGroup.Append>
+        <InputGroup.Text id="basic-addon2">@example.com</InputGroup.Text>
       </InputGroup>
 
       <label htmlFor="basic-url">Your vanity URL</label>
       <InputGroup className="mb-3">
-        <InputGroup.Prepend>
-          <InputGroup.Text id="basic-addon3">
-            https://example.com/users/
-          </InputGroup.Text>
-        </InputGroup.Prepend>
+        <InputGroup.Text id="basic-addon3">
+          https://example.com/users/
+        </InputGroup.Text>
         <FormControl id="basic-url" aria-describedby="basic-addon3" />
       </InputGroup>
 
       <InputGroup className="mb-3">
-        <InputGroup.Prepend>
-          <InputGroup.Text>$</InputGroup.Text>
-        </InputGroup.Prepend>
+        <InputGroup.Text>$</InputGroup.Text>
         <FormControl aria-label="Amount (to the nearest dollar)" />
-        <InputGroup.Append>
-          <InputGroup.Text>.00</InputGroup.Text>
-        </InputGroup.Append>
+        <InputGroup.Text>.00</InputGroup.Text>
       </InputGroup>
 
       <InputGroup>
-        <InputGroup.Prepend>
-          <InputGroup.Text>With textarea</InputGroup.Text>
-        </InputGroup.Prepend>
+        <InputGroup.Text>With textarea</InputGroup.Text>
         <FormControl as="textarea" aria-label="With textarea" />
       </InputGroup>
     </div>

--- a/www/src/examples/InputGroup/Basic.js
+++ b/www/src/examples/InputGroup/Basic.js
@@ -1,8 +1,6 @@
-<div>
+<>
   <InputGroup className="mb-3">
-    <InputGroup.Prepend>
-      <InputGroup.Text id="basic-addon1">@</InputGroup.Text>
-    </InputGroup.Prepend>
+    <InputGroup.Text id="basic-addon1">@</InputGroup.Text>
     <FormControl
       placeholder="Username"
       aria-label="Username"
@@ -16,35 +14,25 @@
       aria-label="Recipient's username"
       aria-describedby="basic-addon2"
     />
-    <InputGroup.Append>
-      <InputGroup.Text id="basic-addon2">@example.com</InputGroup.Text>
-    </InputGroup.Append>
+    <InputGroup.Text id="basic-addon2">@example.com</InputGroup.Text>
   </InputGroup>
 
-  <label htmlFor="basic-url">Your vanity URL</label>
+  <Form.Label htmlFor="basic-url">Your vanity URL</Form.Label>
   <InputGroup className="mb-3">
-    <InputGroup.Prepend>
-      <InputGroup.Text id="basic-addon3">
-        https://example.com/users/
-      </InputGroup.Text>
-    </InputGroup.Prepend>
+    <InputGroup.Text id="basic-addon3">
+      https://example.com/users/
+    </InputGroup.Text>
     <FormControl id="basic-url" aria-describedby="basic-addon3" />
   </InputGroup>
 
   <InputGroup className="mb-3">
-    <InputGroup.Prepend>
-      <InputGroup.Text>$</InputGroup.Text>
-    </InputGroup.Prepend>
+    <InputGroup.Text>$</InputGroup.Text>
     <FormControl aria-label="Amount (to the nearest dollar)" />
-    <InputGroup.Append>
-      <InputGroup.Text>.00</InputGroup.Text>
-    </InputGroup.Append>
+    <InputGroup.Text>.00</InputGroup.Text>
   </InputGroup>
 
   <InputGroup>
-    <InputGroup.Prepend>
-      <InputGroup.Text>With textarea</InputGroup.Text>
-    </InputGroup.Prepend>
+    <InputGroup.Text>With textarea</InputGroup.Text>
     <FormControl as="textarea" aria-label="With textarea" />
   </InputGroup>
-</div>;
+</>;

--- a/www/src/examples/InputGroup/ButtonDropdowns.js
+++ b/www/src/examples/InputGroup/ButtonDropdowns.js
@@ -1,7 +1,6 @@
 <>
   <InputGroup className="mb-3">
     <DropdownButton
-      as={InputGroup.Prepend}
       variant="outline-secondary"
       title="Dropdown"
       id="input-group-dropdown-1"
@@ -12,21 +11,44 @@
       <Dropdown.Divider />
       <Dropdown.Item href="#">Separated link</Dropdown.Item>
     </DropdownButton>
-    <FormControl aria-describedby="basic-addon1" />
+    <FormControl aria-label="Text input with dropdown button" />
   </InputGroup>
 
-  <InputGroup>
-    <FormControl
-      placeholder="Recipient's username"
-      aria-label="Recipient's username"
-      aria-describedby="basic-addon2"
-    />
+  <InputGroup className="mb-3">
+    <FormControl aria-label="Text input with dropdown button" />
 
     <DropdownButton
-      as={InputGroup.Append}
       variant="outline-secondary"
       title="Dropdown"
       id="input-group-dropdown-2"
+      alignRight
+    >
+      <Dropdown.Item href="#">Action</Dropdown.Item>
+      <Dropdown.Item href="#">Another action</Dropdown.Item>
+      <Dropdown.Item href="#">Something else here</Dropdown.Item>
+      <Dropdown.Divider />
+      <Dropdown.Item href="#">Separated link</Dropdown.Item>
+    </DropdownButton>
+  </InputGroup>
+
+  <InputGroup>
+    <DropdownButton
+      variant="outline-secondary"
+      title="Dropdown"
+      id="input-group-dropdown-3"
+    >
+      <Dropdown.Item href="#">Action</Dropdown.Item>
+      <Dropdown.Item href="#">Another action</Dropdown.Item>
+      <Dropdown.Item href="#">Something else here</Dropdown.Item>
+      <Dropdown.Divider />
+      <Dropdown.Item href="#">Separated link</Dropdown.Item>
+    </DropdownButton>
+    <FormControl aria-label="Text input with 2 dropdown buttons" />
+    <DropdownButton
+      variant="outline-secondary"
+      title="Dropdown"
+      id="input-group-dropdown-4"
+      alignRight
     >
       <Dropdown.Item href="#">Action</Dropdown.Item>
       <Dropdown.Item href="#">Another action</Dropdown.Item>

--- a/www/src/examples/InputGroup/Buttons.js
+++ b/www/src/examples/InputGroup/Buttons.js
@@ -1,9 +1,12 @@
-<div>
+<>
   <InputGroup className="mb-3">
-    <InputGroup.Prepend>
-      <Button variant="outline-secondary">Button</Button>
-    </InputGroup.Prepend>
-    <FormControl aria-describedby="basic-addon1" />
+    <Button variant="outline-secondary" id="button-addon1">
+      Button
+    </Button>
+    <FormControl
+      aria-label="Example text with button addon"
+      aria-describedby="basic-addon1"
+    />
   </InputGroup>
 
   <InputGroup className="mb-3">
@@ -12,28 +15,23 @@
       aria-label="Recipient's username"
       aria-describedby="basic-addon2"
     />
-    <InputGroup.Append>
-      <Button variant="outline-secondary">Button</Button>
-    </InputGroup.Append>
+    <Button variant="outline-secondary" id="button-addon2">
+      Button
+    </Button>
   </InputGroup>
 
   <InputGroup className="mb-3">
-    <InputGroup.Prepend>
-      <Button variant="outline-secondary">Button</Button>
-      <Button variant="outline-secondary">Button</Button>
-    </InputGroup.Prepend>
-    <FormControl aria-describedby="basic-addon1" />
+    <Button variant="outline-secondary">Button</Button>
+    <Button variant="outline-secondary">Button</Button>
+    <FormControl aria-label="Example text with two button addons" />
   </InputGroup>
 
   <InputGroup>
     <FormControl
       placeholder="Recipient's username"
-      aria-label="Recipient's username"
-      aria-describedby="basic-addon2"
+      aria-label="Recipient's username with two button addons"
     />
-    <InputGroup.Append>
-      <Button variant="outline-secondary">Button</Button>
-      <Button variant="outline-secondary">Button</Button>
-    </InputGroup.Append>
+    <Button variant="outline-secondary">Button</Button>
+    <Button variant="outline-secondary">Button</Button>
   </InputGroup>
-</div>;
+</>;

--- a/www/src/examples/InputGroup/Checkboxes.js
+++ b/www/src/examples/InputGroup/Checkboxes.js
@@ -1,14 +1,10 @@
-<div>
+<>
   <InputGroup className="mb-3">
-    <InputGroup.Prepend>
-      <InputGroup.Checkbox aria-label="Checkbox for following text input" />
-    </InputGroup.Prepend>
+    <InputGroup.Checkbox aria-label="Checkbox for following text input" />
     <FormControl aria-label="Text input with checkbox" />
   </InputGroup>
   <InputGroup>
-    <InputGroup.Prepend>
-      <InputGroup.Radio aria-label="Radio button for following text input" />
-    </InputGroup.Prepend>
+    <InputGroup.Radio aria-label="Radio button for following text input" />
     <FormControl aria-label="Text input with radio button" />
   </InputGroup>
-</div>;
+</>;

--- a/www/src/examples/InputGroup/MultipleAddons.js
+++ b/www/src/examples/InputGroup/MultipleAddons.js
@@ -1,22 +1,12 @@
-<div>
+<>
   <InputGroup className="mb-3">
-    <InputGroup.Prepend>
-      <InputGroup.Text>$</InputGroup.Text>
-      <InputGroup.Text>0.00</InputGroup.Text>
-    </InputGroup.Prepend>
-    <FormControl
-      placeholder="Recipient's username"
-      aria-label="Amount (to the nearest dollar)"
-    />
+    <InputGroup.Text>$</InputGroup.Text>
+    <InputGroup.Text>0.00</InputGroup.Text>
+    <FormControl aria-label="Dollar amount (with dot and two decimal places)" />
   </InputGroup>
-  <InputGroup className="mb-3">
-    <FormControl
-      placeholder="Recipient's username"
-      aria-label="Amount (to the nearest dollar)"
-    />
-    <InputGroup.Append>
-      <InputGroup.Text>$</InputGroup.Text>
-      <InputGroup.Text>0.00</InputGroup.Text>
-    </InputGroup.Append>
+  <InputGroup>
+    <FormControl aria-label="Dollar amount (with dot and two decimal places)" />
+    <InputGroup.Text>$</InputGroup.Text>
+    <InputGroup.Text>0.00</InputGroup.Text>
   </InputGroup>
-</div>;
+</>;

--- a/www/src/examples/InputGroup/MultipleInputs.js
+++ b/www/src/examples/InputGroup/MultipleInputs.js
@@ -1,7 +1,5 @@
 <InputGroup className="mb-3">
-  <InputGroup.Prepend>
-    <InputGroup.Text>First and last name</InputGroup.Text>
-  </InputGroup.Prepend>
-  <FormControl />
-  <FormControl />
+  <InputGroup.Text>First and last name</InputGroup.Text>
+  <FormControl aria-label="First name" />
+  <FormControl aria-label="Last name" />
 </InputGroup>;

--- a/www/src/examples/InputGroup/Sizes.js
+++ b/www/src/examples/InputGroup/Sizes.js
@@ -1,15 +1,11 @@
-<div>
+<>
   <InputGroup size="sm" className="mb-3">
-    <InputGroup.Prepend>
-      <InputGroup.Text id="inputGroup-sizing-sm">Small</InputGroup.Text>
-    </InputGroup.Prepend>
+    <InputGroup.Text id="inputGroup-sizing-sm">Small</InputGroup.Text>
     <FormControl aria-label="Small" aria-describedby="inputGroup-sizing-sm" />
   </InputGroup>
   <br />
   <InputGroup className="mb-3">
-    <InputGroup.Prepend>
-      <InputGroup.Text id="inputGroup-sizing-default">Default</InputGroup.Text>
-    </InputGroup.Prepend>
+    <InputGroup.Text id="inputGroup-sizing-default">Default</InputGroup.Text>
     <FormControl
       aria-label="Default"
       aria-describedby="inputGroup-sizing-default"
@@ -17,9 +13,7 @@
   </InputGroup>
   <br />
   <InputGroup size="lg">
-    <InputGroup.Prepend>
-      <InputGroup.Text id="inputGroup-sizing-lg">Large</InputGroup.Text>
-    </InputGroup.Prepend>
+    <InputGroup.Text id="inputGroup-sizing-lg">Large</InputGroup.Text>
     <FormControl aria-label="Large" aria-describedby="inputGroup-sizing-sm" />
   </InputGroup>
-</div>;
+</>;

--- a/www/src/pages/components/input-group.js
+++ b/www/src/pages/components/input-group.js
@@ -54,7 +54,10 @@ export default withLayout(function InputGroupSection({ data }) {
       <LinkedHeading h="2" id="input-group-multiple-addons">
         Multiple addons
       </LinkedHeading>
-      <p>Multiple add-ons are supported and can be mixed</p>
+      <p>
+        Multiple add-ons are supported and can be mixed with checkbox and radio
+        input versions.
+      </p>
       <ReactPlayground codeText={MultipleAddons} />
 
       <LinkedHeading h="2" id="input-group-buttons">

--- a/www/src/pages/migrating.mdx
+++ b/www/src/pages/migrating.mdx
@@ -58,3 +58,7 @@ Below is a _rough_ account of the breaking API changes as well as the minimal ch
 ### FormRow
 
 - removed. Use `Row` instead.
+
+### InputGroup
+
+- dropped `InputGroupPrepend` and `InputGroupAppend`. Buttons and `InputGroupText` can now be added as direct children.


### PR DESCRIPTION
https://v5.getbootstrap.com/docs/5.0/forms/input-group/

Note: 
I did run into an issue with the dropdowns that might need to be solved in another PR.  The new markup for dropdowns has the dropdown toggle and menu directly under the `InputGroup`.  

In v4 this was solved with `<DropdownButton as={InputGroup.Prepend}>`, but there's no parent element within `InputGroup` this time.

I don't think there's a way to solve this with the existing components... anybody have any suggestions?

Changes:
- Drop `InputGroupPrepend` and `InputGroupAppend`
- Replace input in `InputGroupCheckbox` with `FormCheckInput`
- Fix tests and examples