### PR TITLE
feat(InputGroup): Add hasValidation prop

### DIFF
--- a/src/InputGroup.tsx
+++ b/src/InputGroup.tsx
@@ -32,6 +32,7 @@ const InputGroupRadio = (props) => (
 
 export interface InputGroupProps extends BsPrefixPropsWithChildren {
   size?: 'sm' | 'lg';
+  hasValidation?: boolean;
 }
 
 type InputGroupExtras = {
@@ -49,11 +50,18 @@ const propTypes = {
   bsPrefix: PropTypes.string,
 
   /**
-   * Control the size of buttons and form elements from the top-level .
+   * Control the size of buttons and form elements from the top-level.
    *
    * @type {('sm'|'lg')}
    */
   size: PropTypes.string,
+
+  /**
+   * Handles the input's rounded corners when using form validation.
+   *
+   * Use this when your input group contains both an input and feedback element.
+   */
+  hasValidation: PropTypes.bool,
 
   as: PropTypes.elementType,
 };
@@ -71,6 +79,7 @@ const InputGroup: InputGroup = React.forwardRef(
     {
       bsPrefix,
       size,
+      hasValidation,
       className,
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
@@ -88,6 +97,7 @@ const InputGroup: InputGroup = React.forwardRef(
           className,
           bsPrefix,
           size && `${bsPrefix}-${size}`,
+          hasValidation && 'has-validation',
         )}
       />
     );

--- a/test/InputGroupSpec.js
+++ b/test/InputGroupSpec.js
@@ -13,6 +13,10 @@ describe('<InputGroup>', () => {
     mount(<InputGroup size="sm" />).assertSingle('.input-group-sm');
   });
 
+  it('Should render hasValidation correctly', () => {
+    mount(<InputGroup hasValidation />).assertSingle('.has-validation');
+  });
+
   describe('<Checkbox>', () => {
     it('Should forward props to underlying input element', () => {
       const name = 'foobar';

--- a/www/src/examples/Form/ValidationFormik.js
+++ b/www/src/examples/Form/ValidationFormik.js
@@ -7,7 +7,7 @@ const schema = yup.object().shape({
   city: yup.string().required(),
   state: yup.string().required(),
   zip: yup.string().required(),
-  terms: yup.bool().required().oneOf([true], "Terms must be accepted"),
+  terms: yup.bool().required().oneOf([true], 'Terms must be accepted'),
 });
 
 function FormExample() {
@@ -61,7 +61,7 @@ function FormExample() {
             </Form.Group>
             <Form.Group as={Col} md="4" controlId="validationFormikUsername">
               <Form.Label>Username</Form.Label>
-              <InputGroup>
+              <InputGroup hasValidation>
                 <InputGroup.Prepend>
                   <InputGroup.Text id="inputGroupPrepend">@</InputGroup.Text>
                 </InputGroup.Prepend>

--- a/www/src/examples/Form/ValidationInputGroup.js
+++ b/www/src/examples/Form/ValidationInputGroup.js
@@ -1,0 +1,9 @@
+<InputGroup hasValidation>
+  <InputGroup.Prepend>
+    <InputGroup.Text>@</InputGroup.Text>
+  </InputGroup.Prepend>
+  <Form.Control type="text" required isInvalid />
+  <Form.Control.Feedback type="invalid">
+    Please choose a username.
+  </Form.Control.Feedback>
+</InputGroup>;

--- a/www/src/examples/Form/ValidationNative.js
+++ b/www/src/examples/Form/ValidationNative.js
@@ -36,7 +36,7 @@ function FormExample() {
         </Form.Group>
         <Form.Group as={Col} md="4" controlId="validationCustomUsername">
           <Form.Label>Username</Form.Label>
-          <InputGroup>
+          <InputGroup hasValidation>
             <InputGroup.Prepend>
               <InputGroup.Text id="inputGroupPrepend">@</InputGroup.Text>
             </InputGroup.Prepend>

--- a/www/src/examples/Form/ValidationTooltips.js
+++ b/www/src/examples/Form/ValidationTooltips.js
@@ -8,7 +8,7 @@ const schema = yup.object().shape({
   state: yup.string().required(),
   zip: yup.string().required(),
   file: yup.mixed().required(),
-  terms: yup.bool().required().oneOf([true], "terms must be accepted"),
+  terms: yup.bool().required().oneOf([true], 'terms must be accepted'),
 });
 
 function FormExample() {
@@ -63,7 +63,7 @@ function FormExample() {
             </Form.Group>
             <Form.Group as={Col} md="4" controlId="validationFormikUsername2">
               <Form.Label>Username</Form.Label>
-              <InputGroup>
+              <InputGroup hasValidation>
                 <InputGroup.Prepend>
                   <InputGroup.Text id="inputGroupPrepend">@</InputGroup.Text>
                 </InputGroup.Prepend>

--- a/www/src/pages/components/forms.js
+++ b/www/src/pages/components/forms.js
@@ -44,6 +44,7 @@ import FileButtonTextScss from '../../examples/Form/FileButtonTextScss';
 import FileApi from '../../examples/Form/FileApi';
 import FormTextControls from '../../examples/Form/TextControls';
 import ValidationFormik from '../../examples/Form/ValidationFormik';
+import ValidationInputGroup from '../../examples/Form/ValidationInputGroup';
 import ValidationNative from '../../examples/Form/ValidationNative';
 import ValidationTooltips from '../../examples/Form/ValidationTooltips';
 import withLayout from '../../withLayout';
@@ -447,6 +448,16 @@ export default withLayout(function FormControlsSection({ data }) {
         but your project may require an alternative setup.
       </p>
       <ReactPlayground codeText={ValidationTooltips} />
+
+      <LinkedHeading h="3" id="forms-validation-input-group">
+        Input group validation
+      </LinkedHeading>
+      <p>
+        To properly show rounded corners in an <code>{'<InputGroup>'}</code>{' '}
+        with validation, the <code>{'<InputGroup>'}</code> requires the{' '}
+        <code>hasValidation</code> prop.
+      </p>
+      <ReactPlayground codeText={ValidationInputGroup} />
 
       <LinkedHeading h="3" id="forms-validation-examples">
         Examples


### PR DESCRIPTION
> To detect what elements need rounded corners inside an input group with validation, an input group requires an additional .has-validation class.

Ref: https://getbootstrap.com/docs/4.6/components/forms/#input-group-validation