### PR TITLE
Remove extra `onChange` check

### DIFF
--- a/src/ToggleButtonGroup.tsx
+++ b/src/ToggleButtonGroup.tsx
@@ -99,7 +99,7 @@ const ToggleButtonGroup: BsPrefixRefForwardingComponent<
     const isActive = values.indexOf(inputVal) !== -1;
 
     if (type === 'radio') {
-      if (!isActive && onChange) onChange(inputVal, event);
+      if (!isActive) onChange(inputVal, event);
       return;
     }
 


### PR DESCRIPTION
This const variable is already checked on line 95, so must be truthy here as well.

This bug was accidently detected by TypeScript 4.7-RC