### PR TITLE
docs(Popover): fix example

### DIFF
--- a/www/src/examples/Overlays/ScheduleUpdate.js
+++ b/www/src/examples/Overlays/ScheduleUpdate.js
@@ -6,7 +6,7 @@ const UpdatingPopover = React.forwardRef(
     }, [children, popper]);
 
     return (
-      <Popover ref={ref} content {...props}>
+      <Popover ref={ref} body {...props}>
         {children}
       </Popover>
     );


### PR DESCRIPTION
Change `content` prop to `body` in an example.  Missed this in the PopoverBody refactor.