### PR TITLE
fix: use shared modal manager to sync container state

### DIFF
--- a/src/BootstrapModalManager.tsx
+++ b/src/BootstrapModalManager.tsx
@@ -9,7 +9,7 @@ const Selector = {
   NAVBAR_TOGGLER: '.navbar-toggler',
 };
 
-export default class BootstrapModalManager extends ModalManager {
+class BootstrapModalManager extends ModalManager {
   private adjustAndStore<T extends keyof CSSStyleDeclaration>(
     prop: T,
     element: HTMLElement,
@@ -66,3 +66,11 @@ export default class BootstrapModalManager extends ModalManager {
     );
   }
 }
+
+let sharedManager: BootstrapModalManager | undefined;
+export function getSharedManager() {
+  if (!sharedManager) sharedManager = new BootstrapModalManager();
+  return sharedManager;
+}
+
+export default BootstrapModalManager;

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -13,7 +13,7 @@ import PropTypes from 'prop-types';
 import * as React from 'react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import BaseModal, { BaseModalProps } from 'react-overlays/Modal';
-import BootstrapModalManager from './BootstrapModalManager';
+import { getSharedManager } from './BootstrapModalManager';
 import Fade from './Fade';
 import ModalBody from './ModalBody';
 import ModalContext from './ModalContext';
@@ -51,8 +51,6 @@ export interface ModalProps
   scrollable?: boolean;
   [other: string]: any;
 }
