### PR TITLE
show tooltips for func overlay without transition

### DIFF
--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -205,6 +205,7 @@ function Overlay({
             ...overlayProps,
             placement,
             show,
+            className: !transition && show && 'show',
             popper,
             arrowProps,
           });

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -205,7 +205,7 @@ function Overlay({
             ...overlayProps,
             placement,
             show,
-            className: !transition && show && 'show',
+            ...(!transition && show && { className: 'show' }),
             popper,
             arrowProps,
           });

--- a/test/OverlayTriggerSpec.js
+++ b/test/OverlayTriggerSpec.js
@@ -39,6 +39,27 @@ describe('<OverlayTrigger>', () => {
     wrapper.assertSingle('div.test');
   });
 
+  it('Should show the tooltip when transitions are disabled', () => {
+    const overlay = ({ className, ...props }) => (
+      <Div {...props} className={`${className} test`} />
+    );
+    const wrapper = mount(
+      <OverlayTrigger
+        transition={false}
+        trigger={['hover', 'focus']}
+        overlay={overlay}
+      >
+        <button type="button">button</button>
+      </OverlayTrigger>,
+    );
+
+    wrapper.assertNone('.test');
+
+    wrapper.find('button').simulate('focus');
+
+    wrapper.assertSingle('div.test.show');
+  });
+
   it('Should call OverlayTrigger onClick prop to child', () => {
     const callback = sinon.spy();
 


### PR DESCRIPTION
#5621 

How about this? The user will have to add the classes himself when he is using a function `overlay`