### PR TITLE
refactor(Col)!: remove default span value in breakpoint object

### DIFF
--- a/src/Col.tsx
+++ b/src/Col.tsx
@@ -137,7 +137,7 @@ export function useCol({
     let order: ColOrder | undefined;
 
     if (typeof propValue === 'object' && propValue != null) {
-      ({ span = true, offset, order } = propValue);
+      ({ span, offset, order } = propValue);
     } else {
       span = propValue;
     }

--- a/www/src/pages/migrating.mdx
+++ b/www/src/pages/migrating.mdx
@@ -54,6 +54,7 @@ Below is a _rough_ account of the breaking API changes as well as the minimal ch
 ### Col
 
 - `ColOrder` is now maximum 5 instead of 12.
+- When using objects in breakpoint props, `span` is no longer `true` by default.
 
 ### Dropdown
 - dropdown dividers use `hr` by default instead of `div`.


### PR DESCRIPTION
BREAKING CHANGE: When using objects in breakpoint props, `span` is no longer `true` by default

As discussed in #5205, removing `true` because it seemed wrong as a default value.