### PR TITLE
Pass through the menuAlign prop for NavDropdown to the embedded Dropdown.Menu.

### DIFF
--- a/src/NavDropdown.tsx
+++ b/src/NavDropdown.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Dropdown, { DropdownProps } from './Dropdown';
+import { alignPropType as DropdownMenuAlignPropType } from './DropdownMenu';
 import NavItem from './NavItem';
 import NavLink from './NavLink';
 import { BsPrefixRefForwardingComponent } from './helpers';
@@ -13,6 +14,7 @@ export interface NavDropdownProps
   title: React.ReactNode;
   disabled?: boolean;
   active?: boolean;
+  menuAlign?: string;
   menuRole?: string;
   renderMenuOnMount?: boolean;
   rootCloseEvent?: 'click' | 'mousedown';
@@ -39,6 +41,17 @@ const propTypes = {
   /** The content of the non-toggle Button.  */
   title: PropTypes.node.isRequired,
 
+  /**
+   * Aligns the dropdown menu to the specified side of the container. You can also align
+   * the menu responsively for breakpoints starting at `sm` and up. The alignment
+   * direction will affect the specified breakpoint or larger.
+   *
+   * *Note: Using responsive alignment will disable Popper usage for positioning.*
+   *
+   * @type {"left"|"right"|{ sm: "left"|"right" }|{ md: "left"|"right" }|{ lg: "left"|"right" }|{ xl: "left"|"right"} }
+   */
+  menuAlign: DropdownMenuAlignPropType,
+
   /** Disables the toggle NavLink  */
   disabled: PropTypes.bool,
 
@@ -62,6 +75,10 @@ const propTypes = {
   bsPrefix: PropTypes.string,
 };
 
+const defaultProps: Partial<NavDropdownProps> = {
+  menuAlign: 'left',
+};
+
 const NavDropdown: NavDropdown = (React.forwardRef(
   (
     {
@@ -71,6 +88,7 @@ const NavDropdown: NavDropdown = (React.forwardRef(
       bsPrefix,
       rootCloseEvent,
       menuRole,
+      menuAlign,
       disabled,
       active,
       renderMenuOnMount,
@@ -92,6 +110,7 @@ const NavDropdown: NavDropdown = (React.forwardRef(
 
       <Dropdown.Menu
         role={menuRole}
+        align={menuAlign}
         renderOnMount={renderMenuOnMount}
         rootCloseEvent={rootCloseEvent}
       >
@@ -103,6 +122,7 @@ const NavDropdown: NavDropdown = (React.forwardRef(
 
 NavDropdown.displayName = 'NavDropdown';
 NavDropdown.propTypes = propTypes;
+NavDropdown.defaultProps = defaultProps;
 NavDropdown.Item = Dropdown.Item;
 NavDropdown.ItemText = Dropdown.ItemText;
 NavDropdown.Divider = Dropdown.Divider;


### PR DESCRIPTION
There is no way to align the `Dropdown.Menu` inside the `NavDropdown` to the left. This implements it by adding the prop `menuAlign` to `NavDropdown` and passing it's value to the `align` prop of `Dropdown.Menu`.