### PR TITLE
Add custom variant support for Dropdown.Menu Component.

### DIFF
--- a/src/DropdownMenu.tsx
+++ b/src/DropdownMenu.tsx
@@ -19,7 +19,7 @@ import {
 } from './helpers';
 import { AlignType, AlignDirection, alignPropType } from './types';
 
-export type DropdownMenuVariant = 'dark';
+export type DropdownMenuVariant = 'dark' | string;
 
 export interface DropdownMenuProps
   extends BsPrefixProps,
@@ -90,7 +90,7 @@ const propTypes = {
    *
    * Omitting this will use the default light color.
    */
-  variant: PropTypes.oneOf<DropdownMenuVariant>(['dark']),
+  variant: PropTypes.string,
 };
 
 const defaultProps: Partial<DropdownMenuProps> = {


### PR DESCRIPTION
In the earlier version, only dark variant was available by adding type string developer will have more control of dropdown variant.
 