### PR TITLE
docs: fix examples and editor layout

### DIFF
--- a/src/Col.tsx
+++ b/src/Col.tsx
@@ -154,7 +154,7 @@ export function useCol({
   });
 
   return [
-    { ...props, className: classNames(className, ...classes, ...spans) },
+    { ...props, className: classNames(className, ...spans, ...classes) },
     {
       as,
       bsPrefix,

--- a/www/src/components/PropTable.js
+++ b/www/src/components/PropTable.js
@@ -4,7 +4,6 @@ import capitalize from 'lodash/capitalize';
 import sortBy from 'lodash/sortBy';
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import Badge from 'react-bootstrap/Badge';
 import Table from 'react-bootstrap/Table';
 
 function getDoclet(doclets = [], tag) {
@@ -185,7 +184,7 @@ class PropTable extends React.Component {
       return null;
     }
 
-    return <Badge text="danger">required</Badge>;
+    return <sup className="text-danger">required</sup>;
   }
 
   render() {

--- a/www/src/components/ReactPlayground.js
+++ b/www/src/components/ReactPlayground.js
@@ -3,8 +3,16 @@ import classNames from 'classnames';
 import qsa from 'dom-helpers/querySelectorAll';
 import * as formik from 'formik';
 import PropTypes from 'prop-types';
-import { useCallback, useContext, useEffect, useRef, useState } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import * as ReactBootstrap from 'react-bootstrap';
+import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
 import ReactDOM from 'react-dom';
 import {
   LiveContext,
@@ -14,13 +22,11 @@ import {
   LiveProvider,
 } from 'react-live';
 import * as yup from 'yup';
+import useEventCallback from '@restart/hooks/useEventCallback';
 import useIsomorphicEffect from '@restart/hooks/useIsomorphicEffect';
 import useMutationObserver from '@restart/hooks/useMutationObserver';
 import PlaceholderImage from './PlaceholderImage';
 import Sonnet from './Sonnet';
-import styles from '../css/CopyButton.module.css';
-import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
-import React from 'react';
 
 const scope = {
   useEffect,
@@ -169,68 +175,101 @@ const StyledEditor = styled(LiveEditor)`
   border-radius: 0 0 8px 8px !important;
 `;
 
-const EditorInfoMessage = styled('div')`
+const EditorInfoMessage = styled.div`
   composes: p-2 alert alert-info from global;
 
-  position: absolute;
-  top: 0;
-  right: 0;
-  border-top-left-radius: 0;
-  border-top-right-radius: 0;
-  border-bottom-right-radius: 0;
   font-size: 70%;
   pointer-events: none;
+  margin-bottom: 0;
+  margin-right: 0.5rem;
+`;
+
+const EditorToolbar = styled.div`
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  align-items: start;
 `;
 
 let uid = 0;
 
-function Editor({ handleCodeChange }) {
+const CopyTooltip = forwardRef(
+  ({ popper, children, show: _, ...props }, ref) => {
+    useEffect(() => {
+      popper.scheduleUpdate();
+    }, [children, popper]);
+
+    return (
+      <Tooltip ref={ref} body {...props}>
+        {children}
+      </Tooltip>
+    );
+  },
+);
+
+function Editor() {
+  const live = useContext(LiveContext);
+
   const [focused, setFocused] = useState(false);
   const [ignoreTab, setIgnoreTab] = useState(false);
   const [keyboardFocused, setKeyboardFocused] = useState(false);
+  const [copyStatus, setCopyStatus] = useState('Copy to clipboard');
+  const [code, setCode] = useState('');
+
   const mouseDownRef = useRef(false);
 
   const idRef = useRef(null);
   if (idRef.current === null) idRef.current = `described-by-${++uid}`;
   const id = idRef.current;
 
-  const handleKeyDown = useCallback(
-    (e) => {
-      if (ignoreTab) {
-        if (e.key !== 'Tab' && e.key !== 'Shift') {
-          if (e.key === 'Enter') e.preventDefault();
-          setIgnoreTab(false);
-        }
-      } else if (e.key === 'Escape') {
-        setIgnoreTab(true);
+  const handleKeyDown = useEventCallback((e) => {
+    if (ignoreTab) {
+      if (e.key !== 'Tab' && e.key !== 'Shift') {
+        if (e.key === 'Enter') e.preventDefault();
+        setIgnoreTab(false);
       }
-    },
-    [ignoreTab]
-  );
+    } else if (e.key === 'Escape') {
+      setIgnoreTab(true);
+    }
+  });
 
-  const handleFocus = useCallback(() => {
+  const handleFocus = useEventCallback(() => {
     setFocused(true);
     setIgnoreTab(!mouseDownRef.current);
     setKeyboardFocused(!mouseDownRef.current);
-  }, []);
+  });
 
-  const handleBlur = useCallback((e) => {
-    handleCodeChange(e);
+  const handleBlur = useEventCallback(() => {
     setFocused(false);
-  }, []);
+  });
 
-  const handleMouseDown = useCallback(() => {
+  const handleMouseDown = useEventCallback(() => {
     mouseDownRef.current = true;
     window.setTimeout(() => {
       mouseDownRef.current = false;
     });
-  }, []);
+  });
+
+  const handleTooltipExited = useEventCallback(() => {
+    setCopyStatus('Copy to clipboard');
+  });
+
+  const handleCopy = useEventCallback(() => {
+    navigator.clipboard.writeText(code).then(setCopyStatus('Copied!'));
+  });
+
+  const handleCodeChange = useEventCallback((codeText) => {
+    live.onChange(codeText);
+    setCode(codeText);
+  });
 
   const showMessage = keyboardFocused || (focused && !ignoreTab);
 
   return (
     <div className="position-relative">
       <StyledEditor
+        onChange={handleCodeChange}
         onFocus={handleFocus}
         onBlur={handleBlur}
         onKeyDown={handleKeyDown}
@@ -241,19 +280,31 @@ function Editor({ handleCodeChange }) {
         padding={20}
       />
 
-      {showMessage && (
-        <EditorInfoMessage id={id} aria-live="polite">
-          {ignoreTab ? (
-            <>
-              Press <kbd>enter</kbd> or type a key to enable tab-to-indent
-            </>
-          ) : (
-            <>
-              Press <kbd>esc</kbd> to disable tab trapping
-            </>
-          )}
-        </EditorInfoMessage>
-      )}
+      <EditorToolbar>
+        {showMessage && (
+          <EditorInfoMessage id={id} aria-live="polite">
+            {ignoreTab ? (
+              <>
+                Press <kbd>enter</kbd> or type a key to enable tab-to-indent
+              </>
+            ) : (
+              <>
+                Press <kbd>esc</kbd> to disable tab trapping
+              </>
+            )}
+          </EditorInfoMessage>
+        )}
+
+        <OverlayTrigger
+          onExited={handleTooltipExited}
+          trigger={['hover', 'focus']}
+          overlay={<CopyTooltip id="copy-tooltip">{copyStatus}</CopyTooltip>}
+        >
+          <Button onClick={handleCopy} variant="outline-light" size="sm">
+            Copy
+          </Button>
+        </OverlayTrigger>
+      </EditorToolbar>
     </div>
   );
 }
@@ -265,43 +316,13 @@ const propTypes = {
   codeText: PropTypes.string.isRequired,
 };
 
-const UpdatingPopover = React.forwardRef(
-  ({ popper, children, show: _, ...props }, ref) => {
-    useEffect(() => {
-      popper.scheduleUpdate();
-    }, [children, popper]);
-
-    return (
-      <Popover ref={ref} body {...props}>
-        {children}
-      </Popover>
-    );
-  }
-);
-
 function Playground({ codeText, exampleClassName, showCode = true }) {
   // Remove Prettier comments and trailing semicolons in JSX in displayed code.
-  const [copyStatus, setCopy] = useState('Copy to clipboard');
-
   const code = codeText
     .replace(PRETTIER_IGNORE_REGEX, '')
     .trim()
     .replace(/>;$/, '>');
 
-  const [codeToCopy, setcodeToCopy] = useState(code);
-  const handleCodeChange = (e) => {
-    setcodeToCopy(e.target.value);
-  };
-
-  const handleCopy = () => {
-    navigator.clipboard
-      .writeText(codeToCopy) //copies code to clipboard
-      .then(setCopy('Copied!'));
-  };
-
-  const resetCopyStatus = () => {
-    setCopy('Copy to clipboard');
-  };
   return (
     <StyledContainer>
       <LiveProvider
@@ -311,30 +332,7 @@ function Playground({ codeText, exampleClassName, showCode = true }) {
         noInline={codeText.includes('render(')}
       >
         <Preview showCode={showCode} className={exampleClassName} />
-        {showCode && (
-          <>
-            <div>
-              <OverlayTrigger
-                onExited={resetCopyStatus}
-                trigger={['hover', 'focus']}
-                overlay={
-                  <UpdatingPopover id="popover-contained">
-                    {copyStatus}
-                  </UpdatingPopover>
-                }
-              >
-                <Button
-                  onClick={handleCopy}
-                  className={styles.styledCopyButton}
-                  variant="dark"
-                >
-                  Copy
-                </Button>
-              </OverlayTrigger>
-            </div>
-            <Editor handleCodeChange={handleCodeChange} />
-          </>
-        )}
+        {showCode && <Editor />}
       </LiveProvider>
     </StyledContainer>
   );

--- a/www/src/css/CopyButton.module.css
+++ b/www/src/css/CopyButton.module.css
@@ -1,7 +1,0 @@
-.styledCopyButton{
-  border-radius: 5px 5px 0px 0px;
-}
-.styledCopyButton:focus{
-  outline: none;
-  box-shadow: none;
-}

--- a/www/src/examples/Overlays/PopoverContained.js
+++ b/www/src/examples/Overlays/PopoverContained.js
@@ -16,7 +16,7 @@ function Example() {
         show={show}
         target={target}
         placement="bottom"
-        container={ref.current}
+        container={ref}
         containerPadding={20}
       >
         <Popover id="popover-contained">


### PR DESCRIPTION
Closes #6025
Address example in #6009

Also fixes some styling in react code editor for the copy button and the required tag in props table