### PR TITLE
Perform ref forwarding in Form.Label when rendering as a Col

### DIFF
--- a/src/FormLabel.tsx
+++ b/src/FormLabel.tsx
@@ -106,7 +106,13 @@ const FormLabel: BsPrefixRefForwardingComponent<'label', FormLabelProps> =
 
       if (column)
         return (
-          <Col as="label" className={classes} htmlFor={htmlFor} {...props} />
+          <Col
+            ref={ref as React.ForwardedRef<HTMLLabelElement>}
+            as="label"
+            className={classes}
+            htmlFor={htmlFor}
+            {...props}
+          />
         );
 
       return (

--- a/test/FormLabelSpec.js
+++ b/test/FormLabelSpec.js
@@ -71,6 +71,27 @@ describe('<FormLabel>', () => {
     expect(instance.input.tagName).to.equal('LABEL');
   });
 
+  it('should support ref forwarding when rendered as a Col', () => {
+    class Container extends React.Component {
+      render() {
+        return (
+          <FormGroup controlId="foo">
+            <FormLabel
+              type="text"
+              column
+              ref={(ref) => {
+                this.input = ref;
+              }}
+            />
+          </FormGroup>
+        );
+      }
+    }
+
+    const instance = mount(<Container />).instance();
+    expect(instance.input.tagName).to.equal('LABEL');
+  });
+
   it('accepts as prop', () => {
     mount(<FormLabel as="legend">body</FormLabel>).assertSingle('legend');
   });


### PR DESCRIPTION
When the `<Form.Label>` component is rendered with the prop `column={true}`, it doesn't forward refs. (It does forward them correctly otherwise.)