### PR TITLE
fix(FormSelect) props not being defined

### DIFF
--- a/src/FormSelect.tsx
+++ b/src/FormSelect.tsx
@@ -8,7 +8,7 @@ import FormContext from './FormContext';
 
 export interface FormSelectProps
   extends BsPrefixOnlyProps,
-    React.SelectHTMLAttributes<HTMLSelectElement> {
+    Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'size'> {
   htmlSize?: number;
   size?: 'sm' | 'lg';
   isValid?: boolean;


### PR DESCRIPTION
Fixes #6105 by changing HTMLAttributes to SelectHTMLAttributes in FormSelect