### PR TITLE
fix(ToggleButton): remove `role="button"` from label

### DIFF
--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -86,8 +86,8 @@ const Button: BsPrefixRefForwardingComponent<'button', ButtonProps> =
 
       return (
         <Component
-          {...props}
           {...buttonProps}
+          {...props}
           ref={ref}
           className={classNames(
             className,

--- a/src/ToggleButton.tsx
+++ b/src/ToggleButton.tsx
@@ -112,6 +112,7 @@ const ToggleButton = React.forwardRef<HTMLLabelElement, ToggleButtonProps>(
           ref={ref}
           className={classNames(className, disabled && 'disabled')}
           type={undefined}
+          role={undefined}
           as="label"
           htmlFor={id}
         />

--- a/test/ToggleButtonGroupSpec.tsx
+++ b/test/ToggleButtonGroupSpec.tsx
@@ -1,34 +1,7 @@
-import * as React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import sinon from 'sinon';
 
 import ToggleButtonGroup from '../src/ToggleButtonGroup';
-
-describe('ToggleButton', () => {
-  it('should forward refs to the label', () => {
-    const ref = React.createRef<HTMLLabelElement>();
-    render(
-      <div>
-        <ToggleButtonGroup.Button id="id" ref={ref} value={3}>
-          Option 3
-        </ToggleButtonGroup.Button>
-      </div>,
-    );
-
-    ref.current!.tagName.should.equal('LABEL');
-  });
-
-  it('should add an inputRef', () => {
-    const ref = React.createRef<HTMLInputElement>();
-    render(
-      <ToggleButtonGroup.Button id="id" inputRef={ref} value={3}>
-        Option 3
-      </ToggleButtonGroup.Button>,
-    );
-
-    ref.current!.tagName.should.equal('INPUT');
-  });
-});
 
 describe('ToggleButtonGroup', () => {
   it('should render checkboxes', () => {

--- a/test/ToggleButtonSpec.tsx
+++ b/test/ToggleButtonSpec.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import { expect } from 'chai';
+
+import ToggleButton from '../src/ToggleButton';
+
+describe('ToggleButton', () => {
+  it('should forward refs to the label', () => {
+    const ref = React.createRef<HTMLLabelElement>();
+    render(
+      <ToggleButton id="id" ref={ref} value={1}>
+        Option
+      </ToggleButton>,
+    );
+
+    ref.current!.tagName.should.equal('LABEL');
+  });
+
+  it('should add an inputRef', () => {
+    const ref = React.createRef<HTMLInputElement>();
+    render(
+      <ToggleButton id="id" inputRef={ref} value={1}>
+        Option
+      </ToggleButton>,
+    );
+
+    ref.current!.tagName.should.equal('INPUT');
+  });
+
+  it('should not have a role on the label button', () => {
+    const { getByText } = render(
+      <ToggleButton id="id" value={1}>
+        Option
+      </ToggleButton>,
+    );
+
+    expect(getByText('Option').getAttribute('role')).to.not.exist;
+  });
+});


### PR DESCRIPTION
Fixes #6198

Also moved the ToggleButton tests into its own file