### PR TITLE
feat(v5): Change Toast default delay to 5000

### DIFF
--- a/src/Toast.tsx
+++ b/src/Toast.tsx
@@ -72,7 +72,7 @@ const Toast: BsPrefixRefForwardingComponent<
       transition: Transition = Fade,
       show = true,
       animation = true,
-      delay = 3000,
+      delay = 5000,
       autohide = false,
       onClose,
       ...props

--- a/www/src/pages/migrating.mdx
+++ b/www/src/pages/migrating.mdx
@@ -96,6 +96,10 @@ spacing, use margin utilities instead.
 
 - dropped `InputGroupPrepend` and `InputGroupAppend`. Buttons and `InputGroupText` can now be added as direct children.
 
+### Toast
+
+- `delay` is now default 5000 ms.
+
 ### ToggleButton
 
 - add `bsPrefix`.


### PR DESCRIPTION
https://getbootstrap.com/docs/5.0/migration/#toasts-1

> Made default toast duration 5 seconds.