### PR TITLE
docs(CloseButton): add component page

### DIFF
--- a/www/src/components/SideNav.js
+++ b/www/src/components/SideNav.js
@@ -117,6 +117,7 @@ const components = [
   'button-group',
   'cards',
   'carousel',
+  'close-button',
   'dropdowns',
   'forms',
   'input-group',

--- a/www/src/examples/CloseButton/Basic.js
+++ b/www/src/examples/CloseButton/Basic.js
@@ -1,0 +1,1 @@
+<CloseButton />;

--- a/www/src/examples/CloseButton/Disabled.js
+++ b/www/src/examples/CloseButton/Disabled.js
@@ -1,0 +1,1 @@
+<CloseButton disabled />;

--- a/www/src/examples/CloseButton/Labelled.js
+++ b/www/src/examples/CloseButton/Labelled.js
@@ -1,0 +1,1 @@
+<CloseButton aria-label="Hide" />;

--- a/www/src/examples/CloseButton/Variants.js
+++ b/www/src/examples/CloseButton/Variants.js
@@ -1,0 +1,4 @@
+<div className="bg-dark p-3">
+  <CloseButton variant="white" />
+  <CloseButton variant="white" disabled />
+</div>;

--- a/www/src/pages/components/close-button.mdx
+++ b/www/src/pages/components/close-button.mdx
@@ -1,0 +1,51 @@
+import { graphql } from 'gatsby';
+
+import ComponentApi from '../../components/ComponentApi';
+import ReactPlayground from '../../components/ReactPlayground';
+import CloseButtonBasic from '../../examples/CloseButton/Basic';
+import CloseButtonDisabled from '../../examples/CloseButton/Disabled';
+import CloseButtonVariants from '../../examples/CloseButton/Variants';
+import CloseButtonLabelled from '../../examples/CloseButton/Labelled';
+
+
+# Close Button
+
+A generic close button for dismissing content such as modals and alerts.
+
+<ReactPlayground codeText={CloseButtonBasic} />
+
+## Disabled state
+
+Bootstrap adds relevant styling to a disabled close button to prevent user
+interactions.
+
+<ReactPlayground codeText={CloseButtonDisabled} />
+
+## Variants
+
+Change the default dark color to white using `variant="white"`.
+
+<ReactPlayground codeText={CloseButtonVariants} />
+
+## Accessibility
+
+To ensure the maximum accessibility for Close Button components, it is
+recommended that you provide relevant text for screen readers.  The example
+below provides an example of accessible usage of this component by way of the
+`aria-label` property.
+
+<ReactPlayground codeText={CloseButtonLabelled} />
+
+## API
+
+<ComponentApi metadata={props.data.metadata} />
+
+
+export const query = graphql`
+  query CloseButton {
+    metadata: componentMetadata(displayName: { eq: "CloseButton" }) {
+      displayName
+      ...ComponentApi_metadata
+    }
+  }
+`;


### PR DESCRIPTION
See #5468. Some adjustment of the TS API may be required, see below where the `variant`'s type is the string literal of `'white'` (`PropTypes.oneOf[null, 'white']`?):

![image](https://user-images.githubusercontent.com/1002811/95710541-72ed3f80-0c50-11eb-8430-00f365ed313d.png)

