### PR TITLE
refactor(types): simplify types

### DIFF
--- a/src/Accordion.tsx
+++ b/src/Accordion.tsx
@@ -11,14 +11,14 @@ import AccordionContext from './AccordionContext';
 import AccordionHeader from './AccordionHeader';
 import AccordionItem from './AccordionItem';
 import {
-  BsPrefixPropsWithChildren,
+  BsPrefixProps,
   BsPrefixRefForwardingComponent,
   SelectCallback,
 } from './helpers';
 
 export interface AccordionProps
   extends Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'>,
-    BsPrefixPropsWithChildren {
+    BsPrefixProps {
   activeKey?: string;
   defaultActiveKey?: string;
   onSelect?: SelectCallback;

--- a/src/AccordionBody.tsx
+++ b/src/AccordionBody.tsx
@@ -5,13 +5,10 @@ import PropTypes from 'prop-types';
 import { useBootstrapPrefix } from './ThemeProvider';
 import AccordionCollapse from './AccordionCollapse';
 import AccordionItemContext from './AccordionItemContext';
-import {
-  BsPrefixRefForwardingComponent,
-  BsPrefixPropsWithChildren,
-} from './helpers';
+import { BsPrefixRefForwardingComponent, BsPrefixProps } from './helpers';
 
 export interface AccordionBodyProps
-  extends BsPrefixPropsWithChildren,
+  extends BsPrefixProps,
     React.HTMLAttributes<HTMLElement> {}
 
 const propTypes = {

--- a/src/AccordionButton.tsx
+++ b/src/AccordionButton.tsx
@@ -4,17 +4,14 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import AccordionContext from './AccordionContext';
 import AccordionItemContext from './AccordionItemContext';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 import { useBootstrapPrefix } from './ThemeProvider';
 
 type EventHandler = React.EventHandler<React.SyntheticEvent>;
 
 export interface AccordionButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    BsPrefixPropsWithChildren {}
+    BsPrefixProps {}
 
 const propTypes = {
   /** Set a custom element for this component */

--- a/src/AccordionCollapse.tsx
+++ b/src/AccordionCollapse.tsx
@@ -6,13 +6,10 @@ import { Transition } from 'react-transition-group';
 import { useBootstrapPrefix } from './ThemeProvider';
 import Collapse, { CollapseProps } from './Collapse';
 import AccordionContext from './AccordionContext';
-import {
-  BsPrefixRefForwardingComponent,
-  BsPrefixAndClassNameOnlyProps,
-} from './helpers';
+import { BsPrefixRefForwardingComponent, BsPrefixOnlyProps } from './helpers';
 
 export interface AccordionCollapseProps
-  extends BsPrefixAndClassNameOnlyProps,
+  extends BsPrefixOnlyProps,
     CollapseProps {
   eventKey: string;
 }

--- a/src/AccordionHeader.tsx
+++ b/src/AccordionHeader.tsx
@@ -3,13 +3,10 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useBootstrapPrefix } from './ThemeProvider';
 import AccordionButton from './AccordionButton';
-import {
-  BsPrefixRefForwardingComponent,
-  BsPrefixPropsWithChildren,
-} from './helpers';
+import { BsPrefixRefForwardingComponent, BsPrefixProps } from './helpers';
 
 export interface AccordionHeaderProps
-  extends BsPrefixPropsWithChildren,
+  extends BsPrefixProps,
     React.HTMLAttributes<HTMLElement> {}
 
 const propTypes = {

--- a/src/AccordionItem.tsx
+++ b/src/AccordionItem.tsx
@@ -6,13 +6,10 @@ import { useBootstrapPrefix } from './ThemeProvider';
 import AccordionItemContext, {
   AccordionItemContextValue,
 } from './AccordionItemContext';
-import {
-  BsPrefixRefForwardingComponent,
-  BsPrefixPropsWithChildren,
-} from './helpers';
+import { BsPrefixRefForwardingComponent, BsPrefixProps } from './helpers';
 
 export interface AccordionItemProps
-  extends BsPrefixPropsWithChildren,
+  extends BsPrefixProps,
     React.HTMLAttributes<HTMLElement> {
   eventKey: string;
 }

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -4,17 +4,14 @@ import PropTypes from 'prop-types';
 
 import { useBootstrapPrefix } from './ThemeProvider';
 import SafeAnchor from './SafeAnchor';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 import { ButtonVariant } from './types';
 
 export type ButtonType = 'button' | 'reset' | 'submit' | string;
 
 export interface ButtonProps
   extends React.HTMLAttributes<HTMLElement>,
-    BsPrefixPropsWithChildren {
+    BsPrefixProps {
   active?: boolean;
   variant?: ButtonVariant;
   size?: 'sm' | 'lg';

--- a/src/CardImg.tsx
+++ b/src/CardImg.tsx
@@ -5,7 +5,9 @@ import PropTypes from 'prop-types';
 import { useBootstrapPrefix } from './ThemeProvider';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface CardImgProps extends BsPrefixProps {
+export interface CardImgProps
+  extends BsPrefixProps,
+    React.ImgHTMLAttributes<HTMLImageElement> {
   variant?: 'top' | 'bottom';
 }
 

--- a/src/FormRange.tsx
+++ b/src/FormRange.tsx
@@ -2,10 +2,10 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { useBootstrapPrefix } from './ThemeProvider';
-import { BsPrefixAndClassNameOnlyProps } from './helpers';
+import { BsPrefixOnlyProps } from './helpers';
 
 export interface FormRangeProps
-  extends BsPrefixAndClassNameOnlyProps,
+  extends BsPrefixOnlyProps,
     Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'> {}
 
 const propTypes = {

--- a/src/FormSelect.tsx
+++ b/src/FormSelect.tsx
@@ -2,13 +2,10 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { useBootstrapPrefix } from './ThemeProvider';
-import {
-  BsPrefixAndClassNameOnlyProps,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixOnlyProps, BsPrefixRefForwardingComponent } from './helpers';
 
 export interface FormSelectProps
-  extends BsPrefixAndClassNameOnlyProps,
+  extends BsPrefixOnlyProps,
     React.HTMLAttributes<HTMLSelectElement> {
   htmlSize?: number;
   size?: 'sm' | 'lg';

--- a/src/Image.tsx
+++ b/src/Image.tsx
@@ -3,11 +3,10 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 
 import { useBootstrapPrefix } from './ThemeProvider';
-
-import { BsPrefixAndClassNameOnlyProps } from './helpers';
+import { BsPrefixOnlyProps } from './helpers';
 
 export interface ImageProps
-  extends BsPrefixAndClassNameOnlyProps,
+  extends BsPrefixOnlyProps,
     React.ImgHTMLAttributes<HTMLImageElement> {
   fluid?: boolean;
   rounded?: boolean;

--- a/src/InputGroup.tsx
+++ b/src/InputGroup.tsx
@@ -6,10 +6,7 @@ import * as React from 'react';
 import createWithBsPrefix from './createWithBsPrefix';
 import { useBootstrapPrefix } from './ThemeProvider';
 import FormCheckInput from './FormCheckInput';
-import {
-  BsPrefixPropsWithChildren,
-  BsPrefixRefForwardingComponent,
-} from './helpers';
+import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 const InputGroupText = createWithBsPrefix('input-group-text', {
   Component: 'span',
@@ -27,7 +24,9 @@ const InputGroupRadio = (props) => (
   </InputGroupText>
 );
 
-export interface InputGroupProps extends BsPrefixPropsWithChildren {
+export interface InputGroupProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {
   size?: 'sm' | 'lg';
   hasValidation?: boolean;
 }

--- a/src/ModalHeader.tsx
+++ b/src/ModalHeader.tsx
@@ -7,10 +7,10 @@ import useEventCallback from '@restart/hooks/useEventCallback';
 import { useBootstrapPrefix } from './ThemeProvider';
 import CloseButton, { CloseButtonVariant } from './CloseButton';
 import ModalContext from './ModalContext';
-import { BsPrefixAndClassNameOnlyProps } from './helpers';
+import { BsPrefixOnlyProps } from './helpers';
 
 export interface ModalHeaderProps
-  extends BsPrefixAndClassNameOnlyProps,
+  extends BsPrefixOnlyProps,
     React.HTMLAttributes<HTMLDivElement> {
   closeLabel?: string;
   closeVariant?: CloseButtonVariant;

--- a/src/SplitButton.tsx
+++ b/src/SplitButton.tsx
@@ -6,12 +6,12 @@ import ButtonGroup from './ButtonGroup';
 import Dropdown, { DropdownProps } from './Dropdown';
 import { alignPropType, AlignType } from './DropdownMenu';
 import { PropsFromToggle } from './DropdownToggle';
-import { BsPrefixPropsWithChildren } from './helpers';
+import { BsPrefixProps } from './helpers';
 
 export interface SplitButtonProps
   extends Omit<DropdownProps, 'title' | 'id'>,
     PropsFromToggle,
-    BsPrefixPropsWithChildren {
+    BsPrefixProps {
   id: string | number;
   menuAlign?: AlignType;
   menuRole?: string;

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -3,10 +3,10 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { useBootstrapPrefix } from './ThemeProvider';
 
-import { BsPrefixAndClassNameOnlyProps } from './helpers';
+import { BsPrefixOnlyProps } from './helpers';
 
 export interface TableProps
-  extends BsPrefixAndClassNameOnlyProps,
+  extends BsPrefixOnlyProps,
     React.TableHTMLAttributes<HTMLTableElement> {
   striped?: boolean;
   bordered?: boolean;

--- a/src/ToastHeader.tsx
+++ b/src/ToastHeader.tsx
@@ -7,10 +7,10 @@ import useEventCallback from '@restart/hooks/useEventCallback';
 import { useBootstrapPrefix } from './ThemeProvider';
 import CloseButton, { CloseButtonVariant } from './CloseButton';
 import ToastContext from './ToastContext';
-import { BsPrefixAndClassNameOnlyProps } from './helpers';
+import { BsPrefixOnlyProps } from './helpers';
 
 export interface ToastHeaderProps
-  extends BsPrefixAndClassNameOnlyProps,
+  extends BsPrefixOnlyProps,
     React.HTMLAttributes<HTMLDivElement> {
   closeLabel?: string;
   closeVariant?: CloseButtonVariant;

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -8,23 +8,17 @@ export type ReplaceProps<Inner extends React.ElementType, P> = Omit<
 > &
   P;
 
-export interface BsPrefixAndClassNameOnlyProps {
+export interface BsPrefixOnlyProps {
   bsPrefix?: string;
-  className?: string;
-}
-
-export interface BsPrefixProps<As extends React.ElementType = React.ElementType>
-  extends BsPrefixAndClassNameOnlyProps {
-  as?: As;
 }
 
 export interface AsProp<As extends React.ElementType = React.ElementType> {
   as?: As;
 }
 
-export type BsPrefixPropsWithChildren<
-  As extends React.ElementType = React.ElementType
-> = React.PropsWithChildren<BsPrefixProps<As>>;
+export interface BsPrefixProps<As extends React.ElementType = React.ElementType>
+  extends BsPrefixOnlyProps,
+    AsProp<As> {}
 
 export interface BsPrefixRefForwardingComponent<
   TInitial extends React.ElementType,


### PR DESCRIPTION
Simplify some types in helper.ts.  We don't need to re-declare `className` or `children` ourselves, since it's already handled in the base react props.