### PR TITLE
Fix autocomplete for button and progress bar types

### DIFF
--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -10,7 +10,7 @@ import {
 } from './helpers';
 import { ButtonVariant } from './types';
 
-export type ButtonType = 'button' | 'reset' | 'submit' | string;
+export type ButtonType = 'button' | 'reset' | 'submit' | (string & {});
 
 export interface ButtonProps
   extends React.HTMLAttributes<HTMLElement>,

--- a/src/ProgressBar.tsx
+++ b/src/ProgressBar.tsx
@@ -17,7 +17,7 @@ export interface ProgressBarProps
   srOnly?: boolean;
   striped?: boolean;
   animated?: boolean;
-  variant?: 'success' | 'danger' | 'warning' | 'info' | string;
+  variant?: 'success' | 'danger' | 'warning' | 'info' | (string & {});
   isChild?: boolean;
 }
 

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,13 +1,12 @@
-export type Variant =
-  | 'primary'
-  | 'secondary'
-  | 'success'
-  | 'danger'
-  | 'warning'
-  | 'info'
-  | 'dark'
-  | 'light'
-  | string;
+export type Variant = ( | 'primary'
+	| 'secondary'
+	| 'success'
+	| 'danger'
+	| 'warning'
+	| 'info'
+	| 'dark'
+	| 'light'
+) | (string & {});
 export type ButtonVariant =
   | Variant
   | 'link'


### PR DESCRIPTION
The autocompletion for variants is missing.

This PR is base on:
https://github.com/microsoft/TypeScript/issues/29729

Here's a sample of the autocomplete: 
![image](https://user-images.githubusercontent.com/63862061/99647298-8d56dc00-2a8c-11eb-931b-593494641a95.png)
