### PR TITLE
fix(Button): display variant only when set

### DIFF
--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -106,7 +106,7 @@ const Button: Button = React.forwardRef(
       className,
       prefix,
       active && 'active',
-      `${prefix}-${variant}`,
+      variant && `${prefix}-${variant}`,
       block && `${prefix}-block`,
       size && `${prefix}-${size}`,
     );

--- a/test/ButtonSpec.js
+++ b/test/ButtonSpec.js
@@ -110,6 +110,24 @@ describe('<Button>', () => {
     mount(<Button>Title</Button>).assertSingle(`.btn-primary`);
   });
 
+  it('Should remove default variant', () => {
+    mount(<Button variant={null}>Title</Button>)
+      .find(`.btn-primary`)
+      .should.have.length(0);
+  });
+
+  it('Should not output null variant', () => {
+    mount(<Button variant="">Title</Button>)
+      .find(`.btn-null`)
+      .should.have.length(0);
+  });
+
+  it('Should not output empty variant', () => {
+    mount(<Button variant="">Title</Button>)
+      .find(`.btn-`)
+      .should.have.length(0);
+  });
+
   it('Should be active', () => {
     mount(<Button active>Title</Button>).assertSingle(`.active`);
   });


### PR DESCRIPTION
This bugfix aligns the `<button>` variant class implementation with Alert/Badge/Navbar -- only outputing a `prefix-variant` formatted class when a variant is specified and avoiding the situation of outputting `.btn-null` or `.btn-` when the variant is null or an empty string respectively.

This adds several tests to confirm that the default variant gets removed but also the invalid variants don't get outputted.

Split from #5456