### PR TITLE
docs(v5): Fix errors and warnings

### DIFF
--- a/www/src/examples/ButtonGroup/Toolbar.js
+++ b/www/src/examples/ButtonGroup/Toolbar.js
@@ -7,9 +7,7 @@
       <Button variant="secondary">4</Button>
     </ButtonGroup>
     <InputGroup>
-      <InputGroup.Prepend>
-        <InputGroup.Text id="btnGroupAddon">@</InputGroup.Text>
-      </InputGroup.Prepend>
+      <InputGroup.Text id="btnGroupAddon">@</InputGroup.Text>
       <FormControl
         type="text"
         placeholder="Input group example"
@@ -30,9 +28,7 @@
       <Button variant="secondary">4</Button>
     </ButtonGroup>
     <InputGroup>
-      <InputGroup.Prepend>
-        <InputGroup.Text id="btnGroupAddon2">@</InputGroup.Text>
-      </InputGroup.Prepend>
+      <InputGroup.Text id="btnGroupAddon2">@</InputGroup.Text>
       <FormControl
         type="text"
         placeholder="Input group example"

--- a/www/src/examples/Form/ColorPicker.js
+++ b/www/src/examples/Form/ColorPicker.js
@@ -3,7 +3,7 @@
   <Form.Control
     type="color"
     id="exampleColorInput"
-    value="#563d7c"
+    defaultValue="#563d7c"
     title="Choose your color"
   />
 </>;

--- a/www/src/examples/Form/FileApi.js
+++ b/www/src/examples/Form/FileApi.js
@@ -1,6 +1,6 @@
 <Form>
   <div className="mb-3">
-    <Form.File id="formcheck-api-custom" custom>
+    <Form.File id="formcheck-api-custom">
       <Form.File.Input isValid />
       <Form.File.Label>
         <Form.File.Text>Custom file input</Form.File.Text>

--- a/www/src/examples/Form/GridAutoSizing.js
+++ b/www/src/examples/Form/GridAutoSizing.js
@@ -15,9 +15,7 @@
         Username
       </Form.Label>
       <InputGroup className="mb-2">
-        <InputGroup.Prepend>
-          <InputGroup.Text>@</InputGroup.Text>
-        </InputGroup.Prepend>
+        <InputGroup.Text>@</InputGroup.Text>
         <FormControl id="inlineFormInputGroup" placeholder="Username" />
       </InputGroup>
     </Col>

--- a/www/src/examples/Form/GridAutoSizingColMix.js
+++ b/www/src/examples/Form/GridAutoSizingColMix.js
@@ -11,9 +11,7 @@
         Username
       </Form.Label>
       <InputGroup>
-        <InputGroup.Prepend>
-          <InputGroup.Text>@</InputGroup.Text>
-        </InputGroup.Prepend>
+        <InputGroup.Text>@</InputGroup.Text>
         <FormControl id="inlineFormInputGroupUsername" placeholder="Username" />
       </InputGroup>
     </Col>

--- a/www/src/examples/Form/GridAutoSizingCustom.js
+++ b/www/src/examples/Form/GridAutoSizingCustom.js
@@ -16,7 +16,6 @@
         type="checkbox"
         id="customControlAutosizing"
         label="Remember my preference"
-        custom
       />
     </Col>
     <Col xs="auto" className="my-1">

--- a/www/src/examples/Form/Validation.js
+++ b/www/src/examples/Form/Validation.js
@@ -47,9 +47,7 @@
   <Form.Group controlId="formValidationWarning3" validationState="warning">
     <Form.Label>Input group with warning</Form.Label>
     <InputGroup>
-      <InputGroup.Prepend>
-        <InputGroup.Text>@</InputGroup.Text>
-      </InputGroup.Prepend>
+      <InputGroup.Text>@</InputGroup.Text>
       <Form.Control type="text" />
     </InputGroup>
     <Form.Control />
@@ -72,9 +70,7 @@
       </Col>
       <Col xs={9}>
         <InputGroup>
-          <InputGroup.Prepend>
-            <InputGroup.Text>@</InputGroup.Text>
-          </InputGroup.Prepend>
+          <InputGroup.Text>@</InputGroup.Text>
           <Form.Control type="text" />
         </InputGroup>
         <Form.Control />
@@ -90,9 +86,7 @@
     <Form.Group controlId="formValidationError4" validationState="error">
       <Form.Label>Input group with error</Form.Label>{' '}
       <InputGroup>
-        <InputGroup.Prepend>
-          <InputGroup.Text>@</InputGroup.Text>
-        </InputGroup.Prepend>
+        <InputGroup.Text>@</InputGroup.Text>
         <Form.Control type="text" />
       </InputGroup>
       <Form.Control />

--- a/www/src/examples/Form/ValidationFormik.js
+++ b/www/src/examples/Form/ValidationFormik.js
@@ -57,9 +57,7 @@ function FormExample() {
             <Form.Group as={Col} md="4" controlId="validationFormikUsername">
               <Form.Label>Username</Form.Label>
               <InputGroup>
-                <InputGroup.Prepend>
-                  <InputGroup.Text id="inputGroupPrepend">@</InputGroup.Text>
-                </InputGroup.Prepend>
+                <InputGroup.Text id="inputGroupPrepend">@</InputGroup.Text>
                 <Form.Control
                   type="text"
                   placeholder="Username"

--- a/www/src/examples/Form/ValidationNative.js
+++ b/www/src/examples/Form/ValidationNative.js
@@ -37,9 +37,7 @@ function FormExample() {
         <Form.Group as={Col} md="4" controlId="validationCustomUsername">
           <Form.Label>Username</Form.Label>
           <InputGroup>
-            <InputGroup.Prepend>
-              <InputGroup.Text id="inputGroupPrepend">@</InputGroup.Text>
-            </InputGroup.Prepend>
+            <InputGroup.Text id="inputGroupPrepend">@</InputGroup.Text>
             <Form.Control
               type="text"
               placeholder="Username"

--- a/www/src/examples/Form/ValidationTooltips.js
+++ b/www/src/examples/Form/ValidationTooltips.js
@@ -58,9 +58,7 @@ function FormExample() {
             <Form.Group as={Col} md="4" controlId="validationFormikUsername2">
               <Form.Label>Username</Form.Label>
               <InputGroup>
-                <InputGroup.Prepend>
-                  <InputGroup.Text id="inputGroupPrepend">@</InputGroup.Text>
-                </InputGroup.Prepend>
+                <InputGroup.Text id="inputGroupPrepend">@</InputGroup.Text>
                 <Form.Control
                   type="text"
                   placeholder="Username"


### PR DESCRIPTION
Missed a bunch of `InputGroup.Prepend`s in the forms page.  Fixed that along with some console warnings from other examples.