### PR TITLE
Increase modal test coverage

### DIFF
--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -170,6 +170,15 @@ describe('<Modal>', () => {
     ).find('.modal-dialog.modal-dialog-centered');
   });
 
+  it('Should pass scrollable to the dialog', () => {
+    const noOp = () => {};
+    mount(
+      <Modal show scrollable onHide={noOp}>
+        <strong>Message</strong>
+      </Modal>,
+    ).find('.modal-dialog.modal-dialog-scrollable');
+  });
+
   it('Should pass dialog style to the dialog', () => {
     const noOp = () => {};
     const dialog = mount(

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -161,6 +161,15 @@ describe('<Modal>', () => {
     ).find('.modal-dialog.modal-sm');
   });
 
+  it('Should pass centered to the dialog', () => {
+    const noOp = () => {};
+    mount(
+      <Modal show centered onHide={noOp}>
+        <strong>Message</strong>
+      </Modal>,
+    ).find('.modal-dialog.modal-dialog-centered');
+  });
+
   it('Should pass dialog style to the dialog', () => {
     const noOp = () => {};
     const dialog = mount(


### PR DESCRIPTION
Added coverage for `centered` and `scrollable` props.

Related to [#3889](https://github.com/react-bootstrap/react-bootstrap/issues/3889)

Happy Hacktoberfest!