### PR TITLE
docs: add defaultActiveKey propType to Nav

### DIFF
--- a/src/Nav.tsx
+++ b/src/Nav.tsx
@@ -49,6 +49,11 @@ const propTypes = {
   activeKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
   /**
+   * The default active key that is selected on start.
+   */
+  defaultActiveKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+
+  /**
    * Have all `NavItem`s proportionately fill all available width.
    */
   fill: PropTypes.bool,


### PR DESCRIPTION
PR that Closes #6141 
Updates the "navs" docs prop table to include entry for 'defaultActiveKey' via TSDoc comments.