### PR TITLE
Fix toggle button controlled example by using id for each toggle button

### DIFF
--- a/www/src/examples/Button/ToggleButtonGroupControlled.js
+++ b/www/src/examples/Button/ToggleButtonGroupControlled.js
@@ -11,9 +11,15 @@ function ToggleButtonGroupControlled() {
 
   return (
     <ToggleButtonGroup type="checkbox" value={value} onChange={handleChange}>
-      <ToggleButton value={1}>Option 1</ToggleButton>
-      <ToggleButton value={2}>Option 2</ToggleButton>
-      <ToggleButton value={3}>Option 3</ToggleButton>
+      <ToggleButton id="tbg-btn-1" value={1}>
+        Option 1
+      </ToggleButton>
+      <ToggleButton id="tbg-btn-2" value={2}>
+        Option 2
+      </ToggleButton>
+      <ToggleButton id="tbg-btn-3" value={3}>
+        Option 3
+      </ToggleButton>
     </ToggleButtonGroup>
   );
 }


### PR DESCRIPTION
Closes #5896 

Fix toggle button group example in the docs by using id for each toggle button
[https://react-bootstrap-v5.netlify.app/components/buttons/#controlled](url)