### PR TITLE
refactor(types): standardize and cleanup types

### DIFF
--- a/src/AbstractNav.tsx
+++ b/src/AbstractNav.tsx
@@ -31,7 +31,7 @@ const propTypes = {
 };
 
 // TODO: is this correct?
-interface AbstractNavProps {
+interface AbstractNavProps extends React.HTMLAttributes<HTMLElement> {
   activeKey?: any;
   as?: React.ElementType;
   getControlledId?: any;
@@ -42,9 +42,10 @@ interface AbstractNavProps {
   role?: string;
 }
 
-type AbstractNav = BsPrefixRefForwardingComponent<'ul', AbstractNavProps>;
-
-const AbstractNav: AbstractNav = React.forwardRef(
+const AbstractNav: BsPrefixRefForwardingComponent<
+  'ul',
+  AbstractNavProps
+> = React.forwardRef<HTMLElement, AbstractNavProps>(
   (
     {
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
@@ -54,7 +55,7 @@ const AbstractNav: AbstractNav = React.forwardRef(
       role,
       onKeyDown,
       ...props
-    }: AbstractNavProps,
+    },
     ref,
   ) => {
     // A ref and forceUpdate for refocus, b/c we only want to trigger when needed

--- a/src/AbstractNavItem.tsx
+++ b/src/AbstractNavItem.tsx
@@ -9,24 +9,16 @@ import SelectableContext, { makeEventKey } from './SelectableContext';
 import { BsPrefixRefForwardingComponent } from './helpers';
 
 // TODO: check this
-interface AbstractNavItemProps {
+export interface AbstractNavItemProps
+  extends Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'> {
   active?: boolean;
   as: React.ElementType;
-  className?: string;
   disabled?: boolean;
   eventKey?: any; // TODO: especially fix this
   href?: string;
-  role?: string;
-  id?: string;
   tabIndex?: number;
-  onClick?: (e: any) => void;
   onSelect?: (navKey: string, e: any) => void;
 }
-
-type AbstractNavItem = BsPrefixRefForwardingComponent<
-  'div',
-  AbstractNavItemProps
->;
 
 const propTypes = {
   id: PropTypes.string,
@@ -49,17 +41,12 @@ const defaultProps = {
   disabled: false,
 };
 
-const AbstractNavItem: AbstractNavItem = React.forwardRef(
+const AbstractNavItem: BsPrefixRefForwardingComponent<
+  'div',
+  AbstractNavItemProps
+> = React.forwardRef<HTMLElement, AbstractNavItemProps>(
   (
-    {
-      active,
-      className,
-      eventKey,
-      onSelect,
-      onClick,
-      as: Component,
-      ...props
-    }: AbstractNavItemProps,
+    { active, className, eventKey, onSelect, onClick, as: Component, ...props },
     ref,
   ) => {
     const navKey = makeEventKey(eventKey, props.href);

--- a/src/Accordion.tsx
+++ b/src/Accordion.tsx
@@ -24,14 +24,6 @@ export interface AccordionProps
   flush?: boolean;
 }
 
-type Accordion = BsPrefixRefForwardingComponent<'div', AccordionProps> & {
-  Button: typeof AccordionButton;
-  Collapse: typeof AccordionCollapse;
-  Item: typeof AccordionItem;
-  Header: typeof AccordionHeader;
-  Body: typeof AccordionBody;
-};
-
 const propTypes = {
   /** Set a custom element for this component */
   as: PropTypes.elementType,
@@ -45,13 +37,14 @@ const propTypes = {
   /** The default active key that is expanded on start */
   defaultActiveKey: PropTypes.string,
 
-  /**
-   * Renders accordion edge-to-edge with its parent container
-   */
+  /** Renders accordion edge-to-edge with its parent container */
   flush: PropTypes.bool,
 };
 
-const Accordion = (React.forwardRef((props: AccordionProps, ref) => {
+const Accordion: BsPrefixRefForwardingComponent<
+  'div',
+  AccordionProps
+> = React.forwardRef<HTMLElement, AccordionProps>((props, ref) => {
   const {
     // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
     as: Component = 'div',
@@ -86,14 +79,15 @@ const Accordion = (React.forwardRef((props: AccordionProps, ref) => {
       </Component>
     </AccordionContext.Provider>
   );
-}) as unknown) as Accordion;
+});
 
 Accordion.displayName = 'Accordion';
 Accordion.propTypes = propTypes;
-Accordion.Button = AccordionButton;
-Accordion.Collapse = AccordionCollapse;
-Accordion.Item = AccordionItem;
-Accordion.Header = AccordionHeader;
-Accordion.Body = AccordionBody;
 
-export default Accordion;
+export default Object.assign(Accordion, {
+  Button: AccordionButton,
+  Collapse: AccordionCollapse,
+  Item: AccordionItem,
+  Header: AccordionHeader,
+  Body: AccordionBody,
+});

--- a/src/AccordionBody.tsx
+++ b/src/AccordionBody.tsx
@@ -13,8 +13,6 @@ export interface AccordionBodyProps
   extends BsPrefixPropsWithChildren,
     React.HTMLAttributes<HTMLElement> {}
 
-type AccordionBody = BsPrefixRefForwardingComponent<'div', AccordionBodyProps>;
-
 const propTypes = {
   /** Set a custom element for this component */
   as: PropTypes.elementType,
@@ -23,7 +21,10 @@ const propTypes = {
   bsPrefix: PropTypes.string,
 };
 
-const AccordionBody: AccordionBody = React.forwardRef(
+const AccordionBody: BsPrefixRefForwardingComponent<
+  'div',
+  AccordionBodyProps
+> = React.forwardRef<HTMLElement, AccordionBodyProps>(
   (
     {
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
@@ -31,7 +32,7 @@ const AccordionBody: AccordionBody = React.forwardRef(
       bsPrefix,
       className,
       ...props
-    }: AccordionBodyProps,
+    },
     ref,
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'accordion-body');

--- a/src/AccordionButton.tsx
+++ b/src/AccordionButton.tsx
@@ -15,11 +15,6 @@ export interface AccordionButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     BsPrefixPropsWithChildren {}
 
-type AccordionButton = BsPrefixRefForwardingComponent<
-  'div',
-  AccordionButtonProps
->;
-
 const propTypes = {
   /** Set a custom element for this component */
   as: PropTypes.elementType,
@@ -49,7 +44,10 @@ export function useAccordionButton(
   };
 }
 
-const AccordionButton: AccordionButton = React.forwardRef(
+const AccordionButton: BsPrefixRefForwardingComponent<
+  'div',
+  AccordionButtonProps
+> = React.forwardRef<HTMLButtonElement, AccordionButtonProps>(
   (
     {
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
@@ -59,7 +57,7 @@ const AccordionButton: AccordionButton = React.forwardRef(
       children,
       onClick,
       ...props
-    }: AccordionButtonProps,
+    },
     ref,
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'accordion-button');

--- a/src/AccordionCollapse.tsx
+++ b/src/AccordionCollapse.tsx
@@ -15,11 +15,6 @@ export interface AccordionCollapseProps
   eventKey: string;
 }
 
-type AccordionCollapse = BsPrefixRefForwardingComponent<
-  'div',
-  AccordionCollapseProps
->;
-
 const propTypes = {
   /**
    * A key that corresponds to the toggler that triggers this collapse's expand or collapse.
@@ -30,17 +25,11 @@ const propTypes = {
   children: PropTypes.element.isRequired,
 };
 
-const AccordionCollapse: AccordionCollapse = React.forwardRef<typeof Collapse>(
-  (
-    {
-      bsPrefix,
-      className,
-      children,
-      eventKey,
-      ...props
-    }: AccordionCollapseProps,
-    ref,
-  ) => {
+const AccordionCollapse: BsPrefixRefForwardingComponent<
+  'div',
+  AccordionCollapseProps
+> = React.forwardRef<typeof Collapse, AccordionCollapseProps>(
+  ({ bsPrefix, className, children, eventKey, ...props }, ref) => {
     const { activeEventKey } = useContext(AccordionContext);
     bsPrefix = useBootstrapPrefix(bsPrefix, 'accordion-collapse');
 

--- a/src/AccordionHeader.tsx
+++ b/src/AccordionHeader.tsx
@@ -12,11 +12,6 @@ export interface AccordionHeaderProps
   extends BsPrefixPropsWithChildren,
     React.HTMLAttributes<HTMLElement> {}
 
-type AccordionHeader = BsPrefixRefForwardingComponent<
-  'h2',
-  AccordionHeaderProps
->;
-
 const propTypes = {
   /** Set a custom element for this component */
   as: PropTypes.elementType,
@@ -28,7 +23,10 @@ const propTypes = {
   onClick: PropTypes.func,
 };
 
-const AccordionHeader: AccordionHeader = React.forwardRef(
+const AccordionHeader: BsPrefixRefForwardingComponent<
+  'h2',
+  AccordionHeaderProps
+> = React.forwardRef<HTMLElement, AccordionHeaderProps>(
   (
     {
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
@@ -38,7 +36,7 @@ const AccordionHeader: AccordionHeader = React.forwardRef(
       children,
       onClick,
       ...props
-    }: AccordionHeaderProps,
+    },
     ref,
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'accordion-header');

--- a/src/AccordionItem.tsx
+++ b/src/AccordionItem.tsx
@@ -16,8 +16,6 @@ export interface AccordionItemProps
   eventKey: string;
 }
 
-type AccordionItem = BsPrefixRefForwardingComponent<'div', AccordionItemProps>;
-
 const propTypes = {
   /** Set a custom element for this component */
   as: PropTypes.elementType,
@@ -32,7 +30,10 @@ const propTypes = {
   eventKey: PropTypes.string.isRequired,
 };
 
-const AccordionItem: AccordionItem = React.forwardRef(
+const AccordionItem: BsPrefixRefForwardingComponent<
+  'div',
+  AccordionItemProps
+> = React.forwardRef<HTMLElement, AccordionItemProps>(
   (
     {
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
@@ -41,7 +42,7 @@ const AccordionItem: AccordionItem = React.forwardRef(
       className,
       eventKey,
       ...props
-    }: AccordionItemProps,
+    },
     ref,
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'accordion-item');

--- a/src/Alert.tsx
+++ b/src/Alert.tsx
@@ -13,7 +13,7 @@ import createWithBsPrefix from './createWithBsPrefix';
 import SafeAnchor from './SafeAnchor';
 import { TransitionType } from './helpers';
 
-export interface AlertProps extends React.HTMLProps<HTMLDivElement> {
+export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   bsPrefix?: string;
   variant?: Variant;
   dismissible?: boolean;
@@ -34,11 +34,6 @@ const AlertHeading = createWithBsPrefix('alert-heading', {
 const AlertLink = createWithBsPrefix('alert-link', {
   Component: SafeAnchor,
 });
-
-type Alert = React.ForwardRefExoticComponent<AlertProps> & {
-  Link: typeof AlertLink;
-  Heading: typeof AlertHeading;
-};
 
 const propTypes = {
   /**
@@ -97,7 +92,7 @@ const defaultProps = {
   closeLabel: 'Close alert',
 };
 
-const Alert = (React.forwardRef<HTMLDivElement, AlertProps>(
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
   (uncontrolledProps: AlertProps, ref) => {
     const {
       bsPrefix,
@@ -153,12 +148,13 @@ const Alert = (React.forwardRef<HTMLDivElement, AlertProps>(
       </Transition>
     );
   },
-) as unknown) as Alert;
+);
 
 Alert.displayName = 'Alert';
-Alert.defaultProps = defaultProps as any;
+Alert.defaultProps = defaultProps;
 Alert.propTypes = propTypes;
-Alert.Link = AlertLink;
-Alert.Heading = AlertHeading;
 
-export default Alert;
+export default Object.assign(Alert, {
+  Link: AlertLink,
+  Heading: AlertHeading,
+});

--- a/src/Badge.tsx
+++ b/src/Badge.tsx
@@ -6,13 +6,13 @@ import { useBootstrapPrefix } from './ThemeProvider';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 import { Color, Variant } from './types';
 
-export interface BadgeProps extends BsPrefixProps {
+export interface BadgeProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   bg?: Variant;
   pill?: boolean;
   text?: Color;
 }
-
-type Badge = BsPrefixRefForwardingComponent<'span', BadgeProps>;
 
 const propTypes = {
   /** @default 'badge' */
@@ -29,7 +29,7 @@ const propTypes = {
    * Add the `pill` modifier to make badges more rounded with
    * some additional horizontal padding
    */
-  pill: PropTypes.bool.isRequired,
+  pill: PropTypes.bool,
 
   /**
    * Sets badge text color
@@ -37,6 +37,7 @@ const propTypes = {
    * @type {('primary'|'secondary'|'success'|'danger'|'warning'|'info'|'light'|'dark')}
    */
   text: PropTypes.string,
+
   /** @default span */
   as: PropTypes.elementType,
 };
@@ -45,17 +46,12 @@ const defaultProps = {
   pill: false,
 };
 
-const Badge: Badge = React.forwardRef(
+const Badge: BsPrefixRefForwardingComponent<
+  'span',
+  BadgeProps
+> = React.forwardRef<HTMLElement, BadgeProps>(
   (
-    {
-      bsPrefix,
-      bg,
-      pill,
-      text,
-      className,
-      as: Component = 'span',
-      ...props
-    }: BadgeProps,
+    { bsPrefix, bg, pill, text, className, as: Component = 'span', ...props },
     ref,
   ) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'badge');

--- a/src/Breadcrumb.tsx
+++ b/src/Breadcrumb.tsx
@@ -4,31 +4,27 @@ import PropTypes from 'prop-types';
 
 import { useBootstrapPrefix } from './ThemeProvider';
 import BreadcrumbItem from './BreadcrumbItem';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface BreadcrumbProps extends BsPrefixPropsWithChildren {
-  className?: string;
+export interface BreadcrumbProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   label?: string;
   listProps?: React.OlHTMLAttributes<HTMLOListElement>;
 }
-
-type Breadcrumb = BsPrefixRefForwardingComponent<'nav', BreadcrumbProps> & {
-  Item: typeof BreadcrumbItem;
-};
 
 const propTypes = {
   /**
    * @default 'breadcrumb'
    */
   bsPrefix: PropTypes.string,
+
   /**
    * ARIA label for the nav element
    * https://www.w3.org/TR/wai-aria-practices/#breadcrumb
    */
   label: PropTypes.string,
+
   /**
    * Additional props passed as-is to the underlying `<ol>` element
    */
@@ -42,7 +38,10 @@ const defaultProps = {
   listProps: {},
 };
 
-const Breadcrumb: Breadcrumb = (React.forwardRef(
+const Breadcrumb: BsPrefixRefForwardingComponent<
+  'nav',
+  BreadcrumbProps
+> = React.forwardRef<HTMLElement, BreadcrumbProps>(
   (
     {
       bsPrefix,
@@ -53,7 +52,7 @@ const Breadcrumb: Breadcrumb = (React.forwardRef(
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'nav',
       ...props
-    }: BreadcrumbProps,
+    },
     ref,
   ) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'breadcrumb');
@@ -66,11 +65,12 @@ const Breadcrumb: Breadcrumb = (React.forwardRef(
       </Component>
     );
   },
-) as unknown) as Breadcrumb;
+);
 
 Breadcrumb.displayName = 'Breadcrumb';
 Breadcrumb.propTypes = propTypes;
 Breadcrumb.defaultProps = defaultProps;
-Breadcrumb.Item = BreadcrumbItem;
 
-export default Breadcrumb;
+export default Object.assign(Breadcrumb, {
+  Item: BreadcrumbItem,
+});

--- a/src/BreadcrumbItem.tsx
+++ b/src/BreadcrumbItem.tsx
@@ -4,12 +4,11 @@ import PropTypes from 'prop-types';
 
 import SafeAnchor from './SafeAnchor';
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface BreadcrumbItemProps extends BsPrefixPropsWithChildren {
+export interface BreadcrumbItemProps
+  extends BsPrefixProps,
+    Omit<React.HTMLAttributes<HTMLElement>, 'title'> {
   active?: boolean;
   href?: string;
   linkAs?: React.ElementType;
@@ -17,8 +16,6 @@ export interface BreadcrumbItemProps extends BsPrefixPropsWithChildren {
   title?: React.ReactNode;
   linkProps?: Record<string, any>; // the generic is to much work here
 }
-
-type BreadcrumbItem = BsPrefixRefForwardingComponent<'li', BreadcrumbItemProps>;
 
 const propTypes = {
   /**
@@ -59,7 +56,10 @@ const defaultProps = {
   linkProps: {},
 };
 
-const BreadcrumbItem: BreadcrumbItem = React.forwardRef(
+const BreadcrumbItem: BsPrefixRefForwardingComponent<
+  'li',
+  BreadcrumbItemProps
+> = React.forwardRef<HTMLElement, BreadcrumbItemProps>(
   (
     {
       bsPrefix,
@@ -74,7 +74,7 @@ const BreadcrumbItem: BreadcrumbItem = React.forwardRef(
       title,
       target,
       ...props
-    }: BreadcrumbItemProps,
+    },
     ref,
   ) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'breadcrumb-item');

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -24,7 +24,6 @@ export interface ButtonProps
   target?: any;
 }
 
-type Button = BsPrefixRefForwardingComponent<'button', ButtonProps>;
 export type CommonButtonProps = 'href' | 'size' | 'variant' | 'disabled';
 
 const propTypes = {
@@ -81,20 +80,11 @@ const defaultProps = {
   disabled: false,
 };
 
-const Button: Button = React.forwardRef(
-  (
-    {
-      bsPrefix,
-      variant,
-      size,
-      active,
-      className,
-      type,
-      as,
-      ...props
-    }: ButtonProps,
-    ref,
-  ) => {
+const Button: BsPrefixRefForwardingComponent<
+  'button',
+  ButtonProps
+> = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ bsPrefix, variant, size, active, className, type, as, ...props }, ref) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'btn');
 
     const classes = classNames(
@@ -116,18 +106,12 @@ const Button: Button = React.forwardRef(
       );
     }
 
-    if (ref) {
-      (props as any).ref = ref;
-    }
-
-    if (type) {
-      (props as any).type = type;
-    } else if (!as) {
-      (props as any).type = 'button';
+    if (!type && !as) {
+      type = 'button';
     }
 
     const Component = as || 'button';
-    return <Component {...props} className={classes} />;
+    return <Component {...props} ref={ref} type={type} className={classes} />;
   },
 );
 

--- a/src/ButtonGroup.tsx
+++ b/src/ButtonGroup.tsx
@@ -3,18 +3,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface ButtonGroupProps extends BsPrefixPropsWithChildren {
-  role?: string;
+export interface ButtonGroupProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   size?: 'sm' | 'lg';
   vertical?: boolean;
 }
-
-type ButtonGroup = BsPrefixRefForwardingComponent<'div', ButtonGroupProps>;
 
 const propTypes = {
   /**
@@ -47,7 +43,10 @@ const defaultProps = {
   role: 'group',
 };
 
-const ButtonGroup: ButtonGroup = React.forwardRef(
+const ButtonGroup: BsPrefixRefForwardingComponent<
+  'div',
+  ButtonGroupProps
+> = React.forwardRef(
   (
     {
       bsPrefix,

--- a/src/ButtonToolbar.tsx
+++ b/src/ButtonToolbar.tsx
@@ -4,16 +4,11 @@ import React from 'react';
 
 import { useBootstrapPrefix } from './ThemeProvider';
 
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps } from './helpers';
 
-export interface ButtonToolbarProps extends BsPrefixPropsWithChildren {
-  role?: string;
-}
-
-type ButtonToolbar = BsPrefixRefForwardingComponent<'div', ButtonToolbarProps>;
+export interface ButtonToolbarProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
 
 const propTypes = {
   /**
@@ -33,14 +28,15 @@ const defaultProps = {
   role: 'toolbar',
 };
 
-const ButtonToolbar: ButtonToolbar = React.forwardRef<
-  HTMLDivElement,
-  ButtonToolbarProps
->(({ bsPrefix, className, ...props }, ref) => {
-  const prefix = useBootstrapPrefix(bsPrefix, 'btn-toolbar');
+const ButtonToolbar = React.forwardRef<HTMLDivElement, ButtonToolbarProps>(
+  ({ bsPrefix, className, ...props }, ref) => {
+    const prefix = useBootstrapPrefix(bsPrefix, 'btn-toolbar');
 
-  return <div {...props} ref={ref} className={classNames(className, prefix)} />;
-});
+    return (
+      <div {...props} ref={ref} className={classNames(className, prefix)} />
+    );
+  },
+);
 
 ButtonToolbar.displayName = 'ButtonToolbar';
 ButtonToolbar.propTypes = propTypes;

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -7,10 +7,7 @@ import createWithBsPrefix from './createWithBsPrefix';
 import divWithClassName from './divWithClassName';
 import CardContext from './CardContext';
 import CardImg from './CardImg';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 import { Color, Variant } from './types';
 
 const DivStyledAsH5 = divWithClassName('h5');
@@ -28,24 +25,14 @@ const CardHeader = createWithBsPrefix('card-header');
 const CardFooter = createWithBsPrefix('card-footer');
 const CardImgOverlay = createWithBsPrefix('card-img-overlay');
 
-export interface CardProps extends BsPrefixPropsWithChildren {
+export interface CardProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   bg?: Variant;
   text?: Color;
   border?: Variant;
   body?: boolean;
 }
-
-type Card = BsPrefixRefForwardingComponent<'div', CardProps> & {
-  Img: typeof CardImg;
-  Title: typeof CardTitle;
-  Subtitle: typeof CardSubtitle;
-  Body: typeof CardBody;
-  Link: typeof CardLink;
-  Text: typeof CardText;
-  Header: typeof CardHeader;
-  Footer: typeof CardFooter;
-  ImgOverlay: typeof CardImgOverlay;
-};
 
 const propTypes = {
   /**
@@ -87,7 +74,10 @@ const defaultProps = {
   body: false,
 };
 
-const Card: Card = (React.forwardRef(
+const Card: BsPrefixRefForwardingComponent<'div', CardProps> = React.forwardRef<
+  HTMLElement,
+  CardProps
+>(
   (
     {
       bsPrefix,
@@ -100,7 +90,7 @@ const Card: Card = (React.forwardRef(
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
       ...props
-    }: CardProps,
+    },
     ref,
   ) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'card');
@@ -124,30 +114,25 @@ const Card: Card = (React.forwardRef(
             border && `border-${border}`,
           )}
         >
-          {body ? (
-            // @ts-ignore
-            <CardBody>{children}</CardBody>
-          ) : (
-            children
-          )}
+          {body ? <CardBody>{children}</CardBody> : children}
         </Component>
       </CardContext.Provider>
     );
   },
-) as unknown) as Card;
+);
 
 Card.displayName = 'Card';
 Card.propTypes = propTypes;
 Card.defaultProps = defaultProps;
 
-Card.Img = CardImg;
-Card.Title = CardTitle;
-Card.Subtitle = CardSubtitle;
-Card.Body = CardBody;
-Card.Link = CardLink;
-Card.Text = CardText;
-Card.Header = CardHeader;
-Card.Footer = CardFooter;
-Card.ImgOverlay = CardImgOverlay;
-
-export default Card;
+export default Object.assign(Card, {
+  Img: CardImg,
+  Title: CardTitle,
+  Subtitle: CardSubtitle,
+  Body: CardBody,
+  Link: CardLink,
+  Text: CardText,
+  Header: CardHeader,
+  Footer: CardFooter,
+  ImgOverlay: CardImgOverlay,
+});

--- a/src/CardImg.tsx
+++ b/src/CardImg.tsx
@@ -6,10 +6,8 @@ import { useBootstrapPrefix } from './ThemeProvider';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 export interface CardImgProps extends BsPrefixProps {
-  variant?: 'top' | 'bottom' | null;
+  variant?: 'top' | 'bottom';
 }
-
-type CardImg = BsPrefixRefForwardingComponent<'img', CardImgProps>;
 
 const propTypes = {
   /**
@@ -23,16 +21,15 @@ const propTypes = {
    *
    * @type {('top'|'bottom')}
    */
-  variant: PropTypes.oneOf(['top', 'bottom', null]),
+  variant: PropTypes.oneOf(['top', 'bottom']),
 
   as: PropTypes.elementType,
 };
 
-const defaultProps = {
-  variant: null,
-};
-
-const CardImg: CardImg = React.forwardRef(
+const CardImg: BsPrefixRefForwardingComponent<
+  'img',
+  CardImgProps
+> = React.forwardRef(
   // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
   (
     {
@@ -60,6 +57,5 @@ const CardImg: CardImg = React.forwardRef(
 );
 CardImg.displayName = 'CardImg';
 CardImg.propTypes = propTypes;
-CardImg.defaultProps = defaultProps;
 
 export default CardImg;

--- a/src/CarouselItem.tsx
+++ b/src/CarouselItem.tsx
@@ -2,16 +2,13 @@ import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface CarouselItemProps extends BsPrefixPropsWithChildren {
+export interface CarouselItemProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   interval?: number;
 }
-
-type CarouselItem = BsPrefixRefForwardingComponent<'div', CarouselItemProps>;
 
 const propTypes = {
   /** Set a custom element for this component */
@@ -24,29 +21,27 @@ const propTypes = {
   interval: PropTypes.number,
 };
 
-const CarouselItem = (React.forwardRef(
+const CarouselItem: BsPrefixRefForwardingComponent<
+  'div',
+  CarouselItemProps
+> = React.forwardRef<HTMLElement, CarouselItemProps>(
   (
     {
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
       bsPrefix,
-      children,
       className,
       ...props
-    }: CarouselItemProps,
+    },
     ref,
   ) => {
     const finalClassName = classNames(
       className,
       useBootstrapPrefix(bsPrefix, 'carousel-item'),
     );
-    return (
-      <Component ref={ref} {...props} className={finalClassName}>
-        {children}
-      </Component>
-    );
+    return <Component ref={ref} {...props} className={finalClassName} />;
   },
-) as unknown) as CarouselItem;
+);
 
 CarouselItem.displayName = 'CarouselItem';
 CarouselItem.propTypes = propTypes;

--- a/src/Col.tsx
+++ b/src/Col.tsx
@@ -3,10 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 type NumberAttr =
   | number
@@ -30,7 +27,9 @@ type ColSpec =
   | ColSize
   | { span?: ColSize; offset?: NumberAttr; order?: ColOrder };
 
-export interface ColProps extends BsPrefixPropsWithChildren {
+export interface ColProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   xs?: ColSpec;
   sm?: ColSpec;
   md?: ColSpec;
@@ -112,9 +111,12 @@ const propTypes = {
   xxl: column,
 };
 
-const Col: BsPrefixRefForwardingComponent<'div', ColProps> = React.forwardRef(
+const Col: BsPrefixRefForwardingComponent<'div', ColProps> = React.forwardRef<
+  HTMLElement,
+  ColProps
+>(
   // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
-  ({ bsPrefix, className, as: Component = 'div', ...props }: ColProps, ref) => {
+  ({ bsPrefix, className, as: Component = 'div', ...props }, ref) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'col');
     const spans: string[] = [];
     const classes: string[] = [];

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -3,16 +3,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface ContainerProps extends BsPrefixPropsWithChildren {
+export interface ContainerProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   fluid?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 }
-
-type Container = BsPrefixRefForwardingComponent<'div', ContainerProps>;
 
 const containerSizes = PropTypes.oneOfType([
   PropTypes.bool,
@@ -40,7 +37,10 @@ const defaultProps = {
   fluid: false,
 };
 
-const Container: Container = React.forwardRef(
+const Container: BsPrefixRefForwardingComponent<
+  'div',
+  ContainerProps
+> = React.forwardRef<HTMLElement, ContainerProps>(
   (
     {
       bsPrefix,
@@ -49,7 +49,7 @@ const Container: Container = React.forwardRef(
       as: Component = 'div',
       className,
       ...props
-    }: ContainerProps,
+    },
     ref,
   ) => {
     const prefix = useBootstrapPrefix(bsPrefix, 'container');

--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -12,7 +12,7 @@ import SelectableContext from './SelectableContext';
 import { useBootstrapPrefix } from './ThemeProvider';
 import createWithBsPrefix from './createWithBsPrefix';
 import {
-  BsPrefixPropsWithChildren,
+  BsPrefixProps,
   BsPrefixRefForwardingComponent,
   SelectCallback,
 } from './helpers';
@@ -28,29 +28,22 @@ const DropdownItemText = createWithBsPrefix('dropdown-item-text', {
   Component: 'span',
 });
 
-export interface DropdownProps extends BsPrefixPropsWithChildren {
+export interface DropdownProps
+  extends BsPrefixProps,
+    Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'> {
   drop?: 'up' | 'start' | 'end' | 'down';
   alignRight?: boolean;
   show?: boolean;
   flip?: boolean;
   onToggle?: (
     isOpen: boolean,
-    event: React.SyntheticEvent<Dropdown>,
+    event: React.SyntheticEvent,
     metadata: { source: 'select' | 'click' | 'rootClose' | 'keydown' },
   ) => void;
   focusFirstItemOnShow?: boolean | 'keyboard';
   onSelect?: SelectCallback;
   navbar?: boolean;
 }
-
-type Dropdown = BsPrefixRefForwardingComponent<'div', DropdownProps> & {
-  Toggle: typeof DropdownToggle;
-  Menu: typeof DropdownMenu;
-  Item: typeof DropdownItem;
-  ItemText: typeof DropdownItemText;
-  Divider: typeof DropdownDivider;
-  Header: typeof DropdownHeader;
-};
 
 const propTypes = {
   /** @default 'dropdown' */
@@ -126,7 +119,10 @@ const defaultProps = {
   navbar: false,
 };
 
-const Dropdown: Dropdown = (React.forwardRef((pProps: DropdownProps, ref) => {
+const Dropdown: BsPrefixRefForwardingComponent<
+  'div',
+  DropdownProps
+> = React.forwardRef<HTMLElement, DropdownProps>((pProps, ref) => {
   const {
     bsPrefix,
     drop,
@@ -196,17 +192,17 @@ const Dropdown: Dropdown = (React.forwardRef((pProps: DropdownProps, ref) => {
       </BaseDropdown>
     </SelectableContext.Provider>
   );
-}) as unknown) as Dropdown;
+});
 
 Dropdown.displayName = 'Dropdown';
 Dropdown.propTypes = propTypes;
 Dropdown.defaultProps = defaultProps;
 
-Dropdown.Divider = DropdownDivider;
-Dropdown.Header = DropdownHeader;
-Dropdown.Item = DropdownItem;
-Dropdown.ItemText = DropdownItemText;
-Dropdown.Menu = DropdownMenu;
-Dropdown.Toggle = DropdownToggle;
-
-export default Dropdown;
+export default Object.assign(Dropdown, {
+  Toggle: DropdownToggle,
+  Menu: DropdownMenu,
+  Item: DropdownItem,
+  ItemText: DropdownItemText,
+  Divider: DropdownDivider,
+  Header: DropdownHeader,
+});

--- a/src/DropdownButton.tsx
+++ b/src/DropdownButton.tsx
@@ -9,29 +9,19 @@ import DropdownMenu, {
   DropdownMenuVariant,
 } from './DropdownMenu';
 
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 export interface DropdownButtonProps
-  extends DropdownProps,
-    Omit<React.HTMLAttributes<HTMLElement>, 'onSelect' | 'title'>,
+  extends Omit<DropdownProps, 'title'>,
     PropsFromToggle,
-    BsPrefixPropsWithChildren {
+    BsPrefixProps {
   title: React.ReactNode;
   menuAlign?: AlignType;
   menuRole?: string;
   renderMenuOnMount?: boolean;
   rootCloseEvent?: 'click' | 'mousedown';
-  bsPrefix?: string;
   menuVariant?: DropdownMenuVariant;
 }
-
-type DropdownButton = BsPrefixRefForwardingComponent<
-  'div',
-  DropdownButtonProps
->;
 
 const propTypes = {
   /**
@@ -99,10 +89,10 @@ const propTypes = {
  * the Button `variant`, `size` and `bsPrefix` props are passed to the toggle,
  * along with menu-related props are passed to the `Dropdown.Menu`
  */
-const DropdownButton: DropdownButton = React.forwardRef<
-  HTMLDivElement,
+const DropdownButton: BsPrefixRefForwardingComponent<
+  'div',
   DropdownButtonProps
->(
+> = React.forwardRef<HTMLDivElement, DropdownButtonProps>(
   (
     {
       title,
@@ -147,6 +137,6 @@ const DropdownButton: DropdownButton = React.forwardRef<
 );
 
 DropdownButton.displayName = 'DropdownButton';
-DropdownButton.propTypes = propTypes as any;
+DropdownButton.propTypes = propTypes;
 
 export default DropdownButton;

--- a/src/DropdownItem.tsx
+++ b/src/DropdownItem.tsx
@@ -8,24 +8,20 @@ import { useBootstrapPrefix } from './ThemeProvider';
 import NavContext from './NavContext';
 import SafeAnchor from './SafeAnchor';
 import {
-  BsPrefixPropsWithChildren,
+  BsPrefixProps,
   BsPrefixRefForwardingComponent,
   SelectCallback,
 } from './helpers';
 
-export interface DropdownItemProps extends BsPrefixPropsWithChildren {
+export interface DropdownItemProps
+  extends BsPrefixProps,
+    Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'> {
   active?: boolean;
   disabled?: boolean;
   eventKey?: string;
   href?: string;
-  onClick?: React.MouseEventHandler<this>;
   onSelect?: SelectCallback;
 }
-
-type DropdownItem = BsPrefixRefForwardingComponent<
-  typeof SafeAnchor,
-  DropdownItemProps
->;
 
 const propTypes = {
   /** @default 'dropdown-item' */
@@ -73,7 +69,10 @@ const defaultProps = {
   disabled: false,
 };
 
-const DropdownItem: DropdownItem = React.forwardRef(
+const DropdownItem: BsPrefixRefForwardingComponent<
+  typeof SafeAnchor,
+  DropdownItemProps
+> = React.forwardRef(
   (
     {
       bsPrefix,

--- a/src/DropdownMenu.tsx
+++ b/src/DropdownMenu.tsx
@@ -13,7 +13,7 @@ import { useBootstrapPrefix } from './ThemeProvider';
 import useWrappedRefWithWarning from './useWrappedRefWithWarning';
 import usePopperMarginModifiers from './usePopperMarginModifiers';
 import {
-  BsPrefixPropsWithChildren,
+  BsPrefixProps,
   BsPrefixRefForwardingComponent,
   SelectCallback,
 } from './helpers';
@@ -30,7 +30,9 @@ export type AlignType = AlignDirection | ResponsiveAlignProp;
 
 export type DropdownMenuVariant = 'dark';
 
-export interface DropdownMenuProps extends BsPrefixPropsWithChildren {
+export interface DropdownMenuProps
+  extends BsPrefixProps,
+    Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'> {
   show?: boolean;
   renderOnMount?: boolean;
   flip?: boolean;
@@ -41,8 +43,6 @@ export interface DropdownMenuProps extends BsPrefixPropsWithChildren {
   popperConfig?: UseDropdownMenuOptions['popperConfig'];
   variant?: DropdownMenuVariant;
 }
-
-type DropdownMenu = BsPrefixRefForwardingComponent<'div', DropdownMenuProps>;
 
 const alignDirection = PropTypes.oneOf<AlignDirection>(['start', 'end']);
 
@@ -129,7 +129,10 @@ const defaultProps: Partial<DropdownMenuProps> = {
 // TODO: remove this hack
 type UseDropdownMenuValueHack = UseDropdownMenuValue & { placement: any };
 
-const DropdownMenu: DropdownMenu = React.forwardRef(
+const DropdownMenu: BsPrefixRefForwardingComponent<
+  'div',
+  DropdownMenuProps
+> = React.forwardRef<HTMLElement, DropdownMenuProps>(
   (
     {
       bsPrefix,
@@ -147,7 +150,7 @@ const DropdownMenu: DropdownMenu = React.forwardRef(
       popperConfig,
       variant,
       ...props
-    }: DropdownMenuProps,
+    },
     ref,
   ) => {
     const isNavbar = useContext(NavbarContext);

--- a/src/DropdownToggle.tsx
+++ b/src/DropdownToggle.tsx
@@ -7,26 +7,21 @@ import useMergedRefs from '@restart/hooks/useMergedRefs';
 import Button, { ButtonProps, CommonButtonProps } from './Button';
 import { useBootstrapPrefix } from './ThemeProvider';
 import useWrappedRefWithWarning from './useWrappedRefWithWarning';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixRefForwardingComponent } from './helpers';
 
-export interface DropdownToggleProps
-  extends BsPrefixPropsWithChildren,
-    ButtonProps {
+export interface DropdownToggleProps extends ButtonProps {
   split?: boolean;
   childBsPrefix?: string;
   eventKey?: any; // TODO: fix this type
 }
 
-type DropdownToggle = BsPrefixRefForwardingComponent<
+type DropdownToggleComponent = BsPrefixRefForwardingComponent<
   'button',
   DropdownToggleProps
 >;
 
 export type PropsFromToggle = Partial<
-  Pick<React.ComponentPropsWithRef<DropdownToggle>, CommonButtonProps>
+  Pick<React.ComponentPropsWithRef<DropdownToggleComponent>, CommonButtonProps>
 >;
 
 const propTypes = {
@@ -53,7 +48,7 @@ const propTypes = {
   childBsPrefix: PropTypes.string,
 };
 
-const DropdownToggle: DropdownToggle = React.forwardRef(
+const DropdownToggle: DropdownToggleComponent = React.forwardRef(
   (
     {
       bsPrefix,

--- a/src/Feedback.tsx
+++ b/src/Feedback.tsx
@@ -1,16 +1,17 @@
 import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
+import { AsProp, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface FeedbackProps extends BsPrefixProps {
-  className?: string;
+export interface FeedbackProps
+  extends AsProp,
+    React.HTMLAttributes<HTMLElement> {
+  // I think this is because we use BsPrefixRefForwardingComponent below
+  // which includes bsPrefix.
   bsPrefix?: never;
   type?: 'valid' | 'invalid';
   tooltip?: boolean;
 }
-
-type Feedback = BsPrefixRefForwardingComponent<'div', FeedbackProps>;
 
 const propTypes = {
   /**
@@ -26,7 +27,10 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-const Feedback: Feedback = React.forwardRef(
+const Feedback: BsPrefixRefForwardingComponent<
+  'div',
+  FeedbackProps
+> = React.forwardRef(
   // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
   (
     {

--- a/src/Figure.tsx
+++ b/src/Figure.tsx
@@ -1,17 +1,12 @@
 import createWithBsPrefix from './createWithBsPrefix';
-import { BsPrefixRefForwardingComponent } from './helpers';
 import FigureImage from './FigureImage';
 import FigureCaption from './FigureCaption';
 
-type Figure = BsPrefixRefForwardingComponent<'figure'> & {
-  Image: typeof FigureImage;
-  Caption: typeof FigureCaption;
-};
-
-const Figure: Figure = (createWithBsPrefix('figure', {
+const Figure = createWithBsPrefix('figure', {
   Component: 'figure',
-}) as unknown) as Figure;
+});
 
-Figure.Image = FigureImage;
-Figure.Caption = FigureCaption;
-export default Figure;
+export default Object.assign(Figure, {
+  Image: FigureImage,
+  Caption: FigureCaption,
+});

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -9,26 +9,13 @@ import FormRange from './FormRange';
 import FormSelect from './FormSelect';
 import FormText from './FormText';
 import Switch from './Switch';
-import { AsProp } from './helpers';
+import { BsPrefixRefForwardingComponent, AsProp } from './helpers';
 
 export interface FormProps
-  extends React.HTMLAttributes<HTMLFormElement>,
+  extends React.FormHTMLAttributes<HTMLFormElement>,
     AsProp {
   validated?: boolean;
 }
-
-type Form = React.ForwardRefExoticComponent<
-  FormProps & React.RefAttributes<HTMLElement>
-> & {
-  Group: typeof FormGroup;
-  Control: typeof FormControl;
-  Check: typeof FormCheck;
-  Switch: typeof Switch;
-  Label: typeof FormLabel;
-  Text: typeof FormText;
-  Range: typeof FormRange;
-  Select: typeof FormSelect;
-};
 
 const propTypes = {
   /**
@@ -49,7 +36,10 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-const FormImpl: Form = (React.forwardRef(
+const Form: BsPrefixRefForwardingComponent<
+  'form',
+  FormProps
+> = React.forwardRef<HTMLFormElement, FormProps>(
   (
     {
       className,
@@ -57,7 +47,7 @@ const FormImpl: Form = (React.forwardRef(
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'form',
       ...props
-    }: FormProps,
+    },
     ref,
   ) => {
     return (
@@ -68,18 +58,18 @@ const FormImpl: Form = (React.forwardRef(
       />
     );
   },
-) as unknown) as Form;
+);
 
-FormImpl.displayName = 'Form';
-FormImpl.propTypes = propTypes as any;
+Form.displayName = 'Form';
+Form.propTypes = propTypes as any;
 
-FormImpl.Group = FormGroup;
-FormImpl.Control = FormControl;
-FormImpl.Check = FormCheck;
-FormImpl.Switch = Switch;
-FormImpl.Label = FormLabel;
-FormImpl.Text = FormText;
-FormImpl.Range = FormRange;
-FormImpl.Select = FormSelect;
-
-export default FormImpl;
+export default Object.assign(Form, {
+  Group: FormGroup,
+  Control: FormControl,
+  Check: FormCheck,
+  Switch,
+  Label: FormLabel,
+  Text: FormText,
+  Range: FormRange,
+  Select: FormSelect,
+});

--- a/src/FormCheck.tsx
+++ b/src/FormCheck.tsx
@@ -6,15 +6,12 @@ import FormCheckInput from './FormCheckInput';
 import FormCheckLabel from './FormCheckLabel';
 import FormContext from './FormContext';
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 export type FormCheckType = 'checkbox' | 'radio' | 'switch';
 
 export interface FormCheckProps
-  extends BsPrefixPropsWithChildren,
+  extends BsPrefixProps,
     React.InputHTMLAttributes<HTMLInputElement> {
   inline?: boolean;
   disabled?: boolean;
@@ -26,11 +23,6 @@ export interface FormCheckProps
   feedback?: React.ReactNode;
   bsSwitchPrefix?: string;
 }
-
-type FormCheck = BsPrefixRefForwardingComponent<'input', FormCheckProps> & {
-  Input: typeof FormCheckInput;
-  Label: typeof FormCheckLabel;
-};
 
 const propTypes = {
   /**
@@ -121,7 +113,10 @@ const propTypes = {
   feedback: PropTypes.node,
 };
 
-const FormCheck: FormCheck = (React.forwardRef(
+const FormCheck: BsPrefixRefForwardingComponent<
+  'input',
+  FormCheckProps
+> = React.forwardRef<HTMLInputElement, FormCheckProps>(
   (
     {
       id,
@@ -142,7 +137,7 @@ const FormCheck: FormCheck = (React.forwardRef(
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as = 'input',
       ...props
-    }: FormCheckProps,
+    },
     ref,
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'form-check');
@@ -201,12 +196,12 @@ const FormCheck: FormCheck = (React.forwardRef(
       </FormContext.Provider>
     );
   },
-) as unknown) as FormCheck;
+);
 
 FormCheck.displayName = 'FormCheck';
 FormCheck.propTypes = propTypes;
 
-FormCheck.Input = FormCheckInput;
-FormCheck.Label = FormCheckLabel;
-
-export default FormCheck;
+export default Object.assign(FormCheck, {
+  Input: FormCheckInput,
+  Label: FormCheckLabel,
+});

--- a/src/FormCheckInput.tsx
+++ b/src/FormCheckInput.tsx
@@ -7,17 +7,14 @@ import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 type FormCheckInputType = 'checkbox' | 'radio';
 
-export interface FormCheckInputProps extends BsPrefixProps {
+export interface FormCheckInputProps
+  extends BsPrefixProps,
+    React.InputHTMLAttributes<HTMLInputElement> {
   id?: string;
   type?: FormCheckInputType;
   isValid?: boolean;
   isInvalid?: boolean;
 }
-
-type FormCheckInput = BsPrefixRefForwardingComponent<
-  'input',
-  FormCheckInputProps
->;
 
 const propTypes = {
   /**
@@ -45,7 +42,10 @@ const propTypes = {
   isInvalid: PropTypes.bool,
 };
 
-const FormCheckInput: FormCheckInput = React.forwardRef(
+const FormCheckInput: BsPrefixRefForwardingComponent<
+  'input',
+  FormCheckInputProps
+> = React.forwardRef<HTMLInputElement, FormCheckInputProps>(
   (
     {
       id,
@@ -57,7 +57,7 @@ const FormCheckInput: FormCheckInput = React.forwardRef(
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'input',
       ...props
-    }: FormCheckInputProps,
+    },
     ref,
   ) => {
     const { controlId } = useContext(FormContext);

--- a/src/FormControl.tsx
+++ b/src/FormControl.tsx
@@ -9,7 +9,9 @@ import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 type FormControlElement = HTMLInputElement | HTMLTextAreaElement;
 
-export interface FormControlProps extends BsPrefixProps {
+export interface FormControlProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<FormControlElement> {
   htmlSize?: number;
   size?: 'sm' | 'lg';
   plaintext?: boolean;
@@ -103,7 +105,7 @@ const propTypes = {
 const FormControl: BsPrefixRefForwardingComponent<
   'input',
   FormControlProps
-> = React.forwardRef(
+> = React.forwardRef<FormControlElement, FormControlProps>(
   (
     {
       bsPrefix,

--- a/src/FormGroup.tsx
+++ b/src/FormGroup.tsx
@@ -10,8 +10,6 @@ export interface FormGroupProps
   controlId?: string;
 }
 
-type FormGroup = BsPrefixRefForwardingComponent<'div', FormGroupProps>;
-
 const propTypes = {
   as: PropTypes.elementType,
 
@@ -31,7 +29,10 @@ const propTypes = {
   _ref: PropTypes.any,
 };
 
-const FormGroup: FormGroup = React.forwardRef(
+const FormGroup: BsPrefixRefForwardingComponent<
+  'div',
+  FormGroupProps
+> = React.forwardRef(
   (
     {
       children,

--- a/src/FormLabel.tsx
+++ b/src/FormLabel.tsx
@@ -6,12 +6,11 @@ import warning from 'warning';
 import Col, { ColProps } from './Col';
 import FormContext from './FormContext';
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-interface FormLabelBaseProps extends BsPrefixPropsWithChildren {
+interface FormLabelBaseProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   htmlFor?: string;
   visuallyHidden?: boolean;
 }
@@ -25,8 +24,6 @@ export interface FormLabelWithColProps extends FormLabelBaseProps, ColProps {
 }
 
 export type FormLabelProps = FormLabelWithColProps | FormLabelOwnProps;
-
-type FormLabel = BsPrefixRefForwardingComponent<'label', FormLabelProps>;
 
 const propTypes = {
   /**
@@ -70,7 +67,10 @@ const defaultProps = {
   visuallyHidden: false,
 };
 
-const FormLabel: FormLabel = React.forwardRef(
+const FormLabel: BsPrefixRefForwardingComponent<
+  'label',
+  FormLabelProps
+> = React.forwardRef<HTMLElement, FormLabelProps>(
   (
     {
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595

--- a/src/FormRange.tsx
+++ b/src/FormRange.tsx
@@ -2,14 +2,11 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixAndClassNameOnlyProps,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixAndClassNameOnlyProps } from './helpers';
 
 export interface FormRangeProps
   extends BsPrefixAndClassNameOnlyProps,
-    React.InputHTMLAttributes<HTMLInputElement> {}
+    Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {}
 
 const propTypes = {
   /**
@@ -27,7 +24,7 @@ const propTypes = {
    * */
   value: PropTypes.oneOfType([
     PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(PropTypes.string.isRequired),
     PropTypes.number,
   ]),
 
@@ -35,10 +32,7 @@ const propTypes = {
   onChange: PropTypes.func,
 };
 
-const FormRange: BsPrefixRefForwardingComponent<
-  'input',
-  FormRangeProps
-> = React.forwardRef<HTMLInputElement, FormRangeProps>(
+const FormRange = React.forwardRef<HTMLInputElement, FormRangeProps>(
   ({ bsPrefix, className, ...props }, ref) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'form-range');
 

--- a/src/FormSelect.tsx
+++ b/src/FormSelect.tsx
@@ -8,7 +8,7 @@ import {
 } from './helpers';
 
 export interface FormSelectProps
-  extends React.PropsWithChildren<BsPrefixAndClassNameOnlyProps>,
+  extends BsPrefixAndClassNameOnlyProps,
     React.HTMLAttributes<HTMLSelectElement> {
   htmlSize?: number;
   size?: 'sm' | 'lg';

--- a/src/FormText.tsx
+++ b/src/FormText.tsx
@@ -7,11 +7,11 @@ import { useBootstrapPrefix } from './ThemeProvider';
 
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface FormTextProps extends BsPrefixProps {
+export interface FormTextProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   muted?: boolean;
 }
-
-type FormText = BsPrefixRefForwardingComponent<'small', FormTextProps>;
 
 const propTypes = {
   /** @default 'form-text' */
@@ -35,7 +35,10 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-const FormText: FormText = React.forwardRef(
+const FormText: BsPrefixRefForwardingComponent<
+  'small',
+  FormTextProps
+> = React.forwardRef<HTMLElement, FormTextProps>(
   // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
   ({ bsPrefix, className, as: Component = 'small', muted, ...props }, ref) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'form-text');

--- a/src/InputGroup.tsx
+++ b/src/InputGroup.tsx
@@ -32,14 +32,6 @@ export interface InputGroupProps extends BsPrefixPropsWithChildren {
   hasValidation?: boolean;
 }
 
-type InputGroupExtras = {
-  Text: typeof InputGroupText;
-  Checkbox: typeof InputGroupCheckbox;
-  Radio: typeof InputGroupRadio;
-};
-
-type InputGroup = BsPrefixRefForwardingComponent<'div', InputGroupProps>;
-
 const propTypes = {
   /** @default 'input-group' */
   bsPrefix: PropTypes.string,
@@ -67,7 +59,10 @@ const propTypes = {
  * @property {InputGroupRadio} Radio
  * @property {InputGroupCheckbox} Checkbox
  */
-const InputGroup: InputGroup = React.forwardRef(
+const InputGroup: BsPrefixRefForwardingComponent<
+  'div',
+  InputGroupProps
+> = React.forwardRef<HTMLElement, InputGroupProps>(
   (
     {
       bsPrefix,
@@ -100,11 +95,8 @@ const InputGroup: InputGroup = React.forwardRef(
 InputGroup.propTypes = propTypes;
 InputGroup.displayName = 'InputGroup';
 
-const InputGroupWithExtras: InputGroup & InputGroupExtras = {
-  ...InputGroup,
+export default Object.assign(InputGroup, {
   Text: InputGroupText,
   Radio: InputGroupRadio,
   Checkbox: InputGroupCheckbox,
-} as any;
-
-export default InputGroupWithExtras;
+});

--- a/src/ListGroup.tsx
+++ b/src/ListGroup.tsx
@@ -14,17 +14,15 @@ import {
   SelectCallback,
 } from './helpers';
 
-export interface ListGroupProps extends BsPrefixProps {
+export interface ListGroupProps
+  extends BsPrefixProps,
+    Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'> {
   variant?: 'flush';
   horizontal?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
   activeKey?: unknown;
   defaultActiveKey?: unknown;
   onSelect?: SelectCallback;
 }
-
-type ListGroup = BsPrefixRefForwardingComponent<'div', ListGroupProps> & {
-  Item: typeof ListGroupItem;
-};
 
 const propTypes = {
   /**
@@ -37,7 +35,7 @@ const propTypes = {
    *
    * @type {('flush')}
    */
-  variant: PropTypes.oneOf(['flush', undefined]),
+  variant: PropTypes.oneOf(['flush']),
 
   /**
    * Changes the flow of the list group items from vertical to horizontal.
@@ -46,7 +44,7 @@ const propTypes = {
    * makes the list group horizontal starting at that breakpoint’s `min-width`.
    * @type {(true|'sm'|'md'|'lg'|'xl'|'xxl')}
    */
-  horizontal: PropTypes.oneOf([true, 'sm', 'md', 'lg', 'xl', 'xxl', undefined]),
+  horizontal: PropTypes.oneOf([true, 'sm', 'md', 'lg', 'xl', 'xxl']),
 
   /**
    * You can use a custom element type for this component.
@@ -54,12 +52,10 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-const defaultProps = {
-  variant: undefined,
-  horizontal: undefined,
-};
-
-const ListGroup: ListGroup = (React.forwardRef((props: ListGroupProps, ref) => {
+const ListGroup: BsPrefixRefForwardingComponent<
+  'div',
+  ListGroupProps
+> = React.forwardRef<HTMLElement, ListGroupProps>((props, ref) => {
   const {
     className,
     bsPrefix: initialBsPrefix,
@@ -74,12 +70,10 @@ const ListGroup: ListGroup = (React.forwardRef((props: ListGroupProps, ref) => {
 
   const bsPrefix = useBootstrapPrefix(initialBsPrefix, 'list-group');
 
-  let horizontalVariant;
+  let horizontalVariant: string | undefined;
   if (horizontal) {
     horizontalVariant =
       horizontal === true ? 'horizontal' : `horizontal-${horizontal}`;
-  } else {
-    horizontalVariant = null;
   }
 
   warning(
@@ -100,12 +94,11 @@ const ListGroup: ListGroup = (React.forwardRef((props: ListGroupProps, ref) => {
       )}
     />
   );
-}) as unknown) as ListGroup;
+});
 
 ListGroup.propTypes = propTypes;
-ListGroup.defaultProps = defaultProps;
 ListGroup.displayName = 'ListGroup';
 
-ListGroup.Item = ListGroupItem;
-
-export default ListGroup;
+export default Object.assign(ListGroup, {
+  Item: ListGroupItem,
+});

--- a/src/ListGroupItem.tsx
+++ b/src/ListGroupItem.tsx
@@ -20,8 +20,6 @@ export interface ListGroupItemProps
   variant?: Variant;
 }
 
-type ListGroupItem = BsPrefixRefForwardingComponent<'a', ListGroupItemProps>;
-
 const propTypes = {
   /**
    * @default 'list-group-item'
@@ -69,7 +67,10 @@ const defaultProps = {
   disabled: false,
 };
 
-const ListGroupItem: ListGroupItem = React.forwardRef(
+const ListGroupItem: BsPrefixRefForwardingComponent<
+  'a',
+  ListGroupItemProps
+> = React.forwardRef<HTMLElement, ListGroupItemProps>(
   (
     {
       bsPrefix,

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -56,16 +56,6 @@ export interface ModalProps
   scrollable?: boolean;
 }
 
-type Modal = BsPrefixRefForwardingComponent<'div', ModalProps> & {
-  Body: typeof ModalBody;
-  Header: typeof ModalHeader;
-  Title: typeof ModalTitle;
-  Footer: typeof ModalFooter;
-  Dialog: typeof ModalDialog;
-  TRANSITION_DURATION: number;
-  BACKDROP_TRANSITION_DURATION: number;
-};
-
 let manager;
 
 const propTypes = {
@@ -254,8 +244,10 @@ function BackdropTransition(props) {
 }
 
 /* eslint-enable no-use-before-define */
-
-const Modal: Modal = (React.forwardRef(
+const Modal: BsPrefixRefForwardingComponent<
+  'div',
+  ModalProps
+> = React.forwardRef(
   (
     {
       bsPrefix,
@@ -536,19 +528,18 @@ const Modal: Modal = (React.forwardRef(
       </ModalContext.Provider>
     );
   },
-) as unknown) as Modal;
+);
 
 Modal.displayName = 'Modal';
 Modal.propTypes = propTypes;
 Modal.defaultProps = defaultProps;
 
-Modal.Body = ModalBody;
-Modal.Header = ModalHeader;
-Modal.Title = ModalTitle;
-Modal.Footer = ModalFooter;
-Modal.Dialog = ModalDialog;
-
-Modal.TRANSITION_DURATION = 300;
-Modal.BACKDROP_TRANSITION_DURATION = 150;
-
-export default Modal;
+export default Object.assign(Modal, {
+  Body: ModalBody,
+  Header: ModalHeader,
+  Title: ModalTitle,
+  Footer: ModalFooter,
+  Dialog: ModalDialog,
+  TRANSITION_DURATION: 300,
+  BACKDROP_TRANSITION_DURATION: 150,
+});

--- a/src/ModalDialog.tsx
+++ b/src/ModalDialog.tsx
@@ -4,11 +4,11 @@ import PropTypes from 'prop-types';
 
 import { useBootstrapPrefix } from './ThemeProvider';
 
-import { BsPrefixPropsWithChildren } from './helpers';
+import { BsPrefixProps } from './helpers';
 
 export interface ModalDialogProps
   extends React.HTMLAttributes<HTMLDivElement>,
-    BsPrefixPropsWithChildren {
+    BsPrefixProps {
   size?: 'sm' | 'lg' | 'xl';
   fullscreen?:
     | true

--- a/src/ModalHeader.tsx
+++ b/src/ModalHeader.tsx
@@ -9,8 +9,8 @@ import ModalContext from './ModalContext';
 import { BsPrefixAndClassNameOnlyProps } from './helpers';
 
 export interface ModalHeaderProps
-  extends React.PropsWithChildren<BsPrefixAndClassNameOnlyProps>,
-    React.ComponentProps<'div'> {
+  extends BsPrefixAndClassNameOnlyProps,
+    React.HTMLAttributes<HTMLDivElement> {
   closeLabel?: string;
   closeVariant?: CloseButtonVariant;
   closeButton?: boolean;

--- a/src/Nav.tsx
+++ b/src/Nav.tsx
@@ -12,12 +12,14 @@ import AbstractNav from './AbstractNav';
 import NavItem from './NavItem';
 import NavLink from './NavLink';
 import {
-  BsPrefixPropsWithChildren,
+  BsPrefixProps,
   BsPrefixRefForwardingComponent,
   SelectCallback,
 } from './helpers';
 
-export interface NavProps extends BsPrefixPropsWithChildren {
+export interface NavProps
+  extends BsPrefixProps,
+    Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'> {
   navbarBsPrefix?: string;
   cardHeaderBsPrefix?: string;
   variant?: 'tabs' | 'pills';
@@ -26,15 +28,8 @@ export interface NavProps extends BsPrefixPropsWithChildren {
   fill?: boolean;
   justify?: boolean;
   onSelect?: SelectCallback;
-  role?: string;
   navbar?: boolean;
-  onKeyDown?: React.KeyboardEventHandler<this>;
 }
-
-type Nav = BsPrefixRefForwardingComponent<'div', NavProps> & {
-  Item: typeof NavItem;
-  Link: typeof NavLink;
-};
 
 const propTypes = {
   /**
@@ -114,7 +109,10 @@ const defaultProps = {
   fill: false,
 };
 
-const Nav: Nav = (React.forwardRef((uncontrolledProps: NavProps, ref) => {
+const Nav: BsPrefixRefForwardingComponent<'div', NavProps> = React.forwardRef<
+  HTMLElement,
+  NavProps
+>((uncontrolledProps, ref) => {
   const {
     as = 'div',
     bsPrefix: initialBsPrefix,
@@ -162,13 +160,13 @@ const Nav: Nav = (React.forwardRef((uncontrolledProps: NavProps, ref) => {
       {children}
     </AbstractNav>
   );
-}) as unknown) as Nav;
+});
 
 Nav.displayName = 'Nav';
 Nav.propTypes = propTypes;
 Nav.defaultProps = defaultProps;
 
-Nav.Item = NavItem;
-Nav.Link = NavLink;
-
-export default Nav;
+export default Object.assign(Nav, {
+  Item: NavItem,
+  Link: NavLink,
+});

--- a/src/NavDropdown.tsx
+++ b/src/NavDropdown.tsx
@@ -9,8 +9,7 @@ import NavLink from './NavLink';
 import { BsPrefixRefForwardingComponent } from './helpers';
 
 export interface NavDropdownProps
-  extends DropdownProps,
-    Omit<React.HTMLAttributes<HTMLElement>, 'onSelect' | 'title'> {
+  extends Omit<DropdownProps, 'onSelect' | 'title'> {
   id: string;
   title: React.ReactNode;
   disabled?: boolean;
@@ -20,13 +19,6 @@ export interface NavDropdownProps
   rootCloseEvent?: 'click' | 'mousedown';
   menuVariant?: DropdownMenuVariant;
 }
-
-type NavDropdown = BsPrefixRefForwardingComponent<'div', NavDropdownProps> & {
-  Item: typeof Dropdown.Item;
-  ItemText: typeof Dropdown.ItemText;
-  Divider: typeof Dropdown.Divider;
-  Header: typeof Dropdown.Header;
-};
 
 const propTypes = {
   /**
@@ -72,7 +64,10 @@ const propTypes = {
   bsPrefix: PropTypes.string,
 };
 
-const NavDropdown: NavDropdown = (React.forwardRef(
+const NavDropdown: BsPrefixRefForwardingComponent<
+  'div',
+  NavDropdownProps
+> = React.forwardRef(
   (
     {
       id,
@@ -121,13 +116,14 @@ const NavDropdown: NavDropdown = (React.forwardRef(
       </Dropdown>
     );
   },
-) as unknown) as NavDropdown;
+);
 
 NavDropdown.displayName = 'NavDropdown';
 NavDropdown.propTypes = propTypes;
-NavDropdown.Item = Dropdown.Item;
-NavDropdown.ItemText = Dropdown.ItemText;
-NavDropdown.Divider = Dropdown.Divider;
-NavDropdown.Header = Dropdown.Header;
 
-export default NavDropdown;
+export default Object.assign(NavDropdown, {
+  Item: Dropdown.Item,
+  ItemText: Dropdown.ItemText,
+  Divider: Dropdown.Divider,
+  Header: Dropdown.Header,
+});

--- a/src/NavItem.tsx
+++ b/src/NavItem.tsx
@@ -3,16 +3,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface NavItemProps extends BsPrefixPropsWithChildren {
-  role?: string;
-}
-
-type NavItem = BsPrefixRefForwardingComponent<'div', NavItemProps>;
+export interface NavItemProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
 
 const propTypes = {
   /**
@@ -26,18 +21,12 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-const NavItem: NavItem = React.forwardRef(
+const NavItem: BsPrefixRefForwardingComponent<
+  'div',
+  NavItemProps
+> = React.forwardRef<HTMLElement, NavItemProps>(
   // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
-  (
-    {
-      bsPrefix,
-      className,
-      children,
-      as: Component = 'div',
-      ...props
-    }: NavItemProps,
-    ref,
-  ) => {
+  ({ bsPrefix, className, children, as: Component = 'div', ...props }, ref) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'nav-item');
 
     return (

--- a/src/NavLink.tsx
+++ b/src/NavLink.tsx
@@ -4,24 +4,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import SafeAnchor from './SafeAnchor';
-import AbstractNavItem from './AbstractNavItem';
+import AbstractNavItem, { AbstractNavItemProps } from './AbstractNavItem';
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-  SelectCallback,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface NavLinkProps extends BsPrefixPropsWithChildren {
-  active?: boolean;
-  disabled?: boolean;
-  role?: string;
-  href?: string;
-  onSelect?: SelectCallback;
-  eventKey?: unknown;
-}
-
-type NavLink = BsPrefixRefForwardingComponent<'a', NavLinkProps>;
+export interface NavLinkProps
+  extends BsPrefixProps,
+    Omit<AbstractNavItemProps, 'as'> {}
 
 const propTypes = {
   /**
@@ -71,18 +60,12 @@ const defaultProps = {
   as: SafeAnchor,
 };
 
-const NavLink: NavLink = React.forwardRef(
+const NavLink: BsPrefixRefForwardingComponent<
+  'a',
+  NavLinkProps
+> = React.forwardRef<HTMLElement, NavLinkProps>(
   (
-    {
-      bsPrefix,
-      disabled,
-      className,
-      href,
-      eventKey,
-      onSelect,
-      as,
-      ...props
-    }: NavLinkProps,
+    { bsPrefix, disabled, className, href, eventKey, onSelect, as, ...props },
     ref,
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'nav-link');

--- a/src/Navbar.tsx
+++ b/src/Navbar.tsx
@@ -12,7 +12,7 @@ import { useBootstrapPrefix } from './ThemeProvider';
 import NavbarContext, { NavbarContextType } from './NavbarContext';
 import SelectableContext from './SelectableContext';
 import {
-  BsPrefixPropsWithChildren,
+  BsPrefixProps,
   BsPrefixRefForwardingComponent,
   SelectCallback,
 } from './helpers';
@@ -21,7 +21,9 @@ const NavbarText = createWithBsPrefix('navbar-text', {
   Component: 'span',
 });
 
-export interface NavbarProps extends BsPrefixPropsWithChildren {
+export interface NavbarProps
+  extends BsPrefixProps,
+    Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'> {
   variant?: 'light' | 'dark';
   expand?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
   bg?: string;
@@ -31,15 +33,7 @@ export interface NavbarProps extends BsPrefixPropsWithChildren {
   onSelect?: SelectCallback;
   collapseOnSelect?: boolean;
   expanded?: boolean;
-  role?: string;
 }
-
-type Navbar = BsPrefixRefForwardingComponent<'nav', NavbarProps> & {
-  Brand: typeof NavbarBrand;
-  Collapse: typeof NavbarCollapse;
-  Text: typeof NavbarText;
-  Toggle: typeof NavbarToggle;
-};
 
 const propTypes = {
   /** @default 'navbar' */
@@ -151,7 +145,10 @@ const defaultProps = {
   collapseOnSelect: false,
 };
 
-const Navbar: Navbar = (React.forwardRef((props: NavbarProps, ref) => {
+const Navbar: BsPrefixRefForwardingComponent<
+  'nav',
+  NavbarProps
+> = React.forwardRef<HTMLElement, NavbarProps>((props, ref) => {
   const {
     bsPrefix: initialBsPrefix,
     expand,
@@ -225,15 +222,15 @@ const Navbar: Navbar = (React.forwardRef((props: NavbarProps, ref) => {
       </SelectableContext.Provider>
     </NavbarContext.Provider>
   );
-}) as unknown) as Navbar;
+});
 
 Navbar.propTypes = propTypes;
 Navbar.defaultProps = defaultProps;
 Navbar.displayName = 'Navbar';
 
-Navbar.Brand = NavbarBrand;
-Navbar.Toggle = NavbarToggle;
-Navbar.Collapse = NavbarCollapse;
-Navbar.Text = NavbarText;
-
-export default Navbar;
+export default Object.assign(Navbar, {
+  Brand: NavbarBrand,
+  Toggle: NavbarToggle,
+  Collapse: NavbarCollapse,
+  Text: NavbarText,
+});

--- a/src/NavbarBrand.tsx
+++ b/src/NavbarBrand.tsx
@@ -5,11 +5,11 @@ import PropTypes from 'prop-types';
 import { useBootstrapPrefix } from './ThemeProvider';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface NavbarBrandProps extends BsPrefixProps {
+export interface NavbarBrandProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   href?: string;
 }
-
-type NavbarBrand = BsPrefixRefForwardingComponent<'a', NavbarBrandProps>;
 
 const propTypes = {
   /** @default 'navbar' */
@@ -26,8 +26,11 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-const NavbarBrand: NavbarBrand = React.forwardRef(
-  ({ bsPrefix, className, as, ...props }: NavbarBrandProps, ref) => {
+const NavbarBrand: BsPrefixRefForwardingComponent<
+  'a',
+  NavbarBrandProps
+> = React.forwardRef<HTMLElement, NavbarBrandProps>(
+  ({ bsPrefix, className, as, ...props }, ref) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'navbar-brand');
 
     const Component = as || (props.href ? 'a' : 'span');

--- a/src/NavbarCollapse.tsx
+++ b/src/NavbarCollapse.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 
 import Collapse, { CollapseProps } from './Collapse';
@@ -16,19 +16,17 @@ const propTypes = {
   bsPrefix: PropTypes.string,
 };
 
-const NavbarCollapse = React.forwardRef(
-  ({ children, bsPrefix, ...props }: NavbarCollapseProps, ref) => {
+const NavbarCollapse = React.forwardRef<HTMLDivElement, NavbarCollapseProps>(
+  ({ children, bsPrefix, ...props }, ref) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'navbar-collapse');
+    const context = useContext(NavbarContext);
+
     return (
-      <NavbarContext.Consumer>
-        {(context) => (
-          <Collapse in={!!(context && context.expanded)} {...props}>
-            <div ref={ref as any} className={bsPrefix}>
-              {children}
-            </div>
-          </Collapse>
-        )}
-      </NavbarContext.Consumer>
+      <Collapse in={!!(context && context.expanded)} {...props}>
+        <div ref={ref} className={bsPrefix}>
+          {children}
+        </div>
+      </Collapse>
     );
   },
 );

--- a/src/NavbarToggle.tsx
+++ b/src/NavbarToggle.tsx
@@ -5,17 +5,13 @@ import useEventCallback from '@restart/hooks/useEventCallback';
 
 import { useBootstrapPrefix } from './ThemeProvider';
 import NavbarContext from './NavbarContext';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface NavbarToggleProps extends BsPrefixPropsWithChildren {
+export interface NavbarToggleProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   label?: string;
-  onClick?: React.MouseEventHandler;
 }
-
-type NavbarToggle = BsPrefixRefForwardingComponent<'button', NavbarToggleProps>;
 
 const propTypes = {
   /** @default 'navbar-toggler' */
@@ -39,7 +35,10 @@ const defaultProps = {
   label: 'Toggle navigation',
 };
 
-const NavbarToggle: NavbarToggle = React.forwardRef(
+const NavbarToggle: BsPrefixRefForwardingComponent<
+  'button',
+  NavbarToggleProps
+> = React.forwardRef<HTMLElement, NavbarToggleProps>(
   (
     {
       bsPrefix,
@@ -50,7 +49,7 @@ const NavbarToggle: NavbarToggle = React.forwardRef(
       as: Component = 'button',
       onClick,
       ...props
-    }: NavbarToggleProps,
+    },
     ref,
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'navbar-toggler');

--- a/src/PageItem.tsx
+++ b/src/PageItem.tsx
@@ -2,23 +2,18 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, { ReactNode } from 'react';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 import SafeAnchor from './SafeAnchor';
 
 export interface PageItemProps
   extends React.HTMLAttributes<HTMLElement>,
-    BsPrefixPropsWithChildren {
+    BsPrefixProps {
   disabled?: boolean;
   active?: boolean;
   activeLabel?: string;
   href?: string;
 }
-
-type PageItem = BsPrefixRefForwardingComponent<'li', PageItemProps>;
 
 const propTypes = {
   /** Disables the PageItem */
@@ -40,7 +35,10 @@ const defaultProps = {
   activeLabel: '(current)',
 };
 
-const PageItem: PageItem = React.forwardRef<HTMLLIElement, PageItemProps>(
+const PageItem: BsPrefixRefForwardingComponent<
+  'li',
+  PageItemProps
+> = React.forwardRef<HTMLLIElement, PageItemProps>(
   (
     {
       active,

--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -4,23 +4,15 @@ import React from 'react';
 
 import { useBootstrapPrefix } from './ThemeProvider';
 import PageItem, { Ellipsis, First, Last, Next, Prev } from './PageItem';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps } from './helpers';
 
-export interface PaginationProps extends BsPrefixPropsWithChildren {
+type PaginationSize = 'sm' | 'lg';
+
+export interface PaginationProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLUListElement> {
   size?: 'sm' | 'lg';
 }
-
-type Pagination = BsPrefixRefForwardingComponent<'ul', PaginationProps> & {
-  First: typeof First;
-  Prev: typeof Prev;
-  Ellipsis: typeof Ellipsis;
-  Item: typeof PageItem;
-  Next: typeof Next;
-  Last: typeof Last;
-};
 
 const propTypes = {
   /**
@@ -33,7 +25,7 @@ const propTypes = {
    *
    * @type {('sm'|'lg')}
    */
-  size: PropTypes.string,
+  size: PropTypes.oneOf<PaginationSize>(['sm', 'lg']),
 };
 
 /**
@@ -44,33 +36,33 @@ const propTypes = {
  * @property {PageItem} Next
  * @property {PageItem} Last
  */
-const Pagination: Pagination = (React.forwardRef<
-  HTMLUListElement,
-  PaginationProps
->(({ bsPrefix, className, children, size, ...props }: PaginationProps, ref) => {
-  const decoratedBsPrefix = useBootstrapPrefix(bsPrefix, 'pagination');
-  return (
-    <ul
-      ref={ref}
-      {...props}
-      className={classNames(
-        className,
-        decoratedBsPrefix,
-        size && `${decoratedBsPrefix}-${size}`,
-      )}
-    >
-      {children}
-    </ul>
-  );
-}) as unknown) as Pagination;
+const Pagination = React.forwardRef<HTMLUListElement, PaginationProps>(
+  ({ bsPrefix, className, children, size, ...props }, ref) => {
+    const decoratedBsPrefix = useBootstrapPrefix(bsPrefix, 'pagination');
+    return (
+      <ul
+        ref={ref}
+        {...props}
+        className={classNames(
+          className,
+          decoratedBsPrefix,
+          size && `${decoratedBsPrefix}-${size}`,
+        )}
+      >
+        {children}
+      </ul>
+    );
+  },
+);
 
 Pagination.propTypes = propTypes;
+Pagination.displayName = 'Pagination';
 
-Pagination.First = First;
-Pagination.Prev = Prev;
-Pagination.Ellipsis = Ellipsis;
-Pagination.Item = PageItem;
-Pagination.Next = Next;
-Pagination.Last = Last;
-
-export default Pagination;
+export default Object.assign(Pagination, {
+  First,
+  Prev,
+  Ellipsis,
+  Item: PageItem,
+  Next,
+  Last,
+});

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -6,14 +6,11 @@ import { useBootstrapPrefix } from './ThemeProvider';
 import PopoverTitle from './PopoverTitle';
 import PopoverContent from './PopoverContent';
 import { ArrowProps, Placement } from './Overlay';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps } from './helpers';
 
 export interface PopoverProps
-  extends React.ComponentPropsWithoutRef<'div'>,
-    BsPrefixPropsWithChildren {
+  extends React.HTMLAttributes<HTMLDivElement>,
+    BsPrefixProps {
   id: string;
   placement?: Placement;
   title?: string;
@@ -22,11 +19,6 @@ export interface PopoverProps
   popper?: any;
   show?: boolean;
 }
-
-type Popover = BsPrefixRefForwardingComponent<'div', PopoverProps> & {
-  Title: typeof PopoverTitle;
-  Content: typeof PopoverContent;
-};
 
 const propTypes = {
   /**
@@ -48,7 +40,7 @@ const propTypes = {
    *
    * > This is generally provided by the `Overlay` component positioning the popover
    */
-  placement: PropTypes.oneOf([
+  placement: PropTypes.oneOf<Placement>([
     'auto-start',
     'auto',
     'auto-end',
@@ -89,11 +81,11 @@ const propTypes = {
   show: PropTypes.bool,
 };
 
-const defaultProps = {
+const defaultProps: Partial<PopoverProps> = {
   placement: 'right',
 };
 
-const Popover: Popover = (React.forwardRef<HTMLDivElement, PopoverProps>(
+const Popover = React.forwardRef<HTMLDivElement, PopoverProps>(
   (
     {
       bsPrefix,
@@ -106,7 +98,7 @@ const Popover: Popover = (React.forwardRef<HTMLDivElement, PopoverProps>(
       popper: _,
       show: _1,
       ...props
-    }: PopoverProps,
+    },
     ref,
   ) => {
     const decoratedBsPrefix = useBootstrapPrefix(bsPrefix, 'popover');
@@ -136,12 +128,12 @@ const Popover: Popover = (React.forwardRef<HTMLDivElement, PopoverProps>(
       </div>
     );
   },
-) as unknown) as Popover;
+);
 
-Popover.propTypes = propTypes;
-Popover.defaultProps = defaultProps as any;
+Popover.propTypes = propTypes as any;
+Popover.defaultProps = defaultProps;
 
-Popover.Title = PopoverTitle;
-Popover.Content = PopoverContent;
-
-export default Popover;
+export default Object.assign(Popover, {
+  Title: PopoverTitle,
+  Content: PopoverContent,
+});

--- a/src/PopoverContent.tsx
+++ b/src/PopoverContent.tsx
@@ -2,17 +2,11 @@ import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-type PopoverContentProps = BsPrefixPropsWithChildren;
-
-type PopoverContent = BsPrefixRefForwardingComponent<
-  'div',
-  PopoverContentProps
->;
+export interface PopoverContentProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
 
 const propTypes = {
   /** Set a custom element for this component */
@@ -22,7 +16,10 @@ const propTypes = {
   bsPrefix: PropTypes.string,
 };
 
-const PopoverContent: PopoverContent = React.forwardRef(
+const PopoverContent: BsPrefixRefForwardingComponent<
+  'div',
+  PopoverContentProps
+> = React.forwardRef<HTMLElement, PopoverContentProps>(
   (
     {
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
@@ -31,7 +28,7 @@ const PopoverContent: PopoverContent = React.forwardRef(
       className,
       children,
       ...props
-    }: PopoverContentProps,
+    },
     ref,
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'popover-body');

--- a/src/PopoverTitle.tsx
+++ b/src/PopoverTitle.tsx
@@ -2,14 +2,11 @@ import classNames from 'classnames';
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-type PopoverTitleProps = BsPrefixPropsWithChildren;
-
-type PopoverTitle = BsPrefixRefForwardingComponent<'div', PopoverTitleProps>;
+export interface PopoverTitleProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
 
 const propTypes = {
   /** Set a custom element for this component */
@@ -19,7 +16,10 @@ const propTypes = {
   bsPrefix: PropTypes.string,
 };
 
-const PopoverTitle: PopoverTitle = React.forwardRef(
+const PopoverTitle: BsPrefixRefForwardingComponent<
+  'div',
+  PopoverTitleProps
+> = React.forwardRef<HTMLElement, PopoverTitleProps>(
   (
     {
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
@@ -28,7 +28,7 @@ const PopoverTitle: PopoverTitle = React.forwardRef(
       className,
       children,
       ...props
-    }: PopoverTitleProps,
+    },
     ref,
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'popover-header');

--- a/src/ProgressBar.tsx
+++ b/src/ProgressBar.tsx
@@ -5,11 +5,11 @@ import PropTypes from 'prop-types';
 import { useBootstrapPrefix } from './ThemeProvider';
 
 import { map } from './ElementChildren';
-import { BsPrefixPropsWithChildren } from './helpers';
+import { BsPrefixProps } from './helpers';
 
 export interface ProgressBarProps
   extends React.HTMLAttributes<HTMLDivElement>,
-    BsPrefixPropsWithChildren {
+    BsPrefixProps {
   min?: number;
   now?: number;
   max?: number;

--- a/src/ResponsiveEmbed.tsx
+++ b/src/ResponsiveEmbed.tsx
@@ -3,20 +3,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps } from './helpers';
 
-export interface ResponsiveEmbedProps extends BsPrefixPropsWithChildren {
+export type AspectRadio = '21by9' | '16by9' | '4by3' | '1by1';
+
+export interface ResponsiveEmbedProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactChild;
-  aspectRatio?: '21by9' | '16by9' | '4by3' | '1by1';
+  aspectRatio?: AspectRadio;
 }
-
-type ResponsiveEmbed = BsPrefixRefForwardingComponent<
-  'div',
-  ResponsiveEmbedProps
->;
 
 const propTypes = {
   /**
@@ -32,27 +28,15 @@ const propTypes = {
   /**
    * Set the aspect ration of the embed
    */
-  aspectRatio: PropTypes.oneOf(['21by9', '16by9', '4by3', '1by1']),
+  aspectRatio: PropTypes.oneOf<AspectRadio>(['21by9', '16by9', '4by3', '1by1']),
 };
 
 const defaultProps = {
   aspectRatio: '1by1' as const,
 };
 
-const ResponsiveEmbed: ResponsiveEmbed = React.forwardRef<
-  HTMLDivElement,
-  ResponsiveEmbedProps
->(
-  (
-    {
-      bsPrefix,
-      className,
-      children,
-      aspectRatio,
-      ...props
-    }: ResponsiveEmbedProps,
-    ref,
-  ) => {
+const ResponsiveEmbed = React.forwardRef<HTMLDivElement, ResponsiveEmbedProps>(
+  ({ bsPrefix, className, children, aspectRatio, ...props }, ref) => {
     const decoratedBsPrefix = useBootstrapPrefix(bsPrefix, 'embed-responsive');
     const child = React.Children.only(children);
     return (

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -4,10 +4,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 type RowColWidth =
   | number
@@ -26,7 +23,9 @@ type RowColWidth =
   | 'auto';
 type RowColumns = RowColWidth | { cols?: RowColWidth };
 
-export interface RowProps extends BsPrefixPropsWithChildren {
+export interface RowProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   noGutters?: boolean;
   xs?: RowColumns;
   sm?: RowColumns;
@@ -35,8 +34,6 @@ export interface RowProps extends BsPrefixPropsWithChildren {
   xl?: RowColumns;
   xxl?: RowColumns;
 }
-
-type Row = BsPrefixRefForwardingComponent<'div', RowProps>;
 
 const DEVICE_SIZES = ['xxl', 'xl', 'lg', 'md', 'sm', 'xs'] as const;
 const rowColWidth = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
@@ -111,7 +108,10 @@ const defaultProps = {
   noGutters: false,
 };
 
-const Row: Row = React.forwardRef<HTMLDivElement, RowProps>(
+const Row: BsPrefixRefForwardingComponent<'div', RowProps> = React.forwardRef<
+  HTMLDivElement,
+  RowProps
+>(
   (
     {
       bsPrefix,

--- a/src/SafeAnchor.tsx
+++ b/src/SafeAnchor.tsx
@@ -13,8 +13,6 @@ export interface SafeAnchorProps
   tabIndex?: number;
 }
 
-type SafeAnchor = BsPrefixRefForwardingComponent<'a', SafeAnchorProps>;
-
 const propTypes = {
   href: PropTypes.string,
   onClick: PropTypes.func,
@@ -40,7 +38,10 @@ function isTrivialHref(href) {
  * button its accessible. It also emulates input `disabled` behavior for
  * links, which is usually desirable for Buttons, NavItems, DropdownItems, etc.
  */
-const SafeAnchor: SafeAnchor = React.forwardRef(
+const SafeAnchor: BsPrefixRefForwardingComponent<
+  'a',
+  SafeAnchorProps
+> = React.forwardRef<HTMLElement, SafeAnchorProps>(
   (
     {
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595

--- a/src/Spinner.tsx
+++ b/src/Spinner.tsx
@@ -3,12 +3,12 @@ import classNames from 'classnames';
 import React from 'react';
 
 import { useBootstrapPrefix } from './ThemeProvider';
-import { BsPrefixPropsWithChildren } from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 import { Variant } from './types';
 
 export interface SpinnerProps
   extends React.HTMLAttributes<HTMLElement>,
-    BsPrefixPropsWithChildren {
+    BsPrefixProps {
   animation: 'border' | 'grow';
   role?: string;
   size?: 'sm';
@@ -59,7 +59,10 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-const Spinner = React.forwardRef(
+const Spinner: BsPrefixRefForwardingComponent<
+  'div',
+  SpinnerProps
+> = React.forwardRef<HTMLElement, SpinnerProps>(
   (
     {
       bsPrefix,
@@ -71,7 +74,7 @@ const Spinner = React.forwardRef(
       as: Component = 'div',
       className,
       ...props
-    }: SpinnerProps,
+    },
     ref,
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'spinner');

--- a/src/SplitButton.tsx
+++ b/src/SplitButton.tsx
@@ -9,8 +9,7 @@ import { PropsFromToggle } from './DropdownToggle';
 import { BsPrefixPropsWithChildren } from './helpers';
 
 export interface SplitButtonProps
-  extends DropdownProps,
-    Omit<React.HTMLAttributes<HTMLElement>, 'onSelect' | 'title' | 'id'>,
+  extends Omit<DropdownProps, 'title' | 'id'>,
     PropsFromToggle,
     BsPrefixPropsWithChildren {
   id: string | number;

--- a/src/Switch.tsx
+++ b/src/Switch.tsx
@@ -4,18 +4,16 @@ import { BsPrefixRefForwardingComponent } from './helpers';
 
 type SwitchProps = Omit<FormCheckProps, 'type'>;
 
-type Switch = BsPrefixRefForwardingComponent<FormCheck, SwitchProps> & {
-  Input: typeof FormCheck.Input;
-  Label: typeof FormCheck.Label;
-};
-
-const Switch: Switch = (React.forwardRef<FormCheck, SwitchProps>(
-  (props, ref) => <FormCheck {...props} ref={ref} type="switch" />,
-) as unknown) as Switch;
+const Switch: BsPrefixRefForwardingComponent<
+  typeof FormCheck,
+  SwitchProps
+> = React.forwardRef<typeof FormCheck, SwitchProps>((props, ref) => (
+  <FormCheck {...props} ref={ref} type="switch" />
+));
 
 Switch.displayName = 'Switch';
 
-Switch.Input = FormCheck.Input;
-Switch.Label = FormCheck.Label;
-
-export default Switch;
+export default Object.assign(Switch, {
+  Input: FormCheck.Input,
+  Label: FormCheck.Label,
+});

--- a/src/Tab.tsx
+++ b/src/Tab.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 
 import TabContainer from './TabContainer';
 import TabContent from './TabContent';
-import TabPane from './TabPane';
+import TabPane, { TabPaneProps } from './TabPane';
 
-export interface TabProps extends React.ComponentPropsWithRef<typeof TabPane> {
+export interface TabProps extends Omit<TabPaneProps, 'title'> {
   eventKey?: string;
   title: React.ReactNode;
   disabled?: boolean;

--- a/src/TabContent.tsx
+++ b/src/TabContent.tsx
@@ -3,13 +3,11 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-type TabContentProps = BsPrefixPropsWithChildren;
-type TabContent = BsPrefixRefForwardingComponent<'div', TabContentProps>;
+export interface TabContentProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
 
 const propTypes = {
   /**
@@ -20,7 +18,10 @@ const propTypes = {
   as: PropTypes.elementType,
 };
 
-const TabContent: TabContent = React.forwardRef(
+const TabContent: BsPrefixRefForwardingComponent<
+  'div',
+  TabContentProps
+> = React.forwardRef<HTMLElement, TabContentProps>(
   (
     {
       bsPrefix,
@@ -28,7 +29,7 @@ const TabContent: TabContent = React.forwardRef(
       as: Component = 'div',
       className,
       ...props
-    }: TabContentProps,
+    },
     ref,
   ) => {
     const decoratedBsPrefix = useBootstrapPrefix(bsPrefix, 'tab-content');

--- a/src/TabPane.tsx
+++ b/src/TabPane.tsx
@@ -13,15 +13,16 @@ import {
   TransitionType,
 } from './helpers';
 
-export interface TabPaneProps extends TransitionCallbacks, BsPrefixProps {
+export interface TabPaneProps
+  extends TransitionCallbacks,
+    BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   eventKey?: any;
   active?: boolean;
   transition?: TransitionType;
   mountOnEnter?: boolean;
   unmountOnExit?: boolean;
 }
-
-type TabPane = BsPrefixRefForwardingComponent<'div', TabPaneProps>;
 
 const propTypes = {
   /**
@@ -124,7 +125,10 @@ function useTabContext(props: TabPaneProps) {
   };
 }
 
-const TabPane: TabPane = React.forwardRef((props: TabPaneProps, ref) => {
+const TabPane: BsPrefixRefForwardingComponent<
+  'div',
+  TabPaneProps
+> = React.forwardRef<HTMLElement, TabPaneProps>((props, ref) => {
   const {
     bsPrefix,
     className,

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -3,12 +3,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useBootstrapPrefix } from './ThemeProvider';
 
-import {
-  BsPrefixAndClassNameOnlyProps,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixAndClassNameOnlyProps } from './helpers';
 
-export interface TableProps extends BsPrefixAndClassNameOnlyProps {
+export interface TableProps
+  extends BsPrefixAndClassNameOnlyProps,
+    React.TableHTMLAttributes<HTMLTableElement> {
   striped?: boolean;
   bordered?: boolean;
   borderless?: boolean;
@@ -17,8 +16,6 @@ export interface TableProps extends BsPrefixAndClassNameOnlyProps {
   variant?: string;
   responsive?: boolean | string;
 }
-
-type Table = BsPrefixRefForwardingComponent<'table', TableProps>;
 
 const propTypes = {
   /**
@@ -70,7 +67,7 @@ const propTypes = {
   responsive: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 };
 
-const Table: Table = React.forwardRef<HTMLTableElement, TableProps>(
+const Table = React.forwardRef<HTMLTableElement, TableProps>(
   (
     {
       bsPrefix,
@@ -83,7 +80,7 @@ const Table: Table = React.forwardRef<HTMLTableElement, TableProps>(
       variant,
       responsive,
       ...props
-    }: TableProps,
+    },
     ref,
   ) => {
     const decoratedBsPrefix = useBootstrapPrefix(bsPrefix, 'table');

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -14,7 +14,8 @@ import TabPane from './TabPane';
 import { forEach, map } from './ElementChildren';
 import { SelectCallback, TransitionType } from './helpers';
 
-export interface TabsProps extends React.PropsWithChildren<unknown> {
+export interface TabsProps
+  extends Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'> {
   activeKey?: unknown;
   defaultActiveKey?: unknown;
   onSelect?: SelectCallback;
@@ -166,8 +167,8 @@ const Tabs = (props: TabsProps) => {
   );
 };
 
-Tabs.propTypes = propTypes as any;
-Tabs.defaultProps = defaultProps as any;
+Tabs.propTypes = propTypes;
+Tabs.defaultProps = defaultProps;
 Tabs.displayName = 'Tabs';
 
 export default Tabs;

--- a/src/Toast.tsx
+++ b/src/Toast.tsx
@@ -9,12 +9,14 @@ import ToastBody from './ToastBody';
 import { useBootstrapPrefix } from './ThemeProvider';
 import ToastContext from './ToastContext';
 import {
-  BsPrefixPropsWithChildren,
+  BsPrefixProps,
   BsPrefixRefForwardingComponent,
   TransitionComponent,
 } from './helpers';
 
-export interface ToastProps extends BsPrefixPropsWithChildren {
+export interface ToastProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   animation?: boolean;
   autohide?: boolean;
   delay?: number;

--- a/src/ToastHeader.tsx
+++ b/src/ToastHeader.tsx
@@ -6,19 +6,15 @@ import useEventCallback from '@restart/hooks/useEventCallback';
 import { useBootstrapPrefix } from './ThemeProvider';
 import CloseButton, { CloseButtonVariant } from './CloseButton';
 import ToastContext from './ToastContext';
-import {
-  BsPrefixAndClassNameOnlyProps,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixAndClassNameOnlyProps } from './helpers';
 
 export interface ToastHeaderProps
-  extends React.PropsWithChildren<BsPrefixAndClassNameOnlyProps> {
+  extends BsPrefixAndClassNameOnlyProps,
+    React.HTMLAttributes<HTMLDivElement> {
   closeLabel?: string;
   closeVariant?: CloseButtonVariant;
   closeButton?: boolean;
 }
-
-type ToastHeader = BsPrefixRefForwardingComponent<'div', ToastHeaderProps>;
 
 const propTypes = {
   bsPrefix: PropTypes.string,
@@ -46,10 +42,7 @@ const defaultProps = {
   closeButton: true,
 };
 
-const ToastHeader: ToastHeader = React.forwardRef<
-  HTMLDivElement,
-  ToastHeaderProps
->(
+const ToastHeader = React.forwardRef<HTMLDivElement, ToastHeaderProps>(
   (
     {
       bsPrefix,

--- a/src/ToggleButton.tsx
+++ b/src/ToggleButton.tsx
@@ -3,24 +3,18 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { useBootstrapPrefix } from './ThemeProvider';
 import Button, { ButtonProps } from './Button';
-import {
-  BsPrefixAndClassNameOnlyProps,
-  BsPrefixComponentClass,
-} from './helpers';
 
-export interface ToggleButtonProps
-  extends ButtonProps,
-    React.PropsWithChildren<BsPrefixAndClassNameOnlyProps> {
-  type?: 'checkbox' | 'radio';
+export type ToggleButtonType = 'checkbox' | 'radio';
+
+export interface ToggleButtonProps extends ButtonProps {
+  type?: ToggleButtonType;
   name?: string;
   checked?: boolean;
   disabled?: boolean;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
   value: string | ReadonlyArray<string> | number;
-  inputRef?: React.LegacyRef<HTMLInputElement>;
+  inputRef?: React.Ref<HTMLInputElement>;
 }
-
-type ToggleButton = BsPrefixComponentClass<'button', ToggleButtonProps>;
 
 const noop = () => undefined;
 
@@ -33,7 +27,7 @@ const propTypes = {
   /**
    * The `<input>` element `type`
    */
-  type: PropTypes.oneOf(['checkbox', 'radio']),
+  type: PropTypes.oneOf<ToggleButtonType>(['checkbox', 'radio']),
 
   /**
    * The HTML input name, used to group like checkboxes or radio buttons together
@@ -68,7 +62,7 @@ const propTypes = {
    */
   value: PropTypes.oneOfType([
     PropTypes.string,
-    PropTypes.arrayOf(PropTypes.string),
+    PropTypes.arrayOf(PropTypes.string.isRequired),
     PropTypes.number,
   ]).isRequired,
 
@@ -76,10 +70,10 @@ const propTypes = {
    * A ref attached to the `<input>` element
    * @type {ReactRef}
    */
-  inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  inputRef: PropTypes.oneOfType([PropTypes.func, PropTypes.any]),
 };
 
-const ToggleButton = React.forwardRef<any, ToggleButtonProps>(
+const ToggleButton = React.forwardRef<HTMLLabelElement, ToggleButtonProps>(
   (
     {
       bsPrefix,
@@ -94,7 +88,7 @@ const ToggleButton = React.forwardRef<any, ToggleButtonProps>(
       id,
       inputRef,
       ...props
-    }: ToggleButtonProps,
+    },
     ref,
   ) => {
     bsPrefix = useBootstrapPrefix(bsPrefix, 'btn-check');
@@ -105,8 +99,8 @@ const ToggleButton = React.forwardRef<any, ToggleButtonProps>(
           className={bsPrefix}
           name={name}
           type={type}
-          value={value as any}
-          ref={inputRef as any}
+          value={value}
+          ref={inputRef}
           autoComplete="off"
           checked={!!checked}
           disabled={!!disabled}
@@ -128,7 +122,7 @@ const ToggleButton = React.forwardRef<any, ToggleButtonProps>(
   },
 );
 
-ToggleButton.propTypes = propTypes as any;
+ToggleButton.propTypes = propTypes;
 ToggleButton.displayName = 'ToggleButton';
 
 export default ToggleButton;

--- a/src/ToggleButtonGroup.tsx
+++ b/src/ToggleButtonGroup.tsx
@@ -9,8 +9,12 @@ import ButtonGroup, { ButtonGroupProps } from './ButtonGroup';
 import ToggleButton from './ToggleButton';
 import { BsPrefixRefForwardingComponent } from './helpers';
 
-export interface ToggleButtonRadioProps<T>
-  extends Omit<ButtonGroupProps, 'toggle'> {
+type BaseToggleButtonProps = Omit<
+  ButtonGroupProps,
+  'toggle' | 'defaultValue' | 'onChange'
+>;
+
+export interface ToggleButtonRadioProps<T> extends BaseToggleButtonProps {
   type?: 'radio';
   name: string;
   value?: T;
@@ -18,8 +22,7 @@ export interface ToggleButtonRadioProps<T>
   onChange?: (value: T, event: any) => void;
 }
 
-export interface ToggleButtonCheckboxProps<T>
-  extends Omit<ButtonGroupProps, 'toggle'> {
+export interface ToggleButtonCheckboxProps<T> extends BaseToggleButtonProps {
   type: 'checkbox';
   name?: string;
   value?: T[];
@@ -30,13 +33,6 @@ export interface ToggleButtonCheckboxProps<T>
 export type ToggleButtonGroupProps<T> =
   | ToggleButtonRadioProps<T>
   | ToggleButtonCheckboxProps<T>;
-
-type ToggleButtonGroup<T> = BsPrefixRefForwardingComponent<
-  'a',
-  ToggleButtonGroupProps<T>
-> & {
-  Button: typeof ToggleButton;
-};
 
 const propTypes = {
   /**
@@ -84,71 +80,72 @@ const defaultProps = {
   vertical: false,
 };
 
-const ToggleButtonGroup: ToggleButtonGroup<any> = (React.forwardRef(
-  (props: ToggleButtonGroupProps<any>, ref) => {
-    const {
-      children,
-      type,
-      name,
-      value,
-      onChange,
-      ...controlledProps
-    } = useUncontrolled(props, {
-      value: 'onChange',
-    });
+const ToggleButtonGroup: BsPrefixRefForwardingComponent<
+  'a',
+  ToggleButtonGroupProps<any>
+> = React.forwardRef<HTMLElement, ToggleButtonGroupProps<any>>((props, ref) => {
+  const {
+    children,
+    type,
+    name,
+    value,
+    onChange,
+    ...controlledProps
+  } = useUncontrolled(props, {
+    value: 'onChange',
+  });
 
-    const getValues: () => any[] = () =>
-      value == null ? [] : [].concat(value);
+  const getValues: () => any[] = () => (value == null ? [] : [].concat(value));
 
-    const handleToggle = (inputVal: any, event: any) => {
-      if (!onChange) {
-        return;
-      }
-      const values = getValues();
-      const isActive = values.indexOf(inputVal) !== -1;
+  const handleToggle = (inputVal: any, event: any) => {
+    if (!onChange) {
+      return;
+    }
+    const values = getValues();
+    const isActive = values.indexOf(inputVal) !== -1;
 
-      if (type === 'radio') {
-        if (!isActive && onChange) onChange(inputVal, event);
-        return;
-      }
+    if (type === 'radio') {
+      if (!isActive && onChange) onChange(inputVal, event);
+      return;
+    }
 
-      if (isActive) {
-        onChange(
-          values.filter((n) => n !== inputVal),
-          event,
-        );
-      } else {
-        onChange([...values, inputVal], event);
-      }
-    };
+    if (isActive) {
+      onChange(
+        values.filter((n) => n !== inputVal),
+        event,
+      );
+    } else {
+      onChange([...values, inputVal], event);
+    }
+  };
 
-    invariant(
-      type !== 'radio' || !!name,
-      'A `name` is required to group the toggle buttons when the `type` ' +
-        'is set to "radio"',
-    );
+  invariant(
+    type !== 'radio' || !!name,
+    'A `name` is required to group the toggle buttons when the `type` ' +
+      'is set to "radio"',
+  );
 
-    return (
-      <ButtonGroup {...controlledProps} ref={ref as any}>
-        {map(children, (child) => {
-          const values = getValues();
-          const { value: childVal, onChange: childOnChange } = child.props;
-          const handler = (e) => handleToggle(childVal, e);
+  return (
+    <ButtonGroup {...controlledProps} ref={ref as any}>
+      {map(children, (child) => {
+        const values = getValues();
+        const { value: childVal, onChange: childOnChange } = child.props;
+        const handler = (e) => handleToggle(childVal, e);
 
-          return React.cloneElement(child, {
-            type,
-            name: (child as any).name || name,
-            checked: values.indexOf(childVal) !== -1,
-            onChange: chainFunction(childOnChange, handler),
-          });
-        })}
-      </ButtonGroup>
-    );
-  },
-) as unknown) as ToggleButtonGroup<any>;
+        return React.cloneElement(child, {
+          type,
+          name: (child as any).name || name,
+          checked: values.indexOf(childVal) !== -1,
+          onChange: chainFunction(childOnChange, handler),
+        });
+      })}
+    </ButtonGroup>
+  );
+});
 
 ToggleButtonGroup.propTypes = propTypes;
 ToggleButtonGroup.defaultProps = defaultProps as any;
-ToggleButtonGroup.Button = ToggleButton;
 
-export default ToggleButtonGroup;
+export default Object.assign(ToggleButtonGroup, {
+  Button: ToggleButton,
+});

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -5,22 +5,17 @@ import isRequiredForA11y from 'prop-types-extra/lib/isRequiredForA11y';
 import { useBootstrapPrefix } from './ThemeProvider';
 
 import { ArrowProps, Placement } from './Overlay';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps } from './helpers';
 
 export interface TooltipProps
   extends React.HTMLAttributes<HTMLDivElement>,
-    BsPrefixPropsWithChildren {
+    BsPrefixProps {
   id: string;
   placement?: Placement;
   arrowProps?: ArrowProps;
   show?: boolean;
   popper?: any;
 }
-
-type Tooltip = BsPrefixRefForwardingComponent<'div', TooltipProps>;
 
 const propTypes = {
   /**
@@ -83,7 +78,7 @@ const defaultProps = {
   placement: 'right',
 };
 
-const Tooltip: Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
+const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
   (
     {
       bsPrefix,
@@ -124,7 +119,7 @@ const Tooltip: Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
   },
 );
 
-Tooltip.propTypes = propTypes;
+Tooltip.propTypes = propTypes as any;
 Tooltip.defaultProps = defaultProps as any;
 Tooltip.displayName = 'Tooltip';
 


### PR DESCRIPTION
This PR aims to fix the following:

- missing attributes in component props with typescript.  When trying to create stories in Storybook, i would have to cast a component prop to `any` because it's missing something like `children` or some other html prop for example
- clean up some of the `as unknown as Component` casting we do for some components.
- fix this issue where VS code's "go to definition" would get confused because a component has the same name as its type

I figure v5 is probably a good time to do it