### PR TITLE
fix: Prevent focus on disabled nav items or list group items only

### DIFF
--- a/src/AbstractNavItem.tsx
+++ b/src/AbstractNavItem.tsx
@@ -93,8 +93,11 @@ const AbstractNavItem: AbstractNavItem = React.forwardRef(
     }
 
     if (props.role === 'tab') {
-      props.tabIndex = isActive ? props.tabIndex : -1;
       props['aria-selected'] = isActive;
+    }
+
+    if (props.disabled) {
+      props.tabIndex = -1;
     }
 
     const handleOnclick = useEventCallback((e) => {

--- a/src/AbstractNavItem.tsx
+++ b/src/AbstractNavItem.tsx
@@ -34,7 +34,7 @@ const propTypes = {
   role: PropTypes.string,
 
   href: PropTypes.string,
-  tabIndex: PropTypes.string,
+  tabIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   eventKey: PropTypes.any,
   onclick: PropTypes.func,
 
@@ -93,11 +93,11 @@ const AbstractNavItem: AbstractNavItem = React.forwardRef(
     }
 
     if (props.role === 'tab') {
+      if (props.disabled) {
+        props.tabIndex = -1;
+        props['aria-disabled'] = true;
+      }
       props['aria-selected'] = isActive;
-    }
-
-    if (props.disabled) {
-      props.tabIndex = -1;
     }
 
     const handleOnclick = useEventCallback((e) => {

--- a/src/ListGroupItem.tsx
+++ b/src/ListGroupItem.tsx
@@ -107,6 +107,7 @@ const ListGroupItem: ListGroupItem = React.forwardRef(
         // eslint-disable-next-line no-nested-ternary
         as={as || (action ? (props.href ? 'a' : 'button') : 'div')}
         onClick={handleClick}
+        disabled={disabled}
         className={classNames(
           className,
           bsPrefix,

--- a/src/ListGroupItem.tsx
+++ b/src/ListGroupItem.tsx
@@ -114,7 +114,6 @@ const ListGroupItem: ListGroupItem = React.forwardRef(
         // eslint-disable-next-line no-nested-ternary
         as={as || (action ? (props.href ? 'a' : 'button') : 'div')}
         onClick={handleClick}
-        disabled={disabled}
         className={classNames(
           className,
           bsPrefix,

--- a/src/ListGroupItem.tsx
+++ b/src/ListGroupItem.tsx
@@ -8,7 +8,9 @@ import { useBootstrapPrefix } from './ThemeProvider';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 import { Variant } from './types';
 
-export interface ListGroupItemProps extends BsPrefixProps {
+export interface ListGroupItemProps
+  extends Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'>,
+    BsPrefixProps {
   action?: boolean;
   active?: boolean;
   disabled?: boolean;
@@ -97,6 +99,11 @@ const ListGroupItem: ListGroupItem = React.forwardRef(
       },
       [disabled, onClick],
     );
+
+    if (disabled && props.tabIndex === undefined) {
+      props.tabIndex = -1;
+      props['aria-disabled'] = true;
+    }
 
     return (
       <AbstractNavItem

--- a/test/ListGroupItemSpec.js
+++ b/test/ListGroupItemSpec.js
@@ -34,6 +34,12 @@ describe('<ListGroupItem>', () => {
     expect(node.getAttribute('tabindex')).to.equal('-1');
   });
 
+  it('should respect user-specified tabIndex', () => {
+    const wrapper = mount(<ListGroupItem disabled tabIndex={4} />);
+    const node = wrapper.find('.list-group-item').first().getDOMNode();
+    expect(node.getAttribute('tabindex')).to.equal('4');
+  });
+
   describe('actions', () => {
     it('renders a button', () => {
       mount(<ListGroupItem action />).assertSingle(

--- a/test/ListGroupItemSpec.js
+++ b/test/ListGroupItemSpec.js
@@ -28,6 +28,12 @@ describe('<ListGroupItem>', () => {
     mount(<ListGroupItem as="span" />).assertSingle('span.list-group-item');
   });
 
+  it('should not be focusable when disabled', () => {
+    const wrapper = mount(<ListGroupItem disabled />);
+    const node = wrapper.find('.list-group-item').first().getDOMNode();
+    expect(node.getAttribute('tabindex')).to.equal('-1');
+  });
+
   describe('actions', () => {
     it('renders a button', () => {
       mount(<ListGroupItem action />).assertSingle(

--- a/test/NavSpec.js
+++ b/test/NavSpec.js
@@ -171,14 +171,14 @@ describe('<Nav>', () => {
 
     afterEach(() => wrapper.unmount());
 
-    it('only the active tab should be focusable', () => {
+    it('should not allow focusing on disabled tabs', () => {
       const links = wrapper.find('a').map((n) => n.getDOMNode());
 
       expect(links[0].getAttribute('tabindex')).to.not.equal('-1');
       expect(links[1].getAttribute('tabindex')).to.equal('-1');
-      expect(links[2].getAttribute('tabindex')).to.equal('-1');
+      expect(links[2].getAttribute('tabindex')).to.not.equal('-1');
       expect(links[3].getAttribute('tabindex')).to.equal('-1');
-      expect(links[4].getAttribute('tabindex')).to.equal('-1');
+      expect(links[4].getAttribute('tabindex')).to.not.equal('-1');
     });
 
     it('should focus the next tab on arrow key', () => {


### PR DESCRIPTION
Fixes a couple of accessibility issues:

- Prevents disabled list group items from being focused when tabbing.
- Allow inactive tab items to be focused when tabbing

Fixes #4737

