### PR TITLE
docs: Fix small typo in Dropdown documentation

### DIFF
--- a/www/src/pages/components/dropdowns.mdx
+++ b/www/src/pages/components/dropdowns.mdx
@@ -38,7 +38,7 @@ dynamic positioning and viewport detection.
 ## Accessibility
 
 The <a href="https://www.w3.org/TR/wai-aria/"><abbr title="Web Accessibility Initiative">WAI</abbr> <ARIA /></a> standard
-defines a [`role="menu"` widget][1], but it's very specific to a certain kind a menu. <ARIA /> menus, must
+defines a [`role="menu"` widget][1], but it's very specific to a certain kind of menu. <ARIA /> menus, must
 only contain `role="menuitem"`, `role="menuitemcheckbox"`, or `role="menuitemradio"`.
 
 On the other hand, Bootstrap's dropdowns are designed to more generic


### PR DESCRIPTION
Changed  'a' to 'of'. It reads a bit nicier and I think it's gramatically correct.

Before:
` but it's very specific to a certain kind a menu. <ARIA /> menus, must`

After:
` but it's very specific to a certain kind of menu. <ARIA /> menus, must`