### PR TITLE
fix(Toast): add optional event arg to Toast onClose

### DIFF
--- a/src/Toast.tsx
+++ b/src/Toast.tsx
@@ -19,7 +19,7 @@ export interface ToastProps
   animation?: boolean;
   autohide?: boolean;
   delay?: number;
-  onClose?: () => void;
+  onClose?: (e?: React.MouseEvent | React.KeyboardEvent) => void;
   show?: boolean;
   transition?: TransitionComponent;
   bg?: Variant;


### PR DESCRIPTION
correct the type signator for the Toast component onClose property

fixes #5726