### PR TITLE
feat: add SSRProvider

### DIFF
--- a/src/SSRProvider.ts
+++ b/src/SSRProvider.ts
@@ -1,0 +1,6 @@
+import { SSRProvider } from '@restart/ui/ssr';
+import type { SSRProviderProps } from '@restart/ui/ssr';
+
+export type { SSRProviderProps };
+
+export default SSRProvider;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -180,6 +180,9 @@ export type { SpinnerProps } from './Spinner';
 export { default as SplitButton } from './SplitButton';
 export type { SplitButtonProps } from './SplitButton';
 
+export { default as SSRProvider } from './SSRProvider';
+export type { SSRProviderProps } from './SSRProvider';
+
 export { default as Tab } from './Tab';
 export type { TabProps } from './Tab';
 

--- a/www/src/components/SideNav.js
+++ b/www/src/components/SideNav.js
@@ -105,6 +105,7 @@ const gettingStarted = [
   'theming',
   'support',
   'rtl',
+  'server-side-rendering',
 ];
 
 const layout = ['grid'];
@@ -160,6 +161,7 @@ const nameOverrides = {
   'why-react-bootstrap': 'Why React-Bootstrap',
   rtl: 'RTL',
   'restart-ui': '@restart/ui',
+  'server-side-rendering': 'Server-side Rendering',
 };
 
 function NavSection({ heading, location: { pathname }, items, path }) {

--- a/www/src/pages/getting-started/server-side-rendering.mdx
+++ b/www/src/pages/getting-started/server-side-rendering.mdx
@@ -1,0 +1,17 @@
+# Server-side Rendering
+
+React-Bootstrap automatically generates an `id` for some 
+components (such as `DropdownToggle`) if they are not provided.
+This is done for accessibility purposes.
+
+In server-side rendered applications, a `SSRProvider` must wrap
+the application in order to ensure that the auto-generated ids
+are consistent between the server and client.
+
+```
+import SSRProvider from 'react-bootstrap/SSRProvider';
+
+<SSRProvider>
+  <App />
+</SSRProvider>
+```


### PR DESCRIPTION
Re-exports `SSRProvider` from @restart/ui and adds SSR docs

Closes #6026