### PR TITLE
chore(ci): add yarn timeout to prevent install errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "git+https://github.com/react-bootstrap/react-bootstrap.git"
   },
   "scripts": {
-    "bootstrap": "yarn && yarn --cwd www",
+    "bootstrap": "yarn --network-timeout 60000 && yarn --cwd www --network-timeout 60000",
     "build": "node tools/build.js",
     "build-docs": "yarn --cwd www build",
     "build-types": "yarn tsc -d --emitDeclarationOnly --outDir types",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "url": "git+https://github.com/react-bootstrap/react-bootstrap.git"
   },
   "scripts": {
-    "bootstrap": "yarn --network-timeout 60000 && yarn --cwd www --network-timeout 60000",
+    "bootstrap": "yarn --network-timeout 100000 && yarn --cwd www --network-timeout 100000",
     "build": "node tools/build.js",
     "build-docs": "yarn --cwd www build",
     "build-types": "yarn tsc -d --emitDeclarationOnly --outDir types",


### PR DESCRIPTION
Let's see if this resolves all those timeout issues in ci when installing deps