### PR TITLE
test: adds tests for mouseover trigger and uses fake timers

### DIFF
--- a/test/OverlayTriggerSpec.js
+++ b/test/OverlayTriggerSpec.js
@@ -111,6 +111,33 @@ describe('<OverlayTrigger>', () => {
     wrapper.assertSingle('div.test');
   });
 
+  it('Should show after mouseover trigger', (done) => {
+    const clock = sinon.useFakeTimers();
+
+    try {
+      const wrapper = mount(
+        <OverlayTrigger overlay={<Div className="test" />}>
+          <span>hover me</span>
+        </OverlayTrigger>,
+      );
+
+      wrapper.assertNone('.test');
+
+      wrapper.find('span').simulate('mouseover');
+
+      wrapper.assertSingle('div.test');
+
+      wrapper.find('span').simulate('mouseout');
+
+      clock.tick(50);
+
+      wrapper.assertNone('.test');
+    } finally {
+      clock.restore();
+      done();
+    }
+  });
+
   it('Should not set aria-describedby if the state is not show', () => {
     const [button] = mount(
       <OverlayTrigger trigger="click" overlay={<Div />}>


### PR DESCRIPTION
The existing coverage is 67% [here](https://codecov.io/gh/react-bootstrap/react-bootstrap/src/master/src/OverlayTrigger.tsx), this branch brings it up to 87% based on my local test runner's report:

<img width="703" alt="119448634-75d00880-bce6-11eb-995d-dc2397a086ed" src="https://user-images.githubusercontent.com/28247931/121114839-251ddc80-c7c9-11eb-8e76-5dfdc59d96c2.png">
