### PR TITLE
feat(v5): add Offcanvas component

### DIFF
--- a/src/AbstractModalHeader.tsx
+++ b/src/AbstractModalHeader.tsx
@@ -1,0 +1,81 @@
+import PropTypes from 'prop-types';
+import * as React from 'react';
+import { useContext } from 'react';
+import useEventCallback from '@restart/hooks/useEventCallback';
+import CloseButton, { CloseButtonVariant } from './CloseButton';
+import ModalContext from './ModalContext';
+
+export interface AbstractModalHeaderProps
+  extends React.HTMLAttributes<HTMLDivElement> {
+  closeLabel?: string;
+  closeVariant?: CloseButtonVariant;
+  closeButton?: boolean;
+  onHide?: () => void;
+}
+
+const propTypes = {
+  /**
+   * Provides an accessible label for the close
+   * button. It is used for Assistive Technology when the label text is not
+   * readable.
+   */
+  closeLabel: PropTypes.string,
+
+  /**
+   * Sets the variant for close button.
+   */
+  closeVariant: PropTypes.oneOf<CloseButtonVariant>(['white']),
+
+  /**
+   * Specify whether the Component should contain a close button
+   */
+  closeButton: PropTypes.bool,
+
+  /**
+   * A Callback fired when the close button is clicked. If used directly inside
+   * a ModalContext, the onHide will automatically be propagated up
+   * to the parent `onHide`.
+   */
+  onHide: PropTypes.func,
+};
+
+const defaultProps = {
+  closeLabel: 'Close',
+  closeButton: false,
+};
+
+const AbstractModalHeader = React.forwardRef<
+  HTMLDivElement,
+  AbstractModalHeaderProps
+>(
+  (
+    { closeLabel, closeVariant, closeButton, onHide, children, ...props },
+    ref,
+  ) => {
+    const context = useContext(ModalContext);
+
+    const handleClick = useEventCallback(() => {
+      context?.onHide();
+      onHide?.();
+    });
+
+    return (
+      <div ref={ref} {...props}>
+        {children}
+
+        {closeButton && (
+          <CloseButton
+            aria-label={closeLabel}
+            variant={closeVariant}
+            onClick={handleClick}
+          />
+        )}
+      </div>
+    );
+  },
+);
+
+AbstractModalHeader.propTypes = propTypes;
+AbstractModalHeader.defaultProps = defaultProps;
+
+export default AbstractModalHeader;

