### PR TITLE
[ Docs - Modal ] Default size prop is missing in Modal documentation. 

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -69,7 +69,7 @@ const propTypes = {
 
   /**
    * Render a large, extra large or small modal.
-   *
+   * When no prop is provided, the modal is rendered with medium (default) size.
    * @type ('sm'|'lg','xl')
    */
   size: PropTypes.string,

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -69,7 +69,7 @@ const propTypes = {
 
   /**
    * Render a large, extra large or small modal.
-   * When no prop is provided, the modal is rendered with medium (default) size.
+   * When not provided, the modal is rendered with medium (default) size.
    * @type ('sm'|'lg','xl')
    */
   size: PropTypes.string,


### PR DESCRIPTION
Fixes [#5447](https://github.com/react-bootstrap/react-bootstrap/issues/5447).