### PR TITLE
feat(FormCheck): Allow custom controls to render without a label

### DIFF
--- a/src/FormCheck.tsx
+++ b/src/FormCheck.tsx
@@ -65,8 +65,10 @@ const propTypes = {
 
   /**
    * A HTML id attribute, necessary for proper form accessibility.
+   * An id is recommended for allowing label clicks to toggle the check control.
    *
-   * This is **required** when `type="switch"`.
+   * This is **required** for custom check controls or when `type="switch"` due to
+   * how they are rendered.
    */
   id: PropTypes.string,
 
@@ -100,13 +102,13 @@ const propTypes = {
 
   /**
    * Label for the control.
-   *
-   * This is **required** when `type="switch"`.
    */
   label: PropTypes.node,
 
   /** Use Bootstrap's custom form elements to replace the browser defaults */
-  custom: PropTypes.bool,
+  custom: all(PropTypes.bool, ({ custom, id }) =>
+    custom && !id ? Error('Custom check controls require an id to work') : null,
+  ),
 
   /**
    * The type of checkable.
@@ -117,10 +119,6 @@ const propTypes = {
     ({ type, custom }) =>
       type === 'switch' && custom === false
         ? Error('`custom` cannot be set to `false` when the type is `switch`')
-        : null,
-    ({ type, label }) =>
-      type === 'switch' && !label
-        ? Error('`label` must be defined when the type is `switch`')
         : null,
     ({ type, id }) =>
       type === 'switch' && !id
@@ -182,7 +180,7 @@ const FormCheck: FormCheck = (React.forwardRef(
       [controlId, custom, id],
     );
 
-    const hasLabel = label != null && label !== false && !children;
+    const hasLabel = custom || (label != null && label !== false && !children);
 
     const input = (
       <FormCheckInput

--- a/src/FormCheck.tsx
+++ b/src/FormCheck.tsx
@@ -16,12 +16,10 @@ export type FormCheckType = 'checkbox' | 'radio' | 'switch';
 
 export interface FormCheckProps
   extends BsPrefixPropsWithChildren,
-    Pick<React.HTMLAttributes<HTMLElement>, 'style'> {
+    React.HTMLAttributes<HTMLInputElement> {
   bsCustomPrefix?: string;
-  id?: string;
   inline?: boolean;
   disabled?: boolean;
-  title?: string;
   label?: React.ReactNode;
   custom?: boolean;
   type?: FormCheckType;
@@ -65,7 +63,11 @@ const propTypes = {
    */
   as: PropTypes.elementType,
 
-  /** A HTML id attribute, necessary for proper form accessibility. */
+  /**
+   * A HTML id attribute, necessary for proper form accessibility.
+   *
+   * This is **required** when `type="switch"`.
+   */
   id: PropTypes.string,
 
   /**
@@ -81,9 +83,26 @@ const propTypes = {
    */
   children: PropTypes.node,
 
+  /**
+   * Groups controls horizontally with other `FormCheck`s.
+   */
   inline: PropTypes.bool,
+
+  /**
+   * Disables the control.
+   */
   disabled: PropTypes.bool,
+
+  /**
+   * `title` attribute for the underlying `FormCheckLabel`.
+   */
   title: PropTypes.string,
+
+  /**
+   * Label for the control.
+   *
+   * This is **required** when `type="switch"`.
+   */
   label: PropTypes.node,
 
   /** Use Bootstrap's custom form elements to replace the browser defaults */
@@ -98,6 +117,14 @@ const propTypes = {
     ({ type, custom }) =>
       type === 'switch' && custom === false
         ? Error('`custom` cannot be set to `false` when the type is `switch`')
+        : null,
+    ({ type, label }) =>
+      type === 'switch' && !label
+        ? Error('`label` must be defined when the type is `switch`')
+        : null,
+    ({ type, id }) =>
+      type === 'switch' && !id
+        ? Error('`id` must be defined when the type is `switch`')
         : null,
   ),
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -17,9 +17,8 @@ export interface BsCustomPrefixProps {
   bsCustomPrefix?: string;
 }
 
-export interface BsPrefixProps<
-  As extends React.ElementType = React.ElementType
-> extends BsPrefixAndClassNameOnlyProps {
+export interface BsPrefixProps<As extends React.ElementType = React.ElementType>
+  extends BsPrefixAndClassNameOnlyProps {
   as?: As;
 }
 

--- a/test/FormCheckSpec.js
+++ b/test/FormCheckSpec.js
@@ -98,7 +98,9 @@ describe('<FormCheck>', () => {
   });
 
   it('should supports switches', () => {
-    let wrapper = mount(<FormCheck type="switch" label="My label" />);
+    let wrapper = mount(
+      <FormCheck type="switch" label="My label" id="switch-id" />,
+    );
 
     wrapper
       .assertSingle('div.custom-control')
@@ -108,7 +110,7 @@ describe('<FormCheck>', () => {
     wrapper.assertSingle('label.custom-control-label');
     wrapper.unmount();
 
-    wrapper = mount(<Switch label="My label" />);
+    wrapper = mount(<Switch label="My label" id="switch-id2" />);
 
     wrapper
       .assertSingle('div.custom-control')

--- a/test/FormCheckSpec.js
+++ b/test/FormCheckSpec.js
@@ -81,8 +81,8 @@ describe('<FormCheck>', () => {
     expect(instance.input.tagName).to.equal('INPUT');
   });
 
-  it('should supports custom', () => {
-    const wrapper = mount(<FormCheck custom label="My label" />);
+  it('should support custom', () => {
+    const wrapper = mount(<FormCheck custom label="My label" id="myid" />);
 
     wrapper
       .assertSingle('div.custom-control')
@@ -93,7 +93,9 @@ describe('<FormCheck>', () => {
   });
 
   it('should support custom with inline', () => {
-    const wrapper = mount(<FormCheck custom inline label="My label" />);
+    const wrapper = mount(
+      <FormCheck custom inline label="My label" id="myid" />,
+    );
     wrapper.assertSingle('div.custom-control-inline');
   });
 

--- a/www/src/pages/components/forms.js
+++ b/www/src/pages/components/forms.js
@@ -495,10 +495,9 @@ export default withLayout(function FormControlsSection({ data }) {
       </Callout>
       <Callout theme="danger">
         <h5>Watch out!</h5>
-        You must specify both <code>label</code> and <code>id</code> props when
-        using switches. Bootstrap renders the control using the label and event
-        handlers are triggered by linking the label with the input via{' '}
-        <code>id</code>.
+        You must specify an <code>id</code> when using custom check controls or
+        switches. Event handlers are triggered by linking the label with the
+        input via <code>id</code>.
       </Callout>
 
       <h3>Inline</h3>

--- a/www/src/pages/components/forms.js
+++ b/www/src/pages/components/forms.js
@@ -493,6 +493,13 @@ export default withLayout(function FormControlsSection({ data }) {
         You can also use the <code>{'<Form.Switch>'}</code> alias which
         encapsulates the above, in a very small component wrapper.
       </Callout>
+      <Callout theme="danger">
+        <h5>Watch out!</h5>
+        You must specify both <code>label</code> and <code>id</code> props when
+        using switches. Bootstrap renders the control using the label and event
+        handlers are triggered by linking the label with the input via{' '}
+        <code>id</code>.
+      </Callout>
 
       <h3>Inline</h3>
       <ReactPlayground codeText={CheckCustomInline} />


### PR DESCRIPTION
This PR improves the docs in the FormCheck component.

Fixes #4767 and #5151

- Mentions that `label` and `id` are required props for a switch and fixes proptypes to check this
- Fill in missing docs for inline, disabled, title, label props
- Fixes switch tests so it doesn't fail with new proptype check
- Fix lint warning in helpers.ts
- Change types to extend HTMLAttributes - I notice that when using inline event handlers, the vars are implicitly set as `any`.  This resolves that to the proper type.