### PR TITLE
feat: support custom breakpoints

### DIFF
--- a/src/Col.tsx
+++ b/src/Col.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import { useBootstrapPrefix } from './ThemeProvider';
+import { useBootstrapPrefix, useBootstrapBreakpoints } from './ThemeProvider';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 type NumberAttr =
@@ -36,9 +36,9 @@ export interface ColProps
   lg?: ColSpec;
   xl?: ColSpec;
   xxl?: ColSpec;
+  [key: string]: any;
 }
 
-const DEVICE_SIZES = ['xxl', 'xl', 'lg', 'md', 'sm', 'xs'] as const;
 const colSize = PropTypes.oneOfType([
   PropTypes.bool,
   PropTypes.number,
@@ -124,11 +124,12 @@ export function useCol({
   ...props
 }: ColProps): [any, UseColMetadata] {
   bsPrefix = useBootstrapPrefix(bsPrefix, 'col');
+  const breakpoints = useBootstrapBreakpoints();
 
   const spans: string[] = [];
   const classes: string[] = [];
 
-  DEVICE_SIZES.forEach((brkPoint) => {
+  breakpoints.forEach((brkPoint) => {
     const propValue = props[brkPoint];
     delete props[brkPoint];
 

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -8,13 +8,8 @@ import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 export interface ContainerProps
   extends BsPrefixProps,
     React.HTMLAttributes<HTMLElement> {
-  fluid?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
+  fluid?: boolean | string | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
 }
-
-const containerSizes = PropTypes.oneOfType([
-  PropTypes.bool,
-  PropTypes.oneOf(['sm', 'md', 'lg', 'xl', 'xxl']),
-]);
 
 const propTypes = {
   /**
@@ -26,7 +21,7 @@ const propTypes = {
    * Allow the Container to fill all of its available horizontal space.
    * @type {(true|"sm"|"md"|"lg"|"xl"|"xxl")}
    */
-  fluid: containerSizes,
+  fluid: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
   /**
    * You can use a custom element for this component
    */

--- a/src/ListGroup.tsx
+++ b/src/ListGroup.tsx
@@ -11,7 +11,7 @@ import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 export interface ListGroupProps extends BsPrefixProps, BaseNavProps {
   variant?: 'flush';
-  horizontal?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
+  horizontal?: boolean | string | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
   defaultActiveKey?: EventKey;
   numbered?: boolean;
 }
@@ -36,7 +36,7 @@ const propTypes = {
    * makes the list group horizontal starting at that breakpoint’s `min-width`.
    * @type {(true|'sm'|'md'|'lg'|'xl'|'xxl')}
    */
-  horizontal: PropTypes.oneOf([true, 'sm', 'md', 'lg', 'xl', 'xxl']),
+  horizontal: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]),
 
   /**
    * Generate numbered list items.

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -38,6 +38,7 @@ export interface ModalProps
   size?: 'sm' | 'lg' | 'xl';
   fullscreen?:
     | true
+    | string
     | 'sm-down'
     | 'md-down'
     | 'lg-down'

--- a/src/ModalDialog.tsx
+++ b/src/ModalDialog.tsx
@@ -12,6 +12,7 @@ export interface ModalDialogProps
   size?: 'sm' | 'lg' | 'xl';
   fullscreen?:
     | true
+    | string
     | 'sm-down'
     | 'md-down'
     | 'lg-down'

--- a/src/Navbar.tsx
+++ b/src/Navbar.tsx
@@ -23,7 +23,7 @@ export interface NavbarProps
   extends BsPrefixProps,
     Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'> {
   variant?: 'light' | 'dark';
-  expand?: boolean | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
+  expand?: boolean | string | 'sm' | 'md' | 'lg' | 'xl' | 'xxl';
   bg?: string;
   fixed?: 'top' | 'bottom';
   sticky?: 'top';
@@ -50,8 +50,7 @@ const propTypes = {
    * The breakpoint, below which, the Navbar will collapse.
    * When `true` the Navbar will always be expanded regardless of screen size.
    */
-  expand: PropTypes.oneOf([false, true, 'sm', 'md', 'lg', 'xl', 'xxl'])
-    .isRequired,
+  expand: PropTypes.oneOfType([PropTypes.bool, PropTypes.string]).isRequired,
 
   /**
    * A convenience prop for adding `bg-*` utility classes since they are so commonly used here.

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import * as React from 'react';
 
-import { useBootstrapPrefix } from './ThemeProvider';
+import { useBootstrapPrefix, useBootstrapBreakpoints } from './ThemeProvider';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 type RowColWidth =
@@ -32,9 +32,9 @@ export interface RowProps
   lg?: RowColumns;
   xl?: RowColumns;
   xxl?: RowColumns;
+  [key: string]: any;
 }
 
-const DEVICE_SIZES = ['xxl', 'xl', 'lg', 'md', 'sm', 'xs'] as const;
 const rowColWidth = PropTypes.oneOfType([PropTypes.number, PropTypes.string]);
 
 const rowColumns = PropTypes.oneOfType([
@@ -116,10 +116,12 @@ const Row: BsPrefixRefForwardingComponent<'div', RowProps> = React.forwardRef<
     ref,
   ) => {
     const decoratedBsPrefix = useBootstrapPrefix(bsPrefix, 'row');
+    const breakpoints = useBootstrapBreakpoints();
+
     const sizePrefix = `${decoratedBsPrefix}-cols`;
     const classes: string[] = [];
 
-    DEVICE_SIZES.forEach((brkPoint) => {
+    breakpoints.forEach((brkPoint) => {
       const propValue = props[brkPoint];
       delete props[brkPoint];
 

--- a/src/Stack.tsx
+++ b/src/Stack.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { useBootstrapPrefix } from './ThemeProvider';
+import { useBootstrapPrefix, useBootstrapBreakpoints } from './ThemeProvider';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 import { GapValue } from './types';
 import createUtilityClassName, {
@@ -46,6 +46,7 @@ const Stack: BsPrefixRefForwardingComponent<'span', StackProps> =
         bsPrefix,
         direction === 'horizontal' ? 'hstack' : 'vstack',
       );
+      const breakpoints = useBootstrapBreakpoints();
 
       return (
         <Component
@@ -56,6 +57,7 @@ const Stack: BsPrefixRefForwardingComponent<'span', StackProps> =
             bsPrefix,
             ...createUtilityClassName({
               gap,
+              breakpoints,
             }),
           )}
         />

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -2,8 +2,11 @@ import PropTypes from 'prop-types';
 import * as React from 'react';
 import { useContext, useMemo } from 'react';
 
+export const DEFAULT_BREAKPOINTS = ['xxl', 'xl', 'lg', 'md', 'sm', 'xs'];
+
 export interface ThemeContextValue {
   prefixes: Record<string, string>;
+  breakpoints: string[];
   dir?: string;
 }
 
@@ -11,16 +14,25 @@ export interface ThemeProviderProps extends Partial<ThemeContextValue> {
   children: React.ReactNode;
 }
 
-const ThemeContext = React.createContext<ThemeContextValue>({ prefixes: {} });
+const ThemeContext = React.createContext<ThemeContextValue>({
+  prefixes: {},
+  breakpoints: DEFAULT_BREAKPOINTS,
+});
 const { Consumer, Provider } = ThemeContext;
 
-function ThemeProvider({ prefixes = {}, dir, children }: ThemeProviderProps) {
+function ThemeProvider({
+  prefixes = {},
+  breakpoints = DEFAULT_BREAKPOINTS,
+  dir,
+  children,
+}: ThemeProviderProps) {
   const contextValue = useMemo(
     () => ({
       prefixes: { ...prefixes },
+      breakpoints,
       dir,
     }),
-    [prefixes, dir],
+    [prefixes, breakpoints, dir],
   );
 
   return <Provider value={contextValue}>{children}</Provider>;
@@ -28,6 +40,7 @@ function ThemeProvider({ prefixes = {}, dir, children }: ThemeProviderProps) {
 
 ThemeProvider.propTypes = {
   prefixes: PropTypes.object,
+  breakpoints: PropTypes.arrayOf(PropTypes.string),
   dir: PropTypes.string,
 } as any;
 
@@ -37,6 +50,11 @@ export function useBootstrapPrefix(
 ): string {
   const { prefixes } = useContext(ThemeContext);
   return prefix || prefixes[defaultPrefix] || defaultPrefix;
+}
+
+export function useBootstrapBreakpoints() {
+  const { breakpoints } = useContext(ThemeContext);
+  return breakpoints;
 }
 
 export function useIsRTL() {

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -39,8 +39,28 @@ function ThemeProvider({
 }
 
 ThemeProvider.propTypes = {
+  /**
+   * An object mapping of Bootstrap component classes that
+   * map to a custom class.
+   *
+   * **Note: Changing prefixes is an escape hatch and generally
+   * shouldn't be used.**
+   *
+   * For more information, see [here](/getting-started/theming/#prefixing-components).
+   */
   prefixes: PropTypes.object,
+
+  /**
+   * An array of breakpoints that your application supports.
+   * Defaults to the standard Bootstrap breakpoints.
+   */
   breakpoints: PropTypes.arrayOf(PropTypes.string),
+
+  /**
+   * Indicates the directionality of the application's text.
+   *
+   * Use `rtl` to set text as "right to left".
+   */
   dir: PropTypes.string,
 } as any;
 

--- a/src/createUtilityClasses.ts
+++ b/src/createUtilityClasses.ts
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { DEFAULT_BREAKPOINTS } from './ThemeProvider';
 
 export type ResponsiveUtilityValue<T> =
   | T
@@ -25,16 +26,15 @@ export function responsivePropType(propType: any) {
   ]);
 }
 
-export const DEVICE_SIZES = ['xxl', 'xl', 'lg', 'md', 'sm', 'xs'] as const;
-
 export default function createUtilityClassName(
   utilityValues: Record<string, ResponsiveUtilityValue<unknown>>,
+  breakpoints = DEFAULT_BREAKPOINTS,
 ) {
   const classes: string[] = [];
   Object.entries(utilityValues).forEach(([utilName, utilValue]) => {
     if (utilValue != null) {
       if (typeof utilValue === 'object') {
-        DEVICE_SIZES.forEach((brkPoint) => {
+        breakpoints.forEach((brkPoint) => {
           const bpValue = utilValue![brkPoint];
           if (bpValue != null) {
             const infix = brkPoint !== 'xs' ? `-${brkPoint}` : '';

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -42,7 +42,8 @@ export type ResponsiveAlignProp =
   | { md: AlignDirection }
   | { lg: AlignDirection }
   | { xl: AlignDirection }
-  | { xxl: AlignDirection };
+  | { xxl: AlignDirection }
+  | Record<string, AlignDirection>;
 
 export type AlignType = AlignDirection | ResponsiveAlignProp;
 
@@ -55,6 +56,7 @@ export const alignPropType = PropTypes.oneOfType([
   PropTypes.shape({ lg: alignDirection }),
   PropTypes.shape({ xl: alignDirection }),
   PropTypes.shape({ xxl: alignDirection }),
+  PropTypes.object,
 ]);
 
 export type RootCloseEvent = 'click' | 'mousedown';

--- a/test/ColSpec.tsx
+++ b/test/ColSpec.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { ThemeProvider } from '../src';
 
 import Col from '../src/Col';
 
@@ -82,5 +83,14 @@ describe('Col', () => {
   it('Should have div as default component', () => {
     const { getByText } = render(<Col>Column</Col>);
     getByText('Column').tagName.toLowerCase().should.equal('div');
+  });
+
+  it('should allow custom breakpoints', () => {
+    const { getByText } = render(
+      <ThemeProvider breakpoints={['custom']}>
+        <Col custom="3">test</Col>
+      </ThemeProvider>,
+    );
+    getByText('test').classList.contains('col-custom-3').should.be.true;
   });
 });

--- a/test/ContainerSpec.tsx
+++ b/test/ContainerSpec.tsx
@@ -30,4 +30,9 @@ describe('<Container>', () => {
     const { getByText } = render(<Container>Container</Container>);
     getByText('Container').tagName.toLowerCase().should.equal('div');
   });
+
+  it('should allow custom breakpoints', () => {
+    const { getByText } = render(<Container fluid="custom">test</Container>);
+    getByText('test').classList.contains('container-custom').should.be.true;
+  });
 });

--- a/test/DropdownMenuSpec.tsx
+++ b/test/DropdownMenuSpec.tsx
@@ -84,6 +84,17 @@ describe('<Dropdown.Menu>', () => {
     container.querySelector('[data-bs-popper="static"]')!.should.exist;
   });
 
+  it('allows custom responsive alignment classes', () => {
+    const { container } = render(
+      <DropdownMenu show align={{ custom: 'end' }}>
+        <DropdownItem>Item</DropdownItem>
+      </DropdownMenu>,
+    );
+
+    container.firstElementChild!.classList.contains('dropdown-menu-custom-end')
+      .should.be.true;
+  });
+
   it('should render variant', () => {
     const { container } = render(
       <DropdownMenu show variant="dark">

--- a/test/ListGroupSpec.tsx
+++ b/test/ListGroupSpec.tsx
@@ -41,7 +41,7 @@ describe('<ListGroup>', () => {
     listGroup.classList.contains('list-group-horizontal').should.be.true;
   });
 
-  (['sm', 'md', 'lg', 'xl'] as const).forEach((breakpoint) => {
+  (['sm', 'md', 'lg', 'xl', 'xxl', 'custom'] as const).forEach((breakpoint) => {
     it(`accepts responsive horizontal ${breakpoint} breakpoint`, () => {
       const { getByTestId } = render(
         <ListGroup horizontal={breakpoint} data-testid="test" />,

--- a/test/ModalSpec.tsx
+++ b/test/ModalSpec.tsx
@@ -183,6 +183,17 @@ describe('<Modal>', () => {
       .be.true;
   });
 
+  it('Should allow custom breakpoints for fullscreen', () => {
+    const { getByTestId } = render(
+      <Modal show fullscreen="custom-down" data-testid="modal">
+        <strong>Message</strong>
+      </Modal>,
+    );
+
+    getByTestId('modal').classList.contains('modal-fullscreen-custom-down')
+      .should.be.true;
+  });
+
   it('Should pass centered to the dialog', () => {
     const { getByTestId } = render(
       <Modal show centered data-testid="modal">

--- a/test/NavbarSpec.tsx
+++ b/test/NavbarSpec.tsx
@@ -277,6 +277,14 @@ describe('<Navbar>', () => {
     getByTestId('test').classList.contains('navbar-expand-sm').should.be.true;
   });
 
+  it('should allow custom breakpoints for expand', () => {
+    const { getByTestId } = render(
+      <Navbar expand="custom" data-testid="test" />,
+    );
+    getByTestId('test').classList.contains('navbar-expand-custom').should.be
+      .true;
+  });
+
   it('Should render correctly when bg is set', () => {
     const { getByTestId } = render(<Navbar bg="light" data-testid="test" />);
     getByTestId('test').classList.contains('bg-light').should.be.true;

--- a/test/RowSpec.tsx
+++ b/test/RowSpec.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import { ThemeProvider } from '../src';
 
 import Row from '../src/Row';
 
@@ -65,5 +66,14 @@ describe('Row', () => {
     const { getByText } = render(<Row as="section">Row</Row>);
     getByText('Row').tagName.toLowerCase().should.equal('section');
     getByText('Row').classList.contains('row').should.be.true;
+  });
+
+  it('should allow custom breakpoints', () => {
+    const { getByText } = render(
+      <ThemeProvider breakpoints={['custom']}>
+        <Row custom="3">test</Row>
+      </ThemeProvider>,
+    );
+    getByText('test').classList.contains('row-cols-custom-3').should.be.true;
   });
 });

--- a/test/createUtilityClassesSpec.ts
+++ b/test/createUtilityClassesSpec.ts
@@ -61,4 +61,16 @@ describe('createUtilityClassName', () => {
       'text-xl-start',
     ]);
   });
+
+  it('should handle custom breakpoints', () => {
+    const classList = createUtilityClasses(
+      {
+        gap: { xs: 2, custom: 3 },
+      },
+      ['xs', 'custom'],
+    );
+
+    classList.length.should.equal(2);
+    classList.should.include.all.members(['gap-2', 'gap-custom-3']);
+  });
 });

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 /* eslint-disable jsx-a11y/aria-role */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as React from 'react';
 
 import {
@@ -20,6 +21,7 @@ import {
   Row,
   Dropdown,
   DropdownButton,
+  DropdownMenu,
   Fade,
   Figure,
   Form,
@@ -43,9 +45,11 @@ import {
   Table,
   Tabs,
   Tab,
+  ThemeProvider,
   ToggleButtonGroup,
   ToggleButton,
   Toast,
+  ModalDialog,
 } from '../src';
 import BootstrapModalManager from '../src/BootstrapModalManager';
 
@@ -55,7 +59,6 @@ const style: React.CSSProperties = {
   color: 'red',
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const RefTest = () => {
   const carouselRef = React.useRef<CarouselRef>();
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -81,7 +84,6 @@ const FunctionComponent: React.FC = () => <div>abc</div>;
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const noop = () => {};
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const MegaComponent = () => (
   <>
     <Fade>
@@ -1036,4 +1038,32 @@ const MegaComponent = () => (
     <Button as="img" src="bla" />
     */}
   </>
+);
+
+const CustomBreakpoints = () => (
+  <ThemeProvider
+    dir="rtl"
+    breakpoints={['customBreakpoint', 'sm']}
+    prefixes={{ a: 'a' }}
+  >
+    <Container fluid="custom" />
+    <Col customBreakpoint="2" />
+    <Dropdown align={{ custom: 'start' }}>
+      <div />
+    </Dropdown>
+    <DropdownButton align={{ custom: 'start' }} title="title">
+      <div />
+    </DropdownButton>
+    <DropdownMenu align={{ custom: 'start' }}>
+      <div />
+    </DropdownMenu>
+    <ListGroup horizontal="custom" />
+    <Modal fullscreen="custom" />
+    <ModalDialog fullscreen="custom" />
+    <Navbar expand="custom" />
+    <Row customBreakpoint="auto" />
+    <SplitButton align={{ custom: 'start' }} title="title">
+      <div />
+    </SplitButton>
+  </ThemeProvider>
 );

--- a/www/src/components/BreakpointTable.js
+++ b/www/src/components/BreakpointTable.js
@@ -1,0 +1,61 @@
+import Table from 'react-bootstrap/Table';
+
+const BreakpointTable = () => {
+  return (
+    <Table>
+      <thead>
+        <tr>
+          <th>Breakpoint</th>
+          <th>Class infix</th>
+          <th>Dimensions</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>X-Small</td>
+          <td>
+            <em>None</em>
+          </td>
+          <td>&lt;576px</td>
+        </tr>
+        <tr>
+          <td>Small</td>
+          <td>
+            <code>sm</code>
+          </td>
+          <td>≥576px</td>
+        </tr>
+        <tr>
+          <td>Medium</td>
+          <td>
+            <code>md</code>
+          </td>
+          <td>≥768px</td>
+        </tr>
+        <tr>
+          <td>Large</td>
+          <td>
+            <code>lg</code>
+          </td>
+          <td>≥992px</td>
+        </tr>
+        <tr>
+          <td>Extra large</td>
+          <td>
+            <code>xl</code>
+          </td>
+          <td>≥1200px</td>
+        </tr>
+        <tr>
+          <td>Extra extra large</td>
+          <td>
+            <code>xxl</code>
+          </td>
+          <td>≥1400px</td>
+        </tr>
+      </tbody>
+    </Table>
+  );
+};
+
+export default BreakpointTable;

--- a/www/src/components/SideNav.js
+++ b/www/src/components/SideNav.js
@@ -111,7 +111,7 @@ const gettingStarted = [
   'server-side-rendering',
 ];
 
-const layout = ['grid', 'stack'];
+const layout = ['breakpoints', 'grid', 'stack'];
 
 const forms = [
   'overview',

--- a/www/src/examples/CustomBreakpoints.js
+++ b/www/src/examples/CustomBreakpoints.js
@@ -1,0 +1,5 @@
+<ThemeProvider
+  breakpoints={['xxxl', 'xxl', 'xl', 'lg', 'md', 'sm', 'xs', 'xxs']}
+>
+  <div>Your app...</div>
+</ThemeProvider>;

--- a/www/src/pages/layout/breakpoints.mdx
+++ b/www/src/pages/layout/breakpoints.mdx
@@ -1,0 +1,48 @@
+import { graphql } from 'gatsby';
+
+import BreakpointTable from '../../components/BreakpointTable';
+import Callout from '../../components/Callout';
+import CodeBlock from '../../components/CodeBlock';
+import ComponentApi from '../../components/ComponentApi';
+import CustomBreakpoints from '../../examples/CustomBreakpoints';
+import DocLink from '../../components/DocLink';
+
+# Breakpoints
+
+<p className="lead">
+  Breakpoints are customizable widths that determine how your responsive layout
+  behaves across device or viewport sizes in Bootstrap.
+</p>
+
+## Available breakpoints
+
+Bootstrap includes six default breakpoints, sometimes referred to as _grid tiers_,
+for building responsively. These breakpoints can be customized if you’re using our
+source Sass files.
+
+<BreakpointTable />
+
+## Custom breakpoints
+
+If you are looking to use custom breakpoints, you must wrap your application with
+a theme provider and use the `breakpoints` prop to specify the breakpoints you
+will use. This ensures that components such as `Row` or `Col` can parse the
+correct custom breakpoint props.
+
+<CodeBlock codeText={CustomBreakpoints} />
+
+## More information
+
+For more information about breakpoints, see the <DocLink path="/layout/breakpoints">Bootstrap documentation</DocLink>.
+
+## API
+
+<ComponentApi metadata={props.data.ThemeProvider} />
+
+export const query = graphql`
+  query ThemeProviderBreakpointsQuery {
+    ThemeProvider: componentMetadata(displayName: { eq: "ThemeProvider" }) {
+      ...ComponentApi_metadata
+    }
+  }
+`;


### PR DESCRIPTION
Closes #6247

Loosens the types for any breakpoint-related prop so it takes in any string.  For the components that use a hard coded breakpoint list, I've allowed the user to specify their own list of breakpoints in the ThemeProvider so these components can take advantage of it.

Haven't added docs yet.  Wanted to make sure the approach looks good before doing so.