### PR TITLE
fix: Allow falsy eventKeys in DropdownItem and ListGroupItem

### DIFF
--- a/src/DropdownItem.tsx
+++ b/src/DropdownItem.tsx
@@ -95,7 +95,8 @@ const DropdownItem: DropdownItem = React.forwardRef(
     const navContext = useContext(NavContext);
 
     const { activeKey } = navContext || {};
-    const key = makeEventKey(eventKey || null, href);
+    // TODO: Restrict eventKey to string in v5?
+    const key = makeEventKey(eventKey as any, href);
 
     const active =
       propActive == null && key != null

--- a/src/ListGroupItem.tsx
+++ b/src/ListGroupItem.tsx
@@ -102,7 +102,8 @@ const ListGroupItem: ListGroupItem = React.forwardRef(
       <AbstractNavItem
         ref={ref}
         {...props}
-        eventKey={makeEventKey(eventKey || null, props.href)}
+        // TODO: Restrict eventKey to string in v5?
+        eventKey={makeEventKey(eventKey as any, props.href)}
         // eslint-disable-next-line no-nested-ternary
         as={as || (action ? (props.href ? 'a' : 'button') : 'div')}
         onClick={handleClick}


### PR DESCRIPTION
Fixes #5401

I kept the TS type for `eventKey` as string in `DropdownItem` since it's been this way back in Aug 2019.