### PR TITLE
fix(Button): Allow `as={Component}` again

### DIFF
--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -10,8 +10,8 @@ import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 import { ButtonVariant } from './types';
 
 export interface ButtonProps
-  extends BaseButtonProps,
-    Omit<BsPrefixProps, 'as'> {
+  extends BsPrefixProps,
+    Omit<BaseButtonProps, 'as'> {
   active?: boolean;
   variant?: ButtonVariant;
   size?: 'sm' | 'lg';
@@ -78,11 +78,12 @@ const Button: BsPrefixRefForwardingComponent<'button', ButtonProps> =
     ({ as, bsPrefix, variant, size, active, className, ...props }, ref) => {
       const prefix = useBootstrapPrefix(bsPrefix, 'btn');
       const [buttonProps, { tagName }] = useButtonProps({
-        tagName: as,
+        // Use 'template' when as={Component}, since it gets no special treatment
+        tagName: as && typeof as !== 'string' ? 'template' : as,
         ...props,
       });
 
-      const Component = tagName as React.ElementType;
+      const Component = as || tagName;
 
       return (
         <Component

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -55,6 +55,21 @@ import BootstrapModalManager from '../src/BootstrapModalManager';
 
 import { CarouselRef } from '../src/Carousel';
 
+// Simplified react-router-dom@6/Link
+// https://github.com/remix-run/react-router/blob/09e90ec885d95b4a35f0eebcf4bac6f796ce9878/packages/react-router-dom/index.tsx#L251-L289
+interface CustomLinkProps
+  extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+  to: string;
+}
+
+const CustomLink = React.forwardRef<HTMLAnchorElement, CustomLinkProps>(
+  ({ children, to, ...rest }, ref) => (
+    <a {...rest} href={to} ref={ref}>
+      {children}
+    </a>
+  ),
+);
+
 const style: React.CSSProperties = {
   color: 'red',
 };
@@ -165,6 +180,17 @@ const MegaComponent = () => (
       as="a"
       disabled={false}
       href="#"
+      size="lg"
+      type="button"
+      variant="primary"
+      bsPrefix="btn"
+      style={style}
+    />
+    <Button
+      active={false}
+      as={CustomLink}
+      to="#"
+      disabled={false}
       size="lg"
       type="button"
       variant="primary"

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -55,21 +55,6 @@ import BootstrapModalManager from '../src/BootstrapModalManager';
 
 import { CarouselRef } from '../src/Carousel';
 
-// Simplified react-router-dom@6/Link
-// https://github.com/remix-run/react-router/blob/09e90ec885d95b4a35f0eebcf4bac6f796ce9878/packages/react-router-dom/index.tsx#L251-L289
-interface CustomLinkProps
-  extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
-  to: string;
-}
-
-const CustomLink = React.forwardRef<HTMLAnchorElement, CustomLinkProps>(
-  ({ children, to, ...rest }, ref) => (
-    <a {...rest} href={to} ref={ref}>
-      {children}
-    </a>
-  ),
-);
-
 const style: React.CSSProperties = {
   color: 'red',
 };
@@ -180,17 +165,6 @@ const MegaComponent = () => (
       as="a"
       disabled={false}
       href="#"
-      size="lg"
-      type="button"
-      variant="primary"
-      bsPrefix="btn"
-      style={style}
-    />
-    <Button
-      active={false}
-      as={CustomLink}
-      to="#"
-      disabled={false}
       size="lg"
       type="button"
       variant="primary"


### PR DESCRIPTION
- Fixes #6003
- Fixes #6103 
- Fixes #6331

The problematic `as: keyof IntrinsicElements` is coming from `@restart/ui/Button`:
https://github.com/react-restart/ui/blob/0db76bbc183c869d80fbc3f460541c2e98aebb01/src/Button.tsx#L114
https://github.com/react-bootstrap/react-bootstrap/blob/e5b7c89410ae26eb9825ae181a2c11ee6b074bb3/src/Button.tsx#L4-L7
https://github.com/react-bootstrap/react-bootstrap/blob/e5b7c89410ae26eb9825ae181a2c11ee6b074bb3/src/Button.tsx#L12-L14

Which `as` to `Omit<>` was probably an arbitrary choice in the [`@restart/ui` migration for `Button`](https://github.com/react-bootstrap/react-bootstrap/commit/73a559ee345bc4033c66fc97858163a6a200126d#diff-9ea0e3c40430fd17705fc6b4399eecbdc8105bc05f169f53d4de480c526a7933), but switching them seems to fix the issue.

I can only actually reproduce the type error by upgrading to React@17.