### PR TITLE
Spelling correction in overlay.js

### DIFF
--- a/www/src/pages/components/overlays.js
+++ b/www/src/pages/components/overlays.js
@@ -125,7 +125,7 @@ export default withLayout(function TooltipSection({ data }) {
       <p>
         For more advanced behaviors <code>{'<OverlayTrigger>'}</code> accepts a
         function child that passes in the injected <code>ref</code> and event
-        handlers that coorespond to the configured <code>trigger</code> prop.
+        handlers that correspond to the configured <code>trigger</code> prop.
       </p>
       <p>
         You can manually apply the props to any element you want or split them


### PR DESCRIPTION
Just a small typo fix I noticed while reading the docs.