### PR TITLE
fix: avoid @popperjs/core console warning

### DIFF
--- a/src/usePopperMarginModifiers.tsx
+++ b/src/usePopperMarginModifiers.tsx
@@ -103,6 +103,7 @@ export default function usePopperMarginModifiers(): [
       name: 'popoverArrowMargins',
       enabled: true,
       phase: 'main',
+      fn: () => undefined,
       requiresIfExists: ['arrow'],
       effect({ state }) {
         if (


### PR DESCRIPTION
`fn` is mandatory for custom modifiers but it may return `undefined` as stated in [popper.js docs](https://popper.js.org/docs/v2/modifiers/#example-modifier).
fixes "Popper: modifier "popoverArrowMargins" provided an invalid "fn" property, expected "function" but got "undefined"" #6017