### PR TITLE
Update Toast Documentation to fix #5742

### DIFF
--- a/www/src/examples/Toast/Placement.js
+++ b/www/src/examples/Toast/Placement.js
@@ -3,21 +3,23 @@
   aria-atomic="true"
   style={{
     position: 'relative',
-    minHeight: '100px',
+    minHeight: '200px',
   }}
 >
-  <Toast
+  <div
     style={{
       position: 'absolute',
       top: 0,
       right: 0,
     }}
   >
-    <Toast.Header>
-      <img src="holder.js/20x20?text=%20" className="rounded mr-2" alt="" />
-      <strong className="mr-auto">Bootstrap</strong>
-      <small>just now</small>
-    </Toast.Header>
-    <Toast.Body>See? Just like this.</Toast.Body>
-  </Toast>
+    <Toast>
+      <Toast.Header>
+        <img src="holder.js/20x20?text=%20" className="rounded mr-2" alt="" />
+        <strong className="mr-auto">Bootstrap</strong>
+        <small>2 seconds ago</small>
+      </Toast.Header>
+      <Toast.Body>Woohoo, you're reading this text in a Toast!</Toast.Body>
+    </Toast>
+  </div>
 </div>;

--- a/www/src/examples/Toast/Placement.js
+++ b/www/src/examples/Toast/Placement.js
@@ -3,23 +3,21 @@
   aria-atomic="true"
   style={{
     position: 'relative',
-    minHeight: '200px',
+    minHeight: '100px',
   }}
 >
-  <div
+  <Toast
     style={{
       position: 'absolute',
       top: 0,
       right: 0,
     }}
   >
-    <Toast>
-      <Toast.Header>
-        <img src="holder.js/20x20?text=%20" className="rounded mr-2" alt="" />
-        <strong className="mr-auto">Bootstrap</strong>
-        <small>2 seconds ago</small>
-      </Toast.Header>
-      <Toast.Body>Woohoo, you're reading this text in a Toast!</Toast.Body>
-    </Toast>
-  </div>
+    <Toast.Header>
+      <img src="holder.js/20x20?text=%20" className="rounded mr-2" alt="" />
+      <strong className="mr-auto">Bootstrap</strong>
+      <small>just now</small>
+    </Toast.Header>
+    <Toast.Body>Woohoo, you're reading this text in a Toast!</Toast.Body>
+  </Toast>
 </div>;


### PR DESCRIPTION
# Approach
* The issue revolved around the short text of inside the `Toast.Body`.
* To maintain the uniformity in the code examples, `mr-auto` has been used on the Brand (Bootstrap) so that it aligns to left always. Possibly, doing something like `mr-2` would have added spacing and solved the issue but it would be exclusive hack for this code example only. 
* So better workaround I found was to change text inside the Toast. Longer text would increase the overall `width` of the div and so this works.
* Maybe adding `width` property might have served the similar solution; but found changing text a simpler and intuitive way.

# Screenshots 
![image](https://user-images.githubusercontent.com/47717492/112766287-ae2cd080-902e-11eb-9ef5-49eb6f83448f.png)

Please let me know your views upon this PR. Would be active in responding to review comments. Thanks :)
