### PR TITLE
fix: make a11y id prop consistent

### DIFF
--- a/src/DropdownButton.tsx
+++ b/src/DropdownButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-
+import isRequiredForA11y from 'prop-types-extra/lib/isRequiredForA11y';
 import Dropdown, { DropdownProps } from './Dropdown';
 import DropdownToggle, { PropsFromToggle } from './DropdownToggle';
 import DropdownMenu, { DropdownMenuVariant } from './DropdownMenu';
@@ -11,6 +11,7 @@ export interface DropdownButtonProps
   extends Omit<DropdownProps, 'title'>,
     PropsFromToggle,
     BsPrefixProps {
+  id: string;
   title: React.ReactNode;
   menuRole?: string;
   renderMenuOnMount?: boolean;
@@ -21,10 +22,10 @@ export interface DropdownButtonProps
 const propTypes = {
   /**
    * An html id attribute for the Toggle button, necessary for assistive technologies, such as screen readers.
-   * @type {string|number}
+   * @type {string}
    * @required
    */
-  id: PropTypes.any,
+  id: isRequiredForA11y(PropTypes.string),
 
   /** An `href` passed to the Toggle component */
   href: PropTypes.string,

--- a/src/DropdownToggle.tsx
+++ b/src/DropdownToggle.tsx
@@ -13,6 +13,7 @@ import useWrappedRefWithWarning from './useWrappedRefWithWarning';
 import { BsPrefixRefForwardingComponent } from './helpers';
 
 export interface DropdownToggleProps extends ButtonProps {
+  id: string;
   split?: boolean;
   childBsPrefix?: string;
 }
@@ -34,10 +35,10 @@ const propTypes = {
 
   /**
    * An html id attribute, necessary for assistive technologies, such as screen readers.
-   * @type {string|number}
+   * @type {string}
    * @required
    */
-  id: isRequiredForA11y(PropTypes.any),
+  id: isRequiredForA11y(PropTypes.string),
 
   split: PropTypes.bool,
 

--- a/src/NavDropdown.tsx
+++ b/src/NavDropdown.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-
+import isRequiredForA11y from 'prop-types-extra/lib/isRequiredForA11y';
 import { useBootstrapPrefix } from './ThemeProvider';
 import Dropdown, { DropdownProps } from './Dropdown';
 import { DropdownMenuVariant } from './DropdownMenu';
@@ -23,10 +23,10 @@ export interface NavDropdownProps
 const propTypes = {
   /**
    * An html id attribute for the Toggle button, necessary for assistive technologies, such as screen readers.
-   * @type {string|number}
+   * @type {string}
    * @required
    */
-  id: PropTypes.any,
+  id: isRequiredForA11y(PropTypes.string),
 
   /** An `onClick` handler passed to the Toggle component */
   onClick: PropTypes.func,
@@ -64,59 +64,57 @@ const propTypes = {
   bsPrefix: PropTypes.string,
 };
 
-const NavDropdown: BsPrefixRefForwardingComponent<
-  'div',
-  NavDropdownProps
-> = React.forwardRef(
-  (
-    {
-      id,
-      title,
-      children,
-      bsPrefix,
-      className,
-      rootCloseEvent,
-      menuRole,
-      disabled,
-      active,
-      renderMenuOnMount,
-      menuVariant,
-      ...props
-    }: NavDropdownProps,
-    ref,
-  ) => {
-    /* NavItem has no additional logic, it's purely presentational. Can set nav item class here to support "as" */
-    const navItemPrefix = useBootstrapPrefix(undefined, 'nav-item');
+const NavDropdown: BsPrefixRefForwardingComponent<'div', NavDropdownProps> =
+  React.forwardRef(
+    (
+      {
+        id,
+        title,
+        children,
+        bsPrefix,
+        className,
+        rootCloseEvent,
+        menuRole,
+        disabled,
+        active,
+        renderMenuOnMount,
+        menuVariant,
+        ...props
+      }: NavDropdownProps,
+      ref,
+    ) => {
+      /* NavItem has no additional logic, it's purely presentational. Can set nav item class here to support "as" */
+      const navItemPrefix = useBootstrapPrefix(undefined, 'nav-item');
 
-    return (
-      <Dropdown
-        ref={ref}
-        {...props}
-        className={classNames(className, navItemPrefix)}
-      >
-        <Dropdown.Toggle
-          id={id}
-          eventKey={null}
-          active={active}
-          disabled={disabled}
-          childBsPrefix={bsPrefix}
-          as={NavLink}
+      return (
+        <Dropdown
+          ref={ref}
+          {...props}
+          className={classNames(className, navItemPrefix)}
         >
-          {title}
-        </Dropdown.Toggle>
+          <Dropdown.Toggle
+            id={id}
+            eventKey={null}
+            active={active}
+            disabled={disabled}
+            childBsPrefix={bsPrefix}
+            as={NavLink}
+          >
+            {title}
+          </Dropdown.Toggle>
 
-        <Dropdown.Menu
-          role={menuRole}
-          renderOnMount={renderMenuOnMount}
-          rootCloseEvent={rootCloseEvent}
-          variant={menuVariant}
-        >
-          {children}
-        </Dropdown.Menu>
-      </Dropdown>
-    );
-  },
-);
+          <Dropdown.Menu
+            role={menuRole}
+            renderOnMount={renderMenuOnMount}
+            rootCloseEvent={rootCloseEvent}
+            variant={menuVariant}
+          >
+            {children}
+          </Dropdown.Menu>
+        </Dropdown>
+      );
+    },
+  );
 
 NavDropdown.displayName = 'NavDropdown';
 NavDropdown.propTypes = propTypes;

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -28,12 +28,10 @@ const propTypes = {
 
   /**
    * An html id attribute, necessary for accessibility
-   * @type {string|number}
+   * @type {string}
    * @required
    */
-  id: isRequiredForA11y(
-    PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  ),
+  id: isRequiredForA11y(PropTypes.string),
 
   /**
    * Sets the direction the Popover is positioned towards.

--- a/src/SplitButton.tsx
+++ b/src/SplitButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-
+import isRequiredForA11y from 'prop-types-extra/lib/isRequiredForA11y';
 import Button, { ButtonType } from './Button';
 import ButtonGroup from './ButtonGroup';
 import Dropdown, { DropdownProps } from './Dropdown';
@@ -12,7 +12,7 @@ export interface SplitButtonProps
   extends Omit<DropdownProps, 'title' | 'id'>,
     PropsFromToggle,
     BsPrefixProps {
-  id: string | number;
+  id: string;
   menuRole?: string;
   renderMenuOnMount?: boolean;
   rootCloseEvent?: 'click' | 'mousedown';
@@ -25,10 +25,10 @@ export interface SplitButtonProps
 const propTypes = {
   /**
    * An html id attribute for the Toggle button, necessary for assistive technologies, such as screen readers.
-   * @type {string|number}
+   * @type {string}
    * @required
    */
-  id: PropTypes.any,
+  id: isRequiredForA11y(PropTypes.string),
 
   /**
    * Accessible label for the toggle; the value of `title` if not specified.
@@ -134,7 +134,7 @@ const SplitButton = React.forwardRef<HTMLElement, SplitButtonProps>(
       </Button>
       <Dropdown.Toggle
         split
-        id={id ? id.toString() : undefined}
+        id={id}
         size={size}
         variant={variant}
         disabled={props.disabled}

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import requiredForA11y from 'prop-types-extra/lib/isRequiredForA11y';
+import isRequiredForA11y from 'prop-types-extra/lib/isRequiredForA11y';
 import { useUncontrolled } from 'uncontrollable';
 
 import Nav from './Nav';
@@ -22,7 +22,7 @@ export interface TabsProps
   onSelect?: SelectCallback;
   variant?: 'tabs' | 'pills';
   transition?: TransitionType;
-  id?: string;
+  id: string;
   mountOnEnter?: boolean;
   unmountOnExit?: boolean;
 }
@@ -58,12 +58,10 @@ const propTypes = {
   ]),
 
   /**
-   * HTML id attribute, required if no `generateChildId` prop
-   * is specified.
-   *
+   * An html id attribute, necessary for accessibility
    * @type {string}
    */
-  id: requiredForA11y(PropTypes.string),
+  id: isRequiredForA11y(PropTypes.string),
 
   /**
    * Callback fired when a Tab is selected.

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -24,12 +24,10 @@ const propTypes = {
 
   /**
    * An html id attribute, necessary for accessibility
-   * @type {string|number}
+   * @type {string}
    * @required
    */
-  id: isRequiredForA11y(
-    PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  ),
+  id: isRequiredForA11y(PropTypes.string),
 
   /**
    * Sets the direction the Tooltip is positioned towards.


### PR DESCRIPTION
Noticed that `id` is a bit inconsistent in several components.  Docs mention it should be required, but TS types sometimes require it/sometimes not. 

I changed it so it's consistent everywhere and removed ability to set a number, just so it matches base TS types for `id` which is a string.