### PR TITLE
docs: typo in `ModalDialog.size` prop type

### DIFF
--- a/src/ModalDialog.tsx
+++ b/src/ModalDialog.tsx
@@ -31,7 +31,7 @@ const propTypes = {
   /**
    * Render a large, extra large or small modal.
    *
-   * @type ('sm'|'lg','xl')
+   * @type ('sm'|'lg'|'xl')
    */
   size: PropTypes.string,
 


### PR DESCRIPTION
Currently looks the following:

![image](https://user-images.githubusercontent.com/4947671/171751572-49d55bac-f621-4e36-804b-de1e767302b8.png)
