### PR TITLE
Add CardColumns ComponentApi component to docs

### DIFF
--- a/www/src/pages/components/cards.mdx
+++ b/www/src/pages/components/cards.mdx
@@ -147,6 +147,7 @@ You can change a card's appearance by changing their `<bg>`, and `<text>` props.
 
 <ComponentApi metadata={props.data.CardDeck} />
 <ComponentApi metadata={props.data.CardGroup} />
+<ComponentApi metadata={props.data.CardColumns} />
 
 
 export const query = graphql`


### PR DESCRIPTION
Looks like this one was missed in the docs, opening so I can send the link to a student learning React 🙂 