### PR TITLE
Fix some bugs in example code in docs.

### DIFF
--- a/www/src/examples/Form/FormTextInline.js
+++ b/www/src/examples/Form/FormTextInline.js
@@ -7,7 +7,7 @@
       id="inputPassword6"
       aria-describedby="passwordHelpInline"
     />
-    <Form.Text id="passwordHelpBlock" muted>
+    <Form.Text id="passwordHelpInline" muted>
       Must be 8-20 characters long.
     </Form.Text>
   </Form.Group>

--- a/www/src/examples/Form/ValidationFormik.js
+++ b/www/src/examples/Form/ValidationFormik.js
@@ -1,13 +1,13 @@
 const { Formik } = formik;
 
-const schema = yup.object({
+const schema = yup.object().shape({
   firstName: yup.string().required(),
   lastName: yup.string().required(),
   username: yup.string().required(),
   city: yup.string().required(),
   state: yup.string().required(),
   zip: yup.string().required(),
-  terms: yup.bool().required(),
+  terms: yup.bool().required().oneOf([true], "Terms must be accepted"),
 });
 
 function FormExample() {
@@ -18,6 +18,11 @@ function FormExample() {
       initialValues={{
         firstName: 'Mark',
         lastName: 'Otto',
+        username: '',
+        city: '',
+        state: '',
+        zip: '',
+        terms: false,
       }}
     >
       {({

--- a/www/src/examples/Form/ValidationTooltips.js
+++ b/www/src/examples/Form/ValidationTooltips.js
@@ -1,14 +1,14 @@
 const { Formik } = formik;
 
-const schema = yup.object({
+const schema = yup.object().shape({
   firstName: yup.string().required(),
   lastName: yup.string().required(),
   username: yup.string().required(),
   city: yup.string().required(),
   state: yup.string().required(),
   zip: yup.string().required(),
-  file: yup.string().required(),
-  terms: yup.bool().required(),
+  file: yup.mixed().required(),
+  terms: yup.bool().required().oneOf([true], "terms must be accepted"),
 });
 
 function FormExample() {
@@ -19,6 +19,12 @@ function FormExample() {
       initialValues={{
         firstName: 'Mark',
         lastName: 'Otto',
+        username: '',
+        city: '',
+        state: '',
+        zip: '',
+        file: null,
+        terms: false,
       }}
     >
       {({


### PR DESCRIPTION
- Fix #5585 
    - Props `id` in `Form.Text` changed to `passwordHelpInline`.
- Fix #5574
    - Added `terms: false` within the `initialValues` prop and set the schema to restrict the checkbox must be checked.