### PR TITLE
Workaround for macOS CI brew update error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,12 @@ jobs:
           node-version: 12.x
       - name: Update Brew (macOS)
         if: matrix.os == 'macOS-latest'
-        run: brew update
+        run: |
+          # Workaround https://github.com/actions/virtual-environments/issues/1811
+          brew untap local/homebrew-openssl
+          brew untap local/homebrew-python2
+          # End workaround
+          brew update
       - name: Install Chrome (macOS)
         if: matrix.os == 'macOS-latest' && matrix.browser == 'ChromeHeadless'
         run: brew cask install google-chrome


### PR DESCRIPTION
Workaround for the error we've been seeing with `brew update`.

Ref: actions/virtual-environments#1811