### PR TITLE
feat(FormCheck): add support for reverse checks and radios

### DIFF
--- a/src/FormCheck.tsx
+++ b/src/FormCheck.tsx
@@ -16,6 +16,7 @@ export interface FormCheckProps
   extends BsPrefixProps,
     React.InputHTMLAttributes<HTMLInputElement> {
   inline?: boolean;
+  reverse?: boolean;
   disabled?: boolean;
   label?: React.ReactNode;
   type?: FormCheckType;
@@ -83,6 +84,11 @@ const propTypes = {
   inline: PropTypes.bool,
 
   /**
+   * Put your checkboxes, radios, and switches on the opposite side.
+   */
+  reverse: PropTypes.bool,
+
+  /**
    * Disables the control.
    */
   disabled: PropTypes.bool,
@@ -124,6 +130,7 @@ const FormCheck: BsPrefixRefForwardingComponent<'input', FormCheckProps> =
         bsPrefix,
         bsSwitchPrefix,
         inline = false,
+        reverse = false,
         disabled = false,
         isValid = false,
         isInvalid = false,
@@ -177,6 +184,7 @@ const FormCheck: BsPrefixRefForwardingComponent<'input', FormCheckProps> =
               className,
               hasLabel && bsPrefix,
               inline && `${bsPrefix}-inline`,
+              reverse && `${bsPrefix}-reverse`,
               type === 'switch' && bsSwitchPrefix,
             )}
           >

--- a/test/FormCheckSpec.tsx
+++ b/test/FormCheckSpec.tsx
@@ -86,6 +86,15 @@ describe('<FormCheck>', () => {
     element!.classList.contains('form-check-inline').should.be.true;
   });
 
+  it('should support in reverse', () => {
+    const {
+      container: { firstElementChild: element },
+    } = render(<FormCheck reverse label="My label" />);
+
+    element!.classList.length.should.equal(2);
+    element!.classList.contains('form-check-reverse').should.be.true;
+  });
+
   it('should support isValid', () => {
     const { getByTestId } = render(<FormCheck isValid data-testid="test-id" />);
 

--- a/www/src/examples/Form/CheckReverse.js
+++ b/www/src/examples/Form/CheckReverse.js
@@ -1,0 +1,27 @@
+<Form>
+  {['checkbox', 'radio'].map((type) => (
+    <div key={`reverse-${type}`} className="mb-3">
+      <Form.Check
+        reverse
+        label="1"
+        name="group1"
+        type={type}
+        id={`reverse-${type}-1`}
+      />
+      <Form.Check
+        reverse
+        label="2"
+        name="group1"
+        type={type}
+        id={`reverse-${type}-2`}
+      />
+      <Form.Check
+        reverse
+        disabled
+        label="3 (disabled)"
+        type={type}
+        id={`reverse-${type}-3`}
+      />
+    </div>
+  ))}
+</Form>;

--- a/www/src/pages/forms/checks-radios.mdx
+++ b/www/src/pages/forms/checks-radios.mdx
@@ -7,6 +7,7 @@ import ReactPlayground from '../../components/ReactPlayground';
 import Check from '../../examples/Form/Check';
 import CheckApi from '../../examples/Form/CheckApi';
 import CheckInline from '../../examples/Form/CheckInline';
+import CheckReverse from '../../examples/Form/CheckReverse';
 import NoLabels from '../../examples/Form/NoLabels';
 import Switch from '../../examples/Form/Switch';
 
@@ -47,6 +48,12 @@ children as `<FormCheck>`.
 Group checkboxes or radios on the same horizontal row by adding the `inline` prop.
 
 <ReactPlayground codeText={CheckInline} />
+
+## Reverse
+
+Put your checkboxes, radios, and switches on the opposite side with the `reverse` prop.
+
+<ReactPlayground codeText={CheckReverse} />
 
 ## Without labels
 


### PR DESCRIPTION
Added support for reverse prop in Checks and Radios as per v5.2

https://getbootstrap.com/docs/5.2/forms/checks-radios/#reverse

<img width="913" alt="image" src="https://user-images.githubusercontent.com/66095650/170179820-55258315-7e0b-4fe3-89aa-eb92d086ad19.png">
