### PR TITLE
no need to specify version in npm install command installation docs, react-bootstrap's latest tag is 5.1.3

### DIFF
--- a/www/src/pages/getting-started/introduction.mdx
+++ b/www/src/pages/getting-started/introduction.mdx
@@ -19,7 +19,7 @@ If you plan on customizing the Bootstrap Sass files, or don't want
 to use a CDN for the stylesheet, it may be helpful to
 install <DocLink path="/getting-started/download/#npm">vanilla Bootstrap</DocLink> as well.
 
-<CodeBlock codeText={`npm install react-bootstrap bootstrap@${config.bootstrapVersion}`} />
+<CodeBlock codeText={`npm install react-bootstrap bootstrap`} />
 
 ## Importing Components
 


### PR DESCRIPTION
npm package bootstrap has 5 tags
latest
latest-5
latest-4
latest-3
latest
The latest tag points to 5.1.3
so there is no need to specify bootstrap's version in the installation command

Expected command: `npm install react-bootstrap bootstrap`
