### PR TITLE
test(form): add test

### DIFF
--- a/test/FormSpec.js
+++ b/test/FormSpec.js
@@ -17,4 +17,8 @@ describe('<Form>', () => {
   it('Should have form as default component', () => {
     mount(<Form />).assertSingle('form');
   });
+
+  it('should have form class `was-validated` if validated', () => {
+    mount(<Form validated />).assertSingle('form.was-validated');
+  });
 });


### PR DESCRIPTION
While running `yarn run tdd`, I noticed that form.tsx line 56 had a missing test coverage for `was-validated`, so I added a test case for it.