### PR TITLE
replace lodash capitalize with upperFirst in PropTable -fixing issue Docs typo at react-bootstrap #6270

### DIFF
--- a/www/src/components/PropTable.js
+++ b/www/src/components/PropTable.js
@@ -1,6 +1,6 @@
 import styled from 'astroturf';
 import { graphql } from 'gatsby';
-import capitalize from 'lodash/capitalize';
+import upperFirst from 'lodash/upperFirst';
 import sortBy from 'lodash/sortBy';
 import PropTypes from 'prop-types';
 import * as React from 'react';
@@ -150,7 +150,7 @@ class PropTable extends React.Component {
     ) : (
       <span>
         controlled by: <Code>{controllable}</Code>, initial prop:{' '}
-        <Code>{`default${capitalize(propName)}`}</Code>
+        <Code>{`default${upperFirst(propName)}`}</Code>
       </span>
     );
 


### PR DESCRIPTION
A fix for this issue: https://github.com/react-bootstrap/react-bootstrap/issues/6270

capitalize downcases all letters but uppercases the first. Upperfirst, uppercases the first letter but leaves all others unchanged. 