### PR TITLE
feat(carousel): add individual item intervals

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -505,7 +505,7 @@ function CarouselFunc(uncontrolledProps: CarouselProps, ref) {
 
     intervalHandleRef.current = window.setInterval(
       document.visibilityState ? nextWhenVisible : next,
-      activeChildIntervalRef.current || interval || undefined,
+      activeChildIntervalRef.current ?? interval ?? undefined,
     );
 
     return () => {

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -251,12 +251,6 @@ function CarouselFunc(uncontrolledProps: CarouselProps, ref) {
     activeIndex || 0,
   );
 
-  const intervals = useRef<number[]>([]);
-
-  const intervalRef = useCommittedRef(
-    intervals.current[activeIndex as number] ?? interval,
-  );
-
   if (!isSliding && activeIndex !== renderedActiveIndex) {
     if (nextDirectionRef.current) {
       setDirection(nextDirectionRef.current);
@@ -278,12 +272,18 @@ function CarouselFunc(uncontrolledProps: CarouselProps, ref) {
   });
 
   let numChildren = 0;
+  let activeChildInterval: number | undefined;
+
   // Iterate to grab all of the children's interval values
   // (and count them, too)
   forEach(children, (child, index) => {
-    intervals.current[index] = child.props.interval as number;
-    numChildren++;
+    ++numChildren;
+    if (index === activeIndex) {
+      activeChildInterval = child.props.interval as number | undefined;
+    }
   });
+
+  const activeChildIntervalRef = useCommittedRef(activeChildInterval);
 
   const prev = useCallback(
     (event) => {
@@ -505,7 +505,7 @@ function CarouselFunc(uncontrolledProps: CarouselProps, ref) {
 
     intervalHandleRef.current = window.setInterval(
       document.visibilityState ? nextWhenVisible : next,
-      intervalRef.current,
+      activeChildIntervalRef.current || interval || undefined,
     );
 
     return () => {
@@ -513,7 +513,7 @@ function CarouselFunc(uncontrolledProps: CarouselProps, ref) {
         clearInterval(intervalHandleRef.current);
       }
     };
-  }, [shouldPlay, next, intervalRef, interval, nextWhenVisible]);
+  }, [shouldPlay, next, activeChildIntervalRef, interval, nextWhenVisible]);
 
   const indicatorOnClicks = useMemo(
     () =>

--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -250,6 +250,8 @@ function CarouselFunc(uncontrolledProps: CarouselProps, ref) {
     activeIndex || 0,
   );
 
+  const intervals = useRef<number[]>([]);
+
   if (!isSliding && activeIndex !== renderedActiveIndex) {
     if (nextDirectionRef.current) {
       setDirection(nextDirectionRef.current);
@@ -492,9 +494,15 @@ function CarouselFunc(uncontrolledProps: CarouselProps, ref) {
       return undefined;
     }
 
+    let chosenInterval = interval || undefined;
+
+    if (activeIndex !== undefined && intervals.current[activeIndex]) {
+      chosenInterval = intervals.current[activeIndex];
+    }
+
     intervalHandleRef.current = window.setInterval(
       document.visibilityState ? nextWhenVisible : next,
-      interval || undefined,
+      chosenInterval,
     );
 
     return () => {
@@ -502,7 +510,7 @@ function CarouselFunc(uncontrolledProps: CarouselProps, ref) {
         clearInterval(intervalHandleRef.current);
       }
     };
-  }, [shouldPlay, next, interval, nextWhenVisible]);
+  }, [shouldPlay, next, activeIndex, interval, nextWhenVisible]);
 
   const indicatorOnClicks = useMemo(
     () =>
@@ -547,6 +555,7 @@ function CarouselFunc(uncontrolledProps: CarouselProps, ref) {
       <div className={`${prefix}-inner`}>
         {map(children, (child, index) => {
           const isActive = index === renderedActiveIndex;
+          intervals.current[index] = child.props.interval as number;
 
           return slide ? (
             <Transition

--- a/src/CarouselItem.tsx
+++ b/src/CarouselItem.tsx
@@ -1,3 +1,54 @@
-import createWithBsPrefix from './createWithBsPrefix';
+import classNames from 'classnames';
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useBootstrapPrefix } from './ThemeProvider';
+import {
+  BsPrefixPropsWithChildren,
+  BsPrefixRefForwardingComponent,
+} from './helpers';
 
-export default createWithBsPrefix('carousel-item');
+export interface CarouselItemProps extends BsPrefixPropsWithChildren {
+  interval?: number;
+}
+
+type CarouselItem = BsPrefixRefForwardingComponent<'div', CarouselItemProps>;
+
+const propTypes = {
+  /** Set a custom element for this component */
+  as: PropTypes.elementType,
+
+  /** @default 'carousel-item' */
+  bsPrefix: PropTypes.string,
+
+  /** The amount of time to delay between automatically cycling this specific item. Will default to the Carousel's `interval` prop value if none is specified. */
+  interval: PropTypes.number,
+};
+
+const CarouselItem = (React.forwardRef(
+  (
+    {
+      // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
+      as: Component = 'div',
+      bsPrefix,
+      children,
+      className,
+      ...props
+    }: CarouselItemProps,
+    ref,
+  ) => {
+    const finalClassName = classNames(
+      className,
+      useBootstrapPrefix(bsPrefix, 'carousel-item'),
+    );
+    return (
+      <Component ref={ref} {...props} className={finalClassName}>
+        {children}
+      </Component>
+    );
+  },
+) as unknown) as CarouselItem;
+
+CarouselItem.displayName = 'CarouselItem';
+CarouselItem.propTypes = propTypes;
+
+export default CarouselItem;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -46,6 +46,8 @@ export { default as Carousel } from './Carousel';
 export type { CarouselProps } from './Carousel';
 
 export { default as CarouselItem } from './CarouselItem';
+export type { CarouselItemProps } from './CarouselItem';
+
 export { default as CloseButton } from './CloseButton';
 export type { CloseButtonProps } from './CloseButton';
 

--- a/test/CarouselSpec.js
+++ b/test/CarouselSpec.js
@@ -340,7 +340,7 @@ describe('<Carousel>', () => {
       );
 
       const total = intervals.reduce((sum, current) => sum + current, 0);
-      clock.tick(total * 1.1);
+      clock.tick(total * 1.7);
 
       expect(onSelectSpy).to.have.been.calledThrice;
       expect(onSelectSpy.firstCall).to.have.been.calledWith(1);

--- a/test/CarouselSpec.js
+++ b/test/CarouselSpec.js
@@ -315,6 +315,39 @@ describe('<Carousel>', () => {
       expect(onSelectSpy).to.have.been.calledOnce;
     });
 
+    it('should go through the items given the specified intervals', () => {
+      const defaultInterval = 5000;
+      const intervals = [
+        1000,
+        500,
+        defaultInterval, // to test for no interval specified, it should be the default
+      ];
+      const itemsWithIntervals = [
+        <Carousel.Item key={1} interval={intervals[0]}>
+          Item 1 content
+        </Carousel.Item>,
+        <Carousel.Item key={2} interval={intervals[1]}>
+          Item 2 content
+        </Carousel.Item>,
+        <Carousel.Item key={3}>Item 3 content</Carousel.Item>,
+      ];
+
+      const onSelectSpy = sinon.spy();
+      mount(
+        <Carousel interval={defaultInterval} onSelect={onSelectSpy}>
+          {itemsWithIntervals}
+        </Carousel>,
+      );
+
+      const total = intervals.reduce((sum, current) => sum + current, 0);
+      clock.tick(total * 1.1);
+
+      expect(onSelectSpy).to.have.been.calledThrice;
+      expect(onSelectSpy.firstCall).to.have.been.calledWith(1);
+      expect(onSelectSpy.secondCall).to.have.been.calledWith(2);
+      expect(onSelectSpy.thirdCall).to.have.been.calledWith(0);
+    });
+
     it('should stop going through items on hover and continue afterwards', () => {
       const onSelectSpy = sinon.spy();
       const interval = 500;

--- a/test/CarouselSpec.js
+++ b/test/CarouselSpec.js
@@ -316,36 +316,21 @@ describe('<Carousel>', () => {
     });
 
     it('should go through the items given the specified intervals', () => {
-      const defaultInterval = 5000;
-      const intervals = [
-        1000,
-        500,
-        defaultInterval, // to test for no interval specified, it should be the default
-      ];
-      const itemsWithIntervals = [
-        <Carousel.Item key={1} interval={intervals[0]}>
-          Item 1 content
-        </Carousel.Item>,
-        <Carousel.Item key={2} interval={intervals[1]}>
-          Item 2 content
-        </Carousel.Item>,
-        <Carousel.Item key={3}>Item 3 content</Carousel.Item>,
-      ];
-
       const onSelectSpy = sinon.spy();
       mount(
-        <Carousel interval={defaultInterval} onSelect={onSelectSpy}>
-          {itemsWithIntervals}
+        <Carousel interval={1000} onSelect={onSelectSpy}>
+          <Carousel.Item interval={100}>Item 1 content</Carousel.Item>
+          <Carousel.Item>Item 2 content</Carousel.Item>
         </Carousel>,
       );
 
-      const total = intervals.reduce((sum, current) => sum + current, 0);
-      clock.tick(total * 1.1);
+      // should be long enough to handle false positive issues
+      // but short enough to not trigger auto-play to occur twice
+      // (since the interval for the second item should be `1000`)
+      clock.tick(200);
 
-      expect(onSelectSpy).to.have.been.calledThrice;
+      expect(onSelectSpy).to.have.been.calledOnce;
       expect(onSelectSpy.firstCall).to.have.been.calledWith(1);
-      expect(onSelectSpy.secondCall).to.have.been.calledWith(2);
-      expect(onSelectSpy.thirdCall).to.have.been.calledWith(0);
     });
 
     it('should stop going through items on hover and continue afterwards', () => {

--- a/test/CarouselSpec.js
+++ b/test/CarouselSpec.js
@@ -340,7 +340,7 @@ describe('<Carousel>', () => {
       );
 
       const total = intervals.reduce((sum, current) => sum + current, 0);
-      clock.tick(total * 1.7);
+      clock.tick(total * 1.1);
 
       expect(onSelectSpy).to.have.been.calledThrice;
       expect(onSelectSpy.firstCall).to.have.been.calledWith(1);

--- a/www/src/examples/Carousel/IndividualIntervals.js
+++ b/www/src/examples/Carousel/IndividualIntervals.js
@@ -1,0 +1,35 @@
+<Carousel>
+  <Carousel.Item interval={1000}>
+    <img
+      className="d-block w-100"
+      src="holder.js/800x400?text=First slide&bg=373940"
+      alt="First slide"
+    />
+    <Carousel.Caption>
+      <h3>First slide label</h3>
+      <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
+    </Carousel.Caption>
+  </Carousel.Item>
+  <Carousel.Item interval={500}>
+    <img
+      className="d-block w-100"
+      src="holder.js/800x400?text=Second slide&bg=282c34"
+      alt="Third slide"
+    />
+    <Carousel.Caption>
+      <h3>Second slide label</h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+    </Carousel.Caption>
+  </Carousel.Item>
+  <Carousel.Item>
+    <img
+      className="d-block w-100"
+      src="holder.js/800x400?text=Third slide&bg=20232a"
+      alt="Third slide"
+    />
+    <Carousel.Caption>
+      <h3>Third slide label</h3>
+      <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur.</p>
+    </Carousel.Caption>
+  </Carousel.Item>
+</Carousel>;

--- a/www/src/pages/components/carousel.mdx
+++ b/www/src/pages/components/carousel.mdx
@@ -4,6 +4,7 @@ import ComponentApi from '../../components/ComponentApi';
 import ReactPlayground from '../../components/ReactPlayground';
 import CarouselControlled from '../../examples/Carousel/Controlled';
 import CarouselUncontrolled from '../../examples/Carousel/Uncontrolled';
+import IndividualIntervals from '../../examples/Carousel/IndividualIntervals';
 
 # Carousels
 
@@ -28,6 +29,13 @@ You can also _control_ the Carousel state, via the
 `activeIndex` prop and `onSelect` handler.
 
 <ReactPlayground codeText={CarouselControlled} />
+
+## Individual Item Intervals
+
+You can specify individual intervals for each carousel item via the `interval`
+prop.
+
+<ReactPlayground codeText={IndividualIntervals} />
 
 ## API
 


### PR DESCRIPTION
Adds the ability to specify intervals per-item, which should
hopefully match the functionality of the upstream feature.

TODOs:
- [x] Fix false positive issues from the feature test
- [x] Add prop types for the `interval` prop for `CarouselItem`

fixes #5305