### PR TITLE
Fix(docs): fix missing img on toast (fix #5729)

### DIFF
--- a/www/src/components/ReactPlayground.js
+++ b/www/src/components/ReactPlayground.js
@@ -122,6 +122,21 @@ function Preview({ showCode, className }) {
       theme: 'gray',
       images: qsa(exampleRef.current, 'img'),
     });
+
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.addedNodes.length > 0) {
+          hjs.run({
+            theme: 'gray',
+            images: qsa(exampleRef.current, 'img'),
+          });
+        }
+      });
+    });
+    observer.observe(exampleRef.current, { childList: true, subtree: true });
+
+    return () => observer.disconnect();
+
   }, [hjs, live.element]);
 
   const handleClick = useCallback((e) => {

--- a/www/src/components/ReactPlayground.js
+++ b/www/src/components/ReactPlayground.js
@@ -21,6 +21,7 @@ import {
 } from 'react-live';
 import * as yup from 'yup';
 import useIsomorphicEffect from '@restart/hooks/useIsomorphicEffect';
+import useMutationObserver from '@restart/hooks/useMutationObserver';
 import PlaceholderImage from './PlaceholderImage';
 import Sonnet from './Sonnet';
 
@@ -122,8 +123,11 @@ function Preview({ showCode, className }) {
       theme: 'gray',
       images: qsa(exampleRef.current, 'img'),
     });
+  }, [hjs, live.element]);
 
-    const observer = new MutationObserver((mutations) => {
+  useMutationObserver(exampleRef.current, {
+    childList: true, subtree: true },
+    (mutations) => {
       mutations.forEach((mutation) => {
         if (mutation.addedNodes.length > 0) {
           hjs.run({
@@ -133,11 +137,6 @@ function Preview({ showCode, className }) {
         }
       });
     });
-    observer.observe(exampleRef.current, { childList: true, subtree: true });
-
-    return () => observer.disconnect();
-
-  }, [hjs, live.element]);
 
   const handleClick = useCallback((e) => {
     if (e.target.tagName === 'A') {


### PR DESCRIPTION
On the toast component page of the documentation, an img element was not rendered when using an animated toast.

The problem was caused by the holder.js not been activated for loading the src of img elements, when the toast component was re-rendered.

In order to solve this issue, we implemented a mutation observer API.