### PR TITLE
fix(Overlay): fix initial positioning of overlays

### DIFF
--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -6,12 +6,16 @@ import BaseOverlay, {
   OverlayProps as BaseOverlayProps,
   OverlayArrowProps,
 } from '@restart/ui/Overlay';
+import { State } from '@restart/ui/usePopper';
 import { componentOrElement, elementType } from 'prop-types-extra';
+import useCallbackRef from '@restart/hooks/useCallbackRef';
+import useEventCallback from '@restart/hooks/useEventCallback';
+import useIsomorphicEffect from '@restart/hooks/useIsomorphicEffect';
 import useMergedRefs from '@restart/hooks/useMergedRefs';
 import useOverlayOffset from './useOverlayOffset';
 import Fade from './Fade';
 import { TransitionType } from './helpers';
-import { Placement, RootCloseEvent } from './types';
+import { Placement, PopperRef, RootCloseEvent } from './types';
 import safeFindDOMNode from './safeFindDOMNode';
 
 export interface OverlayInjectedProps {
@@ -23,12 +27,7 @@ export interface OverlayInjectedProps {
 
   show: boolean;
   placement: Placement | undefined;
-  popper: {
-    state: any;
-    outOfBoundaries: boolean;
-    placement: Placement | undefined;
-    scheduleUpdate?: () => void;
-  };
+  popper: PopperRef;
   [prop: string]: any;
 }
 
@@ -162,12 +161,24 @@ const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
     { children: overlay, transition, popperConfig = {}, ...outerProps },
     outerRef,
   ) => {
-    const popperRef = useRef({});
+    const popperRef = useRef<Partial<PopperRef>>({});
+    const [firstRenderedState, setFirstRenderedState] = useCallbackRef<State>();
     const [ref, modifiers] = useOverlayOffset(outerProps.offset);
     const mergedRef = useMergedRefs(outerRef, ref);
 
     const actualTransition =
       transition === true ? Fade : transition || undefined;
+
+    const handleFirstUpdate = useEventCallback((state) => {
+      setFirstRenderedState(state);
+      popperConfig?.onFirstUpdate?.(state);
+    });
+
+    useIsomorphicEffect(() => {
+      if (firstRenderedState) {
+        popperRef.current.scheduleUpdate?.();
+      }
+    }, [firstRenderedState]);
 
     return (
       <BaseOverlay
@@ -176,6 +187,7 @@ const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
         popperConfig={{
           ...popperConfig,
           modifiers: modifiers.concat(popperConfig.modifiers || []),
+          onFirstUpdate: handleFirstUpdate,
         }}
         transition={actualTransition}
       >

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -5,7 +5,7 @@ import { OverlayArrowProps } from '@restart/ui/Overlay';
 import { useBootstrapPrefix, useIsRTL } from './ThemeProvider';
 import PopoverHeader from './PopoverHeader';
 import PopoverBody from './PopoverBody';
-import { Placement } from './types';
+import { Placement, PopperRef } from './types';
 import { BsPrefixProps, getOverlayDirection } from './helpers';
 
 export interface PopoverProps
@@ -15,7 +15,7 @@ export interface PopoverProps
   title?: string;
   arrowProps?: Partial<OverlayArrowProps>;
   body?: boolean;
-  popper?: any;
+  popper?: PopperRef;
   show?: boolean;
 }
 

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { OverlayArrowProps } from '@restart/ui/Overlay';
 import { useBootstrapPrefix, useIsRTL } from './ThemeProvider';
-import { Placement } from './types';
+import { Placement, PopperRef } from './types';
 import { BsPrefixProps, getOverlayDirection } from './helpers';
 
 export interface TooltipProps
@@ -12,7 +12,7 @@ export interface TooltipProps
   placement?: Placement;
   arrowProps?: Partial<OverlayArrowProps>;
   show?: boolean;
-  popper?: any;
+  popper?: PopperRef;
 }
 
 const propTypes = {

--- a/src/types.tsx
+++ b/src/types.tsx
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import { State } from '@restart/ui/usePopper';
 
 export type Variant =
   | 'primary'
@@ -62,3 +63,10 @@ export const alignPropType = PropTypes.oneOfType([
 export type RootCloseEvent = 'click' | 'mousedown';
 
 export type GapValue = 0 | 1 | 2 | 3 | 4 | 5;
+
+export interface PopperRef {
+  state: State | undefined;
+  outOfBoundaries: boolean;
+  placement: Placement | undefined;
+  scheduleUpdate?: () => void;
+}


### PR DESCRIPTION
Fixes #6343

Tooltips and popovers no longer have `position: absolute` so popper's initial calculation is incorrect.  @jquense has a good explanation of that here: https://github.com/react-restart/ui/pull/36#issuecomment-933680079

This PR uses the `onFirstUpdate` callback to listen for the initial positioning of the popper, then forces an update to put it in the correct position.