### PR TITLE
Fixing small type error in docs for form controls

### DIFF
--- a/www/src/examples/Form/TextControls.js
+++ b/www/src/examples/Form/TextControls.js
@@ -25,6 +25,6 @@
   </Form.Group>
   <Form.Group controlId="exampleForm.ControlTextarea1">
     <Form.Label>Example textarea</Form.Label>
-    <Form.Control as="textarea" rows="3" />
+    <Form.Control as="textarea" rows={3} />
   </Form.Group>
 </Form>;


### PR DESCRIPTION
When using React-Boostrap with TypeScript `rows="3"` will cause a type error: `Type 'string' is not assignable to type 'number | undefined'.`  
Thanks for maintaining React-Bootstrap!