### PR TITLE
cs/move aria label

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -290,6 +290,16 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
       const handleHide = useEventCallback(onHide);
       const isRTL = useIsRTL();
 
+      const ariaProps = Object.keys(props)
+        .filter((prop) => prop.indexOf('aria') !== -1)
+        .reduce<{ [x: string]: any }>(
+          (ariaPropsObject, ariaProp) => ({
+            ...ariaPropsObject,
+            [ariaProp]: props[ariaProp],
+          }),
+          {},
+        );
+
       bsPrefix = useBootstrapPrefix(bsPrefix, 'modal');
 
       const modalContext = useMemo(
@@ -451,6 +461,7 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
         <div
           role="dialog"
           {...dialogProps}
+          {...ariaProps}
           style={baseModalStyle}
           className={classNames(
             className,

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -292,13 +292,14 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
 
       const ariaProps = Object.keys(props)
         .filter((prop) => prop.indexOf('aria') !== -1)
-        .reduce<{ [x: string]: any }>(
-          (ariaPropsObject, ariaProp) => ({
+        .reduce<{ [x: string]: any }>((ariaPropsObject, ariaProp) => {
+          const val = props[ariaProp];
+          delete props[ariaProp];
+          return {
             ...ariaPropsObject,
-            [ariaProp]: props[ariaProp],
-          }),
-          {},
-        );
+            [ariaProp]: val,
+          };
+        }, {});
 
       bsPrefix = useBootstrapPrefix(bsPrefix, 'modal');
 

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -218,6 +218,8 @@ const propTypes = {
   container: PropTypes.any,
 
   'aria-labelledby': PropTypes.any,
+
+  'aria-label': PropTypes.string,
 };
 
 const defaultProps = {
@@ -253,6 +255,7 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
         children,
         dialogAs: Dialog,
         'aria-labelledby': ariaLabelledby,
+        'aria-label': ariaLabel,
 
         /* BaseModal props */
 
@@ -289,17 +292,6 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
       const mergedRef = useMergedRefs(ref, setModalRef);
       const handleHide = useEventCallback(onHide);
       const isRTL = useIsRTL();
-
-      const ariaProps = Object.keys(props)
-        .filter((prop) => prop.indexOf('aria') !== -1)
-        .reduce<{ [x: string]: any }>((ariaPropsObject, ariaProp) => {
-          const val = props[ariaProp];
-          delete props[ariaProp];
-          return {
-            ...ariaPropsObject,
-            [ariaProp]: val,
-          };
-        }, {});
 
       bsPrefix = useBootstrapPrefix(bsPrefix, 'modal');
 
@@ -462,7 +454,6 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
         <div
           role="dialog"
           {...dialogProps}
-          {...ariaProps}
           style={baseModalStyle}
           className={classNames(
             className,
@@ -471,6 +462,7 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
           )}
           onClick={backdrop ? handleClick : undefined}
           onMouseUp={handleMouseUp}
+          aria-label={ariaLabel}
           aria-labelledby={ariaLabelledby}
         >
           {/*

--- a/test/ModalSpec.tsx
+++ b/test/ModalSpec.tsx
@@ -393,6 +393,19 @@ describe('<Modal>', () => {
     );
   });
 
+  it('Should set aria-label to the role="dialog" element if aria-label set', () => {
+    const labelValue = 'modal-label';
+    const { getByRole } = render(
+      <Modal show aria-label={labelValue}>
+        <Modal.Header closeButton>
+          <Modal.Title id="modal-title">Modal heading</Modal.Title>
+        </Modal.Header>
+      </Modal>,
+    );
+
+    expect(getByRole('dialog').getAttribute('aria-label')).to.equal(labelValue);
+  });
+
   it('Should call onEscapeKeyDown when keyboard is true', () => {
     const onEscapeKeyDownSpy = sinon.spy();
     const { getByRole } = render(


### PR DESCRIPTION
*Issue*: https://github.com/react-bootstrap/react-bootstrap/issues/5953

### Effects
- Aria-label now forwarded to the modal instead of its child

### Verify
- Edit the example modal to have an aria property like `aria-label="foo"`. Previously the prop would be passed to the first child instead of the parent


### Quick note:
This is my first time contributing to a big library like this, please let me know if anything should be changed in PR/code formatting. Thank you.