### PR TITLE
refactor(Modal): forward ref to react-overlays Modal

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -6,19 +6,13 @@ import removeEventListener from 'dom-helpers/removeEventListener';
 import getScrollbarSize from 'dom-helpers/scrollbarSize';
 import useCallbackRef from '@restart/hooks/useCallbackRef';
 import useEventCallback from '@restart/hooks/useEventCallback';
+import useMergedRefs from '@restart/hooks/useMergedRefs';
 import useWillUnmount from '@restart/hooks/useWillUnmount';
 import transitionEnd from 'dom-helpers/transitionEnd';
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import {
-  useCallback,
-  useImperativeHandle,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import BaseModal, { ModalProps as BaseModalProps } from 'react-overlays/Modal';
-import warning from 'warning';
 import BootstrapModalManager from './BootstrapModalManager';
 import Fade from './Fade';
 import ModalBody from './ModalBody';
@@ -283,7 +277,7 @@ const Modal: BsPrefixRefForwardingComponent<
       backdropClassName,
       manager: propsManager,
       ...props
-    }: ModalProps,
+    },
     ref,
   ) => {
     const [modalStyle, setStyle] = useState({});
@@ -294,23 +288,10 @@ const Modal: BsPrefixRefForwardingComponent<
 
     // TODO: what's this type
     const [modal, setModalRef] = useCallbackRef<{ dialog: any }>();
+    const mergedRef = useMergedRefs(ref, setModalRef);
     const handleHide = useEventCallback(onHide);
 
     bsPrefix = useBootstrapPrefix(bsPrefix, 'modal');
-
-    useImperativeHandle(
-      ref,
-      () => ({
-        get _modal() {
-          warning(
-            false,
-            'Accessing `_modal` is not supported and will be removed in a future release',
-          );
-          return modal;
-        },
-      }),
-      [modal],
-    );
 
     const modalContext = useMemo(
       () => ({
@@ -421,7 +402,7 @@ const Modal: BsPrefixRefForwardingComponent<
         updateDialogStyle(node);
       }
 
-      if (onEnter) onEnter(node, ...args);
+      onEnter?.(node, ...args);
     };
 
     const handleExit = (node, ...args) => {
@@ -496,7 +477,7 @@ const Modal: BsPrefixRefForwardingComponent<
       <ModalContext.Provider value={modalContext}>
         <BaseModal
           show={show}
-          ref={setModalRef}
+          ref={mergedRef}
           backdrop={backdrop}
           container={container}
           keyboard // Always set true - see handleEscapeKeyDown

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -1,12 +1,22 @@
 import { mount } from 'enzyme';
 import * as React from 'react';
 import Modal from '../src/Modal';
-import { shouldWarn } from './helpers';
 
 describe('<Modal>', () => {
   afterEach(() => {
     // make sure the dangling portal elements get cleaned up
     document.body.innerHTML = '';
+  });
+
+  it('Should forward ref to BaseModal', () => {
+    const noOp = () => {};
+    const ref = React.createRef();
+    mount(
+      <Modal show onHide={noOp} animation={false} ref={ref}>
+        <strong>Message</strong>
+      </Modal>,
+    );
+    ref.current.dialog.should.exist;
   });
 
   it('Should render the modal content', () => {
@@ -206,21 +216,6 @@ describe('<Modal>', () => {
       .getDOMNode();
 
     assert.ok(dialog.style.color === 'red');
-  });
-
-  it('Should warn about ref access', () => {
-    const noOp = () => {};
-    const ref = React.createRef();
-
-    mount(
-      <Modal show ref={ref} onHide={noOp}>
-        <strong>Message</strong>
-      </Modal>,
-    );
-
-    shouldWarn('Accessing `_modal` is not supported');
-
-    ref.current._modal;
   });
 
   it('Should pass dialogClassName to the dialog', () => {


### PR DESCRIPTION
I think this is a good time to remove `ref._modal`? 

Should we merge/pass the ref along to `BaseModal`?