### PR TITLE
Added autoClose behaviour for dropdowns

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -47,6 +47,7 @@ export interface DropdownProps
   focusFirstItemOnShow?: boolean | 'keyboard';
   onSelect?: SelectCallback;
   navbar?: boolean;
+  autoClose: 'true' | 'outside' | 'inside' | 'false';
 }
 
 const propTypes = {
@@ -123,11 +124,18 @@ const propTypes = {
 
   /** @private */
   navbar: PropTypes.bool,
+
+  /**
+   * Controls the auto close behaviour of the dropdown when clicking outside of
+   * the button or the list.
+   */
+  autoClose: PropTypes.oneOf(['true', 'outside', 'inside', 'false']),
 };
 
 const defaultProps: Partial<DropdownProps> = {
   navbar: false,
   align: 'start',
+  autoClose: 'true',
 };
 
 const Dropdown: BsPrefixRefForwardingComponent<'div', DropdownProps> =
@@ -144,6 +152,7 @@ const Dropdown: BsPrefixRefForwardingComponent<'div', DropdownProps> =
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'div',
       navbar: _4,
+      autoClose,
       ...props
     } = useUncontrolled(pProps, { show: 'onToggle' });
 
@@ -156,8 +165,20 @@ const Dropdown: BsPrefixRefForwardingComponent<'div', DropdownProps> =
         if (
           event.currentTarget === document &&
           (source !== 'keydown' || event.key === 'Escape')
-        )
+        ) {
           source = 'rootClose';
+
+          const noOuterCloseModes =
+            autoClose === 'inside' || autoClose === 'false';
+          if (noOuterCloseModes) return;
+        }
+
+        const noAutoAndSelect =
+          !nextShow && autoClose === 'false' && source === 'select';
+        const outsideAndSelect = autoClose === 'outside' && source === 'select';
+
+        if (noAutoAndSelect || outsideAndSelect) return;
+
         onToggle?.(nextShow, event, { source });
       },
     );

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -333,4 +333,141 @@ describe('<Dropdown>', () => {
       ).assertSingle('div.dropdown-menu');
     });
   });
+
+  describe('autoClose behaviour', () => {
+    const createDocumentListenersMock = () => {
+      const listeners = {};
+      const handler = (domEl, event) => listeners?.[event]?.({ target: domEl });
+      document.addEventListener = sinon.spy((event, cb) => {
+        listeners[event] = cb;
+      });
+      document.removeEventListener = sinon.spy((event) => {
+        delete listeners[event];
+      });
+      return {
+        mouseDown: (domEl) => handler(domEl, 'mousedown'),
+        click: (domEl) => handler(domEl, 'click'),
+      };
+    };
+
+    describe('autoClose="true"', () => {
+      it('should close on child selection', () => {
+        const onToggle = sinon.spy();
+
+        const wrapper = mount(simpleDropdown).setProps({
+          show: true,
+          autoClose: 'true',
+          onToggle,
+        });
+
+        wrapper.find('.dropdown-menu a').first().simulate('click');
+
+        onToggle.should.have.been.calledWith(false);
+      });
+
+      it('should close on outer click', () => {
+        const onToggle = sinon.spy();
+        const fireEvent = createDocumentListenersMock();
+
+        mount(simpleDropdown).setProps({
+          show: true,
+          autoClose: 'true',
+          onToggle,
+        });
+
+        fireEvent.click(document.body);
+
+        onToggle.should.have.been.calledWith(false);
+      });
+    });
+
+    describe('autoClose="inside"', () => {
+      it('should close on child selection', () => {
+        const onToggle = sinon.spy();
+
+        const wrapper = mount(simpleDropdown).setProps({
+          show: true,
+          autoClose: 'inside',
+          onToggle,
+        });
+
+        wrapper.find('.dropdown-menu a').first().simulate('click');
+
+        onToggle.should.have.been.calledWith(false);
+      });
+
+      it('should not close on outer click', () => {
+        const fireEvent = createDocumentListenersMock();
+
+        let wrapper = mount(simpleDropdown).setProps({
+          show: true,
+          autoClose: 'inside',
+        });
+
+        fireEvent.click(document.body);
+
+        expect(wrapper.find('Dropdown').prop('show')).to.be.true;
+      });
+    });
+
+    describe('autoClose="outside"', () => {
+      it('should not close on child selection', () => {
+        const onToggle = sinon.spy();
+
+        const wrapper = mount(simpleDropdown).setProps({
+          show: true,
+          autoClose: 'outside',
+          onToggle,
+        });
+
+        wrapper.find('.dropdown-menu a').first().simulate('click');
+
+        onToggle.should.not.have.been.calledWith(false);
+      });
+
+      it('should close on outer click', () => {
+        const onToggle = sinon.spy();
+        const fireEvent = createDocumentListenersMock();
+
+        mount(simpleDropdown).setProps({
+          show: true,
+          autoClose: 'outside',
+          onToggle,
+        });
+
+        fireEvent.click(document.body);
+
+        onToggle.should.have.been.calledWith(false);
+      });
+    });
+
+    describe('autoClose="false"', () => {
+      it('should not close on child selection', () => {
+        const onToggle = sinon.spy();
+
+        const wrapper = mount(simpleDropdown).setProps({
+          show: true,
+          autoClose: 'false',
+          onToggle,
+        });
+
+        wrapper.find('.dropdown-menu a').first().simulate('click');
+
+        onToggle.should.not.have.been.calledWith(false);
+      });
+
+      it('should not close on outer click', () => {
+        const fireEvent = createDocumentListenersMock();
+
+        const wrapper = mount(simpleDropdown).setProps({
+          show: true,
+          autoClose: 'false',
+        });
+
+        fireEvent.click(document.body);
+
+        expect(wrapper.find('Dropdown').prop('show')).to.be.true;
+      });
+    });
+  });
 });

