### PR TITLE
fix(Tabs): fix transition functions

### DIFF
--- a/src/TabPane.tsx
+++ b/src/TabPane.tsx
@@ -106,16 +106,16 @@ const TabPane: BsPrefixRefForwardingComponent<'div', TabPaneProps> =
           className,
           // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
           as: Component = 'div',
-          ...rest
-        },
-        {
-          isActive,
           onEnter,
           onEntering,
           onEntered,
           onExit,
           onExiting,
           onExited,
+          ...rest
+        },
+        {
+          isActive,
           mountOnEnter,
           unmountOnExit,
           transition: Transition = Fade,

--- a/src/TabPane.tsx
+++ b/src/TabPane.tsx
@@ -106,16 +106,16 @@ const TabPane: BsPrefixRefForwardingComponent<'div', TabPaneProps> =
           className,
           // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
           as: Component = 'div',
+          ...rest
+        },
+        {
+          isActive,
           onEnter,
           onEntering,
           onEntered,
           onExit,
           onExiting,
           onExited,
-          ...rest
-        },
-        {
-          isActive,
           mountOnEnter,
           unmountOnExit,
           transition: Transition = Fade,

--- a/test/TabsSpec.tsx
+++ b/test/TabsSpec.tsx
@@ -1,4 +1,5 @@
-import { fireEvent, render } from '@testing-library/react';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import React, { useEffect } from 'react';
 import sinon from 'sinon';
 
 import Tab from '../src/Tab';
@@ -188,6 +189,35 @@ describe('<Tabs>', () => {
     );
 
     getAllByRole('tabpanel').should.have.length(1);
+  });
+
+  it('should fire transition events', async () => {
+    const transitionSpy = sinon.spy();
+    const { getByText } = render(
+      <Tabs data-testid="testid" id="test" defaultActiveKey={2}>
+        <Tab
+          title="Tab 1"
+          eventKey={1}
+          onEnter={transitionSpy}
+          onEntering={transitionSpy}
+          onEntered={transitionSpy}
+          onExit={transitionSpy}
+          onExiting={transitionSpy}
+          onExited={transitionSpy}
+        >
+          Tab 1 content
+        </Tab>
+        <Tab title="Tab 2" eventKey={2}>
+          Tab 2 content
+        </Tab>
+      </Tabs>,
+    );
+
+    fireEvent.click(getByText('Tab 1'));
+    await waitFor(() => transitionSpy.should.have.been.calledThrice);
+
+    fireEvent.click(getByText('Tab 2'));
+    await waitFor(() => transitionSpy.callCount.should.equal(6));
   });
 
   it('should have fade animation by default', () => {


### PR DESCRIPTION
While poking around in `Tab` component, I've noticed that none of the react-transition-group functions work (`onEnter, onExit etc.`). This was because in `useTabPanel` hook we expose them in the first argument, not the second one (https://github.com/react-restart/ui/blob/c6f9e22dd0cfcef412d3d00618aa5ec453f63bb6/src/TabPanel.tsx#L88).

 This PR moves all of these functions to the correct position. Also added a test for it