### PR TITLE
Add @next to installation instructions

### DIFF
--- a/www/src/pages/getting-started/introduction.mdx
+++ b/www/src/pages/getting-started/introduction.mdx
@@ -17,7 +17,7 @@ If you plan on customizing the Bootstrap Sass files, or don't want
 to use a CDN for the stylesheet, it may be helpful to
 install <DocLink path="/getting-started/download/#npm">vanilla Bootstrap</DocLink> as well.
 
-<CodeBlock codeText={`npm install react-bootstrap bootstrap@${config.bootstrapVersion}`} />
+<CodeBlock codeText={`npm install react-bootstrap@next bootstrap@${config.bootstrapVersion}`} />
 
 ## Importing Components
 


### PR DESCRIPTION
Added @next to have compatible versions of react-bootstrap and bootstrap in the docs.
Fixes #5937 .