### PR TITLE
fix(Toast): remove margins on close button

### DIFF
--- a/src/ToastHeader.tsx
+++ b/src/ToastHeader.tsx
@@ -73,7 +73,6 @@ const ToastHeader = React.forwardRef<HTMLDivElement, ToastHeaderProps>(
             aria-label={closeLabel}
             variant={closeVariant}
             onClick={handleClick}
-            className="ms-2 mb-1"
             data-dismiss="toast"
           />
         )}


### PR DESCRIPTION
Upstream doesn't use margins for close button anymore