### PR TITLE
Offcanvas backdropClassName API description

### DIFF
--- a/src/Offcanvas.tsx
+++ b/src/Offcanvas.tsx
@@ -49,7 +49,7 @@ const propTypes = {
   backdrop: PropTypes.bool,
 
   /**
-   * Add an optional extra class name to .modal-backdrop.
+   * Add an optional extra class name to .offcanvas-backdrop.
    */
   backdropClassName: PropTypes.string,
 


### PR DESCRIPTION
Since there's a change from .modal-backdrop to offcanvas-backdrop, the descriptions need to be updated.