### PR TITLE
Update colSpan in Table documentation

### DIFF
--- a/www/src/examples/Table/Basic.js
+++ b/www/src/examples/Table/Basic.js
@@ -22,7 +22,7 @@
     </tr>
     <tr>
       <td>3</td>
-      <td colSpan="2">Larry the Bird</td>
+      <td colSpan={2}>Larry the Bird</td>
       <td>@twitter</td>
     </tr>
   </tbody>

--- a/www/src/examples/Table/Dark.js
+++ b/www/src/examples/Table/Dark.js
@@ -22,7 +22,7 @@
     </tr>
     <tr>
       <td>3</td>
-      <td colSpan="2">Larry the Bird</td>
+      <td colSpan={2}>Larry the Bird</td>
       <td>@twitter</td>
     </tr>
   </tbody>

--- a/www/src/examples/Table/Small.js
+++ b/www/src/examples/Table/Small.js
@@ -22,7 +22,7 @@
     </tr>
     <tr>
       <td>3</td>
-      <td colSpan="2">Larry the Bird</td>
+      <td colSpan={2}>Larry the Bird</td>
       <td>@twitter</td>
     </tr>
   </tbody>


### PR DESCRIPTION
This PR updates the `colSpan` attribute in [Table](https://react-bootstrap.netlify.app/components/table/#tables) in the React-Bootstrap documentation. This attribute must be an integer and not a string (which it currently is). Having it as a string throws an error with ReactJS with Typescript enabled.