### PR TITLE
fix(Fade): fix TS props to work with TransitionType

### DIFF
--- a/src/Fade.tsx
+++ b/src/Fade.tsx
@@ -5,16 +5,18 @@ import React, { useCallback } from 'react';
 import Transition, {
   ENTERED,
   ENTERING,
-  TransitionProps,
 } from 'react-transition-group/Transition';
+import { TransitionCallbacks } from './helpers';
 import triggerBrowserReflow from './triggerBrowserReflow';
 
-export interface FadeProps extends Omit<TransitionProps, 'addEndListener'> {
+export interface FadeProps extends TransitionCallbacks {
+  className?: string;
   in?: boolean;
   mountOnEnter?: boolean;
   unmountOnExit?: boolean;
   appear?: boolean;
   timeout?: number;
+  children: React.ReactElement;
 }
 
 const propTypes = {
@@ -86,7 +88,7 @@ const fadeStyles = {
 };
 
 const Fade = React.forwardRef<Transition<any>, FadeProps>(
-  ({ className, children, ...props }: FadeProps, ref) => {
+  ({ className, children, ...props }, ref) => {
     const handleEnter = useCallback(
       (node) => {
         triggerBrowserReflow(node);

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -18,9 +18,11 @@ import {
   Carousel,
   Container,
   Col,
+  Collapse,
   Row,
   Dropdown,
   DropdownButton,
+  Fade,
   Figure,
   Form,
   FormFile,
@@ -59,6 +61,8 @@ const noop = () => {};
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const MegaComponent = () => (
   <>
+    <Alert transition={Fade} />
+    <Alert transition={Collapse} />
     <Alert
       ref={React.createRef<HTMLDivElement>()}
       style={style}
@@ -66,7 +70,6 @@ const MegaComponent = () => (
       dismissible
       onClose={noop}
       show
-      // transition={} TODO
       variant="primary"
       bsPrefix="alert"
     >


### PR DESCRIPTION
Fixes #5397 and #5336.

Had some difficulties with the types when extending `TransitionProps` from RTG types, so opted to type `Fade` in a similar way to `Collapse`.  Unsure if this is the best way. 