--- a/test/DropdownSpec.js
+++ b/test/DropdownSpec.js
@@ -2,6 +2,7 @@ import { mount } from 'enzyme';
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 import simulant from 'simulant';
+import sinon from 'sinon';
 import Dropdown from '../src/Dropdown';
 import InputGroup from '../src/InputGroup';
 
@@ -335,47 +336,17 @@ describe('<Dropdown>', () => {
   });
 
   describe('autoClose behaviour', () => {
-    const createDocumentListenersMock = () => {
-      const listeners = {};
-      const handler = (domEl, event) => listeners?.[event]?.({ target: domEl });
-      document.addEventListener = sinon.spy((event, cb) => {
-        listeners[event] = cb;
-      });
-      document.removeEventListener = sinon.spy((event) => {
-        delete listeners[event];
-      });
-      return {
-        mouseDown: (domEl) => handler(domEl, 'mousedown'),
-        click: (domEl) => handler(domEl, 'click'),
-      };
-    };
-
     describe('autoClose="true"', () => {
-      it('should close on child selection', () => {
-        const onToggle = sinon.spy();
-
-        const wrapper = mount(simpleDropdown).setProps({
-          show: true,
-          autoClose: 'true',
-          onToggle,
-        });
-
-        wrapper.find('.dropdown-menu a').first().simulate('click');
-
-        onToggle.should.have.been.calledWith(false);
-      });
-
       it('should close on outer click', () => {
         const onToggle = sinon.spy();
-        const fireEvent = createDocumentListenersMock();
 
         mount(simpleDropdown).setProps({
           show: true,
-          autoClose: 'true',
+          autoClose: true,
           onToggle,
         });
 
-        fireEvent.click(document.body);
+        simulant.fire(document.body, 'click');
 
         onToggle.should.have.been.calledWith(false);
       });
@@ -397,14 +368,12 @@ describe('<Dropdown>', () => {
       });
 
       it('should not close on outer click', () => {
-        const fireEvent = createDocumentListenersMock();
-
         let wrapper = mount(simpleDropdown).setProps({
           show: true,
           autoClose: 'inside',
         });
 
-        fireEvent.click(document.body);
+        simulant.fire(document.body, 'click');
 
         expect(wrapper.find('Dropdown').prop('show')).to.be.true;
       });
@@ -422,12 +391,11 @@ describe('<Dropdown>', () => {
 
         wrapper.find('.dropdown-menu a').first().simulate('click');
 
-        onToggle.should.not.have.been.calledWith(false);
+        sinon.assert.notCalled(onToggle);
       });
 
       it('should close on outer click', () => {
         const onToggle = sinon.spy();
-        const fireEvent = createDocumentListenersMock();
 
         mount(simpleDropdown).setProps({
           show: true,
@@ -435,9 +403,9 @@ describe('<Dropdown>', () => {
           onToggle,
         });
 
-        fireEvent.click(document.body);
+        simulant.fire(document.body, 'click');
 
-        onToggle.should.have.been.calledWith(false);
+        onToggle.should.be.calledWith(false);
       });
     });
 
@@ -447,26 +415,27 @@ describe('<Dropdown>', () => {
 
         const wrapper = mount(simpleDropdown).setProps({
           show: true,
-          autoClose: 'false',
+          autoClose: false,
           onToggle,
         });
 
         wrapper.find('.dropdown-menu a').first().simulate('click');
 
-        onToggle.should.not.have.been.calledWith(false);
+        sinon.assert.notCalled(onToggle);
       });
 
       it('should not close on outer click', () => {
-        const fireEvent = createDocumentListenersMock();
+        const onToggle = sinon.spy();
 
-        const wrapper = mount(simpleDropdown).setProps({
+        mount(simpleDropdown).setProps({
           show: true,
-          autoClose: 'false',
+          autoClose: false,
+          onToggle,
         });
 
-        fireEvent.click(document.body);
+        simulant.fire(document.body, 'click');
 
-        expect(wrapper.find('Dropdown').prop('show')).to.be.true;
+        sinon.assert.notCalled(onToggle);
       });
     });
   });

--- a/www/src/examples/Dropdown/AutoClose.js
+++ b/www/src/examples/Dropdown/AutoClose.js
@@ -1,0 +1,15 @@
+<>
+  {['true', 'outside', 'inside', 'false'].map((autoClose) => (
+    <Dropdown autoClose={autoClose} className="d-inline mx-2">
+      <Dropdown.Toggle id={`dropdown-autoclose-${autoClose}`}>
+        AutoClose {autoClose}
+      </Dropdown.Toggle>
+
+      <Dropdown.Menu>
+        <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
+        <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
+        <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
+  ))}
+</>;

--- a/www/src/examples/Dropdown/AutoClose.js
+++ b/www/src/examples/Dropdown/AutoClose.js
@@ -1,8 +1,8 @@
 <>
-  {['true', 'outside', 'inside', 'false'].map((autoClose) => (
+  {[true, 'outside', 'inside', false].map((autoClose, index) => (
     <Dropdown autoClose={autoClose} className="d-inline mx-2">
-      <Dropdown.Toggle id={`dropdown-autoclose-${autoClose}`}>
-        AutoClose {autoClose}
+      <Dropdown.Toggle id={`dropdown-autoclose-${index}`}>
+        AutoClose {autoClose.toString()}
       </Dropdown.Toggle>
 
       <Dropdown.Menu>

--- a/www/src/pages/components/dropdowns.mdx
+++ b/www/src/pages/components/dropdowns.mdx
@@ -20,6 +20,7 @@ import SplitVariants from '../../examples/Dropdown/SplitVariants';
 import DropdownVariants from '../../examples/Dropdown/Variants';
 import ButtonDark from '../../examples/Dropdown/ButtonDark';
 import NavbarDark from '../../examples/Dropdown/NavbarDark';
+import AutoClose from '../../examples/Dropdown/AutoClose';
 
 import styles from '../../css/examples.module.scss';
 
@@ -163,6 +164,19 @@ Separate groups of related menu items with a divider.
   codeText={MenuDividers}
   exampleClassName={styles.staticDropdownMenu}
 />
+
+## AutoClose
+
+By default, the dropdown menu is closed when selecting a menu item or clicking outside of the
+dropdown menu. This behaviour can be changed by using the `autoClose` property.
+
+By default, `autoClose` is set to the default value `true` and behaves like expected. By choosing `false`, the dropdown
+menu can only be toggled by clicking on the dropdown button. `inside` makes the dropdown disappear __only__
+by choosing a menu item and `outside` closes the dropdown menu __only__ by clicking outside.
+
+__Notice__ how the dropdown is toggled in each scenario by clicking on the button.
+
+<ReactPlayground codeText={AutoClose} />
 
 ## Customization
 


### PR DESCRIPTION
More about the autoClose behaviour [here](https://getbootstrap.com/docs/5.0/components/dropdowns/#auto-close-behavior).

Additionally to the implementation, I've added

- a playground example
- a documentation section
- unit-tests

Preview: https://deploy-preview-5873--react-bootstrap.netlify.app/