### PR TITLE
fix(types): Specify FormCheck's onChange type exactly

### DIFF
--- a/src/FormCheck.tsx
+++ b/src/FormCheck.tsx
@@ -16,7 +16,7 @@ export type FormCheckType = 'checkbox' | 'radio' | 'switch';
 
 export interface FormCheckProps
   extends BsPrefixPropsWithChildren,
-    React.HTMLAttributes<HTMLInputElement> {
+    React.InputHTMLAttributes<HTMLInputElement> {
   bsCustomPrefix?: string;
   inline?: boolean;
   disabled?: boolean;


### PR DESCRIPTION
This should make e.g. `onChange={e => e.target.checked}` work out of the box.