### PR TITLE
docs: fix alt attribute of the second slide in examples of <Carousel>

### DIFF
--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -221,7 +221,7 @@ const MegaComponent = () => (
         <img
           className="d-block w-100"
           src="holder.js/800x400?text=Second slide&bg=282c34"
-          alt="Third slide"
+          alt="Second slide"
         />
 
         <Carousel.Caption>

--- a/www/src/examples/Carousel/IndividualIntervals.js
+++ b/www/src/examples/Carousel/IndividualIntervals.js
@@ -14,7 +14,7 @@
     <img
       className="d-block w-100"
       src="holder.js/800x400?text=Second slide&bg=282c34"
-      alt="Third slide"
+      alt="Second slide"
     />
     <Carousel.Caption>
       <h3>Second slide label</h3>

--- a/www/src/examples/Carousel/Uncontrolled.js
+++ b/www/src/examples/Carousel/Uncontrolled.js
@@ -14,7 +14,7 @@
     <img
       className="d-block w-100"
       src="holder.js/800x400?text=Second slide&bg=282c34"
-      alt="Third slide"
+      alt="Second slide"
     />
 
     <Carousel.Caption>


### PR DESCRIPTION
Fixes #5627

## What I have done
1. The alt attribute in both the [first example (uncontrolled)](https://react-bootstrap.github.io/components/carousel/#example) and [Individual Item Intervals](https://react-bootstrap.github.io/components/carousel/#individual-item-intervals) of Carousel are wrong. I fixed both of them.

2. The same typo appears also in `tests/simple-types-test.tsx`. I am not sure if you prefer that to be also fixed, so I have fixed that with a seperate commit. 