--- a/src/Offcanvas.tsx
+++ b/src/Offcanvas.tsx
@@ -1,0 +1,313 @@
+import classNames from 'classnames';
+import useCallbackRef from '@restart/hooks/useCallbackRef';
+import useEventCallback from '@restart/hooks/useEventCallback';
+import PropTypes from 'prop-types';
+import * as React from 'react';
+import { useCallback, useMemo, useRef } from 'react';
+import BaseModal, {
+  ModalProps as BaseModalProps,
+  ModalHandle,
+} from 'react-overlays/Modal';
+import ModalManager from 'react-overlays/ModalManager';
+import useRootClose from 'react-overlays/useRootClose';
+import OffcanvasBody from './OffcanvasBody';
+import OffcanvasToggling from './OffcanvasToggling';
+import ModalContext from './ModalContext';
+import OffcanvasHeader from './OffcanvasHeader';
+import OffcanvasTitle from './OffcanvasTitle';
+import { BsPrefixRefForwardingComponent } from './helpers';
+import { useBootstrapPrefix } from './ThemeProvider';
+
+export type OffcanvasPlacement = 'start' | 'end' | 'bottom';
+
+export interface OffcanvasProps
+  extends Omit<
+    BaseModalProps,
+    | 'role'
+    | 'renderBackdrop'
+    | 'renderDialog'
+    | 'transition'
+    | 'backdrop'
+    | 'backdropTransition'
+  > {
+  bsPrefix?: string;
+  backdropClassName?: string;
+  scroll?: boolean;
+  placement?: OffcanvasPlacement;
+}
+
+const propTypes = {
+  /**
+   * @default 'offcanvas'
+   */
+  bsPrefix: PropTypes.string,
+
+  /**
+   * Include a backdrop component.
+   */
+  backdrop: PropTypes.bool,
+
+  /**
+   * Add an optional extra class name to .offcanvas-backdrop.
+   */
+  backdropClassName: PropTypes.string,
+
+  /**
+   * Closes the offcanvas when escape key is pressed.
+   */
+  keyboard: PropTypes.bool,
+
+  /**
+   * Allow body scrolling while offcanvas is open.
+   */
+  scroll: PropTypes.bool,
+
+  /**
+   * Which side of the viewport the offcanvas will appear from.
+   */
+  placement: PropTypes.oneOf<OffcanvasPlacement>(['start', 'end', 'bottom']),
+
+  /**
+   * When `true` The offcanvas will automatically shift focus to itself when it
+   * opens, and replace it to the last focused element when it closes.
+   * Generally this should never be set to false as it makes the offcanvas less
+   * accessible to assistive technologies, like screen-readers.
+   */
+  autoFocus: PropTypes.bool,
+
+  /**
+   * When `true` The offcanvas will prevent focus from leaving the offcanvas while
+   * open. Consider leaving the default value here, as it is necessary to make
+   * the offcanvas work well with assistive technologies, such as screen readers.
+   */
+  enforceFocus: PropTypes.bool,
+
+  /**
+   * When `true` The offcanvas will restore focus to previously focused element once
+   * offcanvas is hidden
+   */
+  restoreFocus: PropTypes.bool,
+
+  /**
+   * Options passed to focus function when `restoreFocus` is set to `true`
+   *
+   * @link  https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#Parameters
+   */
+  restoreFocusOptions: PropTypes.shape({
+    preventScroll: PropTypes.bool,
+  }),
+
+  /**
+   * When `true` The offcanvas will show itself.
+   */
+  show: PropTypes.bool,
+
+  /**
+   * A callback fired when the offcanvas is opening.
+   */
+  onShow: PropTypes.func,
+
+  /**
+   * A callback fired when the header closeButton or backdrop is
+   * clicked. Required if either are specified.
+   */
+  onHide: PropTypes.func,
+
+  /**
+   * A callback fired when the escape key, if specified in `keyboard`, is pressed.
+   */
+  onEscapeKeyDown: PropTypes.func,
+
+  /**
+   * Callback fired before the offcanvas transitions in
+   */
+  onEnter: PropTypes.func,
+
+  /**
+   * Callback fired as the offcanvas begins to transition in
+   */
+  onEntering: PropTypes.func,
+
+  /**
+   * Callback fired after the offcanvas finishes transitioning in
+   */
+  onEntered: PropTypes.func,
+
+  /**
+   * Callback fired right before the offcanvas transitions out
+   */
+  onExit: PropTypes.func,
+
+  /**
+   * Callback fired as the offcanvas begins to transition out
+   */
+  onExiting: PropTypes.func,
+
+  /**
+   * Callback fired after the offcanvas finishes transitioning out
+   */
+  onExited: PropTypes.func,
+
+  /**
+   * @private
+   */
+  container: PropTypes.any,
+
+  'aria-labelledby': PropTypes.string,
+};
+
+const defaultProps: Partial<OffcanvasProps> = {
+  show: false,
+  backdrop: true,
+  keyboard: true,
+  scroll: false,
+  autoFocus: true,
+  enforceFocus: true,
+  restoreFocus: true,
+  placement: 'start',
+};
+
+function DialogTransition(props) {
+  return <OffcanvasToggling {...props} />;
+}
+
+const Offcanvas: BsPrefixRefForwardingComponent<
+  'div',
+  OffcanvasProps
+> = React.forwardRef<ModalHandle, OffcanvasProps>(
+  (
+    {
+      bsPrefix,
+      className,
+      children,
+      'aria-labelledby': ariaLabelledby,
+      placement,
+
+      /* BaseModal props */
+
+      show,
+      backdrop,
+      keyboard,
+      scroll,
+      onEscapeKeyDown,
+      onShow,
+      onHide,
+      container,
+      autoFocus,
+      enforceFocus,
+      restoreFocus,
+      restoreFocusOptions,
+      onEntered,
+      onExit,
+      onExiting,
+      onEnter,
+      onEntering,
+      onExited,
+      backdropClassName,
+      manager: propsManager,
+      ...props
+    },
+    ref,
+  ) => {
+    const [dialogElement, setDialogElement] = useCallbackRef<HTMLElement>();
+    const modalManager = useRef<ModalManager>();
+    const handleHide = useEventCallback(onHide);
+
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'offcanvas');
+
+    // If there's a backdrop, let BaseModal handle closing.
+    useRootClose(dialogElement, handleHide, {
+      disabled: backdrop,
+    });
+
+    const modalContext = useMemo(
+      () => ({
+        onHide: handleHide,
+      }),
+      [handleHide],
+    );
+
+    function getModalManager() {
+      if (propsManager) return propsManager;
+      if (!modalManager.current)
+        modalManager.current = new ModalManager({
+          handleContainerOverflow: !scroll,
+        });
+      return modalManager.current;
+    }
+
+    const handleEnter = (node, ...args) => {
+      if (node) node.style.visibility = 'visible';
+      onEnter?.(node, ...args);
+      setDialogElement(node);
+    };
+
+    const handleExited = (node, ...args) => {
+      if (node) node.style.visibility = '';
+      onExited?.(...args);
+      setDialogElement(null);
+    };
+
+    const renderBackdrop = useCallback(
+      (backdropProps) => (
+        <div
+          {...backdropProps}
+          className={classNames(`${bsPrefix}-backdrop`, backdropClassName)}
+        />
+      ),
+      [backdropClassName, bsPrefix],
+    );
+
+    const renderDialog = (dialogProps) => (
+      <div
+        role="dialog"
+        {...dialogProps}
+        {...props}
+        className={classNames(className, bsPrefix, `${bsPrefix}-${placement}`)}
+        aria-labelledby={ariaLabelledby}
+      >
+        {children}
+      </div>
+    );
+
+    return (
+      <ModalContext.Provider value={modalContext}>
+        <BaseModal
+          show={show}
+          ref={ref}
+          backdrop={backdrop}
+          container={container}
+          keyboard={keyboard}
+          autoFocus={autoFocus}
+          enforceFocus={enforceFocus}
+          restoreFocus={restoreFocus}
+          restoreFocusOptions={restoreFocusOptions}
+          onEscapeKeyDown={onEscapeKeyDown}
+          onShow={onShow}
+          onHide={onHide}
+          onEnter={handleEnter}
+          onEntering={onEntering}
+          onEntered={onEntered}
+          onExit={onExit}
+          onExiting={onExiting}
+          onExited={handleExited}
+          manager={getModalManager()}
+          containerClassName={`${bsPrefix}-open`}
+          transition={DialogTransition}
+          renderBackdrop={renderBackdrop}
+          renderDialog={renderDialog}
+        />
+      </ModalContext.Provider>
+    );
+  },
+);
+
+Offcanvas.displayName = 'Offcanvas';
+Offcanvas.propTypes = propTypes;
+Offcanvas.defaultProps = defaultProps;
+
+export default Object.assign(Offcanvas, {
+  Body: OffcanvasBody,
+  Header: OffcanvasHeader,
+  Title: OffcanvasTitle,
+});

