### PR TITLE
feat(Tabs): Added possibility of passing custom attributes to Tab com…

### DIFF
--- a/src/Tab.tsx
+++ b/src/Tab.tsx
@@ -11,6 +11,7 @@ export interface TabProps extends Omit<TabPaneProps, 'title'> {
   title: React.ReactNode;
   disabled?: boolean;
   tabClassName?: string;
+  tabAttrs?: Record<string, any>;
 }
 
 /* eslint-disable react/no-unused-prop-types */
@@ -31,6 +32,11 @@ const propTypes = {
    * Class to pass to the underlying nav link.
    */
   tabClassName: PropTypes.string,
+
+  /**
+   * Object containing attributes for `<Tab />` component
+   */
+  tabAttrs: PropTypes.object,
 };
 
 const Tab: React.FC<TabProps> = () => {

--- a/src/Tab.tsx
+++ b/src/Tab.tsx
@@ -34,7 +34,7 @@ const propTypes = {
   tabClassName: PropTypes.string,
 
   /**
-   * Object containing attributes for `<Tab />` component
+   * Object containing attributes to pass to underlying nav link.
    */
   tabAttrs: PropTypes.object,
 };

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -108,7 +108,7 @@ function getDefaultActiveKey(children) {
 }
 
 function renderTab(child) {
-  const { title, eventKey, disabled, tabClassName, id } = child.props;
+  const { title, eventKey, disabled, tabClassName, tabAttrs, id } = child.props;
   if (title == null) {
     return null;
   }
@@ -122,6 +122,7 @@ function renderTab(child) {
         disabled={disabled}
         id={id}
         className={tabClassName}
+        {...tabAttrs}
       >
         {title}
       </NavLink>
@@ -163,6 +164,7 @@ const Tabs = (props: TabsProps) => {
           delete childProps.title;
           delete childProps.disabled;
           delete childProps.tabClassName;
+          delete childProps.tabAttrs;
 
           return <TabPane {...childProps} />;
         })}


### PR DESCRIPTION
…ponent

Resolves:  #5644 

`<Tab />` can now receive `tabAttrs` object which will be passed to underlying navlink component as attributes where `key` is the name of attribute and `value` is it's value