### PR TITLE
Update tests section of contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ _Note: Occasionally issues are opened that are unclear, or we cannot verify them
 
 ## Tests
 
-All commits that fix bugs or add features need a test. You can run `npm run tdd MyComponentName` for component specific tests.
+All commits that fix bugs or add features need a test. Follow the instructions at [Local Setup](https://github.com/react-bootstrap/react-bootstrap#local-setup) to configure your enivronment and how to run the test commands.
 
 ## API Design
 


### PR DESCRIPTION
Previously, the contributing doc mentioned an outdated `npm run tdd [compontentID]` command (which doesn't work as the `tdd` script, `karma start` doesn't take arguments).  This change cleans this up by linking to the README and its updated instructions.