### PR TITLE
Properly rest html props for `Alert` when `transition={false}`

### DIFF
--- a/src/Alert.tsx
+++ b/src/Alert.tsx
@@ -118,7 +118,7 @@ const Alert = (React.forwardRef<HTMLDivElement, AlertProps>(
     const alert = (
       <div
         role="alert"
-        {...(Transition ? props : undefined)}
+        {...(!Transition ? props : undefined)}
         ref={ref}
         className={classNames(
           className,

--- a/test/AlertSpec.js
+++ b/test/AlertSpec.js
@@ -48,6 +48,26 @@ describe('<Alert>', () => {
     expect(wrapper.find('.fade').length).to.equal(0);
   });
 
+  it('should spread props to alert when transition=false', () => {
+    const alertId = 'alert-id';
+    const wrapper = mount(
+      <Alert transition={false} id={alertId}>
+        Message
+      </Alert>,
+    );
+    expect(wrapper.getDOMNode().getAttribute('id')).to.equal(alertId);
+  });
+
+  it('should spread props to alert when transition=true', () => {
+    const alertId = 'alert-id';
+    const wrapper = mount(
+      <Alert transition id={alertId}>
+        Message
+      </Alert>,
+    );
+    expect(wrapper.getDOMNode().getAttribute('id')).to.equal(alertId);
+  });
+
   it('should use Fade when transition=true', () => {
     mount(
       <Alert variant="danger" transition>


### PR DESCRIPTION
I believe this is the fix for the following issue I opened: https://github.com/react-bootstrap/react-bootstrap/issues/5544

It looked like the ternary was just backwards, where if a Transition was being used, it would add the props both to the Alert, and the Transition, where it should be the other way around, and only add the props to the Alert, if NO Transition is being used.

The test I wrote fails without this change.

Manual testing and tests seem to verify this conclusion.