### PR TITLE
feat: add NavbarOffcanvas component

### DIFF
--- a/src/Navbar.tsx
+++ b/src/Navbar.tsx
@@ -10,6 +10,7 @@ import createWithBsPrefix from './createWithBsPrefix';
 import NavbarBrand from './NavbarBrand';
 import NavbarCollapse from './NavbarCollapse';
 import NavbarToggle from './NavbarToggle';
+import NavbarOffcanvas from './NavbarOffcanvas';
 import { useBootstrapPrefix } from './ThemeProvider';
 import NavbarContext, { NavbarContextType } from './NavbarContext';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
@@ -49,7 +50,8 @@ const propTypes = {
    * The breakpoint, below which, the Navbar will collapse.
    * When `true` the Navbar will always be expanded regardless of screen size.
    */
-  expand: PropTypes.oneOf([true, 'sm', 'md', 'lg', 'xl', 'xxl']).isRequired,
+  expand: PropTypes.oneOf([false, true, 'sm', 'md', 'lg', 'xl', 'xxl'])
+    .isRequired,
 
   /**
    * A convenience prop for adding `bg-*` utility classes since they are so commonly used here.
@@ -220,7 +222,8 @@ Navbar.displayName = 'Navbar';
 
 export default Object.assign(Navbar, {
   Brand: NavbarBrand,
-  Toggle: NavbarToggle,
   Collapse: NavbarCollapse,
+  Offcanvas: NavbarOffcanvas,
   Text: NavbarText,
+  Toggle: NavbarToggle,
 });

--- a/src/NavbarOffcanvas.tsx
+++ b/src/NavbarOffcanvas.tsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { useContext } from 'react';
+import Offcanvas, { OffcanvasProps } from './Offcanvas';
+import NavbarContext from './NavbarContext';
+
+const NavbarOffcanvas = React.forwardRef<HTMLDivElement, OffcanvasProps>(
+  (props, ref) => {
+    const context = useContext(NavbarContext);
+
+    return <Offcanvas ref={ref} show={!!context?.expanded} {...props} />;
+  },
+);
+
+NavbarOffcanvas.displayName = 'NavbarOffcanvas';
+
+export default NavbarOffcanvas;

--- a/src/Offcanvas.tsx
+++ b/src/Offcanvas.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import useEventCallback from '@restart/hooks/useEventCallback';
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useContext, useMemo, useRef } from 'react';
 import BaseModal, {
   ModalProps as BaseModalProps,
   ModalHandle,
@@ -11,6 +11,7 @@ import Fade from './Fade';
 import OffcanvasBody from './OffcanvasBody';
 import OffcanvasToggling from './OffcanvasToggling';
 import ModalContext from './ModalContext';
+import NavbarContext from './NavbarContext';
 import OffcanvasHeader from './OffcanvasHeader';
 import OffcanvasTitle from './OffcanvasTitle';
 import { BsPrefixRefForwardingComponent } from './helpers';
@@ -218,9 +219,13 @@ const Offcanvas: BsPrefixRefForwardingComponent<'div', OffcanvasProps> =
       ref,
     ) => {
       const modalManager = useRef<BootstrapModalManager>();
-      const handleHide = useEventCallback(onHide);
-
       bsPrefix = useBootstrapPrefix(bsPrefix, 'offcanvas');
+      const { onToggle } = useContext(NavbarContext) || {};
+
+      const handleHide = useEventCallback(() => {
+        onToggle?.();
+        onHide?.();
+      });
 
       const modalContext = useMemo(
         () => ({
@@ -258,10 +263,7 @@ const Offcanvas: BsPrefixRefForwardingComponent<'div', OffcanvasProps> =
         (backdropProps) => (
           <div
             {...backdropProps}
-            className={classNames(
-              `${bsPrefix}-backdrop`,
-              backdropClassName,
-            )}
+            className={classNames(`${bsPrefix}-backdrop`, backdropClassName)}
           />
         ),
         [backdropClassName, bsPrefix],
@@ -297,7 +299,7 @@ const Offcanvas: BsPrefixRefForwardingComponent<'div', OffcanvasProps> =
             restoreFocusOptions={restoreFocusOptions}
             onEscapeKeyDown={onEscapeKeyDown}
             onShow={onShow}
-            onHide={onHide}
+            onHide={handleHide}
             onEnter={handleEnter}
             onEntering={onEntering}
             onEntered={onEntered}

--- a/test/NavbarOffcanvasSpec.tsx
+++ b/test/NavbarOffcanvasSpec.tsx
@@ -1,0 +1,34 @@
+import { fireEvent, render } from '@testing-library/react';
+import sinon from 'sinon';
+
+import Navbar from '../src/Navbar';
+import Offcanvas from '../src/Offcanvas';
+
+describe('<NavbarOffcanvas>', () => {
+  it('should should open the offcanvas', () => {
+    const { getByTestId } = render(
+      <Navbar>
+        <Navbar.Toggle data-testid="toggle" />
+        <Navbar.Offcanvas data-testid="offcanvas">hello</Navbar.Offcanvas>
+      </Navbar>,
+    );
+
+    fireEvent.click(getByTestId('toggle'));
+    getByTestId('offcanvas').classList.contains('show').should.be.true;
+  });
+
+  it('should close the offcanvas on header close button click', () => {
+    const onToggleSpy = sinon.spy();
+    const { getByLabelText } = render(
+      <Navbar onToggle={onToggleSpy} expanded>
+        <Navbar.Toggle data-testid="toggle" />
+        <Navbar.Offcanvas data-testid="offcanvas">
+          <Offcanvas.Header closeButton>header</Offcanvas.Header>
+        </Navbar.Offcanvas>
+      </Navbar>,
+    );
+
+    fireEvent.click(getByLabelText('Close'));
+    onToggleSpy.should.have.been.calledWith(false);
+  });
+});

--- a/www/src/examples/Navbar/NavScroll.js
+++ b/www/src/examples/Navbar/NavScroll.js
@@ -1,32 +1,36 @@
 <Navbar bg="light" expand="lg">
-  <Navbar.Brand href="#">Navbar scroll</Navbar.Brand>
-  <Navbar.Toggle aria-controls="navbarScroll" />
-  <Navbar.Collapse id="navbarScroll">
-    <Nav
-      className="mr-auto my-2 my-lg-0"
-      style={{ maxHeight: '100px' }}
-      navbarScroll
-    >
-      <Nav.Link href="#action1">Home</Nav.Link>
-      <Nav.Link href="#action2">Link</Nav.Link>
-      <NavDropdown title="Link" id="navbarScrollingDropdown">
-        <NavDropdown.Item href="#action3">Action</NavDropdown.Item>
-        <NavDropdown.Item href="#action4">Another action</NavDropdown.Item>
-        <NavDropdown.Divider />
-        <NavDropdown.Item href="#action5">Something else here</NavDropdown.Item>
-      </NavDropdown>
-      <Nav.Link href="#" disabled>
-        Link
-      </Nav.Link>
-    </Nav>
-    <Form className="d-flex">
-      <FormControl
-        type="search"
-        placeholder="Search"
-        className="mr-2"
-        aria-label="Search"
-      />
-      <Button variant="outline-success">Search</Button>
-    </Form>
-  </Navbar.Collapse>
+  <Container fluid>
+    <Navbar.Brand href="#">Navbar scroll</Navbar.Brand>
+    <Navbar.Toggle aria-controls="navbarScroll" />
+    <Navbar.Collapse id="navbarScroll">
+      <Nav
+        className="me-auto my-2 my-lg-0"
+        style={{ maxHeight: '100px' }}
+        navbarScroll
+      >
+        <Nav.Link href="#action1">Home</Nav.Link>
+        <Nav.Link href="#action2">Link</Nav.Link>
+        <NavDropdown title="Link" id="navbarScrollingDropdown">
+          <NavDropdown.Item href="#action3">Action</NavDropdown.Item>
+          <NavDropdown.Item href="#action4">Another action</NavDropdown.Item>
+          <NavDropdown.Divider />
+          <NavDropdown.Item href="#action5">
+            Something else here
+          </NavDropdown.Item>
+        </NavDropdown>
+        <Nav.Link href="#" disabled>
+          Link
+        </Nav.Link>
+      </Nav>
+      <Form className="d-flex">
+        <FormControl
+          type="search"
+          placeholder="Search"
+          className="me-2"
+          aria-label="Search"
+        />
+        <Button variant="outline-success">Search</Button>
+      </Form>
+    </Navbar.Collapse>
+  </Container>
 </Navbar>;

--- a/www/src/examples/Navbar/Offcanvas.js
+++ b/www/src/examples/Navbar/Offcanvas.js
@@ -1,0 +1,38 @@
+<Navbar bg="light" expand={false}>
+  <Container fluid>
+    <Navbar.Brand href="#">Navbar Offcanvas</Navbar.Brand>
+    <Navbar.Toggle aria-controls="offcanvasNavbar" />
+    <Navbar.Offcanvas
+      id="offcanvasNavbar"
+      aria-labelledby="offcanvasNavbarLabel"
+      placement="end"
+    >
+      <Offcanvas.Header closeButton>
+        <Offcanvas.Title id="offcanvasNavbarLabel">Offcanvas</Offcanvas.Title>
+      </Offcanvas.Header>
+      <Offcanvas.Body>
+        <Nav className="justify-content-end flex-grow-1 pe-3">
+          <Nav.Link href="#action1">Home</Nav.Link>
+          <Nav.Link href="#action2">Link</Nav.Link>
+          <NavDropdown title="Dropdown" id="offcanvasNavbarDropdown">
+            <NavDropdown.Item href="#action3">Action</NavDropdown.Item>
+            <NavDropdown.Item href="#action4">Another action</NavDropdown.Item>
+            <NavDropdown.Divider />
+            <NavDropdown.Item href="#action5">
+              Something else here
+            </NavDropdown.Item>
+          </NavDropdown>
+        </Nav>
+        <Form className="d-flex">
+          <FormControl
+            type="search"
+            placeholder="Search"
+            className="me-2"
+            aria-label="Search"
+          />
+          <Button variant="outline-success">Search</Button>
+        </Form>
+      </Offcanvas.Body>
+    </Navbar.Offcanvas>
+  </Container>
+</Navbar>;

--- a/www/src/pages/components/navbar.js
+++ b/www/src/pages/components/navbar.js
@@ -11,6 +11,7 @@ import NavbarBrand from '../../examples/Navbar/Brand';
 import NavbarCollapsible from '../../examples/Navbar/Collapsible';
 import NavbarColorSchemes from '../../examples/Navbar/ColorSchemes';
 import NavScroll from '../../examples/Navbar/NavScroll';
+import NavbarOffcanvas from '../../examples/Navbar/Offcanvas';
 import NavbarTextLink from '../../examples/Navbar/TextLink';
 import ContainerOutside from '../../examples/Navbar/ContainerOutside';
 import ContainerInside from '../../examples/Navbar/ContainerInside';
@@ -177,6 +178,25 @@ export default withLayout(function NaπvbarSection({ data }) {
         <code>expand</code> in order for the Navbar to collapse at all.
       </Callout>
       <ReactPlayground codeText={NavbarCollapsible} />
+
+      <LinkedHeading h="3" id="navbar-offcanvas">
+        Offcanvas
+      </LinkedHeading>
+
+      <p>
+        Transform your expanding and collapsing navbar into an offcanvas drawer
+        with the offcanvas component. We extend both the offcanvas default
+        styles and use the <code>expand</code> prop to create a dynamic and
+        flexible navigation sidebar.
+      </p>
+
+      <p>
+        In the example below, to create an offcanvas navbar that is always
+        collapsed across all breakpoints, set the <code>expand</code> prop to{' '}
+        <code>false</code>.
+      </p>
+
+      <ReactPlayground codeText={NavbarOffcanvas} />
 
       <LinkedHeading h="2" id="navbar-api">
         API


### PR DESCRIPTION
Ref: https://getbootstrap.com/docs/5.1/components/navbar/#offcanvas

Adds component and related docs.

Also fixes the navbar scroll example for bootstrap 5 by adding missing container

Preview: https://deploy-preview-5999--react-bootstrap.netlify.app/components/navbar/#navbar-offcanvas