--- a/src/OffcanvasBody.tsx
+++ b/src/OffcanvasBody.tsx
@@ -1,0 +1,3 @@
+import createWithBsPrefix from './createWithBsPrefix';
+
+export default createWithBsPrefix('offcanvas-body');

--- a/src/OffcanvasHeader.tsx
+++ b/src/OffcanvasHeader.tsx
@@ -8,13 +8,13 @@ import AbstractModalHeader, {
 } from './AbstractModalHeader';
 import { BsPrefixOnlyProps } from './helpers';
 
-export interface ModalHeaderProps
+export interface OffcanvasHeaderProps
   extends AbstractModalHeaderProps,
     BsPrefixOnlyProps {}
 
 const propTypes = {
   /**
-   * @default 'modal-header'
+   * @default 'offcanvas-header'
    */
   bsPrefix: PropTypes.string,
 
@@ -37,8 +37,8 @@ const propTypes = {
 
   /**
    * A Callback fired when the close button is clicked. If used directly inside
-   * a Modal component, the onHide will automatically be propagated up to the
-   * parent Modal `onHide`.
+   * a Offcanvas component, the onHide will automatically be propagated up to the
+   * parent Offcanvas `onHide`.
    */
   onHide: PropTypes.func,
 };
@@ -48,9 +48,9 @@ const defaultProps = {
   closeButton: false,
 };
 
-const ModalHeader = React.forwardRef<HTMLDivElement, ModalHeaderProps>(
+const OffcanvasHeader = React.forwardRef<HTMLDivElement, OffcanvasHeaderProps>(
   ({ bsPrefix, className, ...props }, ref) => {
-    bsPrefix = useBootstrapPrefix(bsPrefix, 'modal-header');
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'offcanvas-header');
     return (
       <AbstractModalHeader
         ref={ref}
@@ -61,8 +61,8 @@ const ModalHeader = React.forwardRef<HTMLDivElement, ModalHeaderProps>(
   },
 );
 
-ModalHeader.displayName = 'ModalHeader';
-ModalHeader.propTypes = propTypes;
-ModalHeader.defaultProps = defaultProps;
+OffcanvasHeader.displayName = 'OffcanvasHeader';
+OffcanvasHeader.propTypes = propTypes;
+OffcanvasHeader.defaultProps = defaultProps;
 
-export default ModalHeader;
+export default OffcanvasHeader;

--- a/src/OffcanvasTitle.tsx
+++ b/src/OffcanvasTitle.tsx
@@ -1,0 +1,8 @@
+import createWithBsPrefix from './createWithBsPrefix';
+import divWithClassName from './divWithClassName';
+
+const DivStyledAsH5 = divWithClassName('h5');
+
+export default createWithBsPrefix('offcanvas-title', {
+  Component: DivStyledAsH5,
+});

--- a/src/OffcanvasToggling.tsx
+++ b/src/OffcanvasToggling.tsx
@@ -1,0 +1,127 @@
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import * as React from 'react';
+import Transition, {
+  TransitionStatus,
+  ENTERED,
+  ENTERING,
+  EXITING,
+} from 'react-transition-group/Transition';
+import transitionEndListener from './transitionEndListener';
+import { TransitionCallbacks, BsPrefixOnlyProps } from './helpers';
+import TransitionWrapper from './TransitionWrapper';
+import { useBootstrapPrefix } from './ThemeProvider';
+
+export interface OffcanvasTogglingProps
+  extends TransitionCallbacks,
+    BsPrefixOnlyProps {
+  className?: string;
+  in?: boolean;
+  mountOnEnter?: boolean;
+  unmountOnExit?: boolean;
+  appear?: boolean;
+  timeout?: number;
+  children: React.ReactElement;
+}
+
+const propTypes = {
+  /**
+   * Show the component; triggers the fade in or fade out animation
+   */
+  in: PropTypes.bool,
+
+  /**
+   * Wait until the first "enter" transition to mount the component (add it to the DOM)
+   */
+  mountOnEnter: PropTypes.bool,
+
+  /**
+   * Unmount the component (remove it from the DOM) when it is faded out
+   */
+  unmountOnExit: PropTypes.bool,
+
+  /**
+   * Run the fade in animation when the component mounts, if it is initially
+   * shown
+   */
+  appear: PropTypes.bool,
+
+  /**
+   * Duration of the fade animation in milliseconds, to ensure that finishing
+   * callbacks are fired even if the original browser transition end events are
+   * canceled
+   */
+  timeout: PropTypes.number,
+
+  /**
+   * Callback fired before the component fades in
+   */
+  onEnter: PropTypes.func,
+  /**
+   * Callback fired after the component starts to fade in
+   */
+  onEntering: PropTypes.func,
+  /**
+   * Callback fired after the has component faded in
+   */
+  onEntered: PropTypes.func,
+  /**
+   * Callback fired before the component fades out
+   */
+  onExit: PropTypes.func,
+  /**
+   * Callback fired after the component starts to fade out
+   */
+  onExiting: PropTypes.func,
+  /**
+   * Callback fired after the component has faded out
+   */
+  onExited: PropTypes.func,
+};
+
+const defaultProps = {
+  in: false,
+  mountOnEnter: false,
+  unmountOnExit: false,
+  appear: false,
+};
+
+const transitionStyles = {
+  [ENTERING]: 'show',
+  [ENTERED]: 'show',
+};
+
+const OffcanvasToggling = React.forwardRef<
+  Transition<any>,
+  OffcanvasTogglingProps
+>(({ bsPrefix, className, children, ...props }, ref) => {
+  bsPrefix = useBootstrapPrefix(bsPrefix, 'offcanvas');
+
+  return (
+    <TransitionWrapper
+      ref={ref}
+      addEndListener={transitionEndListener}
+      {...props}
+      childRef={(children as any).ref}
+    >
+      {(status: TransitionStatus, innerProps: Record<string, unknown>) =>
+        React.cloneElement(children, {
+          ...innerProps,
+          className: classNames(
+            className,
+            children.props.className,
+            (status === ENTERING || status === EXITING) &&
+              `${bsPrefix}-toggling`,
+            transitionStyles[status],
+          ),
+        })
+      }
+    </TransitionWrapper>
+  );
+});
+
+OffcanvasToggling.propTypes = propTypes as any;
+OffcanvasToggling.defaultProps = defaultProps;
+OffcanvasToggling.displayName = 'OffcanvasToggling';
+
+export default OffcanvasToggling;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -128,6 +128,13 @@ export { default as NavItem } from './NavItem';
 export { default as NavLink } from './NavLink';
 export type { NavLinkProps } from './NavLink';
 
+export { default as Offcanvas } from './Offcanvas';
+export type { OffcanvasProps } from './Offcanvas';
+export { default as OffcanvasHeader } from './OffcanvasHeader';
+export type { OffcanvasHeaderProps } from './OffcanvasHeader';
+export { default as OffcanvasTitle } from './OffcanvasTitle';
+export { default as OffcanvasBody } from './OffcanvasBody';
+
 export { default as Overlay } from './Overlay';
 export type { OverlayProps } from './Overlay';
 

--- a/test/OffcanvasSpec.js
+++ b/test/OffcanvasSpec.js
@@ -1,0 +1,230 @@
+import { mount } from 'enzyme';
+import * as React from 'react';
+import simulant from 'simulant';
+import ModalManager from 'react-overlays/ModalManager';
+import Offcanvas from '../src/Offcanvas';
+
+describe('<Offcanvas>', () => {
+  afterEach(() => {
+    // make sure the dangling portal elements get cleaned up
+    document.body.innerHTML = '';
+  });
+
+  it('Should render the modal content', () => {
+    const noOp = () => {};
+    mount(
+      <Offcanvas show onHide={noOp}>
+        <strong>Message</strong>
+      </Offcanvas>,
+    )
+      .find('strong')
+      .text()
+      .should.equal('Message');
+  });
+
+  it('Should set `visibility: visible` to `div.offcanvas`', () => {
+    const node = mount(
+      <Offcanvas show>
+        <strong>Message</strong>
+      </Offcanvas>,
+    )
+      .find('div.offcanvas')
+      .getDOMNode();
+
+    expect(node.style.visibility).to.equal('visible');
+  });
+
+  it('Should close the offcanvas when the modal close button is clicked', (done) => {
+    const doneOp = () => {
+      done();
+    };
+
+    mount(
+      <Offcanvas show onHide={doneOp}>
+        <Offcanvas.Header closeButton />
+        <strong>Message</strong>
+      </Offcanvas>,
+    )
+      .find('.btn-close')
+      .simulate('click');
+  });
+
+  it('Should pass className to the offcanvas', () => {
+    const noOp = () => {};
+    mount(
+      <Offcanvas show className="myoffcanvas" onHide={noOp}>
+        <strong>Message</strong>
+      </Offcanvas>,
+    ).assertSingle('div.offcanvas.myoffcanvas');
+  });
+
+  it('Should pass backdropClassName to the backdrop', () => {
+    const noOp = () => {};
+
+    mount(
+      <Offcanvas show backdropClassName="custom-backdrop" onHide={noOp}>
+        <strong>Message</strong>
+      </Offcanvas>,
+    ).find('.offcanvas-backdrop.custom-backdrop');
+  });
+
+  it('Should pass style to the offcanvas', () => {
+    const noOp = () => {};
+    const dialog = mount(
+      <Offcanvas show style={{ color: 'red' }} onHide={noOp}>
+        <strong>Message</strong>
+      </Offcanvas>,
+    )
+      .find('div.offcanvas')
+      .getDOMNode();
+
+    assert.ok(dialog.style.color === 'red');
+  });
+
+  it('Should pass transition callbacks to Transition', (done) => {
+    const increment = sinon.spy();
+
+    const instance = mount(
+      <Offcanvas
+        show
+        onHide={() => {}}
+        onExit={increment}
+        onExiting={increment}
+        onExited={() => {
+          increment();
+          expect(increment.callCount).to.equal(6);
+          done();
+        }}
+        onEnter={increment}
+        onEntering={increment}
+        onEntered={() => {
+          increment();
+          instance.setProps({ show: false });
+        }}
+      >
+        <strong>Message</strong>
+      </Offcanvas>,
+    );
+  });
+
+  it('Should close when backdrop clicked', () => {
+    const onHideSpy = sinon.spy();
+    mount(
+      <Offcanvas show onHide={onHideSpy}>
+        <strong>Message</strong>
+      </Offcanvas>,
+    )
+      .find('div.offcanvas-backdrop')
+      .simulate('click');
+
+    expect(onHideSpy).to.have.been.called;
+  });
+
+  it('Should close when anything outside offcanvas clicked and backdrop=false', () => {
+    const onHideSpy = sinon.spy();
+    mount(
+      <>
+        <Offcanvas show onHide={onHideSpy} backdrop={false}>
+          <strong>Message</strong>
+        </Offcanvas>
+        <button type="button" id="mybutton">
+          my button
+        </button>
+      </>,
+    );
+
+    simulant.fire(document.body, 'click');
+
+    expect(onHideSpy).to.have.been.called;
+  });
+
+  it('Should not call onHide if the click target comes from inside the offcanvas', () => {
+    const onHideSpy = sinon.spy();
+    const wrapper = mount(
+      <>
+        <Offcanvas show onHide={onHideSpy}>
+          <strong>Message</strong>
+        </Offcanvas>
+        <div id="outside">outside</div>
+      </>,
+    );
+
+    wrapper.find('div.offcanvas').simulate('click');
+
+    expect(onHideSpy).to.not.have.been.called;
+  });
+
+  it('Should set aria-labelledby to the role="dialog" element if aria-labelledby set', () => {
+    const noOp = () => {};
+    mount(
+      <Offcanvas show onHide={noOp} aria-labelledby="offcanvas-title">
+        <Offcanvas.Header closeButton>
+          <Offcanvas.Title id="offcanvas-title">
+            Offcanvas heading
+          </Offcanvas.Title>
+        </Offcanvas.Header>
+      </Offcanvas>,
+    ).assertSingle(
+      'div.offcanvas.show[role="dialog"][aria-labelledby="offcanvas-title"]',
+    );
+  });
+
+  it('Should call onEscapeKeyDown when keyboard is true', () => {
+    const noOp = () => {};
+    const onEscapeKeyDownSpy = sinon.spy();
+    mount(
+      <Offcanvas
+        show
+        onHide={noOp}
+        keyboard
+        onEscapeKeyDown={onEscapeKeyDownSpy}
+      >
+        <strong>Message</strong>
+      </Offcanvas>,
+    );
+
+    const event = new KeyboardEvent('keydown', { keyCode: 27 });
+    document.dispatchEvent(event);
+
+    expect(onEscapeKeyDownSpy).to.have.been.called;
+  });
+
+  it('Should not call onEscapeKeyDown when keyboard is false', () => {
+    const noOp = () => {};
+    const onEscapeKeyDownSpy = sinon.spy();
+    mount(
+      <Offcanvas
+        show
+        onHide={noOp}
+        keyboard={false}
+        onEscapeKeyDown={onEscapeKeyDownSpy}
+      >
+        <strong>Message</strong>
+      </Offcanvas>,
+    );
+
+    const event = new KeyboardEvent('keydown', { keyCode: 27 });
+    document.dispatchEvent(event);
+
+    expect(onEscapeKeyDownSpy).to.not.have.been.called;
+  });
+
+  it('Should use custom props manager if specified', (done) => {
+    const noOp = () => {};
+
+    class MyModalManager extends ModalManager {
+      add() {
+        done();
+      }
+    }
+
+    const managerRef = React.createRef();
+    managerRef.current = new MyModalManager();
+
+    mount(
+      <Offcanvas show onHide={noOp} manager={managerRef.current}>
+        <strong>Message</strong>
+      </Offcanvas>,
+    );
+  });
+});

--- a/www/src/components/SideNav.js
+++ b/www/src/components/SideNav.js
@@ -127,6 +127,7 @@ const components = [
   'modal',
   'navs',
   'navbar',
+  'offcanvas',
   'overlays',
   'pagination',
   'popovers',

--- a/www/src/examples/Offcanvas/Backdrop.js
+++ b/www/src/examples/Offcanvas/Backdrop.js
@@ -1,0 +1,53 @@
+const options = [
+  {
+    name: 'Enable body scrolling',
+    scroll: true,
+    backdrop: false,
+  },
+  {
+    name: 'Enable backdrop (default)',
+    scroll: false,
+    backdrop: true,
+  },
+  {
+    name: 'Enable both scrolling & backdrop',
+    scroll: true,
+    backdrop: true,
+  },
+];
+
+function OffCanvasExample({ name, ...props }) {
+  const [show, setShow] = useState(false);
+
+  const handleClose = () => setShow(false);
+  const handleShow = () => setShow(true);
+
+  return (
+    <>
+      <Button variant="primary" onClick={handleShow} className="me-2">
+        {name}
+      </Button>
+      <Offcanvas show={show} onHide={handleClose} {...props}>
+        <Offcanvas.Header closeButton>
+          <Offcanvas.Title>Offcanvas</Offcanvas.Title>
+        </Offcanvas.Header>
+        <Offcanvas.Body>
+          Some text as placeholder. In real life you can have the elements you
+          have chosen. Like, text, images, lists, etc.
+        </Offcanvas.Body>
+      </Offcanvas>
+    </>
+  );
+}
+
+function Example() {
+  return (
+    <>
+      {options.map((props, idx) => (
+        <OffCanvasExample key={idx} {...props} />
+      ))}
+    </>
+  );
+}
+
+render(<Example />);

--- a/www/src/examples/Offcanvas/Basic.js
+++ b/www/src/examples/Offcanvas/Basic.js
@@ -1,0 +1,26 @@
+function Example() {
+  const [show, setShow] = useState(false);
+
+  const handleClose = () => setShow(false);
+  const handleShow = () => setShow(true);
+
+  return (
+    <>
+      <Button variant="primary" onClick={handleShow}>
+        Launch
+      </Button>
+
+      <Offcanvas show={show} onHide={handleClose}>
+        <Offcanvas.Header closeButton>
+          <Offcanvas.Title>Offcanvas</Offcanvas.Title>
+        </Offcanvas.Header>
+        <Offcanvas.Body>
+          Some text as placeholder. In real life you can have the elements you
+          have chosen. Like, text, images, lists, etc.
+        </Offcanvas.Body>
+      </Offcanvas>
+    </>
+  );
+}
+
+render(<Example />);

--- a/www/src/examples/Offcanvas/Placement.js
+++ b/www/src/examples/Offcanvas/Placement.js
@@ -1,0 +1,35 @@
+function OffCanvasExample({ name, ...props }) {
+  const [show, setShow] = useState(false);
+
+  const handleClose = () => setShow(false);
+  const handleShow = () => setShow(true);
+
+  return (
+    <>
+      <Button variant="primary" onClick={handleShow} className="me-2">
+        {name}
+      </Button>
+      <Offcanvas show={show} onHide={handleClose} {...props}>
+        <Offcanvas.Header closeButton>
+          <Offcanvas.Title>Offcanvas</Offcanvas.Title>
+        </Offcanvas.Header>
+        <Offcanvas.Body>
+          Some text as placeholder. In real life you can have the elements you
+          have chosen. Like, text, images, lists, etc.
+        </Offcanvas.Body>
+      </Offcanvas>
+    </>
+  );
+}
+
+function Example() {
+  return (
+    <>
+      {['start', 'end', 'bottom'].map((placement, idx) => (
+        <OffCanvasExample key={idx} placement={placement} name={placement} />
+      ))}
+    </>
+  );
+}
+
+render(<Example />);

--- a/www/src/pages/components/offcanvas.mdx
+++ b/www/src/pages/components/offcanvas.mdx
@@ -1,0 +1,70 @@
+import { graphql } from 'gatsby';
+
+import Callout from '../../components/Callout';
+import ComponentApi from '../../components/ComponentApi';
+import ReactPlayground from '../../components/ReactPlayground';
+
+import Basic from '../../examples/Offcanvas/Basic';
+import Backdrop from '../../examples/Offcanvas/Backdrop';
+import Placement from '../../examples/Offcanvas/Placement';
+
+# Offcanvas
+
+<p className="lead">
+  Build hidden sidebars into your project for navigation, shopping carts, and
+  more.
+</p>
+
+## Examples
+
+Offcanvas includes support for a header with a close button and an optional body class 
+for some initial padding. We suggest that you include offcanvas headers with dismiss 
+actions whenever possible, or provide an explicit dismiss action.
+
+### Basic Example
+
+<ReactPlayground codeText={Basic} />
+
+### Placement
+
+Offcanvas supports a few different placements:
+- `start` places offcanvas on the left of the viewport
+- `end` places offcanvas on the right of the viewport
+- `bottom` places offcanvas on the bottom of the viewport
+
+<ReactPlayground codeText={Placement} />
+
+### Backdrop
+
+Scrolling the `<body>` element is disabled when an offcanvas and its backdrop are 
+visible. Use the `scroll` prop to toggle `<body>` scrolling and the `backdrop` prop 
+to toggle the backdrop.
+
+<ReactPlayground codeText={Backdrop} />
+
+## API
+
+<ComponentApi metadata={props.data.Offcanvas} />
+<ComponentApi metadata={props.data.OffcanvasHeader} />
+<ComponentApi metadata={props.data.OffcanvasTitle} />
+<ComponentApi metadata={props.data.OffcanvasBody} />
+
+export const query = graphql`
+  query OffcanvasQuery {
+    Offcanvas: componentMetadata(displayName: { eq: "Offcanvas" }) {
+      displayName
+      ...ComponentApi_metadata
+    }
+    OffcanvasHeader: componentMetadata(displayName: { eq: "OffcanvasHeader" }) {
+      ...ComponentApi_metadata
+    }
+    OffcanvasTitle: componentMetadata(displayName: { eq: "OffcanvasTitle" }) {
+      ...ComponentApi_metadata
+    }
+    OffcanvasBody: componentMetadata(displayName: { eq: "OffcanvasBody" }) {
+      ...ComponentApi_metadata
+    }
+  }
+`;
+
+;


### PR DESCRIPTION
https://getbootstrap.com/docs/5.0/components/offcanvas/

Offcanvas is a simpler version of Modal, so ended up using Modal as a base and removed the unneeded pieces.  I also moved code from `ModalHeader` into `AbstractModalHeader` so both `ModalHeader` and `OffcanvasHeader` can share it.  They only differ by a `bsPrefix`.

I used a root close handler in here to handle the case where there isn't a backdrop.

Preview: https://deploy-preview-5738--react-bootstrap-v5.netlify.app/components/offcanvas/