### PR TITLE
feat(Collpase): Add prefix support

### DIFF
--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -12,11 +12,14 @@ import Transition, {
 import { TransitionCallbacks } from './helpers';
 import createChainedFunction from './createChainedFunction';
 import triggerBrowserReflow from './triggerBrowserReflow';
+import { useBootstrapPrefix } from './ThemeProvider';
 
 type Dimension = 'height' | 'width';
 
 export interface CollapseProps extends TransitionCallbacks {
   className?: string;
+  bsCollapsePrefix?: string;
+  bsCollapsingPrefix?: string;
   in?: boolean;
   mountOnEnter?: boolean;
   unmountOnExit?: boolean;
@@ -49,13 +52,6 @@ function getDefaultDimensionValue(
     parseInt(css(elem, margins[1]), 10)
   );
 }
-
-const collapseStyles = {
-  [EXITED]: 'collapse',
-  [EXITING]: 'collapsing',
-  [ENTERING]: 'collapsing',
-  [ENTERED]: 'collapse show',
-};
 
 const propTypes = {
   /**
@@ -152,6 +148,8 @@ const defaultProps = {
 const Collapse = React.forwardRef(
   (
     {
+      bsCollapsePrefix,
+      bsCollapsingPrefix,
       onEnter,
       onEntering,
       onEntered,
@@ -168,6 +166,19 @@ const Collapse = React.forwardRef(
     /* Compute dimension */
     const computedDimension =
       typeof dimension === 'function' ? dimension() : dimension;
+
+    const collapsePrefix = useBootstrapPrefix(bsCollapsePrefix, 'collapse');
+    const collapsingPrefix = useBootstrapPrefix(
+      bsCollapsingPrefix,
+      'collapsing',
+    );
+
+    const collapseStyles = {
+      [EXITED]: collapsePrefix,
+      [EXITING]: collapsingPrefix,
+      [ENTERING]: collapsingPrefix,
+      [ENTERED]: `${collapsePrefix} show`,
+    };
 
     /* -- Expanding -- */
     const handleEnter = useMemo(

--- a/test/CollapseSpec.js
+++ b/test/CollapseSpec.js
@@ -37,6 +37,21 @@ describe('<Collapse>', () => {
     mount(<Component>Panel content</Component>).assertSingle('.collapse');
   });
 
+  it('Should allow a custom collapse prefix', () => {
+    mount(
+      <Component bsCollapsePrefix="my-collapse">Panel content</Component>,
+    ).assertSingle('.my-collapse');
+  });
+
+  it('Should allow a custom collapse prefix', () => {
+    wrapper = mount(
+      <Component bsCollapsingPrefix="my-collapsing">Panel content</Component>,
+    );
+    wrapper.setState({ in: true });
+
+    assert.equal(wrapper.getDOMNode().className, 'my-collapsing');
+  });
+
   describe('from collapsed to expanded', () => {
     beforeEach(() => {
       wrapper = mount(<Component>Panel content</Component>);


### PR DESCRIPTION
# Description

At my company, we use both Bootstrap 3 and 4. While the `collapsing` class is compatible, we get a conflict with the `collapse` class where Bootstrap 3 uses `collapse in` instead of `collapse show`.