### PR TITLE
fix(deps): clean up @types deps list

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,11 +62,7 @@
     "@babel/runtime": "^7.17.2",
     "@restart/hooks": "^0.4.6",
     "@restart/ui": "^1.2.0",
-    "@types/invariant": "^2.2.35",
-    "@types/prop-types": "^15.7.4",
-    "@types/react": ">=16.14.8",
     "@types/react-transition-group": "^4.4.4",
-    "@types/warning": "^3.0.0",
     "classnames": "^2.3.1",
     "dom-helpers": "^5.2.1",
     "invariant": "^2.2.4",
@@ -89,10 +85,13 @@
     "@testing-library/react": "^12.1.4",
     "@testing-library/user-event": "^13.5.0",
     "@types/chai": "^4.3.0",
+    "@types/invariant": "^2.2.35",
     "@types/mocha": "^9.1.0",
+    "@types/prop-types": "^15.7.4",
     "@types/react-dom": "^16.9.14",
     "@types/sinon": "^10.0.11",
     "@types/sinon-chai": "^3.2.8",
+    "@types/warning": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "babel-eslint": "^10.1.0",
@@ -147,8 +146,14 @@
     "webpack": "^5.70.0"
   },
   "peerDependencies": {
+    "@types/react": ">=16.14.8",
     "react": ">=16.14.0",
     "react-dom": ">=16.14.0"
+  },
+  "peerDependenciesMeta": {
+    "@types/react": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "directory": "lib"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1550,7 +1550,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.14.8", "@types/react@>=16.9.11":
+"@types/react@*", "@types/react@>=16.9.11":
   version "17.0.8"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.8.tgz#fe76e3ba0fbb5602704110fd1e3035cf394778e3"
   integrity sha512-3sx4c0PbXujrYAKwXxNONXUtRp9C+hE2di0IuxFyf5BELD+B+AXL8G7QrmSKhVwKZDbv0igiAjQAMhXj8Yg3aw==


### PR DESCRIPTION
Moves `@types/react` into peer deps.  This should be safe for npm 7 users when resolving peer dependencies because of the optional field in `peerDependenciesMeta`.  All users using TS would've installed a version of `@types/react` anyway, so we shouldn't have problems here.

For `invariant`, `prop-types`, and `warning`, those can be safely moved into devDeps because their types aren't exposed on the public d.ts files.  They are just used internally within the implementation.