### PR TITLE
refactor(Dropdown)!: simplify menu alignment API

### DIFF
--- a/src/DropdownButton.tsx
+++ b/src/DropdownButton.tsx
@@ -3,20 +3,15 @@ import PropTypes from 'prop-types';
 
 import Dropdown, { DropdownProps } from './Dropdown';
 import DropdownToggle, { PropsFromToggle } from './DropdownToggle';
-import DropdownMenu, {
-  alignPropType,
-  AlignType,
-  DropdownMenuVariant,
-} from './DropdownMenu';
-
+import DropdownMenu, { DropdownMenuVariant } from './DropdownMenu';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
+import { alignPropType } from './types';
 
 export interface DropdownButtonProps
   extends Omit<DropdownProps, 'title'>,
     PropsFromToggle,
     BsPrefixProps {
   title: React.ReactNode;
-  menuAlign?: AlignType;
   menuRole?: string;
   renderMenuOnMount?: boolean;
   rootCloseEvent?: 'click' | 'mousedown';
@@ -44,13 +39,13 @@ const propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * Aligns the dropdown menu responsively.
+   * Aligns the dropdown menu.
    *
    * _see [DropdownMenu](#dropdown-menu-props) for more details_
    *
-   * @type {"start"|"end"|{ sm: "start"|"end" }|{ md: "start"|"end" }|{ lg: "start"|"end" }|{ xl: "start"|"end"} }
+   * @type {"start"|"end"|{ sm: "start"|"end" }|{ md: "start"|"end" }|{ lg: "start"|"end" }|{ xl: "start"|"end"}|{ xxl: "start"|"end"} }
    */
-  menuAlign: alignPropType,
+  align: alignPropType,
 
   /** An ARIA accessible role applied to the Menu component. When set to 'menu', The dropdown */
   menuRole: PropTypes.string,
@@ -101,7 +96,6 @@ const DropdownButton: BsPrefixRefForwardingComponent<
       rootCloseEvent,
       variant,
       size,
-      menuAlign,
       menuRole,
       renderMenuOnMount,
       disabled,
@@ -124,7 +118,6 @@ const DropdownButton: BsPrefixRefForwardingComponent<
         {title}
       </DropdownToggle>
       <DropdownMenu
-        align={menuAlign}
         role={menuRole}
         renderOnMount={renderMenuOnMount}
         rootCloseEvent={rootCloseEvent}

--- a/src/DropdownContext.ts
+++ b/src/DropdownContext.ts
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { AlignType } from './types';
+
+export type DropdownContextValue = {
+  align?: AlignType;
+};
+
+const DropdownContext = React.createContext<DropdownContextValue>({});
+DropdownContext.displayName = 'DropdownContext';
+
+export default DropdownContext;

--- a/src/SplitButton.tsx
+++ b/src/SplitButton.tsx
@@ -4,16 +4,15 @@ import PropTypes from 'prop-types';
 import Button, { ButtonType } from './Button';
 import ButtonGroup from './ButtonGroup';
 import Dropdown, { DropdownProps } from './Dropdown';
-import { alignPropType, AlignType } from './DropdownMenu';
 import { PropsFromToggle } from './DropdownToggle';
 import { BsPrefixProps } from './helpers';
+import { alignPropType } from './types';
 
 export interface SplitButtonProps
   extends Omit<DropdownProps, 'title' | 'id'>,
     PropsFromToggle,
     BsPrefixProps {
   id: string | number;
-  menuAlign?: AlignType;
   menuRole?: string;
   renderMenuOnMount?: boolean;
   rootCloseEvent?: 'click' | 'mousedown';
@@ -55,13 +54,13 @@ const propTypes = {
   disabled: PropTypes.bool,
 
   /**
-   * Aligns the dropdown menu responsively.
+   * Aligns the dropdown menu.
    *
    * _see [DropdownMenu](#dropdown-menu-props) for more details_
    *
-   * @type {"start"|"end"|{ sm: "start"|"end" }|{ md: "start"|"end" }|{ lg: "start"|"end" }|{ xl: "start"|"end"} }
+   * @type {"start"|"end"|{ sm: "start"|"end" }|{ md: "start"|"end" }|{ lg: "start"|"end" }|{ xl: "start"|"end"}|{ xxl: "start"|"end"} }
    */
-  menuAlign: alignPropType,
+  align: alignPropType,
 
   /** An ARIA accessible role applied to the Menu component. When set to 'menu', The dropdown */
   menuRole: PropTypes.string,
@@ -113,7 +112,6 @@ const SplitButton = React.forwardRef<HTMLElement, SplitButtonProps>(
       onClick,
       href,
       target,
-      menuAlign,
       menuRole,
       renderMenuOnMount,
       rootCloseEvent,
@@ -146,7 +144,6 @@ const SplitButton = React.forwardRef<HTMLElement, SplitButtonProps>(
       </Dropdown.Toggle>
 
       <Dropdown.Menu
-        align={menuAlign}
         role={menuRole}
         renderOnMount={renderMenuOnMount}
         rootCloseEvent={rootCloseEvent}

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,3 +1,5 @@
+import PropTypes from 'prop-types';
+
 export type Variant =
   | 'primary'
   | 'secondary'
@@ -39,3 +41,25 @@ export type ArrowProps = {
 };
 
 export type EventKey = string | number;
+
+export type AlignDirection = 'start' | 'end';
+
+export type ResponsiveAlignProp =
+  | { sm: AlignDirection }
+  | { md: AlignDirection }
+  | { lg: AlignDirection }
+  | { xl: AlignDirection }
+  | { xxl: AlignDirection };
+
+export type AlignType = AlignDirection | ResponsiveAlignProp;
+
+const alignDirection = PropTypes.oneOf<AlignDirection>(['start', 'end']);
+
+export const alignPropType = PropTypes.oneOfType([
+  alignDirection,
+  PropTypes.shape({ sm: alignDirection }),
+  PropTypes.shape({ md: alignDirection }),
+  PropTypes.shape({ lg: alignDirection }),
+  PropTypes.shape({ xl: alignDirection }),
+  PropTypes.shape({ xxl: alignDirection }),
+]);

--- a/test/DropdownButtonSpec.js
+++ b/test/DropdownButtonSpec.js
@@ -27,16 +27,16 @@ describe('<DropdownButton>', () => {
     ).assertSingle('.dropdown-menu a.dropdown-item');
   });
 
-  it('forwards alignRight to the Dropdown', () => {
+  it('forwards align="end" to the Dropdown', () => {
     mount(
-      <DropdownButton alignRight title="blah" id="test-id">
+      <DropdownButton align="end" title="blah" id="test-id">
         <DropdownItem>Item 1</DropdownItem>
       </DropdownButton>,
     )
       .find('Dropdown')
       .first()
       .props()
-      .alignRight.should.equal(true);
+      .align.should.equal('end');
   });
 
   it('passes variant and size to the toggle', () => {

--- a/test/DropdownMenuSpec.js
+++ b/test/DropdownMenuSpec.js
@@ -24,9 +24,9 @@ describe('<Dropdown.Menu>', () => {
     ).assertSingle('div.new-fancy-class');
   });
 
-  it('applies alignRight', () => {
+  it('applies align="end"', () => {
     mount(
-      <DropdownMenu show alignRight>
+      <DropdownMenu show align="end">
         <DropdownItem>Item</DropdownItem>
       </DropdownMenu>,
     ).assertSingle('.dropdown-menu-end');
@@ -73,7 +73,9 @@ describe('<Dropdown.Menu>', () => {
       <DropdownMenu show align={{ lg: 'end' }}>
         <DropdownItem>Item</DropdownItem>
       </DropdownMenu>,
-    ).assertSingle('.dropdown-menu-lg-end');
+    )
+      .assertSingle('.dropdown-menu-lg-end')
+      .assertSingle('[data-bs-popper="static"]');
   });
 
   it('should render variant', () => {

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -66,15 +66,15 @@ describe('<Dropdown>', () => {
     buttonNode.getAttribute('id').should.be.ok;
   });
 
-  it('forwards alignRight to menu', () => {
+  it('forwards align="end" to menu', () => {
     const Menu = React.forwardRef(
-      ({ show: _, close: _1, alignRight, ...props }, ref) => (
-        <div {...props} data-align-right={alignRight} ref={ref} />
+      ({ show: _, close: _1, align, ...props }, ref) => (
+        <div {...props} data-align={align} ref={ref} />
       ),
     );
 
     mount(
-      <Dropdown alignRight show>
+      <Dropdown align="end" show>
         <Dropdown.Toggle id="test-id" key="toggle">
           Child Title
         </Dropdown.Toggle>
@@ -83,7 +83,7 @@ describe('<Dropdown>', () => {
           <Dropdown.Item>Item 1</Dropdown.Item>
         </Dropdown.Menu>
       </Dropdown>,
-    ).assertSingle('div[data-align-right=true]');
+    ).assertSingle('div[data-align="end"]');
   });
 
   // NOTE: The onClick event handler is invoked for both the Enter and Space
@@ -293,8 +293,6 @@ describe('<Dropdown>', () => {
           show,
           // eslint-disable-next-line no-unused-vars
           close,
-          // eslint-disable-next-line no-unused-vars
-          alignRight,
           ...props
         },
         ref,

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -317,7 +317,7 @@ const MegaComponent = () => (
     </Container>
     <Container fluid="sm" />
     <Dropdown
-      alignRight
+      align="end"
       as="div"
       drop="up"
       flip
@@ -341,7 +341,6 @@ const MegaComponent = () => (
       </Dropdown.Toggle>
 
       <Dropdown.Menu
-        alignRight
         as="div"
         flip
         onSelect={noop}
@@ -388,7 +387,7 @@ const MegaComponent = () => (
       variant="primary"
       bsPrefix="dropdownbtn"
       style={style}
-      menuAlign={{ sm: 'start' }}
+      align={{ sm: 'start' }}
     >
       <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
       <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
@@ -728,7 +727,7 @@ const MegaComponent = () => (
         bsPrefix="prefix"
         style={style}
         drop="up"
-        alignRight
+        align="end"
         show
         flip={false}
         onToggle={noop}
@@ -916,11 +915,10 @@ const MegaComponent = () => (
       variant="primary"
       bsPrefix="splitbutton"
       style={style}
-      menuAlign={{ sm: 'start' }}
+      align={{ sm: 'start' }}
       drop="up"
       onSelect={noop}
       flip
-      alignRight
       onToggle={noop}
       focusFirstItemOnShow="keyboard"
       navbar

--- a/www/src/examples/Dropdown/MenuAlignResponsive.js
+++ b/www/src/examples/Dropdown/MenuAlignResponsive.js
@@ -2,7 +2,7 @@
   <div>
     <DropdownButton
       as={ButtonGroup}
-      menuAlign={{ lg: 'end' }}
+      align={{ lg: 'end' }}
       title="Left-aligned but right aligned when large screen"
       id="dropdown-menu-align-responsive-1"
     >
@@ -12,7 +12,7 @@
   </div>
   <div className="mt-2">
     <SplitButton
-      menuAlign={{ lg: 'start' }}
+      align={{ lg: 'start' }}
       title="Right-aligned but left aligned when large screen"
       id="dropdown-menu-align-responsive-2"
     >

--- a/www/src/examples/Dropdown/MenuAlignRight.js
+++ b/www/src/examples/Dropdown/MenuAlignRight.js
@@ -1,5 +1,5 @@
 <DropdownButton
-  menuAlign="end"
+  align="end"
   title="Dropdown right"
   id="dropdown-menu-align-right"
 >

--- a/www/src/examples/InputGroup/ButtonDropdowns.js
+++ b/www/src/examples/InputGroup/ButtonDropdowns.js
@@ -21,7 +21,7 @@
       variant="outline-secondary"
       title="Dropdown"
       id="input-group-dropdown-2"
-      alignRight
+      align="end"
     >
       <Dropdown.Item href="#">Action</Dropdown.Item>
       <Dropdown.Item href="#">Another action</Dropdown.Item>
@@ -48,7 +48,7 @@
       variant="outline-secondary"
       title="Dropdown"
       id="input-group-dropdown-4"
-      alignRight
+      align="end"
     >
       <Dropdown.Item href="#">Action</Dropdown.Item>
       <Dropdown.Item href="#">Another action</Dropdown.Item>

--- a/www/src/pages/components/dropdowns.mdx
+++ b/www/src/pages/components/dropdowns.mdx
@@ -128,17 +128,15 @@ Feel free to style further with custom CSS or text utilities.
 ## Menu alignment
 
 By default, a dropdown menu is aligned to the left, but you can switch
-it by passing `end` to the `align` prop on a `<DropdownMenu>` or passing 
-`end` to the `menuAlign` prop on the `<DropdownButton>` or `<SplitButton>`
-as seen below.
+it by passing `align="end"` to a `<Dropdown>`, `<DropdownButton>`, or `<SplitButton>`.
 
 <ReactPlayground codeText={MenuAlignRight} />
 
 ### Responsive alignment
 
-If you want to use responsive menu alignment, pass an object to the `align` prop 
-on the `<DropdownMenu>` or the `menuAlign` prop on the `<DropdownButton>` and 
-`<SplitButton>`. You can specify `start` or `end` for the various breakpoints.
+If you want to use responsive menu alignment, pass an object containing a breakpoint to the 
+`align` prop on the `<DropdownMenu>`, `<DropdownButton>`, or `<SplitButton>`. 
+You can specify `start` or `end` for the various breakpoints.
 
 <Callout theme="danger" title="Warning">
   Using responsive alignment will disable Popper usage so any dynamic positioning 

--- a/www/src/pages/migrating.mdx
+++ b/www/src/pages/migrating.mdx
@@ -55,6 +55,13 @@ Below is a _rough_ account of the breaking API changes as well as the minimal ch
 ### Dropdown
 - dropdown dividers use `hr` by default instead of `div`.
 - Alignment values `left` and `right` changed to `start` and `end` respectively.
+- Removed `alignRight`. Use `align="end"` instead.
+
+### DropdownButton
+- Removed `menuAlign` prop in favor of `align`.
+
+### DropdownMenu
+- Removed `alignRight`. Use `align="end"` instead.
 
 ### Form
 
@@ -63,7 +70,7 @@ Below is a _rough_ account of the breaking API changes as well as the minimal ch
 
 ### FormCheck
 
-- deprecated `bsCustomPrefix` and `custom` in favor of `bsSwitchPrefix`.
+- removed `bsCustomPrefix` and `custom` in favor of `bsSwitchPrefix`.
 
 #### FormCheckInput
 
@@ -112,6 +119,10 @@ spacing, use margin utilities instead.
 ### PopoverTitle
 
 - renamed to PopoverHeader to match class name.
+
+### SplitButton
+
+- Removed `menuAlign` prop in favor of `align`. 
 
 ### Toast
 


### PR DESCRIPTION
This PR simplifies the menu alignment API by consolidating `alignRight` and `menuAlign` props into a single `align` prop that's exposed on the Dropdown and DropdownMenu components.

A couple breaking changes in here:
1. Remove `alignRight` from Dropdown and DropdownMenu
2. Remove `menuAlign` from DropdownButton and SplitButton

Also fixed a couple of things I noticed while refactoring:
1. Added support for XXL breakpoint for responsive menu alignment
2. Fix broken responsive alignment by adding `data-bs-popper` to the DropdownMenu.  Bootstrap now uses this attribute in their css to do the alignment