### PR TITLE
Update Modal's dialog and backdrop transition timeout

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -231,11 +231,11 @@ const defaultProps = {
 
 /* eslint-disable no-use-before-define, react/no-multi-comp */
 function DialogTransition(props) {
-  return <Fade {...props} />;
+  return <Fade {...props} timeout={null} />;
 }
 
 function BackdropTransition(props) {
-  return <Fade {...props} />;
+  return <Fade {...props} timeout={null} />;
 }
 
 /* eslint-enable no-use-before-define */

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -265,6 +265,28 @@ describe('<Modal>', () => {
     );
   });
 
+  it('should call `transitionend` before `exited`', (done) => {
+    const increment = sinon.spy();
+    let modal;
+
+    const instance = mount(
+      <Modal
+        show
+        style={{ transition: 'opacity 1s linear' }}
+        onExited={() => {
+          expect(increment.callCount).to.equal(1);
+          modal.removeEventListener('transitionend', increment);
+          done();
+        }}
+      >
+        <strong>Message</strong>
+      </Modal>,
+    );
+    modal = instance.find('.modal').getDOMNode();
+    modal.addEventListener('transitionend', increment);
+    instance.setProps({ show: false });
+  });
+
   describe('cleanup', () => {
     let offSpy;
 


### PR DESCRIPTION
This PR addresses issue: #5788 

When setting a transition that is longer than the default `300ms` timeout as set by the `Fade` component's default props, the Modal is unmounted on exit before completing the animation. By setting the `timeout=null` for the Fade component, we let the Transition complete fully through the `transitionEndListener`.