### PR TITLE
feat(ToggleButtonGroup): Add vertical option

### DIFF
--- a/src/ToggleButtonGroup.tsx
+++ b/src/ToggleButtonGroup.tsx
@@ -18,6 +18,7 @@ export interface ToggleButtonRadioProps<T> extends BsPrefixPropsWithChildren {
   value?: T;
   defaultValue?: T;
   onChange?: (value: T, event: any) => void;
+  vertical?: boolean;
 }
 
 export interface ToggleButtonCheckboxProps<T>
@@ -27,6 +28,7 @@ export interface ToggleButtonCheckboxProps<T>
   value?: T[];
   defaultValue?: T[];
   onChange?: (value: T[]) => void;
+  vertical?: boolean;
 }
 
 export type ToggleButtonGroupProps<T> =
@@ -69,6 +71,9 @@ const propTypes = {
    * of the buttons
    */
   type: PropTypes.oneOf(['checkbox', 'radio']).isRequired,
+
+  /** Make the set of Buttons appear vertically stacked. */
+  vertical: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/src/ToggleButtonGroup.tsx
+++ b/src/ToggleButtonGroup.tsx
@@ -78,6 +78,7 @@ const propTypes = {
 
 const defaultProps = {
   type: 'radio',
+  vertical: false,
 };
 
 const ToggleButtonGroup: ToggleButtonGroup<any> = (React.forwardRef(
@@ -88,6 +89,7 @@ const ToggleButtonGroup: ToggleButtonGroup<any> = (React.forwardRef(
       name,
       value,
       onChange,
+      vertical,
       ...controlledProps
     } = useUncontrolled(props, {
       value: 'onChange',
@@ -125,7 +127,12 @@ const ToggleButtonGroup: ToggleButtonGroup<any> = (React.forwardRef(
     );
 
     return (
-      <ButtonGroup {...controlledProps} ref={ref as any} toggle>
+      <ButtonGroup
+        {...controlledProps}
+        vertical={vertical}
+        ref={ref as any}
+        toggle
+      >
         {map(children, (child) => {
           const values = getValues();
           const { value: childVal, onChange: childOnChange } = child.props;

--- a/src/ToggleButtonGroup.tsx
+++ b/src/ToggleButtonGroup.tsx
@@ -5,30 +5,26 @@ import { useUncontrolled } from 'uncontrollable';
 
 import chainFunction from './createChainedFunction';
 import { map } from './ElementChildren';
-import ButtonGroup from './ButtonGroup';
+import ButtonGroup, { ButtonGroupProps } from './ButtonGroup';
 import ToggleButton from './ToggleButton';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixRefForwardingComponent } from './helpers';
 
-export interface ToggleButtonRadioProps<T> extends BsPrefixPropsWithChildren {
+export interface ToggleButtonRadioProps<T>
+  extends Omit<ButtonGroupProps, 'toggle'> {
   type?: 'radio';
   name: string;
   value?: T;
   defaultValue?: T;
   onChange?: (value: T, event: any) => void;
-  vertical?: boolean;
 }
 
 export interface ToggleButtonCheckboxProps<T>
-  extends BsPrefixPropsWithChildren {
+  extends Omit<ButtonGroupProps, 'toggle'> {
   type: 'checkbox';
   name?: string;
   value?: T[];
   defaultValue?: T[];
   onChange?: (value: T[]) => void;
-  vertical?: boolean;
 }
 
 export type ToggleButtonGroupProps<T> =
@@ -72,6 +68,13 @@ const propTypes = {
    */
   type: PropTypes.oneOf(['checkbox', 'radio']).isRequired,
 
+  /**
+   * Sets the size for all Buttons in the group.
+   *
+   * @type ('sm'|'lg')
+   */
+  size: PropTypes.string,
+
   /** Make the set of Buttons appear vertically stacked. */
   vertical: PropTypes.bool,
 };
@@ -89,7 +92,6 @@ const ToggleButtonGroup: ToggleButtonGroup<any> = (React.forwardRef(
       name,
       value,
       onChange,
-      vertical,
       ...controlledProps
     } = useUncontrolled(props, {
       value: 'onChange',
@@ -127,12 +129,7 @@ const ToggleButtonGroup: ToggleButtonGroup<any> = (React.forwardRef(
     );
 
     return (
-      <ButtonGroup
-        {...controlledProps}
-        vertical={vertical}
-        ref={ref as any}
-        toggle
-      >
+      <ButtonGroup {...controlledProps} ref={ref as any} toggle>
         {map(children, (child) => {
           const values = getValues();
           const { value: childVal, onChange: childOnChange } = child.props;

--- a/test/ToggleButtonGroupSpec.js
+++ b/test/ToggleButtonGroupSpec.js
@@ -59,6 +59,21 @@ describe('ToggleButtonGroup', () => {
       .length.should.equal(3);
   });
 
+  it('should render checkboxes vertically', () => {
+    const wrapper = mount(
+      <ToggleButtonGroup type="checkbox" vertical>
+        <ToggleButtonGroup.Button value={1}>Option 1</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button value={2}>Option 2</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>
+      </ToggleButtonGroup>,
+    );
+
+    wrapper
+      .assertSingle('.btn-group-vertical.btn-group-toggle')
+      .assertNone('.btn-group');
+    wrapper.find('input[type="checkbox"]').length.should.equal(3);
+  });
+
   it('should render radios', () => {
     mount(
       <ToggleButtonGroup type="radio" name="items">
@@ -69,6 +84,21 @@ describe('ToggleButtonGroup', () => {
     )
       .find('input[type="radio"]')
       .length.should.equal(3);
+  });
+
+  it('should render radios vertically', () => {
+    const wrapper = mount(
+      <ToggleButtonGroup type="radio" name="items" vertical>
+        <ToggleButtonGroup.Button value={1}>Option 1</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button value={2}>Option 2</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>
+      </ToggleButtonGroup>,
+    );
+
+    wrapper
+      .assertSingle('.btn-group-vertical.btn-group-toggle')
+      .assertNone('.btn-group');
+    wrapper.find('input[type="radio"]').length.should.equal(3);
   });
 
   it('should select initial values', () => {

--- a/test/ToggleButtonGroupSpec.js
+++ b/test/ToggleButtonGroupSpec.js
@@ -58,7 +58,7 @@ describe('ToggleButtonGroup', () => {
 
     wrapper
       .assertSingle('.btn-group.btn-group-toggle')
-      .assertNone('btn-group-vertical');
+      .assertNone('.btn-group-vertical');
     wrapper.find('input[type="checkbox"]').length.should.equal(3);
   });
 

--- a/test/ToggleButtonGroupSpec.js
+++ b/test/ToggleButtonGroupSpec.js
@@ -77,6 +77,36 @@ describe('ToggleButtonGroup', () => {
     wrapper.find('input[type="checkbox"]').length.should.equal(3);
   });
 
+  it('should render checkboxes vertically and small', () => {
+    const wrapper = mount(
+      <ToggleButtonGroup type="checkbox" vertical size="sm">
+        <ToggleButtonGroup.Button value={1}>Option 1</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button value={2}>Option 2</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>
+      </ToggleButtonGroup>,
+    );
+
+    wrapper
+      .assertSingle('.btn-group-vertical.btn-group-sm.btn-group-toggle')
+      .assertNone('.btn-group');
+    wrapper.find('input[type="checkbox"]').length.should.equal(3);
+  });
+
+  it('should render checkboxes vertically and large', () => {
+    const wrapper = mount(
+      <ToggleButtonGroup type="checkbox" vertical size="lg">
+        <ToggleButtonGroup.Button value={1}>Option 1</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button value={2}>Option 2</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>
+      </ToggleButtonGroup>,
+    );
+
+    wrapper
+      .assertSingle('.btn-group-vertical.btn-group-lg.btn-group-toggle')
+      .assertNone('.btn-group');
+    wrapper.find('input[type="checkbox"]').length.should.equal(3);
+  });
+
   it('should render radios', () => {
     const wrapper = mount(
       <ToggleButtonGroup type="radio" name="items">
@@ -103,6 +133,36 @@ describe('ToggleButtonGroup', () => {
 
     wrapper
       .assertSingle('.btn-group-vertical.btn-group-toggle')
+      .assertNone('.btn-group');
+    wrapper.find('input[type="radio"]').length.should.equal(3);
+  });
+
+  it('should render radios vertically and small', () => {
+    const wrapper = mount(
+      <ToggleButtonGroup type="radio" name="items" vertical size="sm">
+        <ToggleButtonGroup.Button value={1}>Option 1</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button value={2}>Option 2</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>
+      </ToggleButtonGroup>,
+    );
+
+    wrapper
+      .assertSingle('.btn-group-vertical.btn-group-sm.btn-group-toggle')
+      .assertNone('.btn-group');
+    wrapper.find('input[type="radio"]').length.should.equal(3);
+  });
+
+  it('should render radios vertically and large', () => {
+    const wrapper = mount(
+      <ToggleButtonGroup type="radio" name="items" vertical size="lg">
+        <ToggleButtonGroup.Button value={1}>Option 1</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button value={2}>Option 2</ToggleButtonGroup.Button>
+        <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>
+      </ToggleButtonGroup>,
+    );
+
+    wrapper
+      .assertSingle('.btn-group-vertical.btn-group-lg.btn-group-toggle')
       .assertNone('.btn-group');
     wrapper.find('input[type="radio"]').length.should.equal(3);
   });

--- a/test/ToggleButtonGroupSpec.js
+++ b/test/ToggleButtonGroupSpec.js
@@ -48,15 +48,18 @@ describe('ToggleButton', () => {
 
 describe('ToggleButtonGroup', () => {
   it('should render checkboxes', () => {
-    mount(
+    const wrapper = mount(
       <ToggleButtonGroup type="checkbox">
         <ToggleButtonGroup.Button value={1}>Option 1</ToggleButtonGroup.Button>
         <ToggleButtonGroup.Button value={2}>Option 2</ToggleButtonGroup.Button>
         <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>
       </ToggleButtonGroup>,
-    )
-      .find('input[type="checkbox"]')
-      .length.should.equal(3);
+    );
+
+    wrapper
+      .assertSingle('.btn-group.btn-group-toggle')
+      .assertNone('btn-group-vertical');
+    wrapper.find('input[type="checkbox"]').length.should.equal(3);
   });
 
   it('should render checkboxes vertically', () => {
@@ -75,15 +78,18 @@ describe('ToggleButtonGroup', () => {
   });
 
   it('should render radios', () => {
-    mount(
+    const wrapper = mount(
       <ToggleButtonGroup type="radio" name="items">
         <ToggleButtonGroup.Button value={1}>Option 1</ToggleButtonGroup.Button>
         <ToggleButtonGroup.Button value={2}>Option 2</ToggleButtonGroup.Button>
         <ToggleButtonGroup.Button value={3}>Option 3</ToggleButtonGroup.Button>
       </ToggleButtonGroup>,
-    )
-      .find('input[type="radio"]')
-      .length.should.equal(3);
+    );
+
+    wrapper
+      .assertSingle('.btn-group.btn-group-toggle')
+      .assertNone('btn-group-vertical');
+    wrapper.find('input[type="radio"]').length.should.equal(3);
   });
 
   it('should render radios vertically', () => {

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -999,6 +999,7 @@ const MegaComponent = () => (
       value={[1]}
       style={style}
       vertical
+      size="lg"
     >
       <ToggleButton
         value={1}

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -998,6 +998,7 @@ const MegaComponent = () => (
       onChange={noop}
       value={[1]}
       style={style}
+      vertical
     >
       <ToggleButton
         value={1}


### PR DESCRIPTION
I am using react-bootstrap in a React/TypeScript project and after upgrading from 1.0.1 to 1.3.0 TypeScript tells me, that "Property 'vertical' does not exist on..." on the `ToggleButtonGroup` component.

So here I added the `vertical` property to the `ToggleButtonGroup` component.

(right now I am making heavy use of `// @ts-ignore` before every ToggleButtonGroup and it works as expected) 