### PR TITLE
feat(v5): Set ColOrder types to max 5

### DIFF
--- a/src/Col.tsx
+++ b/src/Col.tsx
@@ -23,7 +23,8 @@ type NumberAttr =
   | '11'
   | '12';
 
-type ColOrder = number | 'first' | 'last' | '1' | '2' | '3' | '4' | '5';
+type ColOrderNumber = number | '1' | '2' | '3' | '4' | '5';
+type ColOrder = ColOrderNumber | 'first' | 'last';
 type ColSize = boolean | 'auto' | NumberAttr;
 type ColSpec =
   | ColSize

--- a/src/Col.tsx
+++ b/src/Col.tsx
@@ -23,7 +23,7 @@ type NumberAttr =
   | '11'
   | '12';
 
-type ColOrder = 'first' | 'last' | NumberAttr;
+type ColOrder = number | 'first' | 'last' | '1' | '2' | '3' | '4' | '5';
 type ColSize = boolean | 'auto' | NumberAttr;
 type ColSpec =
   | ColSize

--- a/www/src/pages/migrating.mdx
+++ b/www/src/pages/migrating.mdx
@@ -32,6 +32,10 @@ Below is a _rough_ account of the breaking API changes as well as the minimal ch
 
 - removed `toggle`.
 
+### Col
+
+- `ColOrder` is now maximum 5 instead of 12.
+
 ### Form
 
 - removed `inline`.


### PR DESCRIPTION
https://v5.getbootstrap.com/docs/5.0/migration/#utilities

> Decreased the number of responsive order utilities per breakpoint. The highest order utility with a number now is .order-5 instead of .order-12.

This PR just changes the TS types to restrict string numbers to max 5