### PR TITLE
Remove `mdxType` and `originalType` from tab children's props

### DIFF
--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -155,9 +155,14 @@ const Tabs = (props: TabsProps) => {
         {map(children, (child) => {
           const childProps = { ...child.props };
 
-          delete childProps.title;
-          delete childProps.disabled;
-          delete childProps.tabClassName;
+          const invalidProps = [
+            'title',
+            'disabled',
+            'tabClassName',
+            'mdxType',
+            'originalType',
+          ];
+          invalidProps.map((prop) => delete childProps[prop]);
 
           return <TabPane {...childProps} />;
         })}


### PR DESCRIPTION
I ran into an issue using the Tabs component in an MDX file. I was seeing this warning:

```
Warning: React does not recognize the `mdxType` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `mdxtype` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
```

I was getting the same issue for `originalType` as well.

I see a couple issues with this solution:

1. It seems brittle and doesn't scale. Feels like I shouldn't be adding specific properties to delete, but could come up with a better method for extracting and removing unwanted props. Figured I'd start here since it was the quick route.
2. I don't know enough about this project to know if Tabs are the only culprit.