### PR TITLE
fix(Docs): increase the z-index of the header of the docs page, so that tooltips do not hover it.

### DIFF
--- a/www/src/components/NavMain.js
+++ b/www/src/components/NavMain.js
@@ -50,7 +50,7 @@ const StyledNavbar = styled(Navbar).attrs({
   @include media-breakpoint-up(md) {
     position: sticky;
     top: 0rem;
-    z-index: 1040;
+    z-index: 1081;
   }
 `;
 


### PR DESCRIPTION
resolves #6209