### PR TITLE
feat(Offcanvas): add responsive support

### DIFF
--- a/src/NavbarOffcanvas.tsx
+++ b/src/NavbarOffcanvas.tsx
@@ -1,85 +1,15 @@
 import * as React from 'react';
 import { useContext } from 'react';
-import classNames from 'classnames';
-import { useBootstrapPrefix } from './ThemeProvider';
 import Offcanvas, { OffcanvasProps } from './Offcanvas';
 import NavbarContext from './NavbarContext';
 
 export type NavbarOffcanvasProps = Omit<OffcanvasProps, 'show'>;
 
 const NavbarOffcanvas = React.forwardRef<HTMLDivElement, NavbarOffcanvasProps>(
-  (
-    {
-      className,
-      bsPrefix,
-      backdrop,
-      backdropClassName,
-      keyboard,
-      scroll,
-      placement,
-      autoFocus,
-      enforceFocus,
-      restoreFocus,
-      restoreFocusOptions,
-      onShow,
-      onHide,
-      onEscapeKeyDown,
-      onEnter,
-      onEntering,
-      onEntered,
-      onExit,
-      onExiting,
-      onExited,
-      ...props
-    },
-    ref,
-  ) => {
+  (props, ref) => {
     const context = useContext(NavbarContext);
-    bsPrefix = useBootstrapPrefix(bsPrefix, 'offcanvas');
 
-    const show = !!context?.expanded;
-
-    return (
-      <>
-        {/* Only render the menu when offcanvas isn't shown so we don't duplicate elements */}
-        {!show && (
-          <div
-            ref={ref}
-            {...props}
-            className={classNames(
-              className,
-              bsPrefix,
-              `${bsPrefix}-${placement}`,
-            )}
-          />
-        )}
-
-        <Offcanvas
-          ref={ref}
-          show={show}
-          bsPrefix={bsPrefix}
-          backdrop={backdrop}
-          backdropClassName={backdropClassName}
-          keyboard={keyboard}
-          scroll={scroll}
-          placement={placement}
-          autoFocus={autoFocus}
-          enforceFocus={enforceFocus}
-          restoreFocus={restoreFocus}
-          restoreFocusOptions={restoreFocusOptions}
-          onShow={onShow}
-          onHide={onHide}
-          onEscapeKeyDown={onEscapeKeyDown}
-          onEnter={onEnter}
-          onEntering={onEntering}
-          onEntered={onEntered}
-          onExit={onExit}
-          onExiting={onExiting}
-          onExited={onExited}
-          {...props}
-        />
-      </>
-    );
+    return <Offcanvas ref={ref} show={!!context?.expanded} {...props} />;
   },
 );
 

--- a/src/Offcanvas.tsx
+++ b/src/Offcanvas.tsx
@@ -36,6 +36,7 @@ export interface OffcanvasProps
   backdropClassName?: string;
   scroll?: boolean;
   placement?: OffcanvasPlacement;
+  responsive?: 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | string;
 }
 
 const propTypes = {
@@ -74,6 +75,12 @@ const propTypes = {
     'top',
     'bottom',
   ]),
+
+  /**
+   * Hide content outside the viewport from a specified breakpoint and down.
+   * @type {("sm"|"md"|"lg"|"xl"|"xxl")}
+   */
+  responsive: PropTypes.string,
 
   /**
    * When `true` The offcanvas will automatically shift focus to itself when it
@@ -192,6 +199,7 @@ const Offcanvas: BsPrefixRefForwardingComponent<'div', OffcanvasProps> =
         children,
         'aria-labelledby': ariaLabelledby,
         placement,
+        responsive,
 
         /* BaseModal props */
 
