### PR TITLE
docs: fix Netlify deployment

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -1,7 +1,6 @@
 const { cleanDoclets } = require('gatsby-transformer-react-docgen/doclets');
 const path = require('path');
 const remarkSlug = require('remark-slug');
-const Fiber = require('fibers');
 
 const defaultDescriptions = require('./src/defaultPropDescriptions');
 
@@ -63,14 +62,7 @@ module.exports = {
       },
     },
     'gatsby-plugin-catch-links',
-    {
-      resolve: 'gatsby-plugin-sass',
-      options: {
-        sassOptions: {
-          fiber: Fiber,
-        },
-      },
-    },
+    'gatsby-plugin-sass',
     {
       resolve: 'gatsby-plugin-astroturf',
       options: { extension: '.module.scss' },

--- a/www/package.json
+++ b/www/package.json
@@ -46,7 +46,6 @@
     "copy-text-to-clipboard": "^3.0.1",
     "docsearch.js": "^2.6.3",
     "dom-helpers": "^5.2.1",
-    "fibers": "^5.0.0",
     "formik": "^2.2.6",
     "gatsby": "^2.32.12",
     "gatsby-plugin-astroturf": "^0.2.1",

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -4131,7 +4131,7 @@ detab@2.0.4, detab@^2.0.0:
   dependencies:
     repeat-string "^1.5.4"
 
-detect-libc@^1.0.2, detect-libc@^1.0.3:
+detect-libc@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-1.0.3.tgz#fa137c4bd698edf55cd5cd02ac559f91a4c4ba9b"
   integrity sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=
@@ -5283,13 +5283,6 @@ fd@~0.0.2:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/fd/-/fd-0.0.3.tgz#b3240de86dbf5a345baae7382a07d4713566ff0c"
   integrity sha512-iAHrIslQb3U68OcMSP0kkNWabp7sSN6d2TBSb2JO3gcLJVDd4owr/hKM4SFJovFOUeeXeItjYgouEDTMWiVAnA==
-
-fibers@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/fibers/-/fibers-5.0.0.tgz#3a60e0695b3ee5f6db94e62726716fa7a59acc41"
-  integrity sha512-UpGv/YAZp7mhKHxDvC1tColrroGRX90sSvh8RMZV9leo+e5+EkRVgCEZPlmXeo3BUNQTZxUaVdLskq1Q2FyCPg==
-  dependencies:
-    detect-libc "^1.0.3"
 
 figgy-pudding@^3.5.1:
   version "3.5.2"


### PR DESCRIPTION
Fixes this error in Netlify deployment:
> node: ../src/coroutine.cc:134: void* find_thread_id_key(void*): Assertion `thread_id_key != 0x7777' failed.
Aborted (core dumped)

Netlify uses node v16 now which isn't compatible with `fibers`

Ref: https://github.com/laverdet/node-fibers/issues/451