### PR TITLE
Fix Formik validation example bug in docs

### DIFF
--- a/www/src/examples/Form/ValidationFormik.js
+++ b/www/src/examples/Form/ValidationFormik.js
@@ -18,6 +18,7 @@ function FormExample() {
       initialValues={{
         firstName: 'Mark',
         lastName: 'Otto',
+        terms: false
       }}
     >
       {({


### PR DESCRIPTION
Added `terms: false` within the `initialValues` prop. This fixed a bug where when trying to check the checkbox, an error appeared that said ``terms must be a `boolean` type, but the final value was: `[ "\"on\"" ]`.``