### PR TITLE
fix(TabPane): Omit Transition when prop is false

### DIFF
--- a/src/TabPane.tsx
+++ b/src/TabPane.tsx
@@ -101,6 +101,7 @@ const propTypes = {
 const TabPane: BsPrefixRefForwardingComponent<'div', TabPaneProps> =
   React.forwardRef<HTMLElement, TabPaneProps>(
     ({ bsPrefix, transition, ...props }, ref) => {
+      const shouldOmitTransition = transition === false;
       const [
         {
           className,
@@ -129,26 +130,33 @@ const TabPane: BsPrefixRefForwardingComponent<'div', TabPaneProps> =
 
       // We provide an empty the TabContext so `<Nav>`s in `<TabPanel>`s don't
       // conflict with the top level one.
+      const content = (
+        <Component
+          {...rest}
+          ref={ref}
+          className={classNames(className, prefix, isActive && 'active')}
+        />
+      );
       return (
         <TabContext.Provider value={null}>
           <SelectableContext.Provider value={null}>
-            <Transition
-              in={isActive}
-              onEnter={onEnter}
-              onEntering={onEntering}
-              onEntered={onEntered}
-              onExit={onExit}
-              onExiting={onExiting}
-              onExited={onExited}
-              mountOnEnter={mountOnEnter}
-              unmountOnExit={unmountOnExit as any}
-            >
-              <Component
-                {...rest}
-                ref={ref}
-                className={classNames(className, prefix, isActive && 'active')}
-              />
-            </Transition>
+            {shouldOmitTransition ? (
+              content
+            ) : (
+              <Transition
+                in={isActive}
+                onEnter={onEnter}
+                onEntering={onEntering}
+                onEntered={onEntered}
+                onExit={onExit}
+                onExiting={onExiting}
+                onExited={onExited}
+                mountOnEnter={mountOnEnter}
+                unmountOnExit={unmountOnExit as any}
+              >
+                {content}
+              </Transition>
+            )}
           </SelectableContext.Provider>
         </TabContext.Provider>
       );

--- a/test/TabsSpec.tsx
+++ b/test/TabsSpec.tsx
@@ -200,6 +200,24 @@ describe('<Tabs>', () => {
     );
     getByRole('tabpanel').classList.contains('fade').should.be.true;
   });
+
+  it('Should omit Transition in TabPane if prop is false ', () => {
+    const { getByText } = render(
+      <Tabs id="test" defaultActiveKey={1}>
+        <Tab title="Tab 1" className="custom" eventKey={1} transition={false}>
+          Tab 1 content
+        </Tab>
+        <Tab title="Tab 2" tabClassName="tcustom" eventKey={2}>
+          Tab 2 content
+        </Tab>
+      </Tabs>,
+    );
+    const firstTabContent = getByText('Tab 1 content');
+    const secondTabContent = getByText('Tab 2 content');
+
+    firstTabContent.classList.contains('fade').should.be.false;
+    secondTabContent.classList.contains('fade').should.be.true;
+  });
 });
 
 // describe('<Tab>', () => {

--- a/www/src/examples/Tabs/NoAnimation.js
+++ b/www/src/examples/Tabs/NoAnimation.js
@@ -4,10 +4,10 @@
   id="noanim-tab-example"
   className="mb-3"
 >
-  <Tab eventKey="home" title="Home">
+  <Tab eventKey="home" title="Home" transition={false}>
     <Sonnet />
   </Tab>
-  <Tab eventKey="profile" title="Profile">
+  <Tab eventKey="profile" title="Profile" transition={false}>
     <Sonnet />
   </Tab>
   <Tab eventKey="contact" title="Contact" disabled>


### PR DESCRIPTION
While using tabs I hit a small issue:

When passing the prop `transition={false}` to Tabs/TabPanes the `fade` class was always applied thus there's always a fade animation when we change Tabs.

I was able to reproduce this using the latest version of the lib and made a [codesandbox](https://codesandbox.io/s/quirky-torvalds-21wjbz)