### PR TITLE
fix(Modal): Remove unnecessary modal-open bootstrap class

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -496,7 +496,6 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
             onExiting={onExiting}
             onExited={handleExited}
             manager={getModalManager()}
-            containerClassName={`${bsPrefix}-open`}
             transition={animation ? DialogTransition : undefined}
             backdropTransition={animation ? BackdropTransition : undefined}
             renderBackdrop={renderBackdrop}

--- a/src/Offcanvas.tsx
+++ b/src/Offcanvas.tsx
@@ -308,7 +308,6 @@ const Offcanvas: BsPrefixRefForwardingComponent<'div', OffcanvasProps> =
             onExiting={onExiting}
             onExited={handleExited}
             manager={getModalManager()}
-            containerClassName={`${bsPrefix}-open`}
             transition={DialogTransition}
             backdropTransition={BackdropTransition}
             renderBackdrop={renderBackdrop}


### PR DESCRIPTION
Resolves: #5856 

Removes `modal-open` as it was removed upstream in https://github.com/twbs/bootstrap/pull/33551