### PR TITLE
fix: Prevent transitionend events in children nodes from cutting off animations

### DIFF
--- a/src/Collapse.tsx
+++ b/src/Collapse.tsx
@@ -1,6 +1,5 @@
 import classNames from 'classnames';
 import css from 'dom-helpers/css';
-import transitionEnd from 'dom-helpers/transitionEnd';
 import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
 import Transition, {
@@ -9,6 +8,7 @@ import Transition, {
   EXITED,
   EXITING,
 } from 'react-transition-group/Transition';
+import transitionEndListener from './transitionEndListener';
 import { TransitionCallbacks } from './helpers';
 import createChainedFunction from './createChainedFunction';
 import triggerBrowserReflow from './triggerBrowserReflow';
@@ -221,7 +221,7 @@ const Collapse = React.forwardRef(
       <Transition
         // @ts-ignore
         ref={ref}
-        addEndListener={transitionEnd}
+        addEndListener={transitionEndListener}
         {...props}
         aria-expanded={props.role ? props.in : null}
         onEnter={handleEnter}

--- a/src/Fade.tsx
+++ b/src/Fade.tsx
@@ -1,11 +1,11 @@
 import classNames from 'classnames';
-import transitionEnd from 'dom-helpers/transitionEnd';
 import PropTypes from 'prop-types';
 import React, { useCallback } from 'react';
 import Transition, {
   ENTERED,
   ENTERING,
 } from 'react-transition-group/Transition';
+import transitionEndListener from './transitionEndListener';
 import { TransitionCallbacks } from './helpers';
 import triggerBrowserReflow from './triggerBrowserReflow';
 
@@ -100,7 +100,7 @@ const Fade = React.forwardRef<Transition<any>, FadeProps>(
     return (
       <Transition
         ref={ref}
-        addEndListener={transitionEnd}
+        addEndListener={transitionEndListener}
         {...props}
         onEnter={handleEnter}
       >

--- a/src/transitionEndListener.ts
+++ b/src/transitionEndListener.ts
@@ -1,0 +1,13 @@
+import transitionEnd from 'dom-helpers/transitionEnd';
+
+export default function transitionEndListener(
+  element: HTMLElement,
+  handler: (e: TransitionEvent) => void,
+) {
+  const remove = transitionEnd(element, (e) => {
+    if (e.target === element) {
+      remove();
+      handler(e);
+    }
+  });
+}


### PR DESCRIPTION
Fixes #5648 
Fixes #5641
Fixes #5230

This replaces the `addEndListener` with one that only invokes the callback only if transition occurs on the element containing the fade/collapse animation.  

Couldn't get tests to work here.  Parsing the transition-duration from the node results in a NaN.