### PR TITLE
Change CSS CDN link to use jsdelivr

### DIFF
--- a/www/src/components/CssCodeBlock.js
+++ b/www/src/components/CssCodeBlock.js
@@ -11,7 +11,7 @@ function CssCodeBlock() {
       codeText={`
 <link
   rel="stylesheet"
-  href="https://maxcdn.bootstrapcdn.com/bootstrap/${bootstrapVersion}/css/bootstrap.min.css"
+  href="https://cdn.jsdelivr.net/npm/bootstrap@${bootstrapVersion}/dist/css/bootstrap.min.css"
   integrity="${cssHash}"
   crossorigin="anonymous"
 />


### PR DESCRIPTION
Fixes #5678

Update the CSS CDN link to use jsdelivr, as Bootstrap's maxcdn link is giving AccessDenied errors.