### PR TITLE
Added prop `escDisabled` to `Dropdown`.

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -39,6 +39,7 @@ export interface DropdownProps extends BsPrefixPropsWithChildren {
   focusFirstItemOnShow?: boolean | 'keyboard';
   onSelect?: SelectCallback;
   navbar?: boolean;
+  escDisabled?: boolean;
 }
 
 type Dropdown = BsPrefixRefForwardingComponent<'div', DropdownProps> & {
@@ -118,10 +119,18 @@ const propTypes = {
 
   /** @private */
   navbar: PropTypes.bool,
+
+  /**
+   * Disables the behavior of pressing the key 'Escape' when the Dropdown is opened.
+   *
+   * The default value is `false`.
+   */
+  escDisabled: PropTypes.bool,
 };
 
 const defaultProps = {
   navbar: false,
+  escDisabled: false,
 };
 
 const Dropdown: Dropdown = (React.forwardRef((pProps: DropdownProps, ref) => {
@@ -137,6 +146,7 @@ const Dropdown: Dropdown = (React.forwardRef((pProps: DropdownProps, ref) => {
     // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
     as: Component = 'div',
     navbar: _4,
+    escDisabled,
     ...props
   } = useUncontrolled(pProps, { show: 'onToggle' });
 
@@ -145,7 +155,16 @@ const Dropdown: Dropdown = (React.forwardRef((pProps: DropdownProps, ref) => {
 
   const handleToggle = useEventCallback(
     (nextShow, event, source = event.type) => {
-      if (event.currentTarget === document) source = 'rootClose';
+      const isEsc = event.type === 'keydown' && event.key === 'Escape';
+      if (
+        (event.type === 'click' && event.currentTarget === document) ||
+        (isEsc && event.currentTarget)
+      ) {
+        source = 'rootClose';
+      }
+      if (!nextShow && isEsc && escDisabled) {
+        return;
+      }
       if (onToggle) {
         onToggle(nextShow, event, { source });
       }

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -259,6 +259,18 @@ describe('<Dropdown>', () => {
     });
   });
 
+  it('disables closing dropdown when pressing Escape', () => {
+    const wrapper = mount(<Dropdown escDisabled>{dropdownChildren}</Dropdown>);
+    wrapper.assertNone('.show');
+    wrapper
+      .find('button')
+      .simulate('keyDown', { key: 'ArrowDown' })
+      .simulate('keyDown', { key: 'Escape' });
+    wrapper.assertSingle('.dropdown.show');
+    wrapper.assertSingle('.dropdown-menu.show');
+    wrapper.assertSingle('button[aria-expanded=true]');
+  });
+
   it('should use each components bsPrefix', () => {
     const wrapper = mount(
       <Dropdown defaultShow bsPrefix="my-dropdown">


### PR DESCRIPTION
Hi! This is my first contribution 🌻 .

**What does this PR do?**
Addressing issue #5505 , `escDisabled` disables the behavior of pressing the key `Escape` when the `Dropdown` is opened.

**Description of tasks completed**
- Added prop `escDisabled: boolean` to `Dropdown` component.
- Created a test for this feature.

**What is the related issue?**
#5505 

**Use**
```
<Dropdown escDisabled>
  ...
</Dropdown>
```