### PR TITLE
feat(v5): ToggleButton changes

### DIFF
--- a/src/ButtonGroup.tsx
+++ b/src/ButtonGroup.tsx
@@ -11,7 +11,6 @@ import {
 export interface ButtonGroupProps extends BsPrefixPropsWithChildren {
   role?: string;
   size?: 'sm' | 'lg';
-  toggle?: boolean;
   vertical?: boolean;
 }
 
@@ -34,13 +33,6 @@ const propTypes = {
   vertical: PropTypes.bool,
 
   /**
-   * Display as a button toggle group.
-   *
-   * (Generally it's better to use `ToggleButtonGroup` directly)
-   */
-  toggle: PropTypes.bool,
-
-  /**
    * An ARIA role describing the button group. Usually the default
    * "group" role is fine. An `aria-label` or `aria-labelledby`
    * prop is also recommended.
@@ -52,7 +44,6 @@ const propTypes = {
 
 const defaultProps = {
   vertical: false,
-  toggle: false,
   role: 'group',
 };
 
@@ -61,7 +52,6 @@ const ButtonGroup: ButtonGroup = React.forwardRef(
     {
       bsPrefix,
       size,
-      toggle,
       vertical,
       className,
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
@@ -83,7 +73,6 @@ const ButtonGroup: ButtonGroup = React.forwardRef(
           className,
           baseClass,
           size && `${prefix}-${size}`,
-          toggle && `${prefix}-toggle`,
         )}
       />
     );

--- a/src/ToggleButton.tsx
+++ b/src/ToggleButton.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, { useCallback, useState } from 'react';
-
+import React from 'react';
+import { useBootstrapPrefix } from './ThemeProvider';
 import Button, { ButtonProps } from './Button';
 import {
   BsPrefixAndClassNameOnlyProps,
@@ -26,6 +26,11 @@ const noop = () => undefined;
 
 const propTypes = {
   /**
+   * @default 'btn-check'
+   */
+  bsPrefix: PropTypes.string,
+
+  /**
    * The `<input>` element `type`
    */
   type: PropTypes.oneOf(['checkbox', 'radio']),
@@ -45,6 +50,11 @@ const propTypes = {
    * The disabled state of both the label and input
    */
   disabled: PropTypes.bool,
+
+  /**
+   * `id` is required for button clicks to toggle input.
+   */
+  id: PropTypes.string.isRequired,
 
   /**
    * A callback fired when the underlying input element changes. This is passed
@@ -68,6 +78,7 @@ const propTypes = {
 const ToggleButton = React.forwardRef<any, ToggleButtonProps>(
   (
     {
+      bsPrefix,
       children,
       name,
       className,
@@ -76,35 +87,18 @@ const ToggleButton = React.forwardRef<any, ToggleButtonProps>(
       onChange,
       value,
       disabled,
+      id,
       inputRef,
       ...props
     }: ToggleButtonProps,
     ref,
   ) => {
-    const [focused, setFocused] = useState(false);
-
-    const handleFocus = useCallback((e) => {
-      if (e.target.tagName === 'INPUT') setFocused(true);
-    }, []);
-
-    const handleBlur = useCallback((e) => {
-      if (e.target.tagName === 'INPUT') setFocused(false);
-    }, []);
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'btn-check');
 
     return (
-      <Button
-        {...props}
-        ref={ref}
-        className={classNames(
-          className,
-          focused && 'focus',
-          disabled && 'disabled',
-        )}
-        type={undefined}
-        active={!!checked}
-        as="label"
-      >
+      <>
         <input
+          className={bsPrefix}
           name={name}
           type={type}
           value={value as any}
@@ -112,13 +106,20 @@ const ToggleButton = React.forwardRef<any, ToggleButtonProps>(
           autoComplete="off"
           checked={!!checked}
           disabled={!!disabled}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
           onChange={onChange || noop}
+          id={id}
         />
-
-        {children}
-      </Button>
+        <Button
+          {...props}
+          ref={ref}
+          className={classNames(className, disabled && 'disabled')}
+          type={undefined}
+          as="label"
+          htmlFor={id}
+        >
+          {children}
+        </Button>
+      </>
     );
   },
 );

--- a/src/ToggleButtonGroup.tsx
+++ b/src/ToggleButtonGroup.tsx
@@ -120,7 +120,7 @@ const ToggleButtonGroup: ToggleButtonGroup<any> = (React.forwardRef(
     );
 
     return (
-      <ButtonGroup {...controlledProps} ref={ref as any} toggle>
+      <ButtonGroup {...controlledProps} ref={ref as any}>
         {map(children, (child) => {
           const values = getValues();
           const { value: childVal, onChange: childOnChange } = child.props;

--- a/test/ButtonGroupSpec.js
+++ b/test/ButtonGroupSpec.js
@@ -30,14 +30,6 @@ describe('ButtonGroup', () => {
       .assertNone('.btn-group');
   });
 
-  it('Should add toggle variation', () => {
-    mount(
-      <ButtonGroup toggle>
-        <Button>Title</Button>
-      </ButtonGroup>,
-    ).assertSingle('.btn-group.btn-group-toggle');
-  });
-
   it('Should have div as default component', () => {
     mount(<ButtonGroup />).assertSingle('div');
   });

--- a/test/ToggleButtonGroupSpec.js
+++ b/test/ToggleButtonGroupSpec.js
@@ -8,7 +8,7 @@ describe('ToggleButton', () => {
     const ref = React.createRef();
     mount(
       <div>
-        <ToggleButtonGroup.Button ref={ref} value={3}>
+        <ToggleButtonGroup.Button id="id" ref={ref} value={3}>
           Option 3
         </ToggleButtonGroup.Button>
       </div>,
@@ -20,29 +20,12 @@ describe('ToggleButton', () => {
   it('should add an inputRef', () => {
     const ref = React.createRef();
     mount(
-      <ToggleButtonGroup.Button inputRef={ref} value={3}>
+      <ToggleButtonGroup.Button id="id" inputRef={ref} value={3}>
         Option 3
       </ToggleButtonGroup.Button>,
     );
 
     ref.current.tagName.should.equal('INPUT');
-  });
-
-  it('should set focus state', () => {
-    const wrapper = mount(
-      <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>,
-    );
-
-    wrapper.find('input').simulate('focus');
-    wrapper.find('Button').hasClass('focus').should.equal(true);
-  });
-
-  it('should set blur state', () => {
-    const wrapper = mount(
-      <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>,
-    );
-    wrapper.find('input').simulate('blur');
-    wrapper.find('Button').hasClass('focus').should.equal(false);
   });
 });
 
@@ -50,9 +33,15 @@ describe('ToggleButtonGroup', () => {
   it('should render checkboxes', () => {
     mount(
       <ToggleButtonGroup type="checkbox">
-        <ToggleButtonGroup.Button value={1}>Option 1</ToggleButtonGroup.Button>
-        <ToggleButtonGroup.Button value={2}>Option 2</ToggleButtonGroup.Button>
-        <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id1" value={1}>
+          Option 1
+        </ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id2" value={2}>
+          Option 2
+        </ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id3" value={3}>
+          Option 3
+        </ToggleButtonGroup.Button>
       </ToggleButtonGroup>,
     )
       .find('input[type="checkbox"]')
@@ -62,9 +51,15 @@ describe('ToggleButtonGroup', () => {
   it('should render radios', () => {
     mount(
       <ToggleButtonGroup type="radio" name="items">
-        <ToggleButtonGroup.Button value={1}>Option 1</ToggleButtonGroup.Button>
-        <ToggleButtonGroup.Button value={2}>Option 2</ToggleButtonGroup.Button>
-        <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id1" value={1}>
+          Option 1
+        </ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id2" value={2}>
+          Option 2
+        </ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id3" value={3}>
+          Option 3
+        </ToggleButtonGroup.Button>
       </ToggleButtonGroup>,
     )
       .find('input[type="radio"]')
@@ -74,9 +69,15 @@ describe('ToggleButtonGroup', () => {
   it('should select initial values', () => {
     mount(
       <ToggleButtonGroup type="checkbox" defaultValue={[1, 3]}>
-        <ToggleButtonGroup.Button value={1}>Option 1</ToggleButtonGroup.Button>
-        <ToggleButtonGroup.Button value={2}>Option 2</ToggleButtonGroup.Button>
-        <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id1" value={1}>
+          Option 1
+        </ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id2" value={2}>
+          Option 2
+        </ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id3" value={3}>
+          Option 3
+        </ToggleButtonGroup.Button>
       </ToggleButtonGroup>,
     )
       .find('input[checked=true]')
@@ -86,13 +87,15 @@ describe('ToggleButtonGroup', () => {
   it('should disable radios', () => {
     const wrapper = mount(
       <ToggleButtonGroup type="radio" name="items">
-        <ToggleButtonGroup.Button value={1} disabled>
+        <ToggleButtonGroup.Button id="id1" value={1} disabled>
           Option 1
         </ToggleButtonGroup.Button>
-        <ToggleButtonGroup.Button value={2} disabled>
+        <ToggleButtonGroup.Button id="id2" value={2} disabled>
           Option 2
         </ToggleButtonGroup.Button>
-        <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id3" value={3}>
+          Option 3
+        </ToggleButtonGroup.Button>
       </ToggleButtonGroup>,
     );
 
@@ -105,9 +108,15 @@ describe('ToggleButtonGroup', () => {
     const spy = sinon.spy();
     mount(
       <ToggleButtonGroup type="checkbox" onChange={spy}>
-        <ToggleButtonGroup.Button value={1}>Option 1</ToggleButtonGroup.Button>
-        <ToggleButtonGroup.Button value={2}>Option 2</ToggleButtonGroup.Button>
-        <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id1" value={1}>
+          Option 1
+        </ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id2" value={2}>
+          Option 2
+        </ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id3" value={3}>
+          Option 3
+        </ToggleButtonGroup.Button>
       </ToggleButtonGroup>,
     )
       .find('input[type="checkbox"]')
@@ -121,9 +130,15 @@ describe('ToggleButtonGroup', () => {
     const spy = sinon.spy();
     mount(
       <ToggleButtonGroup type="radio" name="items" onChange={spy}>
-        <ToggleButtonGroup.Button value={1}>Option 1</ToggleButtonGroup.Button>
-        <ToggleButtonGroup.Button value={2}>Option 2</ToggleButtonGroup.Button>
-        <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id1" value={1}>
+          Option 1
+        </ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id2" value={2}>
+          Option 2
+        </ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id3" value={3}>
+          Option 3
+        </ToggleButtonGroup.Button>
       </ToggleButtonGroup>,
     )
       .find('input[type="radio"]')
@@ -142,8 +157,12 @@ describe('ToggleButtonGroup', () => {
         defaultValue={[1, 2]}
         onChange={spy}
       >
-        <ToggleButtonGroup.Button value={1}>Option 1</ToggleButtonGroup.Button>
-        <ToggleButtonGroup.Button value={2}>Option 2</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id2" value={1}>
+          Option 1
+        </ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button id="id3" value={2}>
+          Option 2
+        </ToggleButtonGroup.Button>
       </ToggleButtonGroup>,
     )
       .find('input[type="checkbox"]')

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -136,7 +136,6 @@ const MegaComponent = () => (
         as="div"
         role="group"
         size="lg"
-        toggle
         vertical
         bsPrefix="btn-group"
         style={style}

--- a/www/src/examples/Button/ToggleButton.js
+++ b/www/src/examples/Button/ToggleButton.js
@@ -10,8 +10,9 @@ function ToggleButtonExample() {
 
   return (
     <>
-      <ButtonGroup toggle className="mb-2">
+      <ButtonGroup className="mb-2">
         <ToggleButton
+          id="toggle-check"
           type="checkbox"
           variant="secondary"
           checked={checked}
@@ -22,12 +23,42 @@ function ToggleButtonExample() {
         </ToggleButton>
       </ButtonGroup>
       <br />
-      <ButtonGroup toggle>
+      <ButtonGroup className="mb-2">
         {radios.map((radio, idx) => (
           <ToggleButton
             key={idx}
+            id={`radio-${idx}`}
             type="radio"
             variant="secondary"
+            name="radio"
+            value={radio.value}
+            checked={radioValue === radio.value}
+            onChange={(e) => setRadioValue(e.currentTarget.value)}
+          >
+            {radio.name}
+          </ToggleButton>
+        ))}
+      </ButtonGroup>
+      <br />
+      <ToggleButton
+        className="mb-2"
+        id="toggle-check"
+        type="checkbox"
+        variant="outline-primary"
+        checked={checked}
+        value="1"
+        onChange={(e) => setChecked(e.currentTarget.checked)}
+      >
+        Checked
+      </ToggleButton>
+      <br />
+      <ButtonGroup>
+        {radios.map((radio, idx) => (
+          <ToggleButton
+            key={idx}
+            id={`radio-${idx}`}
+            type="radio"
+            variant={idx % 2 ? 'outline-success' : 'outline-danger'}
             name="radio"
             value={radio.value}
             checked={radioValue === radio.value}

--- a/www/src/examples/Button/ToggleButtonGroupUncontrolled.js
+++ b/www/src/examples/Button/ToggleButtonGroupUncontrolled.js
@@ -1,13 +1,25 @@
 <>
   <ToggleButtonGroup type="checkbox" defaultValue={[1, 3]} className="mb-2">
-    <ToggleButton value={1}>Checkbox 1 (pre-checked)</ToggleButton>
-    <ToggleButton value={2}>Checkbox 2</ToggleButton>
-    <ToggleButton value={3}>Checkbox 3 (pre-checked)</ToggleButton>
+    <ToggleButton id="tbg-check-1" value={1}>
+      Checkbox 1 (pre-checked)
+    </ToggleButton>
+    <ToggleButton id="tbg-check-2" value={2}>
+      Checkbox 2
+    </ToggleButton>
+    <ToggleButton id="tbg-check-3" value={3}>
+      Checkbox 3 (pre-checked)
+    </ToggleButton>
   </ToggleButtonGroup>
   <br />
   <ToggleButtonGroup type="radio" name="options" defaultValue={1}>
-    <ToggleButton value={1}>Radio 1 (pre-checked)</ToggleButton>
-    <ToggleButton value={2}>Radio 2</ToggleButton>
-    <ToggleButton value={3}>Radio 3</ToggleButton>
+    <ToggleButton id="tbg-radio-1" value={1}>
+      Radio 1 (pre-checked)
+    </ToggleButton>
+    <ToggleButton id="tbg-radio-2" value={2}>
+      Radio 2
+    </ToggleButton>
+    <ToggleButton id="tbg-radio-3" value={3}>
+      Radio 3
+    </ToggleButton>
   </ToggleButtonGroup>
 </>;

--- a/www/src/pages/components/buttons.mdx
+++ b/www/src/pages/components/buttons.mdx
@@ -105,7 +105,7 @@ The above handles styling, But requires manually controlling the
 
 
 For a nicer experience with checked state management use the
-`<ToggleButtonGroup>` instead of a `<ButtonGroup toggle>` component.
+`<ToggleButtonGroup>` instead of a `<ButtonGroup>` component.
 The group behaves as a form component, where the `value` is an array of the selected
 `value`s for a named checkbox group or the single toggled
 `value` in a similarly named radio group.

--- a/www/src/pages/migrating.mdx
+++ b/www/src/pages/migrating.mdx
@@ -28,6 +28,10 @@ there may be a React-Bootstrap v3 targeting Bootstrap 6 depending on what's best
 
 Below is a _rough_ account of the breaking API changes as well as the minimal change to migrate
 
+### ButtonGroup
+
+- removed `toggle`.
+
 ### Form
 
 - removed `inline`.

--- a/www/src/pages/migrating.mdx
+++ b/www/src/pages/migrating.mdx
@@ -72,3 +72,8 @@ spacing, use margin utilities instead.
 ### InputGroup
 
 - dropped `InputGroupPrepend` and `InputGroupAppend`. Buttons and `InputGroupText` can now be added as direct children.
+
+### ToggleButton
+
+- add `bsPrefix`.
+- `id` is now required. This is to allow toggling of the input due to markup changes in Bootstrap.


### PR DESCRIPTION
https://v5.getbootstrap.com/docs/5.0/migration/#buttons
https://v5.getbootstrap.com/docs/5.0/forms/checks/#toggle-buttons

Changes:

- add `bsPrefix` for `.btn-check` -  This is a new class for the input
- `id` is now required - The markup has changed so the label is adjacent to the input.  Need `id` and `htmlFor` to make the button click toggle the input
- removed `focus` and `active` class management from ToggleButton - These are no longer present in upstream ToggleButton examples and are not needed
- dropped `toggle` from ButtonGroup - The `.btn-group-toggle` is gone
- docs/tests updates