### PR TITLE
docs: update links for new v4 site

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,8 @@
   "plugins": ["prettier"],
   "rules": {
     "import/extensions": "off",
-    "prettier/prettier": "warn"
+    "prettier/prettier": "warn",
+    "react/jsx-uses-react": "off",
+    "react/react-in-jsx-scope": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ See the below table on which version of React-Bootstrap you should be using in y
 
 | Bootstrap Version | React-Bootstrap Version | Documentation |
 | ------------- |:-------------:| -----:|
-| v5.x | 2.x beta | [Link](https://react-bootstrap.netlify.app) |
-| v4.x | 1.x | [Link](https://react-bootstrap.github.io) |
-| v3.x | 0.33.x (not maintained) | [Link](https://react-bootstrap-v3.netlify.app) |
+| v5.x | 2.x beta | [Link][v5-documentation] |
+| v4.x | 1.x | [Link][v4-documentation] |
+| v3.x | 0.33.x (not maintained) | [Link][v3-documentation] |
 
 ## Migrating from previous versions
 
 ### Bootstrap 4 to Bootstrap 5
 
-If you would like to update React-Bootstrap within an existing project to use Bootstrap 5, please read our docs for **[migrating to React-Bootstrap V2](https://github.com/react-bootstrap/react-bootstrap/blob/master/www/src/pages/migrating.mdx)**.
+If you would like to update React-Bootstrap within an existing project to use Bootstrap 5, please read our docs for **[migrating to React-Bootstrap V2][v5-migration]**.
 
 ### Bootstrap 3 to Bootstrap 4
 
-If you would like to update React-Bootstrap within an existing project to use Bootstrap 4, please read our docs for **[migrating to React-Bootstrap V1](https://react-bootstrap.github.io/migrating/)**.
+If you would like to update React-Bootstrap within an existing project to use Bootstrap 4, please read our docs for **[migrating to React-Bootstrap V1][v4-migration]**.
 
 ## Related modules
 
@@ -60,7 +60,11 @@ Yes please! See the [contributing guidelines][contributing] for details.
 
 [bootstrap]: https://getbootstrap.com/
 [react]: https://reactjs.org/
-[documentation]: https://react-bootstrap.netlify.app
+[v5-documentation]: https://react-bootstrap.github.io
+[v5-migration]: https://react-bootstrap.github.io/migrating
+[v4-documentation]: https://react-bootstrap-v4.netlify.app
+[v4-migration]: https://react-bootstrap-v4.netlify.app/migrating
+[v3-documentation]: https://react-bootstrap-v3.netlify.app
 [contributing]: CONTRIBUTING.md
 [travis-badge]: https://travis-ci.org/react-bootstrap/react-bootstrap.svg?branch=master
 [travis]: https://travis-ci.org/react-bootstrap/react-bootstrap
@@ -75,6 +79,6 @@ Yes please! See the [contributing guidelines][contributing] for details.
 [discord-badge]: https://img.shields.io/badge/Discord-Join%20chat%20%E2%86%92-738bd7.svg
 [discord]: https://discord.gg/AKfs9vpvRW
 [netlify-badge]: https://api.netlify.com/api/v1/badges/f09d443f-11b2-4454-812b-0645aeaca824/deploy-status
-[netlify]: https://app.netlify.com/sites/react-bootstrap-v5/deploys
+[netlify]: https://app.netlify.com/sites/react-bootstrap/deploys
 [gh-actions-badge]: https://github.com/react-bootstrap/react-bootstrap/workflows/CI/badge.svg
 [gh-actions]: https://github.com/react-bootstrap/react-bootstrap/actions

--- a/www/src/components/NavMain.js
+++ b/www/src/components/NavMain.js
@@ -139,7 +139,7 @@ function NavMain({ activePage }) {
                 {config.bootstrapVersion.split('.').slice(0, 2).join('.')})
               </Dropdown.Toggle>
               <Dropdown.Menu role="menu">
-                <Dropdown.Item href="https://react-bootstrap.github.io">
+                <Dropdown.Item href="https://react-bootstrap-v4.netlify.app">
                   v1.5.2 (Bootstrap 4)
                 </Dropdown.Item>
                 <Dropdown.Item href="https://react-bootstrap-v3.netlify.app">


### PR DESCRIPTION
Updates the links to the new v4 site.

Also disabled a couple rules in eslint since we're using the new jsx transform.