### PR TITLE
Add aria-label to carousel prev/next btn

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -180,10 +180,10 @@ const defaultProps = {
   wrap: true,
   touch: true,
 
-  prevIcon: <span aria-hidden="true" className="carousel-control-prev-icon" />,
+  prevIcon: <span aria-label="previous slide" aria-hidden="true" className="carousel-control-prev-icon" />,
   prevLabel: 'Previous',
 
-  nextIcon: <span aria-hidden="true" className="carousel-control-next-icon" />,
+  nextIcon: <span aria-label="next slide" aria-hidden="true" className="carousel-control-next-icon" />,
   nextLabel: 'Next',
 };
 


### PR DESCRIPTION
Based on this issue on lighthouse I created this pull:
![image](https://user-images.githubusercontent.com/17513392/103180988-00c5e780-489c-11eb-81a3-2c6069267b9d.png)