-
-let manager;
 
 const propTypes = {
   /**
@@ -301,8 +299,7 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
 
       function getModalManager() {
         if (propsManager) return propsManager;
-        if (!manager) manager = new BootstrapModalManager();
-        return manager;
+        return getSharedManager();
       }
 
       function updateDialogStyle(node) {

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -13,6 +13,7 @@ import PropTypes from 'prop-types';
 import * as React from 'react';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import BaseModal, { BaseModalProps } from 'react-overlays/Modal';
+import { ModalInstance } from 'react-overlays/ModalManager';
 import { getSharedManager } from './BootstrapModalManager';
 import Fade from './Fade';
 import ModalBody from './ModalBody';
@@ -282,9 +283,7 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
       const waitingForMouseUpRef = useRef(false);
       const ignoreBackdropClickRef = useRef(false);
       const removeStaticModalAnimationRef = useRef<(() => void) | null>(null);
-
-      // TODO: what's this type
-      const [modal, setModalRef] = useCallbackRef<{ dialog: any }>();
+      const [modal, setModalRef] = useCallbackRef<ModalInstance>();
       const mergedRef = useMergedRefs(ref, setModalRef);
       const handleHide = useEventCallback(onHide);
 
@@ -305,8 +304,9 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
       function updateDialogStyle(node) {
         if (!canUseDOM) return;
 
-        const containerIsOverflowing =
-          getModalManager().isContainerOverflowing(modal);
+        const containerIsOverflowing = getModalManager().isContainerOverflowing(
+          modal!,
+        );
 
         const modalIsOverflowing =
           node.scrollHeight > ownerDocument(node).documentElement.clientHeight;
@@ -355,7 +355,7 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
       const handleStaticModalAnimation = () => {
         setAnimateStaticModal(true);
         removeStaticModalAnimationRef.current = transitionEnd(
-          modal!.dialog,
+          modal!.dialog as any,
           () => {
             setAnimateStaticModal(false);
           },

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -40,8 +40,10 @@ export class BsPrefixComponent<
 > extends React.Component<ReplaceProps<As, BsPrefixProps<As> & P>> {}
 
 // Need to use this instead of typeof Component to get proper type checking.
-export type BsPrefixComponentClass<As extends React.ElementType, P = unknown> =
-  React.ComponentClass<ReplaceProps<As, BsPrefixProps<As> & P>>;
+export type BsPrefixComponentClass<
+  As extends React.ElementType,
+  P = unknown,
+> = React.ComponentClass<ReplaceProps<As, BsPrefixProps<As> & P>>;
 
 export type SelectCallback = (
   eventKey: string | null,

--- a/test/ModalSpec.js
+++ b/test/ModalSpec.js
@@ -1,5 +1,6 @@
 import { mount } from 'enzyme';
 import * as React from 'react';
+import ModalManager from 'react-overlays/ModalManager';
 import Modal from '../src/Modal';
 
 describe('<Modal>', () => {
@@ -406,5 +407,24 @@ describe('<Modal>', () => {
     document.dispatchEvent(event);
 
     expect(onEscapeKeyDownSpy).to.not.have.been.called;
+  });
+
+  it('Should use custom props manager if specified', (done) => {
+    const noOp = () => {};
+
+    class MyModalManager extends ModalManager {
+      add() {
+        done();
+      }
+    }
+
+    const managerRef = React.createRef();
+    managerRef.current = new MyModalManager();
+
+    mount(
+      <Modal show onHide={noOp} manager={managerRef.current}>
+        <strong>Message</strong>
+      </Modal>,
+    );
   });
 });

--- a/test/OffcanvasSpec.js
+++ b/test/OffcanvasSpec.js
@@ -1,6 +1,6 @@
 import { mount } from 'enzyme';
 import * as React from 'react';
-import simulant from 'simulant';
+// import simulant from 'simulant';
 import ModalManager from 'react-overlays/ModalManager';
 import Offcanvas from '../src/Offcanvas';
 
@@ -120,23 +120,25 @@ describe('<Offcanvas>', () => {
     expect(onHideSpy).to.have.been.called;
   });
 
-  it('Should close when anything outside offcanvas clicked and backdrop=false', () => {
-    const onHideSpy = sinon.spy();
-    mount(
-      <>
-        <Offcanvas show onHide={onHideSpy} backdrop={false}>
-          <strong>Message</strong>
-        </Offcanvas>
-        <button type="button" id="mybutton">
-          my button
-        </button>
-      </>,
-    );
+  // TODO: unsure if we need this, since it seems like Offcanvas is still undergoing some
+  // changes upstream.
+  // it('Should close when anything outside offcanvas clicked and backdrop=false', () => {
+  //   const onHideSpy = sinon.spy();
+  //   mount(
+  //     <>
+  //       <Offcanvas show onHide={onHideSpy} backdrop={false}>
+  //         <strong>Message</strong>
+  //       </Offcanvas>
+  //       <button type="button" id="mybutton">
+  //         my button
+  //       </button>
+  //     </>,
+  //   );
 
-    simulant.fire(document.body, 'click');
+  //   simulant.fire(document.body, 'click');
 
-    expect(onHideSpy).to.have.been.called;
-  });
+  //   expect(onHideSpy).to.have.been.called;
+  // });
 
   it('Should not call onHide if the click target comes from inside the offcanvas', () => {
     const onHideSpy = sinon.spy();
@@ -226,5 +228,19 @@ describe('<Offcanvas>', () => {
         <strong>Message</strong>
       </Offcanvas>,
     );
+  });
+
+  it('should not change overflow style when scroll=true', () => {
+    const containerRef = React.createRef();
+    const noOp = () => {};
+    mount(
+      <div ref={containerRef} style={{ height: '2000px', overflow: 'scroll' }}>
+        <Offcanvas show onHide={noOp} container={containerRef} scroll>
+          <strong>Message</strong>
+        </Offcanvas>
+      </div>,
+    );
+
+    expect(containerRef.current.style.overflow).to.equal('scroll');
   });
 });

--- a/www/src/examples/Offcanvas/Backdrop.js
+++ b/www/src/examples/Offcanvas/Backdrop.js
@@ -1,13 +1,18 @@
 const options = [
   {
-    name: 'Enable body scrolling',
-    scroll: true,
-    backdrop: false,
-  },
-  {
     name: 'Enable backdrop (default)',
     scroll: false,
     backdrop: true,
+  },
+  {
+    name: 'Disable backdrop',
+    scroll: false,
+    backdrop: false,
+  },
+  {
+    name: 'Enable body scrolling',
+    scroll: true,
+    backdrop: false,
   },
   {
     name: 'Enable both scrolling & backdrop',
@@ -20,11 +25,11 @@ function OffCanvasExample({ name, ...props }) {
   const [show, setShow] = useState(false);
 
   const handleClose = () => setShow(false);
-  const handleShow = () => setShow(true);
+  const toggleShow = () => setShow((s) => !s);
 
   return (
     <>
-      <Button variant="primary" onClick={handleShow} className="me-2">
+      <Button variant="primary" onClick={toggleShow} className="me-2">
         {name}
       </Button>
       <Offcanvas show={show} onHide={handleClose} {...props}>


### PR DESCRIPTION
Fixes #5905

This fix uses a shared `ModalManager` between `Offcanvas` and `Modal` in order to sync the container state in the scenario where you can trigger the closing/opening of both `Offcanvas` and `Modal` at the same time.  In the case where the `Offcanvas` has the `scroll` prop set to true, we use a local `ModalManager` because the shared one handles overflow styles.  I think this should be ok since we don't need to modify the container styles when scroll is true.

This also fixes some differences in behavior compared to upstream bootstrap where enforce focus should not be enabled when `scroll` is enabled for `Offcanvas`.  The user should be able to select text, or focus outside. In addition, clicking outside `Offcanvas` should not close the `Offcanvas` when `backdrop` is false: https://getbootstrap.com/docs/5.0/components/offcanvas/#backdrop
