### PR TITLE
fix(DropdownMenu): Fix base styles being overridden by popper styles

### DIFF
--- a/src/DropdownMenu.tsx
+++ b/src/DropdownMenu.tsx
@@ -204,10 +204,11 @@ const DropdownMenu: DropdownMenu = React.forwardRef(
       (menuProps as any).alignRight = alignEnd;
     }
 
+    let style = (props as any).style;
     if (placement) {
       // we don't need the default popper style,
       // menus are display: none when not shown.
-      (props as any).style = { ...(props as any).style, ...menuProps.style };
+      style = { ...(props as any).style, ...menuProps.style };
       props['x-placement'] = placement;
     }
 
@@ -215,6 +216,7 @@ const DropdownMenu: DropdownMenu = React.forwardRef(
       <Component
         {...props}
         {...menuProps}
+        style={style}
         className={classNames(
           className,
           prefix,


### PR DESCRIPTION
Passing `style` to `DropdownMenu` currently gets overwritten with the style from popper instead of being merged.  This was a regression from the typescript merge.