### PR TITLE
fix(NavbarOffcanvas): fix render to be SSR safe

### DIFF
--- a/src/NavbarOffcanvas.tsx
+++ b/src/NavbarOffcanvas.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { useContext } from 'react';
-import useBreakpoint from '@restart/hooks/useBreakpoint';
 import classNames from 'classnames';
 import { useBootstrapPrefix } from './ThemeProvider';
 import Offcanvas, { OffcanvasProps } from './Offcanvas';
@@ -37,43 +36,49 @@ const NavbarOffcanvas = React.forwardRef<HTMLDivElement, NavbarOffcanvasProps>(
   ) => {
     const context = useContext(NavbarContext);
     bsPrefix = useBootstrapPrefix(bsPrefix, 'offcanvas');
-    const hasExpandProp = typeof context?.expand === 'string';
-    const shouldExpand = useBreakpoint(
-      (hasExpandProp ? context.expand : 'xs') as any,
-      'up',
-    );
 
-    return hasExpandProp && shouldExpand ? (
-      <div
-        ref={ref}
-        {...props}
-        className={classNames(className, bsPrefix, `${bsPrefix}-${placement}`)}
-      />
-    ) : (
-      <Offcanvas
-        ref={ref}
-        show={!!context?.expanded}
-        bsPrefix={bsPrefix}
-        backdrop={backdrop}
-        backdropClassName={backdropClassName}
-        keyboard={keyboard}
-        scroll={scroll}
-        placement={placement}
-        autoFocus={autoFocus}
-        enforceFocus={enforceFocus}
-        restoreFocus={restoreFocus}
-        restoreFocusOptions={restoreFocusOptions}
-        onShow={onShow}
-        onHide={onHide}
-        onEscapeKeyDown={onEscapeKeyDown}
-        onEnter={onEnter}
-        onEntering={onEntering}
-        onEntered={onEntered}
-        onExit={onExit}
-        onExiting={onExiting}
-        onExited={onExited}
-        {...props}
-      />
+    const show = !!context?.expanded;
+
+    return (
+      <>
+        {/* Only render the menu when offcanvas isn't shown so we don't duplicate elements */}
+        {!show && (
+          <div
+            ref={ref}
+            {...props}
+            className={classNames(
+              className,
+              bsPrefix,
+              `${bsPrefix}-${placement}`,
+            )}
+          />
+        )}
+
+        <Offcanvas
+          ref={ref}
+          show={show}
+          bsPrefix={bsPrefix}
+          backdrop={backdrop}
+          backdropClassName={backdropClassName}
+          keyboard={keyboard}
+          scroll={scroll}
+          placement={placement}
+          autoFocus={autoFocus}
+          enforceFocus={enforceFocus}
+          restoreFocus={restoreFocus}
+          restoreFocusOptions={restoreFocusOptions}
+          onShow={onShow}
+          onHide={onHide}
+          onEscapeKeyDown={onEscapeKeyDown}
+          onEnter={onEnter}
+          onEntering={onEntering}
+          onEntered={onEntered}
+          onExit={onExit}
+          onExiting={onExiting}
+          onExited={onExited}
+          {...props}
+        />
+      </>
     );
   },
 );


### PR DESCRIPTION
Fixes #6359

Simplifies the render so it doesn't rely on the `useBreakpoint` hook which isn't SSR safe.  Should be safe to always render the offcanvas component since it only attaches to the dom when `show=true`