### PR TITLE
fix(OverlayTrigger): Add func as valid prop type for children

### DIFF
--- a/src/OverlayTrigger.tsx
+++ b/src/OverlayTrigger.tsx
@@ -72,7 +72,7 @@ function handleMouseOverOut(
 const triggerType = PropTypes.oneOf(['click', 'hover', 'focus']);
 
 const propTypes = {
-  children: PropTypes.element.isRequired,
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.func]).isRequired,
 
   /**
    * Specify which action or actions trigger Overlay visibility


### PR DESCRIPTION
Should be valid as per:
https://react-bootstrap.github.io/components/overlays/#customizing-trigger-behavior