### PR TITLE
fix(Modal): render aria-describedby on the top level modal element

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -217,8 +217,8 @@ const propTypes = {
    */
   container: PropTypes.any,
 
-  'aria-labelledby': PropTypes.any,
-
+  'aria-labelledby': PropTypes.string,
+  'aria-describedby': PropTypes.string,
   'aria-label': PropTypes.string,
 };
 
@@ -255,6 +255,7 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
         children,
         dialogAs: Dialog,
         'aria-labelledby': ariaLabelledby,
+        'aria-describedby': ariaDescribedby,
         'aria-label': ariaLabel,
 
         /* BaseModal props */
@@ -462,6 +463,7 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
           onMouseUp={handleMouseUp}
           aria-label={ariaLabel}
           aria-labelledby={ariaLabelledby}
+          aria-describedby={ariaDescribedby}
         >
           {/*
         // @ts-ignore */}

--- a/test/ModalSpec.tsx
+++ b/test/ModalSpec.tsx
@@ -393,6 +393,20 @@ describe('<Modal>', () => {
     );
   });
 
+  it('Should set aria-describedby to the role="dialog" element if aria-describedby set', () => {
+    const { getByRole } = render(
+      <Modal show aria-describedby="modal-title">
+        <Modal.Header closeButton>
+          <Modal.Title id="modal-title">Modal heading</Modal.Title>
+        </Modal.Header>
+      </Modal>,
+    );
+
+    expect(getByRole('dialog').getAttribute('aria-describedby')).to.equal(
+      'modal-title',
+    );
+  });
+
   it('Should set aria-label to the role="dialog" element if aria-label set', () => {
     const labelValue = 'modal-label';
     const { getByRole } = render(


### PR DESCRIPTION
`aria-describedby` should be rendered on the element with the `role="dialog"`