### PR TITLE
Code clean up - Remove the noop function

### DIFF
--- a/src/ToggleButton.tsx
+++ b/src/ToggleButton.tsx
@@ -17,8 +17,6 @@ export interface ToggleButtonProps
   inputRef?: React.Ref<HTMLInputElement>;
 }
 
-const noop = () => undefined;
-
 const propTypes = {
   /**
    * @default 'btn-check'
@@ -104,7 +102,7 @@ const ToggleButton = React.forwardRef<HTMLLabelElement, ToggleButtonProps>(
           autoComplete="off"
           checked={!!checked}
           disabled={!!disabled}
-          onChange={onChange || noop}
+          onChange={onChange}
           id={id}
         />
         <Button


### PR DESCRIPTION
While I was running the tests using `yarn run tdd`, I saw that there's a `noop` function test missing in `ToggleButton.tsx` in the test coverage and while trying to write a test for it, I realized it cannot be called and this function is not needed, so I removed it.