### PR TITLE
feat(v5): Set new arrow class for popover and tooltip

### DIFF
--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -109,7 +109,7 @@ const Popover: Popover = (React.forwardRef<HTMLDivElement, PopoverProps>(
         )}
         {...props}
       >
-        <div className="arrow" {...arrowProps} />
+        <div className="popover-arrow" {...arrowProps} />
         {content ? <PopoverContent>{children}</PopoverContent> : children}
       </div>
     );

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -115,7 +115,7 @@ const Tooltip: Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
         )}
         {...props}
       >
-        <div className="arrow" {...arrowProps} />
+        <div className="tooltip-arrow" {...arrowProps} />
         <div className={`${bsPrefix}-inner`}>{children}</div>
       </div>
     );


### PR DESCRIPTION
https://v5.getbootstrap.com/docs/5.0/migration/#popovers
https://v5.getbootstrap.com/docs/5.0/migration/#tooltips

> Popovers
> Renamed .arrow to .popover-arrow

> Tooltips
> Renamed .arrow to .tooltip-arrow