### PR TITLE
Use main Reactiflux invite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ know.
 The issue tracker is the preferred channel for bug reports, features requests
 and submitting pull requests, but please respect the following restrictions:
 
-- Please do not use the issue tracker for personal support requests. Stack Overflow ([react-bootstrap](http://stackoverflow.com/questions/tagged/react-bootstrap) tag), [Discord](https://discord.gg/0ZcbPKXt5bXLs9XK), or [Thinkful](http://start.thinkful.com/react/?utm_source=github&utm_medium=badge&utm_campaign=react-bootstrap) are better places to get help.
+- Please do not use the issue tracker for personal support requests. Stack Overflow ([react-bootstrap](http://stackoverflow.com/questions/tagged/react-bootstrap) tag), [Discord](https://discord.gg/reactiflux), or [Thinkful](http://start.thinkful.com/react/?utm_source=github&utm_medium=badge&utm_campaign=react-bootstrap) are better places to get help.
 - Please do not open issues or pull requests regarding the code in React or Bootstrap (open them in their respective repositories).
 
 _Note: Occasionally issues are opened that are unclear, or we cannot verify them. When the issue author has not responded to our questions for verification within 7 days then we will close the issue._

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -11,7 +11,7 @@ the [Contributing Guide](./CONTRIBUTING.md).
 New issues pop up every day. We need to identify urgent issues (such as nobody
 can use a component, or install React-Bootstrap), close and link duplicates,
 answer questions, etc. Please alert the
-[reactiflux#react-bootstrap](https://discord.gg/0ZcbPKXt5bXLs9XK) chat room of
+[reactiflux#react-bootstrap](https://discord.gg/reactiflux) chat room of
 the urgent issues.
 
 Some issues are opened that are just too vague to do anything about. If after
@@ -38,7 +38,7 @@ this will minimize trivial merge conflicts.
 If you are interested in becoming a react-bootstrap maintainer, start by
 reviewing issues and pull requests. Answer questions for those in need of
 troubleshooting. Join us in the
-[reactiflux#react-bootstrap](https://discord.gg/0ZcbPKXt5bXLs9XK) chat room.
+[reactiflux#react-bootstrap](https://discord.gg/reactiflux) chat room.
 Once we see you helping, either we will reach out and ask you if you want to
 join or you can ask one of the current maintainers to add you. We will try our
 best to be proactive in reaching out to those that are already helping out.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Yes please! See the [contributing guidelines][contributing] for details.
 [codecov-badge]: https://img.shields.io/codecov/c/github/react-bootstrap/react-bootstrap/master.svg
 [codecov]: https://codecov.io/gh/react-bootstrap/react-bootstrap
 [discord-badge]: https://img.shields.io/badge/Discord-Join%20chat%20%E2%86%92-738bd7.svg
-[discord]: https://discord.gg/0ZcbPKXt5bXLs9XK
+[discord]: https://discord.gg/reactiflux
 [netlify-badge]: https://api.netlify.com/api/v1/badges/91501718-8820-4d69-b7fe-1616eff5914e/deploy-status
 [netlify]: https://app.netlify.com/sites/react-bootstrap/deploys
 [gh-actions-badge]: https://github.com/react-bootstrap/react-bootstrap/workflows/CI/badge.svg

--- a/www/src/components/NavMain.js
+++ b/www/src/components/NavMain.js
@@ -161,7 +161,7 @@ function NavMain({ activePage }) {
             overlay={<Tooltip id="t-discord">Discord</Tooltip>}
           >
             <StyledNavLink
-              href="https://discord.gg/0ZcbPKXt5bXLs9XK"
+              href="https://discord.gg/reactiflux"
               target="_blank"
               rel="noopener noreferrer"
             >


### PR DESCRIPTION
The old invite was putting joiners into an error state due to the Code of Conduct gate! Not ideal.