### PR TITLE
Pass on click event to onHide for more options

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -382,7 +382,7 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
           return;
         }
 
-        onHide?.();
+        onHide?.(e);
       };
 
       const handleEscapeKeyDown = (e) => {


### PR DESCRIPTION
onHide is currently not passed the event. This means you cannot e.g. call event.stopPropagation() on the click event, preventing the event from bubbling up and calling actions on containers. Simply passing through the event seems safe and simple and gives more options (you could still ignore the event).