@@ -272,12 +280,11 @@ const Offcanvas: BsPrefixRefForwardingComponent<'div', OffcanvasProps> =
 
       const renderDialog = (dialogProps) => (
         <div
-          role="dialog"
           {...dialogProps}
           {...props}
           className={classNames(
             className,
-            bsPrefix,
+            responsive ? `${bsPrefix}-${responsive}` : bsPrefix,
             `${bsPrefix}-${placement}`,
           )}
           aria-labelledby={ariaLabelledby}
@@ -287,33 +294,41 @@ const Offcanvas: BsPrefixRefForwardingComponent<'div', OffcanvasProps> =
       );
 
       return (
-        <ModalContext.Provider value={modalContext}>
-          <BaseModal
-            show={show}
-            ref={ref}
-            backdrop={backdrop}
-            container={container}
-            keyboard={keyboard}
-            autoFocus={autoFocus}
-            enforceFocus={enforceFocus && !scroll}
-            restoreFocus={restoreFocus}
-            restoreFocusOptions={restoreFocusOptions}
-            onEscapeKeyDown={onEscapeKeyDown}
-            onShow={onShow}
-            onHide={handleHide}
-            onEnter={handleEnter}
-            onEntering={onEntering}
-            onEntered={onEntered}
-            onExit={onExit}
-            onExiting={onExiting}
-            onExited={handleExited}
-            manager={getModalManager()}
-            transition={DialogTransition}
-            backdropTransition={BackdropTransition}
-            renderBackdrop={renderBackdrop}
-            renderDialog={renderDialog}
-          />
-        </ModalContext.Provider>
+        <>
+          {/* 
+            Only render static elements when offcanvas isn't shown so we 
+            don't duplicate elements 
+          */}
+          {!show && renderDialog({})}
+
+          <ModalContext.Provider value={modalContext}>
+            <BaseModal
+              show={show}
+              ref={ref}
+              backdrop={backdrop}
+              container={container}
+              keyboard={keyboard}
+              autoFocus={autoFocus}
+              enforceFocus={enforceFocus && !scroll}
+              restoreFocus={restoreFocus}
+              restoreFocusOptions={restoreFocusOptions}
+              onEscapeKeyDown={onEscapeKeyDown}
+              onShow={onShow}
+              onHide={handleHide}
+              onEnter={handleEnter}
+              onEntering={onEntering}
+              onEntered={onEntered}
+              onExit={onExit}
+              onExiting={onExiting}
+              onExited={handleExited}
+              manager={getModalManager()}
+              transition={DialogTransition}
+              backdropTransition={BackdropTransition}
+              renderBackdrop={renderBackdrop}
+              renderDialog={renderDialog}
+            />
+          </ModalContext.Provider>
+        </>
       );
     },
   );

