### PR TITLE
refactor(Tabs): use buttons instead of anchors

### DIFF
--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -114,14 +114,17 @@ function renderTab(child) {
   }
 
   return (
-    <NavItem
-      as={NavLink}
-      eventKey={eventKey}
-      disabled={disabled}
-      id={id}
-      className={tabClassName}
-    >
-      {title}
+    <NavItem as="li" role="presentation">
+      <NavLink
+        as="button"
+        type="button"
+        eventKey={eventKey}
+        disabled={disabled}
+        id={id}
+        className={tabClassName}
+      >
+        {title}
+      </NavLink>
     </NavItem>
   );
 }
@@ -149,7 +152,7 @@ const Tabs = (props: TabsProps) => {
       mountOnEnter={mountOnEnter}
       unmountOnExit={unmountOnExit}
     >
-      <Nav {...controlledProps} role="tablist" as="nav">
+      <Nav {...controlledProps} role="tablist" as="ul">
         {map(children, renderTab)}
       </Nav>
 

--- a/test/TabsSpec.js
+++ b/test/TabsSpec.js
@@ -19,7 +19,7 @@ describe('<Tabs>', () => {
     );
 
     wrapper.assertSingle('TabPane[eventKey=1] .active');
-    wrapper.assertSingle('NavLink[eventKey=1] a.active');
+    wrapper.assertSingle('NavLink[eventKey=1] button.active');
   });
 
   it('should get defaultActiveKey (if null) from first child tab with eventKey', () => {
@@ -34,7 +34,7 @@ describe('<Tabs>', () => {
       </Tabs>,
     );
     wrapper.assertSingle('TabPane[eventKey=1] .active');
-    wrapper.assertSingle('NavLink[eventKey=1] a.active');
+    wrapper.assertSingle('NavLink[eventKey=1] button.active');
   });
 
   it('Should allow tab to have React components', () => {
@@ -49,7 +49,7 @@ describe('<Tabs>', () => {
           Tab 2 content
         </Tab>
       </Tabs>,
-    ).assertSingle('NavLink a .special-tab');
+    ).assertSingle('NavLink button .special-tab');
   });
 
   it('Should call onSelect when tab is selected', (done) => {
@@ -68,7 +68,7 @@ describe('<Tabs>', () => {
         </Tab>
       </Tabs>,
     )
-      .find('NavLink[eventKey="2"] a')
+      .find('NavLink[eventKey="2"] button')
       .simulate('click');
   });
 
@@ -84,8 +84,8 @@ describe('<Tabs>', () => {
       </Tabs>,
     );
 
-    wrapper.assertSingle('a.nav-link.tcustom');
-    wrapper.assertNone('a.nav-link.custom');
+    wrapper.assertSingle('button.nav-link.tcustom');
+    wrapper.assertNone('button.nav-link.custom');
     wrapper.assertSingle('div.tab-pane.custom#test-tabpane-1');
   });
 
@@ -99,7 +99,7 @@ describe('<Tabs>', () => {
           Tab 2 content
         </Tab>
       </Tabs>,
-    ).assertSingle('nav.nav-pills');
+    ).assertSingle('ul.nav-pills');
   });
 
   it('Should pass disabled to Nav', () => {
@@ -112,7 +112,7 @@ describe('<Tabs>', () => {
           Tab 2 content
         </Tab>
       </Tabs>,
-    ).assertSingle('a.nav-link.disabled');
+    ).assertSingle('button.nav-link.disabled');
   });
 
   it('Should not render a Tab without a title', () => {
@@ -125,7 +125,7 @@ describe('<Tabs>', () => {
         </Tab>
       </Tabs>,
     )
-      .find('a.nav-link')
+      .find('button.nav-link')
       .should.have.length(1);
   });
 });


### PR DESCRIPTION
Changes tabs to use the recommended markup in upstream bootstrap.

Also fixes #5530

Ref: 
https://github.com/twbs/bootstrap/pull/32630
https://getbootstrap.com/docs/5.0/components/navs-tabs/#javascript-behavior