### PR TITLE
fix(Carousel): fix issue where changing `activeIndex` won't work

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -263,21 +263,23 @@ const Carousel: BsPrefixRefForwardingComponent<'div', CarouselProps> =
       activeIndex || 0,
     );
 
-    if (!isSliding && activeIndex !== renderedActiveIndex) {
-      if (nextDirectionRef.current) {
-        setDirection(nextDirectionRef.current);
-      } else {
-        setDirection(
-          (activeIndex || 0) > renderedActiveIndex ? 'next' : 'prev',
-        );
-      }
+    useEffect(() => {
+      if (!isSliding && activeIndex !== renderedActiveIndex) {
+        if (nextDirectionRef.current) {
+          setDirection(nextDirectionRef.current);
+        } else {
+          setDirection(
+            (activeIndex || 0) > renderedActiveIndex ? 'next' : 'prev',
+          );
+        }
 
-      if (slide) {
-        setIsSliding(true);
-      }
+        if (slide) {
+          setIsSliding(true);
+        }
 
-      setRenderedActiveIndex(activeIndex || 0);
-    }
+        setRenderedActiveIndex(activeIndex || 0);
+      }
+    }, [activeIndex, isSliding, renderedActiveIndex, slide]);
 
     useEffect(() => {
       if (nextDirectionRef.current) {

--- a/test/CarouselSpec.tsx
+++ b/test/CarouselSpec.tsx
@@ -408,17 +408,16 @@ describe('<Carousel>', () => {
     it('should go through the items given the specified intervals', () => {
       const onSelectSpy = sinon.spy();
       render(
-        <Carousel interval={1000} onSelect={onSelectSpy}>
-          <Carousel.Item interval={100}>Item 1 content</Carousel.Item>
+        <Carousel interval={5000} onSelect={onSelectSpy}>
+          <Carousel.Item interval={1000}>Item 1 content</Carousel.Item>
           <Carousel.Item>Item 2 content</Carousel.Item>
         </Carousel>,
       );
 
       // should be long enough to handle false positive issues
       // but short enough to not trigger auto-play to occur twice
-      // (since the interval for the second item should be `1000`)
-      clock.tick(200);
-
+      // (since the interval for the second item should be `5000`)
+      clock.tick(1100);
       onSelectSpy.should.have.been.calledOnceWith(1);
     });
 


### PR DESCRIPTION
Issue was brought up in #6263

If you set the slides and then change the `activeIndex`, it will result in the carousel locking up because `isSliding` is set to true and RTG's `onEntered` isn't triggered to reset this.  

Minimal repro:
https://codesandbox.io/s/react-bootstrap-carousel-active-index-forked-xht0f1?file=/src/App.js

Issue appears to be fixed by moving some of the code that handles the rendered active index into a `useEffect` hook.  
Note, I had to tweak the delays of 1 test because the timers seem to be triggering too fast when testing.