--- a/test/OffcanvasSpec.tsx
+++ b/test/OffcanvasSpec.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
+import { expect } from 'chai';
 import ModalManager from '@restart/ui/ModalManager';
 import { fireEvent, render } from '@testing-library/react';
 import sinon from 'sinon';
 import Offcanvas from '../src/Offcanvas';
 
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+const noop = () => {};
+
 describe('<Offcanvas>', () => {
   it('Should render the modal content', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const noop = () => {};
     const { getByTestId } = render(
       <Offcanvas show onHide={noop}>
         <strong data-testid="test">Message</strong>
@@ -50,8 +52,6 @@ describe('<Offcanvas>', () => {
   });
 
   it('Should pass className to the offcanvas', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const noop = () => {};
     const { getByTestId } = render(
       <Offcanvas show className="myoffcanvas" onHide={noop} data-testid="test">
         <strong>Message</strong>
@@ -62,9 +62,6 @@ describe('<Offcanvas>', () => {
   });
 
   it('Should pass backdropClassName to the backdrop', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const noop = () => {};
-
     render(
       <Offcanvas show backdropClassName="custom-backdrop" onHide={noop}>
         <strong>Message</strong>
@@ -76,8 +73,6 @@ describe('<Offcanvas>', () => {
   });
 
   it('Should pass style to the offcanvas', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const noop = () => {};
     const { getByTestId } = render(
       <Offcanvas show style={{ color: 'red' }} onHide={noop} data-testid="test">
         <strong>Message</strong>
@@ -94,8 +89,7 @@ describe('<Offcanvas>', () => {
       return (
         <Offcanvas
           show={show}
-          // eslint-disable-next-line @typescript-eslint/no-empty-function
-          onHide={() => {}}
+          onHide={noop}
           onExit={increment}
           onExiting={increment}
           onExited={() => {
@@ -185,8 +179,6 @@ describe('<Offcanvas>', () => {
   });
 
   it('Should set aria-labelledby to the role="dialog" element if aria-labelledby set', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const noop = () => {};
     const { getByTestId } = render(
       <Offcanvas
         show
@@ -210,8 +202,6 @@ describe('<Offcanvas>', () => {
   });
 
   it('Should call onEscapeKeyDown when keyboard is true', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const noop = () => {};
     const onEscapeKeyDownSpy = sinon.spy();
     render(
       <Offcanvas
@@ -229,8 +219,6 @@ describe('<Offcanvas>', () => {
   });
 
   it('Should not call onEscapeKeyDown when keyboard is false', () => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const noop = () => {};
     const onEscapeKeyDownSpy = sinon.spy();
     render(
       <Offcanvas
@@ -248,9 +236,6 @@ describe('<Offcanvas>', () => {
   });
 
   it('Should use custom props manager if specified', (done) => {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const noop = () => {};
-
     class MyModalManager extends ModalManager {
       add() {
         done();
@@ -270,8 +255,7 @@ describe('<Offcanvas>', () => {
 
   it('should not change overflow style when scroll=true', () => {
     const containerRef = React.createRef<any>();
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    const noop = () => {};
+
     render(
       <div ref={containerRef} style={{ height: '2000px', overflow: 'scroll' }}>
         <Offcanvas show onHide={noop} container={containerRef} scroll>
@@ -281,5 +265,25 @@ describe('<Offcanvas>', () => {
     );
 
     containerRef.current.style.overflow.should.equal('scroll');
+  });
+
+  it('should set responsive class', () => {
+    const { getByTestId } = render(
+      <Offcanvas data-testid="test" responsive="lg" show onHide={noop}>
+        <strong>Message</strong>
+      </Offcanvas>,
+    );
+    const offcanvasElem = getByTestId('test');
+    offcanvasElem.classList.contains('offcanvas-lg').should.be.true;
+  });
+
+  it('should render offcanvas when show=false', () => {
+    const { getByTestId } = render(
+      <Offcanvas data-testid="test" responsive="lg" onHide={noop}>
+        <strong>Message</strong>
+      </Offcanvas>,
+    );
+    const offcanvasElem = getByTestId('test');
+    expect(offcanvasElem.getAttribute('role')).to.not.exist;
   });
 });

--- a/www/src/examples/Offcanvas/Responsive.js
+++ b/www/src/examples/Offcanvas/Responsive.js
@@ -1,0 +1,31 @@
+function Example() {
+  const [show, setShow] = useState(false);
+
+  const handleClose = () => setShow(false);
+  const handleShow = () => setShow(true);
+
+  return (
+    <>
+      <Button variant="primary" className="d-lg-none" onClick={handleShow}>
+        Launch
+      </Button>
+
+      <Alert variant="info" className="d-none d-lg-block">
+        Resize your browser to show the responsive offcanvas toggle.
+      </Alert>
+
+      <Offcanvas show={show} onHide={handleClose} responsive="lg">
+        <Offcanvas.Header closeButton>
+          <Offcanvas.Title>Responsive offcanvas</Offcanvas.Title>
+        </Offcanvas.Header>
+        <Offcanvas.Body>
+          <p className="mb-0">
+            This is content within an <code>.offcanvas-lg</code>.
+          </p>
+        </Offcanvas.Body>
+      </Offcanvas>
+    </>
+  );
+}
+
+render(<Example />);

--- a/www/src/examples/Offcanvas/Responsive.js
+++ b/www/src/examples/Offcanvas/Responsive.js
@@ -1,4 +1,9 @@
-function Example() {
+import { useState } from 'react';
+import Alert from 'react-bootstrap/Alert';
+import Button from 'react-bootstrap/Button';
+import Offcanvas from 'react-bootstrap/Offcanvas';
+
+function ResponsiveExample() {
   const [show, setShow] = useState(false);
 
   const handleClose = () => setShow(false);
@@ -28,4 +33,4 @@ function Example() {
   );
 }
 
-render(<Example />);
+export default ResponsiveExample;

--- a/www/src/pages/components/offcanvas.mdx
+++ b/www/src/pages/components/offcanvas.mdx
@@ -7,6 +7,7 @@ import ReactPlayground from '../../components/ReactPlayground';
 import Basic from '../../examples/Offcanvas/Basic';
 import Backdrop from '../../examples/Offcanvas/Backdrop';
 import StaticBackdrop from '../../examples/Offcanvas/StaticBackdrop';
+import Responsive from '../../examples/Offcanvas/Responsive';
 import Placement from '../../examples/Offcanvas/Placement';
 
 # Offcanvas
@@ -18,17 +19,25 @@ import Placement from '../../examples/Offcanvas/Placement';
 
 ## Examples
 
-Offcanvas includes support for a header with a close button and an optional body class 
-for some initial padding. We suggest that you include offcanvas headers with dismiss 
+Offcanvas includes support for a header with a close button and an optional body class
+for some initial padding. We suggest that you include offcanvas headers with dismiss
 actions whenever possible, or provide an explicit dismiss action.
 
 ### Basic Example
 
 <ReactPlayground codeText={Basic} />
 
+### Responsive
+
+Responsive offcanvas classes hide content outside the viewport from a specified breakpoint
+and down. Above that breakpoint, the contents within will behave as usual.
+
+<ReactPlayground codeText={Responsive} />
+
 ### Placement
 
 Offcanvas supports a few different placements:
+
 - `start` places offcanvas on the left of the viewport
 - `end` places offcanvas on the right of the viewport
 - `top` places offcanvas on the top of the viewport
@@ -38,8 +47,8 @@ Offcanvas supports a few different placements:
 
 ### Backdrop
 
-Scrolling the `<body>` element is disabled when an offcanvas and its backdrop are 
-visible. Use the `scroll` prop to toggle `<body>` scrolling and the `backdrop` prop 
+Scrolling the `<body>` element is disabled when an offcanvas and its backdrop are
+visible. Use the `scroll` prop to toggle `<body>` scrolling and the `backdrop` prop
 to toggle the backdrop.
 
 <ReactPlayground codeText={Backdrop} />


### PR DESCRIPTION
Closes #6357

Adds a `responsive` prop to Offcanvas. Pulled the logic from NavbarOffcanvas into Offcanvas because it was needed for rendering the responsive offcanvas when it's not shown via flyout.

Ref: https://getbootstrap.com/docs/5.2/components/offcanvas/#responsive