### PR TITLE
chore: Remove ast-types from resolutions

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -38,6 +38,7 @@
     "@mdx-js/react": "^1.6.19",
     "@restart/context": "^2.1.4",
     "@restart/hooks": "^0.3.25",
+    "ast-types": "^0.14.2",
     "astroturf": "^0.10.5",
     "bootstrap": "^4.5.3",
     "classnames": "^2.2.6",
@@ -71,8 +72,5 @@
     "remark-slug": "^6.0.0",
     "shakespeare-data": "^3.0.0",
     "yup": "^0.29.3"
-  },
-  "resolutions": {
-    "ast-types": "^0.14.2"
   }
 }

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -2514,7 +2514,14 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
-ast-types@^0.13.4, ast-types@^0.14.2:
+ast-types@^0.13.4:
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.4.tgz#ee0d77b343263965ecc3fb62da16e7222b2b6782"
+  integrity sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==
+  dependencies:
+    tslib "^2.0.1"
+
+ast-types@^0.14.2:
   version "0.14.2"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.14.2.tgz#600b882df8583e3cd4f2df5fa20fa83759d4bdfd"
   integrity sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==


### PR DESCRIPTION
react-docgen updated their dependency, so ast-types doesn't need to be in resolutions anymore.