### PR TITLE
docs(all): Add imports to playground examples (#4952)

### DIFF
--- a/www/src/components/ReactPlayground.js
+++ b/www/src/components/ReactPlayground.js
@@ -25,8 +25,8 @@ import * as yup from 'yup';
 import useEventCallback from '@restart/hooks/useEventCallback';
 import useIsomorphicEffect from '@restart/hooks/useIsomorphicEffect';
 import useMutationObserver from '@restart/hooks/useMutationObserver';
-import PlaceholderImage from './PlaceholderImage';
-import Sonnet from './Sonnet';
+import { PlaceholderImage } from './PlaceholderImage';
+import { Sonnet } from './Sonnet';
 
 const scope = {
   useEffect,
@@ -312,6 +312,8 @@ function Editor() {
 const PRETTIER_IGNORE_REGEX =
   /({\s*\/\*\s+prettier-ignore\s+\*\/\s*})|(\/\/\s+prettier-ignore)/gim;
 
+const IGNORE_IMPORTS_EXPORTS_REGEX = /^.*\b(import|export)\b.*$/gim;
+
 const propTypes = {
   codeText: PropTypes.string.isRequired,
 };
@@ -323,6 +325,9 @@ function Playground({ codeText, exampleClassName, showCode = true }) {
     .trim()
     .replace(/>;$/, '>');
 
+  const transformCode = (rawCode) =>
+    rawCode.replace(IGNORE_IMPORTS_EXPORTS_REGEX, '');
+
   return (
     <StyledContainer>
       <LiveProvider
@@ -330,6 +335,7 @@ function Playground({ codeText, exampleClassName, showCode = true }) {
         code={code}
         mountStylesheet={false}
         noInline={codeText.includes('render(')}
+        transformCode={transformCode}
       >
         <Preview showCode={showCode} className={exampleClassName} />
         {showCode && <Editor />}

--- a/www/src/examples/Accordion/AllCollapse.js
+++ b/www/src/examples/Accordion/AllCollapse.js
@@ -1,26 +1,34 @@
-<Accordion>
-  <Accordion.Item eventKey="0">
-    <Accordion.Header>Accordion Item #1</Accordion.Header>
-    <Accordion.Body>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-      est laborum.
-    </Accordion.Body>
-  </Accordion.Item>
-  <Accordion.Item eventKey="1">
-    <Accordion.Header>Accordion Item #2</Accordion.Header>
-    <Accordion.Body>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-      est laborum.
-    </Accordion.Body>
-  </Accordion.Item>
-</Accordion>;
+import Accordion from 'react-bootstrap/Accordion';
+
+function AllCollapseExample() {
+  return (
+    <Accordion>
+      <Accordion.Item eventKey="0">
+        <Accordion.Header>Accordion Item #1</Accordion.Header>
+        <Accordion.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </Accordion.Body>
+      </Accordion.Item>
+      <Accordion.Item eventKey="1">
+        <Accordion.Header>Accordion Item #2</Accordion.Header>
+        <Accordion.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </Accordion.Body>
+      </Accordion.Item>
+    </Accordion>
+  );
+}
+
+export default AllCollapseExample;

--- a/www/src/examples/Accordion/AlwaysOpen.js
+++ b/www/src/examples/Accordion/AlwaysOpen.js
@@ -1,26 +1,34 @@
-<Accordion defaultActiveKey={['0']} alwaysOpen>
-  <Accordion.Item eventKey="0">
-    <Accordion.Header>Accordion Item #1</Accordion.Header>
-    <Accordion.Body>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-      est laborum.
-    </Accordion.Body>
-  </Accordion.Item>
-  <Accordion.Item eventKey="1">
-    <Accordion.Header>Accordion Item #2</Accordion.Header>
-    <Accordion.Body>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-      est laborum.
-    </Accordion.Body>
-  </Accordion.Item>
-</Accordion>;
+import Accordion from 'react-bootstrap/Accordion';
+
+function AlwaysOpenExample() {
+  return (
+    <Accordion defaultActiveKey={['0']} alwaysOpen>
+      <Accordion.Item eventKey="0">
+        <Accordion.Header>Accordion Item #1</Accordion.Header>
+        <Accordion.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </Accordion.Body>
+      </Accordion.Item>
+      <Accordion.Item eventKey="1">
+        <Accordion.Header>Accordion Item #2</Accordion.Header>
+        <Accordion.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </Accordion.Body>
+      </Accordion.Item>
+    </Accordion>
+  );
+}
+
+export default AlwaysOpenExample;

--- a/www/src/examples/Accordion/Basic.js
+++ b/www/src/examples/Accordion/Basic.js
@@ -1,26 +1,34 @@
-<Accordion defaultActiveKey="0">
-  <Accordion.Item eventKey="0">
-    <Accordion.Header>Accordion Item #1</Accordion.Header>
-    <Accordion.Body>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-      est laborum.
-    </Accordion.Body>
-  </Accordion.Item>
-  <Accordion.Item eventKey="1">
-    <Accordion.Header>Accordion Item #2</Accordion.Header>
-    <Accordion.Body>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-      est laborum.
-    </Accordion.Body>
-  </Accordion.Item>
-</Accordion>;
+import Accordion from 'react-bootstrap/Accordion';
+
+function BasicExample() {
+  return (
+    <Accordion defaultActiveKey="0">
+      <Accordion.Item eventKey="0">
+        <Accordion.Header>Accordion Item #1</Accordion.Header>
+        <Accordion.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </Accordion.Body>
+      </Accordion.Item>
+      <Accordion.Item eventKey="1">
+        <Accordion.Header>Accordion Item #2</Accordion.Header>
+        <Accordion.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </Accordion.Body>
+      </Accordion.Item>
+    </Accordion>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/Accordion/ContextAwareToggle.js
+++ b/www/src/examples/Accordion/ContextAwareToggle.js
@@ -1,3 +1,7 @@
+import Accordion from 'react-bootstrap/Accordion';
+import { useAccordionButton } from 'react-bootstrap/AccordionButton';
+import Card from 'react-bootstrap/Card';
+
 function ContextAwareToggle({ children, eventKey, callback }) {
   const { activeEventKey } = useContext(AccordionContext);
 

--- a/www/src/examples/Accordion/CustomToggle.js
+++ b/www/src/examples/Accordion/CustomToggle.js
@@ -1,3 +1,7 @@
+import Accordion from 'react-bootstrap/Accordion';
+import { useAccordionButton } from 'react-bootstrap/AccordionButton';
+import Card from 'react-bootstrap/Card';
+
 function CustomToggle({ children, eventKey }) {
   const decoratedOnClick = useAccordionButton(eventKey, () =>
     console.log('totally custom!'),

--- a/www/src/examples/Accordion/Flush.js
+++ b/www/src/examples/Accordion/Flush.js
@@ -1,26 +1,34 @@
-<Accordion defaultActiveKey="0" flush>
-  <Accordion.Item eventKey="0">
-    <Accordion.Header>Accordion Item #1</Accordion.Header>
-    <Accordion.Body>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-      est laborum.
-    </Accordion.Body>
-  </Accordion.Item>
-  <Accordion.Item eventKey="1">
-    <Accordion.Header>Accordion Item #2</Accordion.Header>
-    <Accordion.Body>
-      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
-      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
-      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
-      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
-      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
-      est laborum.
-    </Accordion.Body>
-  </Accordion.Item>
-</Accordion>;
+import Accordion from 'react-bootstrap/Accordion';
+
+function FlushExample() {
+  return (
+    <Accordion defaultActiveKey="0" flush>
+      <Accordion.Item eventKey="0">
+        <Accordion.Header>Accordion Item #1</Accordion.Header>
+        <Accordion.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </Accordion.Body>
+      </Accordion.Item>
+      <Accordion.Item eventKey="1">
+        <Accordion.Header>Accordion Item #2</Accordion.Header>
+        <Accordion.Body>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </Accordion.Body>
+      </Accordion.Item>
+    </Accordion>
+  );
+}
+
+export default FlushExample;

--- a/www/src/examples/Alert/AdditionalContent.js
+++ b/www/src/examples/Alert/AdditionalContent.js
@@ -1,13 +1,21 @@
-<Alert variant="success">
-  <Alert.Heading>Hey, nice to see you</Alert.Heading>
-  <p>
-    Aww yeah, you successfully read this important alert message. This example
-    text is going to run a bit longer so that you can see how spacing within an
-    alert works with this kind of content.
-  </p>
-  <hr />
-  <p className="mb-0">
-    Whenever you need to, be sure to use margin utilities to keep things nice
-    and tidy.
-  </p>
-</Alert>;
+import Alert from 'react-bootstrap/Alert';
+
+function AdditionalContentExample() {
+  return (
+    <Alert variant="success">
+      <Alert.Heading>Hey, nice to see you</Alert.Heading>
+      <p>
+        Aww yeah, you successfully read this important alert message. This
+        example text is going to run a bit longer so that you can see how
+        spacing within an alert works with this kind of content.
+      </p>
+      <hr />
+      <p className="mb-0">
+        Whenever you need to, be sure to use margin utilities to keep things
+        nice and tidy.
+      </p>
+    </Alert>
+  );
+}
+
+export default AdditionalContentExample;

--- a/www/src/examples/Alert/Basic.js
+++ b/www/src/examples/Alert/Basic.js
@@ -1,16 +1,24 @@
-<>
-  {[
-    'primary',
-    'secondary',
-    'success',
-    'danger',
-    'warning',
-    'info',
-    'light',
-    'dark',
-  ].map((variant) => (
-    <Alert key={variant} variant={variant}>
-      This is a {variant} alert—check it out!
-    </Alert>
-  ))}
-</>;
+import Alert from 'react-bootstrap/Alert';
+
+function BasicExample() {
+  return (
+    <>
+      {[
+        'primary',
+        'secondary',
+        'success',
+        'danger',
+        'warning',
+        'info',
+        'light',
+        'dark',
+      ].map((variant) => (
+        <Alert key={variant} variant={variant}>
+          This is a {variant} alert—check it out!
+        </Alert>
+      ))}
+    </>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/Alert/Dismissible.js
+++ b/www/src/examples/Alert/Dismissible.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import Alert from 'react-bootstrap/Alert';
+import Button from 'react-bootstrap/Button';
+
 function AlertDismissibleExample() {
   const [show, setShow] = useState(true);
 

--- a/www/src/examples/Alert/DismissibleControlled.js
+++ b/www/src/examples/Alert/DismissibleControlled.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import Alert from 'react-bootstrap/Alert';
+import Button from 'react-bootstrap/Button';
+
 function AlertDismissible() {
   const [show, setShow] = useState(true);
 

--- a/www/src/examples/Alert/Link.js
+++ b/www/src/examples/Alert/Link.js
@@ -1,18 +1,26 @@
-<>
-  {[
-    'primary',
-    'secondary',
-    'success',
-    'danger',
-    'warning',
-    'info',
-    'light',
-    'dark',
-  ].map((variant) => (
-    <Alert key={variant} variant={variant}>
-      This is a {variant} alert with{' '}
-      <Alert.Link href="#">an example link</Alert.Link>. Give it a click if you
-      like.
-    </Alert>
-  ))}
-</>;
+import Alert from 'react-bootstrap/Alert';
+
+function LinksExample() {
+  return (
+    <>
+      {[
+        'primary',
+        'secondary',
+        'success',
+        'danger',
+        'warning',
+        'info',
+        'light',
+        'dark',
+      ].map((variant) => (
+        <Alert key={variant} variant={variant}>
+          This is a {variant} alert with{' '}
+          <Alert.Link href="#">an example link</Alert.Link>. Give it a click if
+          you like.
+        </Alert>
+      ))}
+    </>
+  );
+}
+
+export default LinksExample;

--- a/www/src/examples/Badge/Basic.js
+++ b/www/src/examples/Badge/Basic.js
@@ -1,20 +1,28 @@
-<div>
-  <h1>
-    Example heading <Badge bg="secondary">New</Badge>
-  </h1>
-  <h2>
-    Example heading <Badge bg="secondary">New</Badge>
-  </h2>
-  <h3>
-    Example heading <Badge bg="secondary">New</Badge>
-  </h3>
-  <h4>
-    Example heading <Badge bg="secondary">New</Badge>
-  </h4>
-  <h5>
-    Example heading <Badge bg="secondary">New</Badge>
-  </h5>
-  <h6>
-    Example heading <Badge bg="secondary">New</Badge>
-  </h6>
-</div>;
+import Badge from 'react-bootstrap/Badge';
+
+function BasicExample() {
+  return (
+    <div>
+      <h1>
+        Example heading <Badge bg="secondary">New</Badge>
+      </h1>
+      <h2>
+        Example heading <Badge bg="secondary">New</Badge>
+      </h2>
+      <h3>
+        Example heading <Badge bg="secondary">New</Badge>
+      </h3>
+      <h4>
+        Example heading <Badge bg="secondary">New</Badge>
+      </h4>
+      <h5>
+        Example heading <Badge bg="secondary">New</Badge>
+      </h5>
+      <h6>
+        Example heading <Badge bg="secondary">New</Badge>
+      </h6>
+    </div>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/Badge/Button.js
+++ b/www/src/examples/Badge/Button.js
@@ -1,4 +1,13 @@
-<Button variant="primary">
-  Profile <Badge bg="secondary">9</Badge>
-  <span className="visually-hidden">unread messages</span>
-</Button>;
+import Badge from 'react-bootstrap/Badge';
+import Button from 'react-bootstrap/Button';
+
+function ButtonExample() {
+  return (
+    <Button variant="primary">
+      Profile <Badge bg="secondary">9</Badge>
+      <span className="visually-hidden">unread messages</span>
+    </Button>
+  );
+}
+
+export default ButtonExample;

--- a/www/src/examples/Badge/Pill.js
+++ b/www/src/examples/Badge/Pill.js
@@ -1,26 +1,34 @@
-<div>
-  <Badge pill bg="primary">
-    Primary
-  </Badge>{' '}
-  <Badge pill bg="secondary">
-    Secondary
-  </Badge>{' '}
-  <Badge pill bg="success">
-    Success
-  </Badge>{' '}
-  <Badge pill bg="danger">
-    Danger
-  </Badge>{' '}
-  <Badge pill bg="warning" text="dark">
-    Warning
-  </Badge>{' '}
-  <Badge pill bg="info">
-    Info
-  </Badge>{' '}
-  <Badge pill bg="light" text="dark">
-    Light
-  </Badge>{' '}
-  <Badge pill bg="dark">
-    Dark
-  </Badge>
-</div>;
+import Badge from 'react-bootstrap/Badge';
+
+function PillExample() {
+  return (
+    <div>
+      <Badge pill bg="primary">
+        Primary
+      </Badge>{' '}
+      <Badge pill bg="secondary">
+        Secondary
+      </Badge>{' '}
+      <Badge pill bg="success">
+        Success
+      </Badge>{' '}
+      <Badge pill bg="danger">
+        Danger
+      </Badge>{' '}
+      <Badge pill bg="warning" text="dark">
+        Warning
+      </Badge>{' '}
+      <Badge pill bg="info">
+        Info
+      </Badge>{' '}
+      <Badge pill bg="light" text="dark">
+        Light
+      </Badge>{' '}
+      <Badge pill bg="dark">
+        Dark
+      </Badge>
+    </div>
+  );
+}
+
+export default PillExample;

--- a/www/src/examples/Badge/Variations.js
+++ b/www/src/examples/Badge/Variations.js
@@ -1,12 +1,21 @@
-<div>
-  <Badge bg="primary">Primary</Badge> <Badge bg="secondary">Secondary</Badge>{' '}
-  <Badge bg="success">Success</Badge> <Badge bg="danger">Danger</Badge>{' '}
-  <Badge bg="warning" text="dark">
-    Warning
-  </Badge>{' '}
-  <Badge bg="info">Info</Badge>{' '}
-  <Badge bg="light" text="dark">
-    Light
-  </Badge>{' '}
-  <Badge bg="dark">Dark</Badge>
-</div>;
+import Badge from 'react-bootstrap/Badge';
+
+function VariationsExample() {
+  return (
+    <div>
+      <Badge bg="primary">Primary</Badge>{' '}
+      <Badge bg="secondary">Secondary</Badge>{' '}
+      <Badge bg="success">Success</Badge> <Badge bg="danger">Danger</Badge>{' '}
+      <Badge bg="warning" text="dark">
+        Warning
+      </Badge>{' '}
+      <Badge bg="info">Info</Badge>{' '}
+      <Badge bg="light" text="dark">
+        Light
+      </Badge>{' '}
+      <Badge bg="dark">Dark</Badge>
+    </div>
+  );
+}
+
+export default VariationsExample;

--- a/www/src/examples/Breadcrumb.js
+++ b/www/src/examples/Breadcrumb.js
@@ -1,7 +1,15 @@
-<Breadcrumb>
-  <Breadcrumb.Item href="#">Home</Breadcrumb.Item>
-  <Breadcrumb.Item href="https://getbootstrap.com/docs/4.0/components/breadcrumb/">
-    Library
-  </Breadcrumb.Item>
-  <Breadcrumb.Item active>Data</Breadcrumb.Item>
-</Breadcrumb>;
+import Breadcrumb from 'react-bootstrap/Breadcrumb';
+
+function BreadcrumbExample() {
+  return (
+    <Breadcrumb>
+      <Breadcrumb.Item href="#">Home</Breadcrumb.Item>
+      <Breadcrumb.Item href="https://getbootstrap.com/docs/4.0/components/breadcrumb/">
+        Library
+      </Breadcrumb.Item>
+      <Breadcrumb.Item active>Data</Breadcrumb.Item>
+    </Breadcrumb>
+  );
+}
+
+export default BreadcrumbExample;

--- a/www/src/examples/Button/Active.js
+++ b/www/src/examples/Button/Active.js
@@ -1,8 +1,16 @@
-<>
-  <Button variant="primary" size="lg" active>
-    Primary button
-  </Button>{' '}
-  <Button variant="secondary" size="lg" active>
-    Button
-  </Button>
-</>;
+import Button from 'react-bootstrap/Button';
+
+function ActiveExample() {
+  return (
+    <>
+      <Button variant="primary" size="lg" active>
+        Primary button
+      </Button>{' '}
+      <Button variant="secondary" size="lg" active>
+        Button
+      </Button>
+    </>
+  );
+}
+
+export default ActiveExample;

--- a/www/src/examples/Button/Block.js
+++ b/www/src/examples/Button/Block.js
@@ -1,8 +1,16 @@
-<div className="d-grid gap-2">
-  <Button variant="primary" size="lg">
-    Block level button
-  </Button>
-  <Button variant="secondary" size="lg">
-    Block level button
-  </Button>
-</div>;
+import Button from 'react-bootstrap/Button';
+
+function BlockExample() {
+  return (
+    <div className="d-grid gap-2">
+      <Button variant="primary" size="lg">
+        Block level button
+      </Button>
+      <Button variant="secondary" size="lg">
+        Block level button
+      </Button>
+    </div>
+  );
+}
+
+export default BlockExample;

--- a/www/src/examples/Button/Disabled.js
+++ b/www/src/examples/Button/Disabled.js
@@ -1,11 +1,19 @@
-<>
-  <Button variant="primary" size="lg" disabled>
-    Primary button
-  </Button>{' '}
-  <Button variant="secondary" size="lg" disabled>
-    Button
-  </Button>{' '}
-  <Button href="#" variant="secondary" size="lg" disabled>
-    Link
-  </Button>
-</>;
+import Button from 'react-bootstrap/Button';
+
+function DisabledExample() {
+  return (
+    <>
+      <Button variant="primary" size="lg" disabled>
+        Primary button
+      </Button>{' '}
+      <Button variant="secondary" size="lg" disabled>
+        Button
+      </Button>{' '}
+      <Button href="#" variant="secondary" size="lg" disabled>
+        Link
+      </Button>
+    </>
+  );
+}
+
+export default DisabledExample;

--- a/www/src/examples/Button/Loading.js
+++ b/www/src/examples/Button/Loading.js
@@ -1,3 +1,6 @@
+import React, { useEffect, useState } from 'react';
+import Button from 'react-bootstrap/Button';
+
 function simulateNetworkRequest() {
   return new Promise((resolve) => setTimeout(resolve, 2000));
 }

--- a/www/src/examples/Button/OutlineTypes.js
+++ b/www/src/examples/Button/OutlineTypes.js
@@ -1,10 +1,18 @@
-<>
-  <Button variant="outline-primary">Primary</Button>{' '}
-  <Button variant="outline-secondary">Secondary</Button>{' '}
-  <Button variant="outline-success">Success</Button>{' '}
-  <Button variant="outline-warning">Warning</Button>{' '}
-  <Button variant="outline-danger">Danger</Button>{' '}
-  <Button variant="outline-info">Info</Button>{' '}
-  <Button variant="outline-light">Light</Button>{' '}
-  <Button variant="outline-dark">Dark</Button>
-</>;
+import Button from 'react-bootstrap/Button';
+
+function OutlineTypesExample() {
+  return (
+    <>
+      <Button variant="outline-primary">Primary</Button>{' '}
+      <Button variant="outline-secondary">Secondary</Button>{' '}
+      <Button variant="outline-success">Success</Button>{' '}
+      <Button variant="outline-warning">Warning</Button>{' '}
+      <Button variant="outline-danger">Danger</Button>{' '}
+      <Button variant="outline-info">Info</Button>{' '}
+      <Button variant="outline-light">Light</Button>{' '}
+      <Button variant="outline-dark">Dark</Button>
+    </>
+  );
+}
+
+export default OutlineTypesExample;

--- a/www/src/examples/Button/Sizes.js
+++ b/www/src/examples/Button/Sizes.js
@@ -1,18 +1,26 @@
-<>
-  <div className="mb-2">
-    <Button variant="primary" size="lg">
-      Large button
-    </Button>{' '}
-    <Button variant="secondary" size="lg">
-      Large button
-    </Button>
-  </div>
-  <div>
-    <Button variant="primary" size="sm">
-      Small button
-    </Button>{' '}
-    <Button variant="secondary" size="sm">
-      Small button
-    </Button>
-  </div>
-</>;
+import Button from 'react-bootstrap/Button';
+
+function SizesExample() {
+  return (
+    <>
+      <div className="mb-2">
+        <Button variant="primary" size="lg">
+          Large button
+        </Button>{' '}
+        <Button variant="secondary" size="lg">
+          Large button
+        </Button>
+      </div>
+      <div>
+        <Button variant="primary" size="sm">
+          Small button
+        </Button>{' '}
+        <Button variant="secondary" size="sm">
+          Small button
+        </Button>
+      </div>
+    </>
+  );
+}
+
+export default SizesExample;

--- a/www/src/examples/Button/TagTypes.js
+++ b/www/src/examples/Button/TagTypes.js
@@ -1,6 +1,14 @@
-<>
-  <Button href="#">Link</Button> <Button type="submit">Button</Button>{' '}
-  <Button as="input" type="button" value="Input" />{' '}
-  <Button as="input" type="submit" value="Submit" />{' '}
-  <Button as="input" type="reset" value="Reset" />
-</>;
+import Button from 'react-bootstrap/Button';
+
+function TagTypesExample() {
+  return (
+    <>
+      <Button href="#">Link</Button> <Button type="submit">Button</Button>{' '}
+      <Button as="input" type="button" value="Input" />{' '}
+      <Button as="input" type="submit" value="Submit" />{' '}
+      <Button as="input" type="reset" value="Reset" />
+    </>
+  );
+}
+
+export default TagTypesExample;

--- a/www/src/examples/Button/ToggleButton.js
+++ b/www/src/examples/Button/ToggleButton.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import ToggleButton from 'react-bootstrap/ToggleButton';
+
 function ToggleButtonExample() {
   const [checked, setChecked] = useState(false);
   const [radioValue, setRadioValue] = useState('1');

--- a/www/src/examples/Button/ToggleButtonGroupControlled.js
+++ b/www/src/examples/Button/ToggleButtonGroupControlled.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import ToggleButton from 'react-bootstrap/ToggleButton';
+import ToggleButtonGroup from 'react-bootstrap/ToggleButtonGroup';
+
 function ToggleButtonGroupControlled() {
   const [value, setValue] = useState([1, 3]);
 

--- a/www/src/examples/Button/ToggleButtonGroupUncontrolled.js
+++ b/www/src/examples/Button/ToggleButtonGroupUncontrolled.js
@@ -1,25 +1,34 @@
-<>
-  <ToggleButtonGroup type="checkbox" defaultValue={[1, 3]} className="mb-2">
-    <ToggleButton id="tbg-check-1" value={1}>
-      Checkbox 1 (pre-checked)
-    </ToggleButton>
-    <ToggleButton id="tbg-check-2" value={2}>
-      Checkbox 2
-    </ToggleButton>
-    <ToggleButton id="tbg-check-3" value={3}>
-      Checkbox 3 (pre-checked)
-    </ToggleButton>
-  </ToggleButtonGroup>
-  <br />
-  <ToggleButtonGroup type="radio" name="options" defaultValue={1}>
-    <ToggleButton id="tbg-radio-1" value={1}>
-      Radio 1 (pre-checked)
-    </ToggleButton>
-    <ToggleButton id="tbg-radio-2" value={2}>
-      Radio 2
-    </ToggleButton>
-    <ToggleButton id="tbg-radio-3" value={3}>
-      Radio 3
-    </ToggleButton>
-  </ToggleButtonGroup>
-</>;
+import ToggleButton from 'react-bootstrap/ToggleButton';
+import ToggleButtonGroup from 'react-bootstrap/ToggleButtonGroup';
+
+function ToggleButtonGroupUncontrolled() {
+  return (
+    <>
+      <ToggleButtonGroup type="checkbox" defaultValue={[1, 3]} className="mb-2">
+        <ToggleButton id="tbg-check-1" value={1}>
+          Checkbox 1 (pre-checked)
+        </ToggleButton>
+        <ToggleButton id="tbg-check-2" value={2}>
+          Checkbox 2
+        </ToggleButton>
+        <ToggleButton id="tbg-check-3" value={3}>
+          Checkbox 3 (pre-checked)
+        </ToggleButton>
+      </ToggleButtonGroup>
+      <br />
+      <ToggleButtonGroup type="radio" name="options" defaultValue={1}>
+        <ToggleButton id="tbg-radio-1" value={1}>
+          Radio 1 (pre-checked)
+        </ToggleButton>
+        <ToggleButton id="tbg-radio-2" value={2}>
+          Radio 2
+        </ToggleButton>
+        <ToggleButton id="tbg-radio-3" value={3}>
+          Radio 3
+        </ToggleButton>
+      </ToggleButtonGroup>
+    </>
+  );
+}
+
+export default ToggleButtonGroupUncontrolled;

--- a/www/src/examples/Button/Types.js
+++ b/www/src/examples/Button/Types.js
@@ -1,9 +1,18 @@
-<>
-  <Button variant="primary">Primary</Button>{' '}
-  <Button variant="secondary">Secondary</Button>{' '}
-  <Button variant="success">Success</Button>{' '}
-  <Button variant="warning">Warning</Button>{' '}
-  <Button variant="danger">Danger</Button> <Button variant="info">Info</Button>{' '}
-  <Button variant="light">Light</Button> <Button variant="dark">Dark</Button>{' '}
-  <Button variant="link">Link</Button>
-</>;
+import Button from 'react-bootstrap/Button';
+
+function TypesExample() {
+  return (
+    <>
+      <Button variant="primary">Primary</Button>{' '}
+      <Button variant="secondary">Secondary</Button>{' '}
+      <Button variant="success">Success</Button>{' '}
+      <Button variant="warning">Warning</Button>{' '}
+      <Button variant="danger">Danger</Button>{' '}
+      <Button variant="info">Info</Button>{' '}
+      <Button variant="light">Light</Button>{' '}
+      <Button variant="dark">Dark</Button> <Button variant="link">Link</Button>
+    </>
+  );
+}
+
+export default TypesExample;

--- a/www/src/examples/ButtonGroup/Basic.js
+++ b/www/src/examples/ButtonGroup/Basic.js
@@ -1,5 +1,14 @@
-<ButtonGroup aria-label="Basic example">
-  <Button variant="secondary">Left</Button>
-  <Button variant="secondary">Middle</Button>
-  <Button variant="secondary">Right</Button>
-</ButtonGroup>;
+import Button from 'react-bootstrap/Button';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
+
+function BasicExample() {
+  return (
+    <ButtonGroup aria-label="Basic example">
+      <Button variant="secondary">Left</Button>
+      <Button variant="secondary">Middle</Button>
+      <Button variant="secondary">Right</Button>
+    </ButtonGroup>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/ButtonGroup/Nested.js
+++ b/www/src/examples/ButtonGroup/Nested.js
@@ -1,9 +1,19 @@
-<ButtonGroup>
-  <Button>1</Button>
-  <Button>2</Button>
+import Button from 'react-bootstrap/Button';
+import DropdownButton from 'react-bootstrap/DropdownButton';
+import Dropdown from 'react-bootstrap/Dropdown';
 
-  <DropdownButton as={ButtonGroup} title="Dropdown" id="bg-nested-dropdown">
-    <Dropdown.Item eventKey="1">Dropdown link</Dropdown.Item>
-    <Dropdown.Item eventKey="2">Dropdown link</Dropdown.Item>
-  </DropdownButton>
-</ButtonGroup>;
+function NestedExample() {
+  return (
+    <ButtonGroup>
+      <Button>1</Button>
+      <Button>2</Button>
+
+      <DropdownButton as={ButtonGroup} title="Dropdown" id="bg-nested-dropdown">
+        <Dropdown.Item eventKey="1">Dropdown link</Dropdown.Item>
+        <Dropdown.Item eventKey="2">Dropdown link</Dropdown.Item>
+      </DropdownButton>
+    </ButtonGroup>
+  );
+}
+
+export default NestedExample;

--- a/www/src/examples/ButtonGroup/Sizes.js
+++ b/www/src/examples/ButtonGroup/Sizes.js
@@ -1,19 +1,28 @@
-<>
-  <ButtonGroup size="lg" className="mb-2">
-    <Button>Left</Button>
-    <Button>Middle</Button>
-    <Button>Right</Button>
-  </ButtonGroup>
-  <br />
-  <ButtonGroup className="mb-2">
-    <Button>Left</Button>
-    <Button>Middle</Button>
-    <Button>Right</Button>
-  </ButtonGroup>
-  <br />
-  <ButtonGroup size="sm">
-    <Button>Left</Button>
-    <Button>Middle</Button>
-    <Button>Right</Button>
-  </ButtonGroup>
-</>;
+import Button from 'react-bootstrap/Button';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
+
+function SizesExample() {
+  return (
+    <>
+      <ButtonGroup size="lg" className="mb-2">
+        <Button>Left</Button>
+        <Button>Middle</Button>
+        <Button>Right</Button>
+      </ButtonGroup>
+      <br />
+      <ButtonGroup className="mb-2">
+        <Button>Left</Button>
+        <Button>Middle</Button>
+        <Button>Right</Button>
+      </ButtonGroup>
+      <br />
+      <ButtonGroup size="sm">
+        <Button>Left</Button>
+        <Button>Middle</Button>
+        <Button>Right</Button>
+      </ButtonGroup>
+    </>
+  );
+}
+
+export default SizesExample;

--- a/www/src/examples/ButtonGroup/Toolbar.js
+++ b/www/src/examples/ButtonGroup/Toolbar.js
@@ -1,40 +1,52 @@
-<>
-  <ButtonToolbar className="mb-3" aria-label="Toolbar with Button groups">
-    <ButtonGroup className="me-2" aria-label="First group">
-      <Button variant="secondary">1</Button>{' '}
-      <Button variant="secondary">2</Button>{' '}
-      <Button variant="secondary">3</Button>{' '}
-      <Button variant="secondary">4</Button>
-    </ButtonGroup>
-    <InputGroup>
-      <InputGroup.Text id="btnGroupAddon">@</InputGroup.Text>
-      <FormControl
-        type="text"
-        placeholder="Input group example"
-        aria-label="Input group example"
-        aria-describedby="btnGroupAddon"
-      />
-    </InputGroup>
-  </ButtonToolbar>
+import Button from 'react-bootstrap/Button';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
 
-  <ButtonToolbar
-    className="justify-content-between"
-    aria-label="Toolbar with Button groups"
-  >
-    <ButtonGroup aria-label="First group">
-      <Button variant="secondary">1</Button>{' '}
-      <Button variant="secondary">2</Button>{' '}
-      <Button variant="secondary">3</Button>{' '}
-      <Button variant="secondary">4</Button>
-    </ButtonGroup>
-    <InputGroup>
-      <InputGroup.Text id="btnGroupAddon2">@</InputGroup.Text>
-      <FormControl
-        type="text"
-        placeholder="Input group example"
-        aria-label="Input group example"
-        aria-describedby="btnGroupAddon2"
-      />
-    </InputGroup>
-  </ButtonToolbar>
-</>;
+function ToolbarExample() {
+  return (
+    <>
+      <ButtonToolbar className="mb-3" aria-label="Toolbar with Button groups">
+        <ButtonGroup className="me-2" aria-label="First group">
+          <Button variant="secondary">1</Button>{' '}
+          <Button variant="secondary">2</Button>{' '}
+          <Button variant="secondary">3</Button>{' '}
+          <Button variant="secondary">4</Button>
+        </ButtonGroup>
+        <InputGroup>
+          <InputGroup.Text id="btnGroupAddon">@</InputGroup.Text>
+          <Form.Control
+            type="text"
+            placeholder="Input group example"
+            aria-label="Input group example"
+            aria-describedby="btnGroupAddon"
+          />
+        </InputGroup>
+      </ButtonToolbar>
+
+      <ButtonToolbar
+        className="justify-content-between"
+        aria-label="Toolbar with Button groups"
+      >
+        <ButtonGroup aria-label="First group">
+          <Button variant="secondary">1</Button>{' '}
+          <Button variant="secondary">2</Button>{' '}
+          <Button variant="secondary">3</Button>{' '}
+          <Button variant="secondary">4</Button>
+        </ButtonGroup>
+        <InputGroup>
+          <InputGroup.Text id="btnGroupAddon2">@</InputGroup.Text>
+          <Form.Control
+            type="text"
+            placeholder="Input group example"
+            aria-label="Input group example"
+            aria-describedby="btnGroupAddon2"
+          />
+        </InputGroup>
+      </ButtonToolbar>
+    </>
+  );
+}
+
+export default ToolbarExample;

--- a/www/src/examples/ButtonGroup/ToolbarBasic.js
+++ b/www/src/examples/ButtonGroup/ToolbarBasic.js
@@ -1,11 +1,22 @@
-<ButtonToolbar aria-label="Toolbar with button groups">
-  <ButtonGroup className="me-2" aria-label="First group">
-    <Button>1</Button> <Button>2</Button> <Button>3</Button> <Button>4</Button>
-  </ButtonGroup>
-  <ButtonGroup className="me-2" aria-label="Second group">
-    <Button>5</Button> <Button>6</Button> <Button>7</Button>
-  </ButtonGroup>
-  <ButtonGroup aria-label="Third group">
-    <Button>8</Button>
-  </ButtonGroup>
-</ButtonToolbar>;
+import Button from 'react-bootstrap/Button';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
+
+function ToolbarBasicExample() {
+  return (
+    <ButtonToolbar aria-label="Toolbar with button groups">
+      <ButtonGroup className="me-2" aria-label="First group">
+        <Button>1</Button> <Button>2</Button> <Button>3</Button>{' '}
+        <Button>4</Button>
+      </ButtonGroup>
+      <ButtonGroup className="me-2" aria-label="Second group">
+        <Button>5</Button> <Button>6</Button> <Button>7</Button>
+      </ButtonGroup>
+      <ButtonGroup aria-label="Third group">
+        <Button>8</Button>
+      </ButtonGroup>
+    </ButtonToolbar>
+  );
+}
+
+export default ToolbarBasicExample;

--- a/www/src/examples/ButtonGroup/Vertical.js
+++ b/www/src/examples/ButtonGroup/Vertical.js
@@ -1,22 +1,45 @@
-<ButtonGroup vertical>
-  <Button>Button</Button>
-  <Button>Button</Button>
+import Button from 'react-bootstrap/Button';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import Dropdown from 'react-bootstrap/Dropdown';
+import DropdownButton from 'react-bootstrap/DropdownButton';
 
-  <DropdownButton as={ButtonGroup} title="Dropdown" id="bg-vertical-dropdown-1">
-    <Dropdown.Item eventKey="1">Dropdown link</Dropdown.Item>
-    <Dropdown.Item eventKey="2">Dropdown link</Dropdown.Item>
-  </DropdownButton>
+function VerticalExample() {
+  return (
+    <ButtonGroup vertical>
+      <Button>Button</Button>
+      <Button>Button</Button>
 
-  <Button>Button</Button>
-  <Button>Button</Button>
+      <DropdownButton
+        as={ButtonGroup}
+        title="Dropdown"
+        id="bg-vertical-dropdown-1"
+      >
+        <Dropdown.Item eventKey="1">Dropdown link</Dropdown.Item>
+        <Dropdown.Item eventKey="2">Dropdown link</Dropdown.Item>
+      </DropdownButton>
 
-  <DropdownButton as={ButtonGroup} title="Dropdown" id="bg-vertical-dropdown-2">
-    <Dropdown.Item eventKey="1">Dropdown link</Dropdown.Item>
-    <Dropdown.Item eventKey="2">Dropdown link</Dropdown.Item>
-  </DropdownButton>
+      <Button>Button</Button>
+      <Button>Button</Button>
 
-  <DropdownButton as={ButtonGroup} title="Dropdown" id="bg-vertical-dropdown-3">
-    <Dropdown.Item eventKey="1">Dropdown link</Dropdown.Item>
-    <Dropdown.Item eventKey="2">Dropdown link</Dropdown.Item>
-  </DropdownButton>
-</ButtonGroup>;
+      <DropdownButton
+        as={ButtonGroup}
+        title="Dropdown"
+        id="bg-vertical-dropdown-2"
+      >
+        <Dropdown.Item eventKey="1">Dropdown link</Dropdown.Item>
+        <Dropdown.Item eventKey="2">Dropdown link</Dropdown.Item>
+      </DropdownButton>
+
+      <DropdownButton
+        as={ButtonGroup}
+        title="Dropdown"
+        id="bg-vertical-dropdown-3"
+      >
+        <Dropdown.Item eventKey="1">Dropdown link</Dropdown.Item>
+        <Dropdown.Item eventKey="2">Dropdown link</Dropdown.Item>
+      </DropdownButton>
+    </ButtonGroup>
+  );
+}
+
+export default VerticalExample;

--- a/www/src/examples/Card/Basic.js
+++ b/www/src/examples/Card/Basic.js
@@ -1,11 +1,20 @@
-<Card style={{ width: '18rem' }}>
-  <Card.Img variant="top" src="holder.js/100px180" />
-  <Card.Body>
-    <Card.Title>Card Title</Card.Title>
-    <Card.Text>
-      Some quick example text to build on the card title and make up the bulk of
-      the card's content.
-    </Card.Text>
-    <Button variant="primary">Go somewhere</Button>
-  </Card.Body>
-</Card>;
+import Button from 'react-bootstrap/Button';
+import Card from 'react-bootstrap/Card';
+
+function BasicExample() {
+  return (
+    <Card style={{ width: '18rem' }}>
+      <Card.Img variant="top" src="holder.js/100px180" />
+      <Card.Body>
+        <Card.Title>Card Title</Card.Title>
+        <Card.Text>
+          Some quick example text to build on the card title and make up the
+          bulk of the card's content.
+        </Card.Text>
+        <Button variant="primary">Go somewhere</Button>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/Card/BgColor.js
+++ b/www/src/examples/Card/BgColor.js
@@ -1,29 +1,37 @@
-<>
-  {[
-    'Primary',
-    'Secondary',
-    'Success',
-    'Danger',
-    'Warning',
-    'Info',
-    'Light',
-    'Dark',
-  ].map((variant) => (
-    <Card
-      bg={variant.toLowerCase()}
-      key={variant}
-      text={variant.toLowerCase() === 'light' ? 'dark' : 'white'}
-      style={{ width: '18rem' }}
-      className="mb-2"
-    >
-      <Card.Header>Header</Card.Header>
-      <Card.Body>
-        <Card.Title>{variant} Card Title </Card.Title>
-        <Card.Text>
-          Some quick example text to build on the card title and make up the
-          bulk of the card's content.
-        </Card.Text>
-      </Card.Body>
-    </Card>
-  ))}
-</>;
+import Card from 'react-bootstrap/Card';
+
+function BgColorExample() {
+  return (
+    <>
+      {[
+        'Primary',
+        'Secondary',
+        'Success',
+        'Danger',
+        'Warning',
+        'Info',
+        'Light',
+        'Dark',
+      ].map((variant) => (
+        <Card
+          bg={variant.toLowerCase()}
+          key={variant}
+          text={variant.toLowerCase() === 'light' ? 'dark' : 'white'}
+          style={{ width: '18rem' }}
+          className="mb-2"
+        >
+          <Card.Header>Header</Card.Header>
+          <Card.Body>
+            <Card.Title>{variant} Card Title </Card.Title>
+            <Card.Text>
+              Some quick example text to build on the card title and make up the
+              bulk of the card's content.
+            </Card.Text>
+          </Card.Body>
+        </Card>
+      ))}
+    </>
+  );
+}
+
+export default BgColorExample;

--- a/www/src/examples/Card/BodyOnly.js
+++ b/www/src/examples/Card/BodyOnly.js
@@ -1,3 +1,11 @@
-<Card>
-  <Card.Body>This is some text within a card body.</Card.Body>
-</Card>;
+import Card from 'react-bootstrap/Card';
+
+function BodyOnlyExample() {
+  return (
+    <Card>
+      <Card.Body>This is some text within a card body.</Card.Body>
+    </Card>
+  );
+}
+
+export default BodyOnlyExample;

--- a/www/src/examples/Card/BodyShorthand.js
+++ b/www/src/examples/Card/BodyShorthand.js
@@ -1,1 +1,7 @@
-<Card body>This is some text within a card body.</Card>;
+import Card from 'react-bootstrap/Card';
+
+function BodyShorthandExample() {
+  return <Card body>This is some text within a card body.</Card>;
+}
+
+export default BodyShorthandExample;

--- a/www/src/examples/Card/Border.js
+++ b/www/src/examples/Card/Border.js
@@ -1,97 +1,105 @@
-<>
-  <Card border="primary" style={{ width: '18rem' }}>
-    <Card.Header>Header</Card.Header>
-    <Card.Body>
-      <Card.Title>Primary Card Title</Card.Title>
-      <Card.Text>
-        Some quick example text to build on the card title and make up the bulk
-        of the card's content.
-      </Card.Text>
-    </Card.Body>
-  </Card>
-  <br />
+import Card from 'react-bootstrap/Card';
 
-  <Card border="secondary" style={{ width: '18rem' }}>
-    <Card.Header>Header</Card.Header>
-    <Card.Body>
-      <Card.Title>Secondary Card Title</Card.Title>
-      <Card.Text>
-        Some quick example text to build on the card title and make up the bulk
-        of the card's content.
-      </Card.Text>
-    </Card.Body>
-  </Card>
-  <br />
+function BorderExample() {
+  return (
+    <>
+      <Card border="primary" style={{ width: '18rem' }}>
+        <Card.Header>Header</Card.Header>
+        <Card.Body>
+          <Card.Title>Primary Card Title</Card.Title>
+          <Card.Text>
+            Some quick example text to build on the card title and make up the
+            bulk of the card's content.
+          </Card.Text>
+        </Card.Body>
+      </Card>
+      <br />
 
-  <Card border="success" style={{ width: '18rem' }}>
-    <Card.Header>Header</Card.Header>
-    <Card.Body>
-      <Card.Title>Success Card Title</Card.Title>
-      <Card.Text>
-        Some quick example text to build on the card title and make up the bulk
-        of the card's content.
-      </Card.Text>
-    </Card.Body>
-  </Card>
-  <br />
+      <Card border="secondary" style={{ width: '18rem' }}>
+        <Card.Header>Header</Card.Header>
+        <Card.Body>
+          <Card.Title>Secondary Card Title</Card.Title>
+          <Card.Text>
+            Some quick example text to build on the card title and make up the
+            bulk of the card's content.
+          </Card.Text>
+        </Card.Body>
+      </Card>
+      <br />
 
-  <Card border="danger" style={{ width: '18rem' }}>
-    <Card.Header>Header</Card.Header>
-    <Card.Body>
-      <Card.Title>Danger Card Title</Card.Title>
-      <Card.Text>
-        Some quick example text to build on the card title and make up the bulk
-        of the card's content.
-      </Card.Text>
-    </Card.Body>
-  </Card>
-  <br />
+      <Card border="success" style={{ width: '18rem' }}>
+        <Card.Header>Header</Card.Header>
+        <Card.Body>
+          <Card.Title>Success Card Title</Card.Title>
+          <Card.Text>
+            Some quick example text to build on the card title and make up the
+            bulk of the card's content.
+          </Card.Text>
+        </Card.Body>
+      </Card>
+      <br />
 
-  <Card border="warning" style={{ width: '18rem' }}>
-    <Card.Header>Header</Card.Header>
-    <Card.Body>
-      <Card.Title>Warning Card Title</Card.Title>
-      <Card.Text>
-        Some quick example text to build on the card title and make up the bulk
-        of the card's content.
-      </Card.Text>
-    </Card.Body>
-  </Card>
-  <br />
+      <Card border="danger" style={{ width: '18rem' }}>
+        <Card.Header>Header</Card.Header>
+        <Card.Body>
+          <Card.Title>Danger Card Title</Card.Title>
+          <Card.Text>
+            Some quick example text to build on the card title and make up the
+            bulk of the card's content.
+          </Card.Text>
+        </Card.Body>
+      </Card>
+      <br />
 
-  <Card border="info" style={{ width: '18rem' }}>
-    <Card.Header>Header</Card.Header>
-    <Card.Body>
-      <Card.Title>Info Card Title</Card.Title>
-      <Card.Text>
-        Some quick example text to build on the card title and make up the bulk
-        of the card's content.
-      </Card.Text>
-    </Card.Body>
-  </Card>
-  <br />
+      <Card border="warning" style={{ width: '18rem' }}>
+        <Card.Header>Header</Card.Header>
+        <Card.Body>
+          <Card.Title>Warning Card Title</Card.Title>
+          <Card.Text>
+            Some quick example text to build on the card title and make up the
+            bulk of the card's content.
+          </Card.Text>
+        </Card.Body>
+      </Card>
+      <br />
 
-  <Card border="dark" style={{ width: '18rem' }}>
-    <Card.Header>Header</Card.Header>
-    <Card.Body>
-      <Card.Title>Dark Card Title</Card.Title>
-      <Card.Text>
-        Some quick example text to build on the card title and make up the bulk
-        of the card's content.
-      </Card.Text>
-    </Card.Body>
-  </Card>
-  <br />
+      <Card border="info" style={{ width: '18rem' }}>
+        <Card.Header>Header</Card.Header>
+        <Card.Body>
+          <Card.Title>Info Card Title</Card.Title>
+          <Card.Text>
+            Some quick example text to build on the card title and make up the
+            bulk of the card's content.
+          </Card.Text>
+        </Card.Body>
+      </Card>
+      <br />
 
-  <Card border="light" style={{ width: '18rem' }}>
-    <Card.Header>Header</Card.Header>
-    <Card.Body>
-      <Card.Title>Light Card Title</Card.Title>
-      <Card.Text>
-        Some quick example text to build on the card title and make up the bulk
-        of the card's content.
-      </Card.Text>
-    </Card.Body>
-  </Card>
-  <br />
-</>;
+      <Card border="dark" style={{ width: '18rem' }}>
+        <Card.Header>Header</Card.Header>
+        <Card.Body>
+          <Card.Title>Dark Card Title</Card.Title>
+          <Card.Text>
+            Some quick example text to build on the card title and make up the
+            bulk of the card's content.
+          </Card.Text>
+        </Card.Body>
+      </Card>
+      <br />
+
+      <Card border="light" style={{ width: '18rem' }}>
+        <Card.Header>Header</Card.Header>
+        <Card.Body>
+          <Card.Title>Light Card Title</Card.Title>
+          <Card.Text>
+            Some quick example text to build on the card title and make up the
+            bulk of the card's content.
+          </Card.Text>
+        </Card.Body>
+      </Card>
+      <br />
+    </>
+  );
+}
+
+export default BorderExample;

--- a/www/src/examples/Card/Grid.js
+++ b/www/src/examples/Card/Grid.js
@@ -1,16 +1,27 @@
-<Row xs={1} md={2} className="g-4">
-  {Array.from({ length: 4 }).map((_, idx) => (
-    <Col>
-      <Card>
-        <Card.Img variant="top" src="holder.js/100px160" />
-        <Card.Body>
-          <Card.Title>Card title</Card.Title>
-          <Card.Text>
-            This is a longer card with supporting text below as a natural
-            lead-in to additional content. This content is a little bit longer.
-          </Card.Text>
-        </Card.Body>
-      </Card>
-    </Col>
-  ))}
-</Row>;
+import Card from 'react-bootstrap/Card';
+import Col from 'react-bootstrap/Col';
+import Row from 'react-bootstrap/Row';
+
+function GridExample() {
+  return (
+    <Row xs={1} md={2} className="g-4">
+      {Array.from({ length: 4 }).map((_, idx) => (
+        <Col>
+          <Card>
+            <Card.Img variant="top" src="holder.js/100px160" />
+            <Card.Body>
+              <Card.Title>Card title</Card.Title>
+              <Card.Text>
+                This is a longer card with supporting text below as a natural
+                lead-in to additional content. This content is a little bit
+                longer.
+              </Card.Text>
+            </Card.Body>
+          </Card>
+        </Col>
+      ))}
+    </Row>
+  );
+}
+
+export default GridExample;

--- a/www/src/examples/Card/Group.js
+++ b/www/src/examples/Card/Group.js
@@ -1,42 +1,51 @@
-<CardGroup>
-  <Card>
-    <Card.Img variant="top" src="holder.js/100px160" />
-    <Card.Body>
-      <Card.Title>Card title</Card.Title>
-      <Card.Text>
-        This is a wider card with supporting text below as a natural lead-in to
-        additional content. This content is a little bit longer.
-      </Card.Text>
-    </Card.Body>
-    <Card.Footer>
-      <small className="text-muted">Last updated 3 mins ago</small>
-    </Card.Footer>
-  </Card>
-  <Card>
-    <Card.Img variant="top" src="holder.js/100px160" />
-    <Card.Body>
-      <Card.Title>Card title</Card.Title>
-      <Card.Text>
-        This card has supporting text below as a natural lead-in to additional
-        content.{' '}
-      </Card.Text>
-    </Card.Body>
-    <Card.Footer>
-      <small className="text-muted">Last updated 3 mins ago</small>
-    </Card.Footer>
-  </Card>
-  <Card>
-    <Card.Img variant="top" src="holder.js/100px160" />
-    <Card.Body>
-      <Card.Title>Card title</Card.Title>
-      <Card.Text>
-        This is a wider card with supporting text below as a natural lead-in to
-        additional content. This card has even longer content than the first to
-        show that equal height action.
-      </Card.Text>
-    </Card.Body>
-    <Card.Footer>
-      <small className="text-muted">Last updated 3 mins ago</small>
-    </Card.Footer>
-  </Card>
-</CardGroup>;
+import Card from 'react-bootstrap/Card';
+import CardGroup from 'react-bootstrap/CardGroup';
+
+function GroupExample() {
+  return (
+    <CardGroup>
+      <Card>
+        <Card.Img variant="top" src="holder.js/100px160" />
+        <Card.Body>
+          <Card.Title>Card title</Card.Title>
+          <Card.Text>
+            This is a wider card with supporting text below as a natural lead-in
+            to additional content. This content is a little bit longer.
+          </Card.Text>
+        </Card.Body>
+        <Card.Footer>
+          <small className="text-muted">Last updated 3 mins ago</small>
+        </Card.Footer>
+      </Card>
+      <Card>
+        <Card.Img variant="top" src="holder.js/100px160" />
+        <Card.Body>
+          <Card.Title>Card title</Card.Title>
+          <Card.Text>
+            This card has supporting text below as a natural lead-in to
+            additional content.{' '}
+          </Card.Text>
+        </Card.Body>
+        <Card.Footer>
+          <small className="text-muted">Last updated 3 mins ago</small>
+        </Card.Footer>
+      </Card>
+      <Card>
+        <Card.Img variant="top" src="holder.js/100px160" />
+        <Card.Body>
+          <Card.Title>Card title</Card.Title>
+          <Card.Text>
+            This is a wider card with supporting text below as a natural lead-in
+            to additional content. This card has even longer content than the
+            first to show that equal height action.
+          </Card.Text>
+        </Card.Body>
+        <Card.Footer>
+          <small className="text-muted">Last updated 3 mins ago</small>
+        </Card.Footer>
+      </Card>
+    </CardGroup>
+  );
+}
+
+export default GroupExample;

--- a/www/src/examples/Card/HeaderAndFooter.js
+++ b/www/src/examples/Card/HeaderAndFooter.js
@@ -1,11 +1,20 @@
-<Card className="text-center">
-  <Card.Header>Featured</Card.Header>
-  <Card.Body>
-    <Card.Title>Special title treatment</Card.Title>
-    <Card.Text>
-      With supporting text below as a natural lead-in to additional content.
-    </Card.Text>
-    <Button variant="primary">Go somewhere</Button>
-  </Card.Body>
-  <Card.Footer className="text-muted">2 days ago</Card.Footer>
-</Card>;
+import Button from 'react-bootstrap/Button';
+import Card from 'react-bootstrap/Card';
+
+function HeaderAndFooterExample() {
+  return (
+    <Card className="text-center">
+      <Card.Header>Featured</Card.Header>
+      <Card.Body>
+        <Card.Title>Special title treatment</Card.Title>
+        <Card.Text>
+          With supporting text below as a natural lead-in to additional content.
+        </Card.Text>
+        <Button variant="primary">Go somewhere</Button>
+      </Card.Body>
+      <Card.Footer className="text-muted">2 days ago</Card.Footer>
+    </Card>
+  );
+}
+
+export default HeaderAndFooterExample;

--- a/www/src/examples/Card/ImageAndText.js
+++ b/www/src/examples/Card/ImageAndText.js
@@ -1,21 +1,29 @@
-<>
-  <Card>
-    <Card.Img variant="top" src="holder.js/100px180" />
-    <Card.Body>
-      <Card.Text>
-        Some quick example text to build on the card title and make up the bulk
-        of the card's content.
-      </Card.Text>
-    </Card.Body>
-  </Card>
-  <br />
-  <Card>
-    <Card.Body>
-      <Card.Text>
-        Some quick example text to build on the card title and make up the bulk
-        of the card's content.
-      </Card.Text>
-    </Card.Body>
-    <Card.Img variant="bottom" src="holder.js/100px180" />
-  </Card>
-</>;
+import Card from 'react-bootstrap/Card';
+
+function ImageAndTextExample() {
+  return (
+    <>
+      <Card>
+        <Card.Img variant="top" src="holder.js/100px180" />
+        <Card.Body>
+          <Card.Text>
+            Some quick example text to build on the card title and make up the
+            bulk of the card's content.
+          </Card.Text>
+        </Card.Body>
+      </Card>
+      <br />
+      <Card>
+        <Card.Body>
+          <Card.Text>
+            Some quick example text to build on the card title and make up the
+            bulk of the card's content.
+          </Card.Text>
+        </Card.Body>
+        <Card.Img variant="bottom" src="holder.js/100px180" />
+      </Card>
+    </>
+  );
+}
+
+export default ImageAndTextExample;

--- a/www/src/examples/Card/ImgOverlay.js
+++ b/www/src/examples/Card/ImgOverlay.js
@@ -1,11 +1,19 @@
-<Card className="bg-dark text-white">
-  <Card.Img src="holder.js/100px270" alt="Card image" />
-  <Card.ImgOverlay>
-    <Card.Title>Card title</Card.Title>
-    <Card.Text>
-      This is a wider card with supporting text below as a natural lead-in to
-      additional content. This content is a little bit longer.
-    </Card.Text>
-    <Card.Text>Last updated 3 mins ago</Card.Text>
-  </Card.ImgOverlay>
-</Card>;
+import Card from 'react-bootstrap/Card';
+
+function ImgOverlayExample() {
+  return (
+    <Card className="bg-dark text-white">
+      <Card.Img src="holder.js/100px270" alt="Card image" />
+      <Card.ImgOverlay>
+        <Card.Title>Card title</Card.Title>
+        <Card.Text>
+          This is a wider card with supporting text below as a natural lead-in
+          to additional content. This content is a little bit longer.
+        </Card.Text>
+        <Card.Text>Last updated 3 mins ago</Card.Text>
+      </Card.ImgOverlay>
+    </Card>
+  );
+}
+
+export default ImgOverlayExample;

--- a/www/src/examples/Card/KitchenSink.js
+++ b/www/src/examples/Card/KitchenSink.js
@@ -1,19 +1,28 @@
-<Card style={{ width: '18rem' }}>
-  <Card.Img variant="top" src="holder.js/100px180?text=Image cap" />
-  <Card.Body>
-    <Card.Title>Card Title</Card.Title>
-    <Card.Text>
-      Some quick example text to build on the card title and make up the bulk of
-      the card's content.
-    </Card.Text>
-  </Card.Body>
-  <ListGroup className="list-group-flush">
-    <ListGroupItem>Cras justo odio</ListGroupItem>
-    <ListGroupItem>Dapibus ac facilisis in</ListGroupItem>
-    <ListGroupItem>Vestibulum at eros</ListGroupItem>
-  </ListGroup>
-  <Card.Body>
-    <Card.Link href="#">Card Link</Card.Link>
-    <Card.Link href="#">Another Link</Card.Link>
-  </Card.Body>
-</Card>;
+import Card from 'react-bootstrap/Card';
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function KitchenSinkExample() {
+  return (
+    <Card style={{ width: '18rem' }}>
+      <Card.Img variant="top" src="holder.js/100px180?text=Image cap" />
+      <Card.Body>
+        <Card.Title>Card Title</Card.Title>
+        <Card.Text>
+          Some quick example text to build on the card title and make up the
+          bulk of the card's content.
+        </Card.Text>
+      </Card.Body>
+      <ListGroup className="list-group-flush">
+        <ListGroup.Item>Cras justo odio</ListGroup.Item>
+        <ListGroup.Item>Dapibus ac facilisis in</ListGroup.Item>
+        <ListGroup.Item>Vestibulum at eros</ListGroup.Item>
+      </ListGroup>
+      <Card.Body>
+        <Card.Link href="#">Card Link</Card.Link>
+        <Card.Link href="#">Another Link</Card.Link>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default KitchenSinkExample;

--- a/www/src/examples/Card/ListGroupWithHeader.js
+++ b/www/src/examples/Card/ListGroupWithHeader.js
@@ -1,8 +1,17 @@
-<Card style={{ width: '18rem' }}>
-  <Card.Header>Featured</Card.Header>
-  <ListGroup variant="flush">
-    <ListGroup.Item>Cras justo odio</ListGroup.Item>
-    <ListGroup.Item>Dapibus ac facilisis in</ListGroup.Item>
-    <ListGroup.Item>Vestibulum at eros</ListGroup.Item>
-  </ListGroup>
-</Card>;
+import Card from 'react-bootstrap/Card';
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function ListGroupWithHeaderExample() {
+  return (
+    <Card style={{ width: '18rem' }}>
+      <Card.Header>Featured</Card.Header>
+      <ListGroup variant="flush">
+        <ListGroup.Item>Cras justo odio</ListGroup.Item>
+        <ListGroup.Item>Dapibus ac facilisis in</ListGroup.Item>
+        <ListGroup.Item>Vestibulum at eros</ListGroup.Item>
+      </ListGroup>
+    </Card>
+  );
+}
+
+export default ListGroupWithHeaderExample;

--- a/www/src/examples/Card/ListGroups.js
+++ b/www/src/examples/Card/ListGroups.js
@@ -1,7 +1,16 @@
-<Card style={{ width: '18rem' }}>
-  <ListGroup variant="flush">
-    <ListGroup.Item>Cras justo odio</ListGroup.Item>
-    <ListGroup.Item>Dapibus ac facilisis in</ListGroup.Item>
-    <ListGroup.Item>Vestibulum at eros</ListGroup.Item>
-  </ListGroup>
-</Card>;
+import Card from 'react-bootstrap/Card';
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function ListGroupExample() {
+  return (
+    <Card style={{ width: '18rem' }}>
+      <ListGroup variant="flush">
+        <ListGroup.Item>Cras justo odio</ListGroup.Item>
+        <ListGroup.Item>Dapibus ac facilisis in</ListGroup.Item>
+        <ListGroup.Item>Vestibulum at eros</ListGroup.Item>
+      </ListGroup>
+    </Card>
+  );
+}
+
+export default ListGroupExample;

--- a/www/src/examples/Card/NavPills.js
+++ b/www/src/examples/Card/NavPills.js
@@ -1,24 +1,34 @@
-<Card>
-  <Card.Header>
-    <Nav variant="pills" defaultActiveKey="#first">
-      <Nav.Item>
-        <Nav.Link href="#first">Active</Nav.Link>
-      </Nav.Item>
-      <Nav.Item>
-        <Nav.Link href="#link">Link</Nav.Link>
-      </Nav.Item>
-      <Nav.Item>
-        <Nav.Link href="#disabled" disabled>
-          Disabled
-        </Nav.Link>
-      </Nav.Item>
-    </Nav>
-  </Card.Header>
-  <Card.Body>
-    <Card.Title>Special title treatment</Card.Title>
-    <Card.Text>
-      With supporting text below as a natural lead-in to additional content.
-    </Card.Text>
-    <Button variant="primary">Go somewhere</Button>
-  </Card.Body>
-</Card>;
+import Button from 'react-bootstrap/Button';
+import Card from 'react-bootstrap/Card';
+import Nav from 'react-bootstrap/Nav';
+
+function NavPillsExample() {
+  return (
+    <Card>
+      <Card.Header>
+        <Nav variant="pills" defaultActiveKey="#first">
+          <Nav.Item>
+            <Nav.Link href="#first">Active</Nav.Link>
+          </Nav.Item>
+          <Nav.Item>
+            <Nav.Link href="#link">Link</Nav.Link>
+          </Nav.Item>
+          <Nav.Item>
+            <Nav.Link href="#disabled" disabled>
+              Disabled
+            </Nav.Link>
+          </Nav.Item>
+        </Nav>
+      </Card.Header>
+      <Card.Body>
+        <Card.Title>Special title treatment</Card.Title>
+        <Card.Text>
+          With supporting text below as a natural lead-in to additional content.
+        </Card.Text>
+        <Button variant="primary">Go somewhere</Button>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default NavPillsExample;

--- a/www/src/examples/Card/NavTabs.js
+++ b/www/src/examples/Card/NavTabs.js
@@ -1,24 +1,34 @@
-<Card>
-  <Card.Header>
-    <Nav variant="tabs" defaultActiveKey="#first">
-      <Nav.Item>
-        <Nav.Link href="#first">Active</Nav.Link>
-      </Nav.Item>
-      <Nav.Item>
-        <Nav.Link href="#link">Link</Nav.Link>
-      </Nav.Item>
-      <Nav.Item>
-        <Nav.Link href="#disabled" disabled>
-          Disabled
-        </Nav.Link>
-      </Nav.Item>
-    </Nav>
-  </Card.Header>
-  <Card.Body>
-    <Card.Title>Special title treatment</Card.Title>
-    <Card.Text>
-      With supporting text below as a natural lead-in to additional content.
-    </Card.Text>
-    <Button variant="primary">Go somewhere</Button>
-  </Card.Body>
-</Card>;
+import Button from 'react-bootstrap/Button';
+import Card from 'react-bootstrap/Card';
+import Nav from 'react-bootstrap/Nav';
+
+function NavTabsExample() {
+  return (
+    <Card>
+      <Card.Header>
+        <Nav variant="tabs" defaultActiveKey="#first">
+          <Nav.Item>
+            <Nav.Link href="#first">Active</Nav.Link>
+          </Nav.Item>
+          <Nav.Item>
+            <Nav.Link href="#link">Link</Nav.Link>
+          </Nav.Item>
+          <Nav.Item>
+            <Nav.Link href="#disabled" disabled>
+              Disabled
+            </Nav.Link>
+          </Nav.Item>
+        </Nav>
+      </Card.Header>
+      <Card.Body>
+        <Card.Title>Special title treatment</Card.Title>
+        <Card.Text>
+          With supporting text below as a natural lead-in to additional content.
+        </Card.Text>
+        <Button variant="primary">Go somewhere</Button>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default NavTabsExample;

--- a/www/src/examples/Card/Text.js
+++ b/www/src/examples/Card/Text.js
@@ -1,12 +1,20 @@
-<Card style={{ width: '18rem' }}>
-  <Card.Body>
-    <Card.Title>Card Title</Card.Title>
-    <Card.Subtitle className="mb-2 text-muted">Card Subtitle</Card.Subtitle>
-    <Card.Text>
-      Some quick example text to build on the card title and make up the bulk of
-      the card's content.
-    </Card.Text>
-    <Card.Link href="#">Card Link</Card.Link>
-    <Card.Link href="#">Another Link</Card.Link>
-  </Card.Body>
-</Card>;
+import Card from 'react-bootstrap/Card';
+
+function TextExample() {
+  return (
+    <Card style={{ width: '18rem' }}>
+      <Card.Body>
+        <Card.Title>Card Title</Card.Title>
+        <Card.Subtitle className="mb-2 text-muted">Card Subtitle</Card.Subtitle>
+        <Card.Text>
+          Some quick example text to build on the card title and make up the
+          bulk of the card's content.
+        </Card.Text>
+        <Card.Link href="#">Card Link</Card.Link>
+        <Card.Link href="#">Another Link</Card.Link>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default TextExample;

--- a/www/src/examples/Card/WithHeader.js
+++ b/www/src/examples/Card/WithHeader.js
@@ -1,10 +1,19 @@
-<Card>
-  <Card.Header>Featured</Card.Header>
-  <Card.Body>
-    <Card.Title>Special title treatment</Card.Title>
-    <Card.Text>
-      With supporting text below as a natural lead-in to additional content.
-    </Card.Text>
-    <Button variant="primary">Go somewhere</Button>
-  </Card.Body>
-</Card>;
+import Button from 'react-bootstrap/Button';
+import Card from 'react-bootstrap/Card';
+
+function WithHeaderExample() {
+  return (
+    <Card>
+      <Card.Header>Featured</Card.Header>
+      <Card.Body>
+        <Card.Title>Special title treatment</Card.Title>
+        <Card.Text>
+          With supporting text below as a natural lead-in to additional content.
+        </Card.Text>
+        <Button variant="primary">Go somewhere</Button>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default WithHeaderExample;

--- a/www/src/examples/Card/WithHeaderAndQuote.js
+++ b/www/src/examples/Card/WithHeaderAndQuote.js
@@ -1,15 +1,23 @@
-<Card>
-  <Card.Header>Quote</Card.Header>
-  <Card.Body>
-    <blockquote className="blockquote mb-0">
-      <p>
-        {' '}
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer posuere
-        erat a ante.{' '}
-      </p>
-      <footer className="blockquote-footer">
-        Someone famous in <cite title="Source Title">Source Title</cite>
-      </footer>
-    </blockquote>
-  </Card.Body>
-</Card>;
+import Card from 'react-bootstrap/Card';
+
+function WithHeaderAndQuoteExample() {
+  return (
+    <Card>
+      <Card.Header>Quote</Card.Header>
+      <Card.Body>
+        <blockquote className="blockquote mb-0">
+          <p>
+            {' '}
+            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer
+            posuere erat a ante.{' '}
+          </p>
+          <footer className="blockquote-footer">
+            Someone famous in <cite title="Source Title">Source Title</cite>
+          </footer>
+        </blockquote>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default WithHeaderAndQuoteExample;

--- a/www/src/examples/Card/WithHeaderStyled.js
+++ b/www/src/examples/Card/WithHeaderStyled.js
@@ -1,10 +1,19 @@
-<Card>
-  <Card.Header as="h5">Featured</Card.Header>
-  <Card.Body>
-    <Card.Title>Special title treatment</Card.Title>
-    <Card.Text>
-      With supporting text below as a natural lead-in to additional content.
-    </Card.Text>
-    <Button variant="primary">Go somewhere</Button>
-  </Card.Body>
-</Card>;
+import Button from 'react-bootstrap/Button';
+import Card from 'react-bootstrap/Card';
+
+function WithHeaderStyledExample() {
+  return (
+    <Card>
+      <Card.Header as="h5">Featured</Card.Header>
+      <Card.Body>
+        <Card.Title>Special title treatment</Card.Title>
+        <Card.Text>
+          With supporting text below as a natural lead-in to additional content.
+        </Card.Text>
+        <Button variant="primary">Go somewhere</Button>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default WithHeaderStyledExample;

--- a/www/src/examples/Carousel/CarouselFade.js
+++ b/www/src/examples/Carousel/CarouselFade.js
@@ -1,37 +1,47 @@
-<Carousel fade>
-  <Carousel.Item>
-    <img
-      className="d-block w-100"
-      src="holder.js/800x400?text=First slide&bg=373940"
-      alt="First slide"
-    />
-    <Carousel.Caption>
-      <h3>First slide label</h3>
-      <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
-    </Carousel.Caption>
-  </Carousel.Item>
-  <Carousel.Item>
-    <img
-      className="d-block w-100"
-      src="holder.js/800x400?text=Second slide&bg=282c34"
-      alt="Second slide"
-    />
+import Carousel from 'react-bootstrap/Carousel';
 
-    <Carousel.Caption>
-      <h3>Second slide label</h3>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-    </Carousel.Caption>
-  </Carousel.Item>
-  <Carousel.Item>
-    <img
-      className="d-block w-100"
-      src="holder.js/800x400?text=Third slide&bg=20232a"
-      alt="Third slide"
-    />
+function CarouselFadeExample() {
+  return (
+    <Carousel fade>
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=First slide&bg=373940"
+          alt="First slide"
+        />
+        <Carousel.Caption>
+          <h3>First slide label</h3>
+          <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
+        </Carousel.Caption>
+      </Carousel.Item>
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=Second slide&bg=282c34"
+          alt="Second slide"
+        />
 
-    <Carousel.Caption>
-      <h3>Third slide label</h3>
-      <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur.</p>
-    </Carousel.Caption>
-  </Carousel.Item>
-</Carousel>;
+        <Carousel.Caption>
+          <h3>Second slide label</h3>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        </Carousel.Caption>
+      </Carousel.Item>
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=Third slide&bg=20232a"
+          alt="Third slide"
+        />
+
+        <Carousel.Caption>
+          <h3>Third slide label</h3>
+          <p>
+            Praesent commodo cursus magna, vel scelerisque nisl consectetur.
+          </p>
+        </Carousel.Caption>
+      </Carousel.Item>
+    </Carousel>
+  );
+}
+
+export default CarouselFadeExample;

--- a/www/src/examples/Carousel/Controlled.js
+++ b/www/src/examples/Carousel/Controlled.js
@@ -1,3 +1,6 @@
+import React, { useState } from 'react';
+import Carousel from 'react-bootstrap/Carousel';
+
 function ControlledCarousel() {
   const [index, setIndex] = useState(0);
 

--- a/www/src/examples/Carousel/DarkVariant.js
+++ b/www/src/examples/Carousel/DarkVariant.js
@@ -1,35 +1,45 @@
-<Carousel variant="dark">
-  <Carousel.Item>
-    <img
-      className="d-block w-100"
-      src="holder.js/800x400?text=First slide&bg=f5f5f5"
-      alt="First slide"
-    />
-    <Carousel.Caption>
-      <h5>First slide label</h5>
-      <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
-    </Carousel.Caption>
-  </Carousel.Item>
-  <Carousel.Item>
-    <img
-      className="d-block w-100"
-      src="holder.js/800x400?text=Second slide&bg=eee"
-      alt="Second slide"
-    />
-    <Carousel.Caption>
-      <h5>Second slide label</h5>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-    </Carousel.Caption>
-  </Carousel.Item>
-  <Carousel.Item>
-    <img
-      className="d-block w-100"
-      src="holder.js/800x400?text=Third slide&bg=e5e5e5"
-      alt="Third slide"
-    />
-    <Carousel.Caption>
-      <h5>Third slide label</h5>
-      <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur.</p>
-    </Carousel.Caption>
-  </Carousel.Item>
-</Carousel>;
+import Carousel from 'react-bootstrap/Carousel';
+
+function DarkVariantExample() {
+  return (
+    <Carousel variant="dark">
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=First slide&bg=f5f5f5"
+          alt="First slide"
+        />
+        <Carousel.Caption>
+          <h5>First slide label</h5>
+          <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
+        </Carousel.Caption>
+      </Carousel.Item>
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=Second slide&bg=eee"
+          alt="Second slide"
+        />
+        <Carousel.Caption>
+          <h5>Second slide label</h5>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        </Carousel.Caption>
+      </Carousel.Item>
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=Third slide&bg=e5e5e5"
+          alt="Third slide"
+        />
+        <Carousel.Caption>
+          <h5>Third slide label</h5>
+          <p>
+            Praesent commodo cursus magna, vel scelerisque nisl consectetur.
+          </p>
+        </Carousel.Caption>
+      </Carousel.Item>
+    </Carousel>
+  );
+}
+
+export default DarkVariantExample;

--- a/www/src/examples/Carousel/IndividualIntervals.js
+++ b/www/src/examples/Carousel/IndividualIntervals.js
@@ -1,35 +1,45 @@
-<Carousel>
-  <Carousel.Item interval={1000}>
-    <img
-      className="d-block w-100"
-      src="holder.js/800x400?text=First slide&bg=373940"
-      alt="First slide"
-    />
-    <Carousel.Caption>
-      <h3>First slide label</h3>
-      <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
-    </Carousel.Caption>
-  </Carousel.Item>
-  <Carousel.Item interval={500}>
-    <img
-      className="d-block w-100"
-      src="holder.js/800x400?text=Second slide&bg=282c34"
-      alt="Second slide"
-    />
-    <Carousel.Caption>
-      <h3>Second slide label</h3>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-    </Carousel.Caption>
-  </Carousel.Item>
-  <Carousel.Item>
-    <img
-      className="d-block w-100"
-      src="holder.js/800x400?text=Third slide&bg=20232a"
-      alt="Third slide"
-    />
-    <Carousel.Caption>
-      <h3>Third slide label</h3>
-      <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur.</p>
-    </Carousel.Caption>
-  </Carousel.Item>
-</Carousel>;
+import Carousel from 'react-bootstrap/Carousel';
+
+function IndividualIntervalsExample() {
+  return (
+    <Carousel>
+      <Carousel.Item interval={1000}>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=First slide&bg=373940"
+          alt="First slide"
+        />
+        <Carousel.Caption>
+          <h3>First slide label</h3>
+          <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
+        </Carousel.Caption>
+      </Carousel.Item>
+      <Carousel.Item interval={500}>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=Second slide&bg=282c34"
+          alt="Second slide"
+        />
+        <Carousel.Caption>
+          <h3>Second slide label</h3>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        </Carousel.Caption>
+      </Carousel.Item>
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=Third slide&bg=20232a"
+          alt="Third slide"
+        />
+        <Carousel.Caption>
+          <h3>Third slide label</h3>
+          <p>
+            Praesent commodo cursus magna, vel scelerisque nisl consectetur.
+          </p>
+        </Carousel.Caption>
+      </Carousel.Item>
+    </Carousel>
+  );
+}
+
+export default IndividualIntervalsExample;

--- a/www/src/examples/Carousel/Uncontrolled.js
+++ b/www/src/examples/Carousel/Uncontrolled.js
@@ -1,37 +1,47 @@
-<Carousel>
-  <Carousel.Item>
-    <img
-      className="d-block w-100"
-      src="holder.js/800x400?text=First slide&bg=373940"
-      alt="First slide"
-    />
-    <Carousel.Caption>
-      <h3>First slide label</h3>
-      <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
-    </Carousel.Caption>
-  </Carousel.Item>
-  <Carousel.Item>
-    <img
-      className="d-block w-100"
-      src="holder.js/800x400?text=Second slide&bg=282c34"
-      alt="Second slide"
-    />
+import Carousel from 'react-bootstrap/Carousel';
 
-    <Carousel.Caption>
-      <h3>Second slide label</h3>
-      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-    </Carousel.Caption>
-  </Carousel.Item>
-  <Carousel.Item>
-    <img
-      className="d-block w-100"
-      src="holder.js/800x400?text=Third slide&bg=20232a"
-      alt="Third slide"
-    />
+function UncontrolledExample() {
+  return (
+    <Carousel>
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=First slide&bg=373940"
+          alt="First slide"
+        />
+        <Carousel.Caption>
+          <h3>First slide label</h3>
+          <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
+        </Carousel.Caption>
+      </Carousel.Item>
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=Second slide&bg=282c34"
+          alt="Second slide"
+        />
 
-    <Carousel.Caption>
-      <h3>Third slide label</h3>
-      <p>Praesent commodo cursus magna, vel scelerisque nisl consectetur.</p>
-    </Carousel.Caption>
-  </Carousel.Item>
-</Carousel>;
+        <Carousel.Caption>
+          <h3>Second slide label</h3>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        </Carousel.Caption>
+      </Carousel.Item>
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=Third slide&bg=20232a"
+          alt="Third slide"
+        />
+
+        <Carousel.Caption>
+          <h3>Third slide label</h3>
+          <p>
+            Praesent commodo cursus magna, vel scelerisque nisl consectetur.
+          </p>
+        </Carousel.Caption>
+      </Carousel.Item>
+    </Carousel>
+  );
+}
+
+export default UncontrolledExample;

--- a/www/src/examples/CloseButton/Basic.js
+++ b/www/src/examples/CloseButton/Basic.js
@@ -1,1 +1,7 @@
-<CloseButton />;
+import CloseButton from 'react-bootstrap/CloseButton';
+
+function BasicExample() {
+  return <CloseButton />;
+}
+
+export default BasicExample;

--- a/www/src/examples/CloseButton/Disabled.js
+++ b/www/src/examples/CloseButton/Disabled.js
@@ -1,1 +1,7 @@
-<CloseButton disabled />;
+import CloseButton from 'react-bootstrap/CloseButton';
+
+function DisabledExample() {
+  return <CloseButton disabled />;
+}
+
+export default DisabledExample;

--- a/www/src/examples/CloseButton/Labelled.js
+++ b/www/src/examples/CloseButton/Labelled.js
@@ -1,1 +1,7 @@
-<CloseButton aria-label="Hide" />;
+import CloseButton from 'react-bootstrap/CloseButton';
+
+function LabelledExample() {
+  return <CloseButton aria-label="Hide" />;
+}
+
+export default LabelledExample;

--- a/www/src/examples/CloseButton/Variants.js
+++ b/www/src/examples/CloseButton/Variants.js
@@ -1,4 +1,12 @@
-<div className="bg-dark p-3">
-  <CloseButton variant="white" />
-  <CloseButton variant="white" disabled />
-</div>;
+import CloseButton from 'react-bootstrap/CloseButton';
+
+function VariantsExample() {
+  return (
+    <div className="bg-dark p-3">
+      <CloseButton variant="white" />
+      <CloseButton variant="white" disabled />
+    </div>
+  );
+}
+
+export default VariantsExample;

--- a/www/src/examples/Collapse.js
+++ b/www/src/examples/Collapse.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Collapse from 'react-bootstrap/Collapse';
+
 function Example() {
   const [open, setOpen] = useState(false);
 

--- a/www/src/examples/CollapseHorizontal.js
+++ b/www/src/examples/CollapseHorizontal.js
@@ -1,3 +1,8 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Card from 'react-bootstrap/Card';
+import Collapse from 'react-bootstrap/Collapse';
+
 function Example() {
   const [open, setOpen] = useState(false);
 
@@ -10,13 +15,14 @@ function Example() {
       >
         click
       </Button>
-      <div style={{minHeight: '150px'}}>
+      <div style={{ minHeight: '150px' }}>
         <Collapse in={open} dimension="width">
           <div id="example-collapse-text">
-            <Card body style={{width: '400px'}}>
-                Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus
-                terry richardson ad squid. Nihil anim keffiyeh helvetica, craft beer
-                labore wes anderson cred nesciunt sapiente ea proident.
+            <Card body style={{ width: '400px' }}>
+              Anim pariatur cliche reprehenderit, enim eiusmod high life
+              accusamus terry richardson ad squid. Nihil anim keffiyeh
+              helvetica, craft beer labore wes anderson cred nesciunt sapiente
+              ea proident.
             </Card>
           </div>
         </Collapse>

--- a/www/src/examples/Dropdown/AutoClose.js
+++ b/www/src/examples/Dropdown/AutoClose.js
@@ -1,49 +1,57 @@
-<>
-  <Dropdown className="d-inline mx-2">
-    <Dropdown.Toggle id="dropdown-autoclose-true">
-      Default Dropdown
-    </Dropdown.Toggle>
+import Dropdown from 'react-bootstrap/Dropdown';
 
-    <Dropdown.Menu>
-      <Dropdown.Item href="#">Menu Item</Dropdown.Item>
-      <Dropdown.Item href="#">Menu Item</Dropdown.Item>
-      <Dropdown.Item href="#">Menu Item</Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown>
+function AutoCloseExample() {
+  return (
+    <>
+      <Dropdown className="d-inline mx-2">
+        <Dropdown.Toggle id="dropdown-autoclose-true">
+          Default Dropdown
+        </Dropdown.Toggle>
 
-  <Dropdown className="d-inline mx-2" autoClose="inside">
-    <Dropdown.Toggle id="dropdown-autoclose-inside">
-      Clickable Outside
-    </Dropdown.Toggle>
+        <Dropdown.Menu>
+          <Dropdown.Item href="#">Menu Item</Dropdown.Item>
+          <Dropdown.Item href="#">Menu Item</Dropdown.Item>
+          <Dropdown.Item href="#">Menu Item</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
 
-    <Dropdown.Menu>
-      <Dropdown.Item href="#">Menu Item</Dropdown.Item>
-      <Dropdown.Item href="#">Menu Item</Dropdown.Item>
-      <Dropdown.Item href="#">Menu Item</Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown>
+      <Dropdown className="d-inline mx-2" autoClose="inside">
+        <Dropdown.Toggle id="dropdown-autoclose-inside">
+          Clickable Outside
+        </Dropdown.Toggle>
 
-  <Dropdown className="d-inline mx-2" autoClose="outside">
-    <Dropdown.Toggle id="dropdown-autoclose-outside">
-      Clickable Inside
-    </Dropdown.Toggle>
+        <Dropdown.Menu>
+          <Dropdown.Item href="#">Menu Item</Dropdown.Item>
+          <Dropdown.Item href="#">Menu Item</Dropdown.Item>
+          <Dropdown.Item href="#">Menu Item</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
 
-    <Dropdown.Menu>
-      <Dropdown.Item href="#">Menu Item</Dropdown.Item>
-      <Dropdown.Item href="#">Menu Item</Dropdown.Item>
-      <Dropdown.Item href="#">Menu Item</Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown>
+      <Dropdown className="d-inline mx-2" autoClose="outside">
+        <Dropdown.Toggle id="dropdown-autoclose-outside">
+          Clickable Inside
+        </Dropdown.Toggle>
 
-  <Dropdown className="d-inline mx-2" autoClose={false}>
-    <Dropdown.Toggle id="dropdown-autoclose-false">
-      Manual Close
-    </Dropdown.Toggle>
+        <Dropdown.Menu>
+          <Dropdown.Item href="#">Menu Item</Dropdown.Item>
+          <Dropdown.Item href="#">Menu Item</Dropdown.Item>
+          <Dropdown.Item href="#">Menu Item</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
 
-    <Dropdown.Menu>
-      <Dropdown.Item href="#">Menu Item</Dropdown.Item>
-      <Dropdown.Item href="#">Menu Item</Dropdown.Item>
-      <Dropdown.Item href="#">Menu Item</Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown>
-</>;
+      <Dropdown className="d-inline mx-2" autoClose={false}>
+        <Dropdown.Toggle id="dropdown-autoclose-false">
+          Manual Close
+        </Dropdown.Toggle>
+
+        <Dropdown.Menu>
+          <Dropdown.Item href="#">Menu Item</Dropdown.Item>
+          <Dropdown.Item href="#">Menu Item</Dropdown.Item>
+          <Dropdown.Item href="#">Menu Item</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+    </>
+  );
+}
+
+export default AutoCloseExample;

--- a/www/src/examples/Dropdown/Basic.js
+++ b/www/src/examples/Dropdown/Basic.js
@@ -1,11 +1,19 @@
-<Dropdown>
-  <Dropdown.Toggle variant="success" id="dropdown-basic">
-    Dropdown Button
-  </Dropdown.Toggle>
+import Dropdown from 'react-bootstrap/Dropdown';
 
-  <Dropdown.Menu>
-    <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
-    <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
-    <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
-  </Dropdown.Menu>
-</Dropdown>;
+function BasicExample() {
+  return (
+    <Dropdown>
+      <Dropdown.Toggle variant="success" id="dropdown-basic">
+        Dropdown Button
+      </Dropdown.Toggle>
+
+      <Dropdown.Menu>
+        <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
+        <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
+        <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/Dropdown/BasicButton.js
+++ b/www/src/examples/Dropdown/BasicButton.js
@@ -1,5 +1,14 @@
-<DropdownButton id="dropdown-basic-button" title="Dropdown button">
-  <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
-  <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
-  <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
-</DropdownButton>;
+import Dropdown from 'react-bootstrap/Dropdown';
+import DropdownButton from 'react-bootstrap/DropdownButton';
+
+function BasicButtonExample() {
+  return (
+    <DropdownButton id="dropdown-basic-button" title="Dropdown button">
+      <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
+      <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
+      <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
+    </DropdownButton>
+  );
+}
+
+export default BasicButtonExample;

--- a/www/src/examples/Dropdown/ButtonCustom.js
+++ b/www/src/examples/Dropdown/ButtonCustom.js
@@ -1,27 +1,37 @@
-<>
-  <Dropdown as={ButtonGroup}>
-    <Dropdown.Toggle id="dropdown-custom-1">Pow! Zoom!</Dropdown.Toggle>
-    <Dropdown.Menu className="super-colors">
-      <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-      <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-      <Dropdown.Item eventKey="3" active>
-        Active Item
-      </Dropdown.Item>
-      <Dropdown.Divider />
-      <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown>{' '}
-  <Dropdown as={ButtonGroup}>
-    <Button variant="info">mix it up style-wise</Button>
-    <Dropdown.Toggle split variant="success" id="dropdown-custom-2" />
-    <Dropdown.Menu className="super-colors">
-      <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-      <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-      <Dropdown.Item eventKey="3" active>
-        Active Item
-      </Dropdown.Item>
-      <Dropdown.Divider />
-      <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown>
-</>;
+import Button from 'react-bootstrap/Button';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import Dropdown from 'react-bootstrap/Dropdown';
+
+function ButtonCustomExample() {
+  return (
+    <>
+      <Dropdown as={ButtonGroup}>
+        <Dropdown.Toggle id="dropdown-custom-1">Pow! Zoom!</Dropdown.Toggle>
+        <Dropdown.Menu className="super-colors">
+          <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+          <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+          <Dropdown.Item eventKey="3" active>
+            Active Item
+          </Dropdown.Item>
+          <Dropdown.Divider />
+          <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>{' '}
+      <Dropdown as={ButtonGroup}>
+        <Button variant="info">mix it up style-wise</Button>
+        <Dropdown.Toggle split variant="success" id="dropdown-custom-2" />
+        <Dropdown.Menu className="super-colors">
+          <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+          <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+          <Dropdown.Item eventKey="3" active>
+            Active Item
+          </Dropdown.Item>
+          <Dropdown.Divider />
+          <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+    </>
+  );
+}
+
+export default ButtonCustomExample;

--- a/www/src/examples/Dropdown/ButtonCustomMenu.js
+++ b/www/src/examples/Dropdown/ButtonCustomMenu.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import Dropdown from 'react-bootstrap/Dropdown';
+import Form from 'react-bootstrap/Form';
+
 // The forwardRef is important!!
 // Dropdown needs access to the DOM node in order to position the Menu
 const CustomToggle = React.forwardRef(({ children, onClick }, ref) => (
@@ -27,7 +31,7 @@ const CustomMenu = React.forwardRef(
         className={className}
         aria-labelledby={labeledBy}
       >
-        <FormControl
+        <Form.Control
           autoFocus
           className="mx-3 my-2 w-auto"
           placeholder="Type to filter..."

--- a/www/src/examples/Dropdown/ButtonDark.js
+++ b/www/src/examples/Dropdown/ButtonDark.js
@@ -1,33 +1,42 @@
-<>
-  <Dropdown>
-    <Dropdown.Toggle id="dropdown-button-dark-example1" variant="secondary">
-      Dropdown Button
-    </Dropdown.Toggle>
+import Dropdown from 'react-bootstrap/Dropdown';
+import DropdownButton from 'react-bootstrap/DropdownButton';
 
-    <Dropdown.Menu variant="dark">
-      <Dropdown.Item href="#/action-1" active>
-        Action
-      </Dropdown.Item>
-      <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
-      <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
-      <Dropdown.Divider />
-      <Dropdown.Item href="#/action-4">Separated link</Dropdown.Item>
-    </Dropdown.Menu>
-  </Dropdown>
+function ButtonDarkExample() {
+  return (
+    <>
+      <Dropdown>
+        <Dropdown.Toggle id="dropdown-button-dark-example1" variant="secondary">
+          Dropdown Button
+        </Dropdown.Toggle>
 
-  <DropdownButton
-    id="dropdown-button-dark-example2"
-    variant="secondary"
-    menuVariant="dark"
-    title="Dropdown button"
-    className="mt-2"
-  >
-    <Dropdown.Item href="#/action-1" active>
-      Action
-    </Dropdown.Item>
-    <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
-    <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
-    <Dropdown.Divider />
-    <Dropdown.Item href="#/action-4">Separated link</Dropdown.Item>
-  </DropdownButton>
-</>;
+        <Dropdown.Menu variant="dark">
+          <Dropdown.Item href="#/action-1" active>
+            Action
+          </Dropdown.Item>
+          <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
+          <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
+          <Dropdown.Divider />
+          <Dropdown.Item href="#/action-4">Separated link</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>
+
+      <DropdownButton
+        id="dropdown-button-dark-example2"
+        variant="secondary"
+        menuVariant="dark"
+        title="Dropdown button"
+        className="mt-2"
+      >
+        <Dropdown.Item href="#/action-1" active>
+          Action
+        </Dropdown.Item>
+        <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
+        <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
+        <Dropdown.Divider />
+        <Dropdown.Item href="#/action-4">Separated link</Dropdown.Item>
+      </DropdownButton>
+    </>
+  );
+}
+
+export default ButtonDarkExample;

--- a/www/src/examples/Dropdown/ButtonSizes.js
+++ b/www/src/examples/Dropdown/ButtonSizes.js
@@ -1,37 +1,48 @@
-<>
-  <div className="mb-2">
-    {[DropdownButton, SplitButton].map((DropdownType, idx) => (
-      <DropdownType
-        as={ButtonGroup}
-        key={idx}
-        id={`dropdown-button-drop-${idx}`}
-        size="lg"
-        title="Drop large"
-      >
-        <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-        <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-        <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
-        <Dropdown.Divider />
-        <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-      </DropdownType>
-    ))}
-  </div>
-  <div>
-    {[DropdownButton, SplitButton].map((DropdownType, idx) => (
-      <DropdownType
-        as={ButtonGroup}
-        key={idx}
-        id={`dropdown-button-drop-${idx}`}
-        size="sm"
-        variant="secondary"
-        title="Drop small"
-      >
-        <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-        <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-        <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
-        <Dropdown.Divider />
-        <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-      </DropdownType>
-    ))}
-  </div>
-</>;
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import Dropdown from 'react-bootstrap/Dropdown';
+import DropdownButton from 'react-bootstrap/DropdownButton';
+import SplitButton from 'react-bootstrap/SplitButton';
+
+function ButtonSizesExample() {
+  return (
+    <>
+      <div className="mb-2">
+        {[DropdownButton, SplitButton].map((DropdownType, idx) => (
+          <DropdownType
+            as={ButtonGroup}
+            key={idx}
+            id={`dropdown-button-drop-${idx}`}
+            size="lg"
+            title="Drop large"
+          >
+            <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+            <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+            <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
+            <Dropdown.Divider />
+            <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+          </DropdownType>
+        ))}
+      </div>
+      <div>
+        {[DropdownButton, SplitButton].map((DropdownType, idx) => (
+          <DropdownType
+            as={ButtonGroup}
+            key={idx}
+            id={`dropdown-button-drop-${idx}`}
+            size="sm"
+            variant="secondary"
+            title="Drop small"
+          >
+            <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+            <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+            <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
+            <Dropdown.Divider />
+            <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+          </DropdownType>
+        ))}
+      </div>
+    </>
+  );
+}
+
+export default ButtonSizesExample;

--- a/www/src/examples/Dropdown/DropDirections.js
+++ b/www/src/examples/Dropdown/DropDirections.js
@@ -1,38 +1,48 @@
-<>
-  <div className="mb-2">
-    {['up', 'down', 'start', 'end'].map((direction) => (
-      <DropdownButton
-        as={ButtonGroup}
-        key={direction}
-        id={`dropdown-button-drop-${direction}`}
-        drop={direction}
-        variant="secondary"
-        title={` Drop ${direction} `}
-      >
-        <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-        <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-        <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
-        <Dropdown.Divider />
-        <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-      </DropdownButton>
-    ))}
-  </div>
+import Dropdown from 'react-bootstrap/Dropdown';
+import DropdownButton from 'react-bootstrap/DropdownButton';
+import SplitButton from 'react-bootstrap/SplitButton';
 
-  <div>
-    {['up', 'down', 'start', 'end'].map((direction) => (
-      <SplitButton
-        key={direction}
-        id={`dropdown-button-drop-${direction}`}
-        drop={direction}
-        variant="secondary"
-        title={`Drop ${direction}`}
-      >
-        <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-        <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-        <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
-        <Dropdown.Divider />
-        <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-      </SplitButton>
-    ))}
-  </div>
-</>;
+function DropDirectioExample() {
+  return (
+    <>
+      <div className="mb-2">
+        {['up', 'down', 'start', 'end'].map((direction) => (
+          <DropdownButton
+            as={ButtonGroup}
+            key={direction}
+            id={`dropdown-button-drop-${direction}`}
+            drop={direction}
+            variant="secondary"
+            title={` Drop ${direction} `}
+          >
+            <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+            <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+            <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
+            <Dropdown.Divider />
+            <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+          </DropdownButton>
+        ))}
+      </div>
+
+      <div>
+        {['up', 'down', 'start', 'end'].map((direction) => (
+          <SplitButton
+            key={direction}
+            id={`dropdown-button-drop-${direction}`}
+            drop={direction}
+            variant="secondary"
+            title={`Drop ${direction}`}
+          >
+            <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+            <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+            <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
+            <Dropdown.Divider />
+            <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+          </SplitButton>
+        ))}
+      </div>
+    </>
+  );
+}
+
+export default DropDirectioExample;

--- a/www/src/examples/Dropdown/DropdownItemTags.js
+++ b/www/src/examples/Dropdown/DropdownItemTags.js
@@ -1,6 +1,15 @@
-<DropdownButton id="dropdown-item-button" title="Dropdown button">
-  <Dropdown.ItemText>Dropdown item text</Dropdown.ItemText>
-  <Dropdown.Item as="button">Action</Dropdown.Item>
-  <Dropdown.Item as="button">Another action</Dropdown.Item>
-  <Dropdown.Item as="button">Something else</Dropdown.Item>
-</DropdownButton>;
+import Dropdown from 'react-bootstrap/Dropdown';
+import DropdownButton from 'react-bootstrap/DropdownButton';
+
+function DropdownItemTagsExample() {
+  return (
+    <DropdownButton id="dropdown-item-button" title="Dropdown button">
+      <Dropdown.ItemText>Dropdown item text</Dropdown.ItemText>
+      <Dropdown.Item as="button">Action</Dropdown.Item>
+      <Dropdown.Item as="button">Another action</Dropdown.Item>
+      <Dropdown.Item as="button">Something else</Dropdown.Item>
+    </DropdownButton>
+  );
+}
+
+export default DropdownItemTagsExample;

--- a/www/src/examples/Dropdown/MenuAlignEnd.js
+++ b/www/src/examples/Dropdown/MenuAlignEnd.js
@@ -1,7 +1,20 @@
-<DropdownButton align="end" title="Dropdown end" id="dropdown-menu-align-end">
-  <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-  <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-  <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
-  <Dropdown.Divider />
-  <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-</DropdownButton>;
+import Dropdown from 'react-bootstrap/Dropdown';
+import DropdownButton from 'react-bootstrap/DropdownButton';
+
+function MenuAlignEndExample() {
+  return (
+    <DropdownButton
+      align="end"
+      title="Dropdown end"
+      id="dropdown-menu-align-end"
+    >
+      <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+      <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+      <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
+      <Dropdown.Divider />
+      <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+    </DropdownButton>
+  );
+}
+
+export default MenuAlignEndExample;

--- a/www/src/examples/Dropdown/MenuAlignResponsive.js
+++ b/www/src/examples/Dropdown/MenuAlignResponsive.js
@@ -1,23 +1,33 @@
-<>
-  <div>
-    <DropdownButton
-      as={ButtonGroup}
-      align={{ lg: 'end' }}
-      title="Left-aligned but right aligned when large screen"
-      id="dropdown-menu-align-responsive-1"
-    >
-      <Dropdown.Item eventKey="1">Action 1</Dropdown.Item>
-      <Dropdown.Item eventKey="2">Action 2</Dropdown.Item>
-    </DropdownButton>
-  </div>
-  <div className="mt-2">
-    <SplitButton
-      align={{ lg: 'start' }}
-      title="Right-aligned but left aligned when large screen"
-      id="dropdown-menu-align-responsive-2"
-    >
-      <Dropdown.Item eventKey="1">Action 1</Dropdown.Item>
-      <Dropdown.Item eventKey="2">Action 2</Dropdown.Item>
-    </SplitButton>
-  </div>
-</>;
+import Dropdown from 'react-bootstrap/Dropdown';
+import DropdownButton from 'react-bootstrap/DropdownButton';
+import SplitButton from 'react-bootstrap/SplitButton';
+
+function MenuAlignResponsiveExample() {
+  return (
+    <>
+      <div>
+        <DropdownButton
+          as={ButtonGroup}
+          align={{ lg: 'end' }}
+          title="Left-aligned but right aligned when large screen"
+          id="dropdown-menu-align-responsive-1"
+        >
+          <Dropdown.Item eventKey="1">Action 1</Dropdown.Item>
+          <Dropdown.Item eventKey="2">Action 2</Dropdown.Item>
+        </DropdownButton>
+      </div>
+      <div className="mt-2">
+        <SplitButton
+          align={{ lg: 'start' }}
+          title="Right-aligned but left aligned when large screen"
+          id="dropdown-menu-align-responsive-2"
+        >
+          <Dropdown.Item eventKey="1">Action 1</Dropdown.Item>
+          <Dropdown.Item eventKey="2">Action 2</Dropdown.Item>
+        </SplitButton>
+      </div>
+    </>
+  );
+}
+
+export default MenuAlignResponsiveExample;

--- a/www/src/examples/Dropdown/MenuDividers.js
+++ b/www/src/examples/Dropdown/MenuDividers.js
@@ -1,7 +1,15 @@
-<Dropdown.Menu show>
-  <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-  <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-  <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
-  <Dropdown.Divider />
-  <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-</Dropdown.Menu>;
+import Dropdown from 'react-bootstrap/Dropdown';
+
+function MenuDividersExample() {
+  return (
+    <Dropdown.Menu show>
+      <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+      <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+      <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
+      <Dropdown.Divider />
+      <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+    </Dropdown.Menu>
+  );
+}
+
+export default MenuDividersExample;

--- a/www/src/examples/Dropdown/MenuHeaders.js
+++ b/www/src/examples/Dropdown/MenuHeaders.js
@@ -1,5 +1,13 @@
-<Dropdown.Menu show>
-  <Dropdown.Header>Dropdown header</Dropdown.Header>
-  <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-  <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
-</Dropdown.Menu>;
+import Dropdown from 'react-bootstrap/Dropdown';
+
+function MenuHeadersExample() {
+  return (
+    <Dropdown.Menu show>
+      <Dropdown.Header>Dropdown header</Dropdown.Header>
+      <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+      <Dropdown.Item eventKey="3">Something else here</Dropdown.Item>
+    </Dropdown.Menu>
+  );
+}
+
+export default MenuHeadersExample;

--- a/www/src/examples/Dropdown/NavbarDark.js
+++ b/www/src/examples/Dropdown/NavbarDark.js
@@ -1,21 +1,36 @@
-<Navbar variant="dark" bg="dark" expand="lg">
-  <Container fluid>
-    <Navbar.Brand href="#home">React-Bootstrap</Navbar.Brand>
-    <Navbar.Toggle aria-controls="navbar-dark-example" />
-    <Navbar.Collapse id="navbar-dark-example">
-      <Nav>
-        <NavDropdown
-          id="nav-dropdown-dark-example"
-          title="Dropdown"
-          menuVariant="dark"
-        >
-          <NavDropdown.Item href="#action/3.1">Action</NavDropdown.Item>
-          <NavDropdown.Item href="#action/3.2">Another action</NavDropdown.Item>
-          <NavDropdown.Item href="#action/3.3">Something</NavDropdown.Item>
-          <NavDropdown.Divider />
-          <NavDropdown.Item href="#action/3.4">Separated link</NavDropdown.Item>
-        </NavDropdown>
-      </Nav>
-    </Navbar.Collapse>
-  </Container>
-</Navbar>;
+import Container from 'react-bootstrap/Container';
+import Nav from 'react-bootstrap/Nav';
+import Navbar from 'react-bootstrap/Navbar';
+import NavDropdown from 'react-bootstrap/NavDropdown';
+
+function NavbarDarkExample() {
+  return (
+    <Navbar variant="dark" bg="dark" expand="lg">
+      <Container fluid>
+        <Navbar.Brand href="#home">React-Bootstrap</Navbar.Brand>
+        <Navbar.Toggle aria-controls="navbar-dark-example" />
+        <Navbar.Collapse id="navbar-dark-example">
+          <Nav>
+            <NavDropdown
+              id="nav-dropdown-dark-example"
+              title="Dropdown"
+              menuVariant="dark"
+            >
+              <NavDropdown.Item href="#action/3.1">Action</NavDropdown.Item>
+              <NavDropdown.Item href="#action/3.2">
+                Another action
+              </NavDropdown.Item>
+              <NavDropdown.Item href="#action/3.3">Something</NavDropdown.Item>
+              <NavDropdown.Divider />
+              <NavDropdown.Item href="#action/3.4">
+                Separated link
+              </NavDropdown.Item>
+            </NavDropdown>
+          </Nav>
+        </Navbar.Collapse>
+      </Container>
+    </Navbar>
+  );
+}
+
+export default NavbarDarkExample;

--- a/www/src/examples/Dropdown/SplitBasic.js
+++ b/www/src/examples/Dropdown/SplitBasic.js
@@ -1,11 +1,21 @@
-<Dropdown as={ButtonGroup}>
-  <Button variant="success">Split Button</Button>
+import Button from 'react-bootstrap/Button';
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import Dropdown from 'react-bootstrap/Dropdown';
 
-  <Dropdown.Toggle split variant="success" id="dropdown-split-basic" />
+function SplitBasicExample() {
+  return (
+    <Dropdown as={ButtonGroup}>
+      <Button variant="success">Split Button</Button>
 
-  <Dropdown.Menu>
-    <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
-    <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
-    <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
-  </Dropdown.Menu>
-</Dropdown>;
+      <Dropdown.Toggle split variant="success" id="dropdown-split-basic" />
+
+      <Dropdown.Menu>
+        <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
+        <Dropdown.Item href="#/action-2">Another action</Dropdown.Item>
+        <Dropdown.Item href="#/action-3">Something else</Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+}
+
+export default SplitBasicExample;

--- a/www/src/examples/Dropdown/SplitVariants.js
+++ b/www/src/examples/Dropdown/SplitVariants.js
@@ -1,20 +1,29 @@
-<>
-  {['Primary', 'Secondary', 'Success', 'Info', 'Warning', 'Danger'].map(
-    (variant) => (
-      <SplitButton
-        key={variant}
-        id={`dropdown-split-variants-${variant}`}
-        variant={variant.toLowerCase()}
-        title={variant}
-      >
-        <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-        <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-        <Dropdown.Item eventKey="3" active>
-          Active Item
-        </Dropdown.Item>
-        <Dropdown.Divider />
-        <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-      </SplitButton>
-    ),
-  )}
-</>;
+import Dropdown from 'react-bootstrap/Dropdown';
+import SplitButton from 'react-bootstrap/SplitButton';
+
+function SplitVariantExample() {
+  return (
+    <>
+      {['Primary', 'Secondary', 'Success', 'Info', 'Warning', 'Danger'].map(
+        (variant) => (
+          <SplitButton
+            key={variant}
+            id={`dropdown-split-variants-${variant}`}
+            variant={variant.toLowerCase()}
+            title={variant}
+          >
+            <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+            <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+            <Dropdown.Item eventKey="3" active>
+              Active Item
+            </Dropdown.Item>
+            <Dropdown.Divider />
+            <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+          </SplitButton>
+        ),
+      )}
+    </>
+  );
+}
+
+export default SplitVariantExample;

--- a/www/src/examples/Dropdown/Variants.js
+++ b/www/src/examples/Dropdown/Variants.js
@@ -1,21 +1,31 @@
-<>
-  {['Primary', 'Secondary', 'Success', 'Info', 'Warning', 'Danger'].map(
-    (variant) => (
-      <DropdownButton
-        as={ButtonGroup}
-        key={variant}
-        id={`dropdown-variants-${variant}`}
-        variant={variant.toLowerCase()}
-        title={variant}
-      >
-        <Dropdown.Item eventKey="1">Action</Dropdown.Item>
-        <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
-        <Dropdown.Item eventKey="3" active>
-          Active Item
-        </Dropdown.Item>
-        <Dropdown.Divider />
-        <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
-      </DropdownButton>
-    ),
-  )}
-</>;
+import ButtonGroup from 'react-bootstrap/ButtonGroup';
+import Dropdown from 'react-bootstrap/Dropdown';
+import DropdownButton from 'react-bootstrap/DropdownButton';
+
+function VariantsExample() {
+  return (
+    <>
+      {['Primary', 'Secondary', 'Success', 'Info', 'Warning', 'Danger'].map(
+        (variant) => (
+          <DropdownButton
+            as={ButtonGroup}
+            key={variant}
+            id={`dropdown-variants-${variant}`}
+            variant={variant.toLowerCase()}
+            title={variant}
+          >
+            <Dropdown.Item eventKey="1">Action</Dropdown.Item>
+            <Dropdown.Item eventKey="2">Another action</Dropdown.Item>
+            <Dropdown.Item eventKey="3" active>
+              Active Item
+            </Dropdown.Item>
+            <Dropdown.Divider />
+            <Dropdown.Item eventKey="4">Separated link</Dropdown.Item>
+          </DropdownButton>
+        ),
+      )}
+    </>
+  );
+}
+
+export default VariantsExample;

--- a/www/src/examples/Fade.js
+++ b/www/src/examples/Fade.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Fade from 'react-bootstrap/Fade';
+
 function Example() {
   const [open, setOpen] = useState(false);
 

--- a/www/src/examples/Figure.js
+++ b/www/src/examples/Figure.js
@@ -1,11 +1,19 @@
-<Figure>
-  <Figure.Image
-    width={171}
-    height={180}
-    alt="171x180"
-    src="holder.js/171x180"
-  />
-  <Figure.Caption>
-    Nulla vitae elit libero, a pharetra augue mollis interdum.
-  </Figure.Caption>
-</Figure>;
+import Figure from 'react-bootstrap/Figure';
+
+function FigureExample() {
+  return (
+    <Figure>
+      <Figure.Image
+        width={171}
+        height={180}
+        alt="171x180"
+        src="holder.js/171x180"
+      />
+      <Figure.Caption>
+        Nulla vitae elit libero, a pharetra augue mollis interdum.
+      </Figure.Caption>
+    </Figure>
+  );
+}
+
+export default FigureExample;

--- a/www/src/examples/Form/Basic.js
+++ b/www/src/examples/Form/Basic.js
@@ -1,20 +1,29 @@
-<Form>
-  <Form.Group className="mb-3" controlId="formBasicEmail">
-    <Form.Label>Email address</Form.Label>
-    <Form.Control type="email" placeholder="Enter email" />
-    <Form.Text className="text-muted">
-      We'll never share your email with anyone else.
-    </Form.Text>
-  </Form.Group>
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
 
-  <Form.Group className="mb-3" controlId="formBasicPassword">
-    <Form.Label>Password</Form.Label>
-    <Form.Control type="password" placeholder="Password" />
-  </Form.Group>
-  <Form.Group className="mb-3" controlId="formBasicCheckbox">
-    <Form.Check type="checkbox" label="Check me out" />
-  </Form.Group>
-  <Button variant="primary" type="submit">
-    Submit
-  </Button>
-</Form>;
+function BasicExample() {
+  return (
+    <Form>
+      <Form.Group className="mb-3" controlId="formBasicEmail">
+        <Form.Label>Email address</Form.Label>
+        <Form.Control type="email" placeholder="Enter email" />
+        <Form.Text className="text-muted">
+          We'll never share your email with anyone else.
+        </Form.Text>
+      </Form.Group>
+
+      <Form.Group className="mb-3" controlId="formBasicPassword">
+        <Form.Label>Password</Form.Label>
+        <Form.Control type="password" placeholder="Password" />
+      </Form.Group>
+      <Form.Group className="mb-3" controlId="formBasicCheckbox">
+        <Form.Check type="checkbox" label="Check me out" />
+      </Form.Group>
+      <Button variant="primary" type="submit">
+        Submit
+      </Button>
+    </Form>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/Form/Check.js
+++ b/www/src/examples/Form/Check.js
@@ -1,18 +1,26 @@
-<Form>
-  {['checkbox', 'radio'].map((type) => (
-    <div key={`default-${type}`} className="mb-3">
-      <Form.Check // prettier-ignore
-        type={type}
-        id={`default-${type}`}
-        label={`default ${type}`}
-      />
+import Form from 'react-bootstrap/Form';
 
-      <Form.Check
-        disabled
-        type={type}
-        label={`disabled ${type}`}
-        id={`disabled-default-${type}`}
-      />
-    </div>
-  ))}
-</Form>;
+function CheckExample() {
+  return (
+    <Form>
+      {['checkbox', 'radio'].map((type) => (
+        <div key={`default-${type}`} className="mb-3">
+          <Form.Check // prettier-ignore
+            type={type}
+            id={`default-${type}`}
+            label={`default ${type}`}
+          />
+
+          <Form.Check
+            disabled
+            type={type}
+            label={`disabled ${type}`}
+            id={`disabled-default-${type}`}
+          />
+        </div>
+      ))}
+    </Form>
+  );
+}
+
+export default CheckExample;

--- a/www/src/examples/Form/CheckApi.js
+++ b/www/src/examples/Form/CheckApi.js
@@ -1,11 +1,21 @@
-<Form>
-  {['checkbox', 'radio'].map((type) => (
-    <div key={type} className="mb-3">
-      <Form.Check type={type} id={`check-api-${type}`}>
-        <Form.Check.Input type={type} isValid />
-        <Form.Check.Label>{`Custom api ${type}`}</Form.Check.Label>
-        <Form.Control.Feedback type="valid">You did it!</Form.Control.Feedback>
-      </Form.Check>
-    </div>
-  ))}
-</Form>;
+import Form from 'react-bootstrap/Form';
+
+function CheckApiExample() {
+  return (
+    <Form>
+      {['checkbox', 'radio'].map((type) => (
+        <div key={type} className="mb-3">
+          <Form.Check type={type} id={`check-api-${type}`}>
+            <Form.Check.Input type={type} isValid />
+            <Form.Check.Label>{`Custom api ${type}`}</Form.Check.Label>
+            <Form.Control.Feedback type="valid">
+              You did it!
+            </Form.Control.Feedback>
+          </Form.Check>
+        </div>
+      ))}
+    </Form>
+  );
+}
+
+export default CheckApiExample;

--- a/www/src/examples/Form/CheckInline.js
+++ b/www/src/examples/Form/CheckInline.js
@@ -1,27 +1,35 @@
-<Form>
-  {['checkbox', 'radio'].map((type) => (
-    <div key={`inline-${type}`} className="mb-3">
-      <Form.Check
-        inline
-        label="1"
-        name="group1"
-        type={type}
-        id={`inline-${type}-1`}
-      />
-      <Form.Check
-        inline
-        label="2"
-        name="group1"
-        type={type}
-        id={`inline-${type}-2`}
-      />
-      <Form.Check
-        inline
-        disabled
-        label="3 (disabled)"
-        type={type}
-        id={`inline-${type}-3`}
-      />
-    </div>
-  ))}
-</Form>;
+import Form from 'react-bootstrap/Form';
+
+function CheckInlineExample() {
+  return (
+    <Form>
+      {['checkbox', 'radio'].map((type) => (
+        <div key={`inline-${type}`} className="mb-3">
+          <Form.Check
+            inline
+            label="1"
+            name="group1"
+            type={type}
+            id={`inline-${type}-1`}
+          />
+          <Form.Check
+            inline
+            label="2"
+            name="group1"
+            type={type}
+            id={`inline-${type}-2`}
+          />
+          <Form.Check
+            inline
+            disabled
+            label="3 (disabled)"
+            type={type}
+            id={`inline-${type}-3`}
+          />
+        </div>
+      ))}
+    </Form>
+  );
+}
+
+export default CheckInlineExample;

--- a/www/src/examples/Form/CheckReverse.js
+++ b/www/src/examples/Form/CheckReverse.js
@@ -1,27 +1,35 @@
-<Form>
-  {['checkbox', 'radio'].map((type) => (
-    <div key={`reverse-${type}`} className="mb-3">
-      <Form.Check
-        reverse
-        label="1"
-        name="group1"
-        type={type}
-        id={`reverse-${type}-1`}
-      />
-      <Form.Check
-        reverse
-        label="2"
-        name="group1"
-        type={type}
-        id={`reverse-${type}-2`}
-      />
-      <Form.Check
-        reverse
-        disabled
-        label="3 (disabled)"
-        type={type}
-        id={`reverse-${type}-3`}
-      />
-    </div>
-  ))}
-</Form>;
+import Form from 'react-bootstrap/Form';
+
+function CheckReverseExample() {
+  return (
+    <Form>
+      {['checkbox', 'radio'].map((type) => (
+        <div key={`reverse-${type}`} className="mb-3">
+          <Form.Check
+            reverse
+            label="1"
+            name="group1"
+            type={type}
+            id={`reverse-${type}-1`}
+          />
+          <Form.Check
+            reverse
+            label="2"
+            name="group1"
+            type={type}
+            id={`reverse-${type}-2`}
+          />
+          <Form.Check
+            reverse
+            disabled
+            label="3 (disabled)"
+            type={type}
+            id={`reverse-${type}-3`}
+          />
+        </div>
+      ))}
+    </Form>
+  );
+}
+
+export default CheckReverseExample;

--- a/www/src/examples/Form/ColorPicker.js
+++ b/www/src/examples/Form/ColorPicker.js
@@ -1,9 +1,17 @@
-<>
-  <Form.Label htmlFor="exampleColorInput">Color picker</Form.Label>
-  <Form.Control
-    type="color"
-    id="exampleColorInput"
-    defaultValue="#563d7c"
-    title="Choose your color"
-  />
-</>;
+import Form from 'react-bootstrap/Form';
+
+function ColorPickerExample() {
+  return (
+    <>
+      <Form.Label htmlFor="exampleColorInput">Color picker</Form.Label>
+      <Form.Control
+        type="color"
+        id="exampleColorInput"
+        defaultValue="#563d7c"
+        title="Choose your color"
+      />
+    </>
+  );
+}
+
+export default ColorPickerExample;

--- a/www/src/examples/Form/FormControlDisabled.js
+++ b/www/src/examples/Form/FormControlDisabled.js
@@ -1,16 +1,24 @@
-<>
-  <Form.Control
-    type="text"
-    placeholder="Disabled input"
-    aria-label="Disabled input example"
-    disabled
-    readOnly
-  />
-  <br />
-  <Form.Control
-    type="text"
-    placeholder="Disabled readonly input"
-    aria-label="Disabled input example"
-    readOnly
-  />
-</>;
+import Form from 'react-bootstrap/Form';
+
+function FormControlDisabledExample() {
+  return (
+    <>
+      <Form.Control
+        type="text"
+        placeholder="Disabled input"
+        aria-label="Disabled input example"
+        disabled
+        readOnly
+      />
+      <br />
+      <Form.Control
+        type="text"
+        placeholder="Disabled readonly input"
+        aria-label="Disabled input example"
+        readOnly
+      />
+    </>
+  );
+}
+
+export default FormControlDisabledExample;

--- a/www/src/examples/Form/FormDisabled.js
+++ b/www/src/examples/Form/FormDisabled.js
@@ -1,22 +1,31 @@
-<Form>
-  <fieldset disabled>
-    <Form.Group className="mb-3">
-      <Form.Label htmlFor="disabledTextInput">Disabled input</Form.Label>
-      <Form.Control id="disabledTextInput" placeholder="Disabled input" />
-    </Form.Group>
-    <Form.Group className="mb-3">
-      <Form.Label htmlFor="disabledSelect">Disabled select menu</Form.Label>
-      <Form.Select id="disabledSelect">
-        <option>Disabled select</option>
-      </Form.Select>
-    </Form.Group>
-    <Form.Group className="mb-3">
-      <Form.Check
-        type="checkbox"
-        id="disabledFieldsetCheck"
-        label="Can't check this"
-      />
-    </Form.Group>
-    <Button type="submit">Submit</Button>
-  </fieldset>
-</Form>;
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+
+function FormDisabledExample() {
+  return (
+    <Form>
+      <fieldset disabled>
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="disabledTextInput">Disabled input</Form.Label>
+          <Form.Control id="disabledTextInput" placeholder="Disabled input" />
+        </Form.Group>
+        <Form.Group className="mb-3">
+          <Form.Label htmlFor="disabledSelect">Disabled select menu</Form.Label>
+          <Form.Select id="disabledSelect">
+            <option>Disabled select</option>
+          </Form.Select>
+        </Form.Group>
+        <Form.Group className="mb-3">
+          <Form.Check
+            type="checkbox"
+            id="disabledFieldsetCheck"
+            label="Can't check this"
+          />
+        </Form.Group>
+        <Button type="submit">Submit</Button>
+      </fieldset>
+    </Form>
+  );
+}
+
+export default FormDisabledExample;

--- a/www/src/examples/Form/FormDisabledInputs.js
+++ b/www/src/examples/Form/FormDisabledInputs.js
@@ -1,15 +1,23 @@
-<>
-  <Form.Group className="mb-3">
-    <Form.Label>Disabled input</Form.Label>
-    <Form.Control placeholder="Disabled input" disabled />
-  </Form.Group>
-  <Form.Group className="mb-3">
-    <Form.Label>Disabled select menu</Form.Label>
-    <Form.Select disabled>
-      <option>Disabled select</option>
-    </Form.Select>
-  </Form.Group>
-  <Form.Group className="mb-3">
-    <Form.Check type="checkbox" label="Can't check this" disabled />
-  </Form.Group>
-</>;
+import Form from 'react-bootstrap/Form';
+
+function FormDisabledInputExample() {
+  return (
+    <>
+      <Form.Group className="mb-3">
+        <Form.Label>Disabled input</Form.Label>
+        <Form.Control placeholder="Disabled input" disabled />
+      </Form.Group>
+      <Form.Group className="mb-3">
+        <Form.Label>Disabled select menu</Form.Label>
+        <Form.Select disabled>
+          <option>Disabled select</option>
+        </Form.Select>
+      </Form.Group>
+      <Form.Group className="mb-3">
+        <Form.Check type="checkbox" label="Can't check this" disabled />
+      </Form.Group>
+    </>
+  );
+}
+
+export default FormDisabledInputExample;

--- a/www/src/examples/Form/FormFile.js
+++ b/www/src/examples/Form/FormFile.js
@@ -1,22 +1,30 @@
-<>
-  <Form.Group controlId="formFile" className="mb-3">
-    <Form.Label>Default file input example</Form.Label>
-    <Form.Control type="file" />
-  </Form.Group>
-  <Form.Group controlId="formFileMultiple" className="mb-3">
-    <Form.Label>Multiple files input example</Form.Label>
-    <Form.Control type="file" multiple />
-  </Form.Group>
-  <Form.Group controlId="formFileDisabled" className="mb-3">
-    <Form.Label>Disabled file input example</Form.Label>
-    <Form.Control type="file" disabled />
-  </Form.Group>
-  <Form.Group controlId="formFileSm" className="mb-3">
-    <Form.Label>Small file input example</Form.Label>
-    <Form.Control type="file" size="sm" />
-  </Form.Group>
-  <Form.Group controlId="formFileLg" className="mb-3">
-    <Form.Label>Large file input example</Form.Label>
-    <Form.Control type="file" size="lg" />
-  </Form.Group>
-</>;
+import Form from 'react-bootstrap/Form';
+
+function FormFileExample() {
+  return (
+    <>
+      <Form.Group controlId="formFile" className="mb-3">
+        <Form.Label>Default file input example</Form.Label>
+        <Form.Control type="file" />
+      </Form.Group>
+      <Form.Group controlId="formFileMultiple" className="mb-3">
+        <Form.Label>Multiple files input example</Form.Label>
+        <Form.Control type="file" multiple />
+      </Form.Group>
+      <Form.Group controlId="formFileDisabled" className="mb-3">
+        <Form.Label>Disabled file input example</Form.Label>
+        <Form.Control type="file" disabled />
+      </Form.Group>
+      <Form.Group controlId="formFileSm" className="mb-3">
+        <Form.Label>Small file input example</Form.Label>
+        <Form.Control type="file" size="sm" />
+      </Form.Group>
+      <Form.Group controlId="formFileLg" className="mb-3">
+        <Form.Label>Large file input example</Form.Label>
+        <Form.Control type="file" size="lg" />
+      </Form.Group>
+    </>
+  );
+}
+
+export default FormFileExample;

--- a/www/src/examples/Form/FormFloatingBasic.js
+++ b/www/src/examples/Form/FormFloatingBasic.js
@@ -1,12 +1,21 @@
-<>
-  <FloatingLabel
-    controlId="floatingInput"
-    label="Email address"
-    className="mb-3"
-  >
-    <Form.Control type="email" placeholder="name@example.com" />
-  </FloatingLabel>
-  <FloatingLabel controlId="floatingPassword" label="Password">
-    <Form.Control type="password" placeholder="Password" />
-  </FloatingLabel>
-</>;
+import FloatingLabel from 'react-bootstrap/FloatingLabel';
+import Form from 'react-bootstrap/Form';
+
+function FormFloatingBasicExample() {
+  return (
+    <>
+      <FloatingLabel
+        controlId="floatingInput"
+        label="Email address"
+        className="mb-3"
+      >
+        <Form.Control type="email" placeholder="name@example.com" />
+      </FloatingLabel>
+      <FloatingLabel controlId="floatingPassword" label="Password">
+        <Form.Control type="password" placeholder="Password" />
+      </FloatingLabel>
+    </>
+  );
+}
+
+export default FormFloatingBasicExample;

--- a/www/src/examples/Form/FormFloatingCustom.js
+++ b/www/src/examples/Form/FormFloatingCustom.js
@@ -1,18 +1,26 @@
-<>
-  <Form.Floating className="mb-3">
-    <Form.Control
-      id="floatingInputCustom"
-      type="email"
-      placeholder="name@example.com"
-    />
-    <label htmlFor="floatingInputCustom">Email address</label>
-  </Form.Floating>
-  <Form.Floating>
-    <Form.Control
-      id="floatingPasswordCustom"
-      type="password"
-      placeholder="Password"
-    />
-    <label htmlFor="floatingPasswordCustom">Password</label>
-  </Form.Floating>
-</>;
+import Form from 'react-bootstrap/Form';
+
+function FormFloatingCustom() {
+  return (
+    <>
+      <Form.Floating className="mb-3">
+        <Form.Control
+          id="floatingInputCustom"
+          type="email"
+          placeholder="name@example.com"
+        />
+        <label htmlFor="floatingInputCustom">Email address</label>
+      </Form.Floating>
+      <Form.Floating>
+        <Form.Control
+          id="floatingPasswordCustom"
+          type="password"
+          placeholder="Password"
+        />
+        <label htmlFor="floatingPasswordCustom">Password</label>
+      </Form.Floating>
+    </>
+  );
+}
+
+export default FormFloatingCustom;

--- a/www/src/examples/Form/FormFloatingLayout.js
+++ b/www/src/examples/Form/FormFloatingLayout.js
@@ -1,17 +1,31 @@
-<Row className="g-2">
-  <Col md>
-    <FloatingLabel controlId="floatingInputGrid" label="Email address">
-      <Form.Control type="email" placeholder="name@example.com" />
-    </FloatingLabel>
-  </Col>
-  <Col md>
-    <FloatingLabel controlId="floatingSelectGrid" label="Works with selects">
-      <Form.Select aria-label="Floating label select example">
-        <option>Open this select menu</option>
-        <option value="1">One</option>
-        <option value="2">Two</option>
-        <option value="3">Three</option>
-      </Form.Select>
-    </FloatingLabel>
-  </Col>
-</Row>;
+import Col from 'react-bootstrap/Col';
+import FloatingLabel from 'react-bootstrap/FloatingLabel';
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
+
+function FormFloatingLayoutExample() {
+  return (
+    <Row className="g-2">
+      <Col md>
+        <FloatingLabel controlId="floatingInputGrid" label="Email address">
+          <Form.Control type="email" placeholder="name@example.com" />
+        </FloatingLabel>
+      </Col>
+      <Col md>
+        <FloatingLabel
+          controlId="floatingSelectGrid"
+          label="Works with selects"
+        >
+          <Form.Select aria-label="Floating label select example">
+            <option>Open this select menu</option>
+            <option value="1">One</option>
+            <option value="2">Two</option>
+            <option value="3">Three</option>
+          </Form.Select>
+        </FloatingLabel>
+      </Col>
+    </Row>
+  );
+}
+
+export default FormFloatingLayoutExample;

--- a/www/src/examples/Form/FormFloatingSelect.js
+++ b/www/src/examples/Form/FormFloatingSelect.js
@@ -1,8 +1,17 @@
-<FloatingLabel controlId="floatingSelect" label="Works with selects">
-  <Form.Select aria-label="Floating label select example">
-    <option>Open this select menu</option>
-    <option value="1">One</option>
-    <option value="2">Two</option>
-    <option value="3">Three</option>
-  </Form.Select>
-</FloatingLabel>;
+import FloatingLabel from 'react-bootstrap/FloatingLabel';
+import Form from 'react-bootstrap/Form';
+
+function FormFloatingSelectExample() {
+  return (
+    <FloatingLabel controlId="floatingSelect" label="Works with selects">
+      <Form.Select aria-label="Floating label select example">
+        <option>Open this select menu</option>
+        <option value="1">One</option>
+        <option value="2">Two</option>
+        <option value="3">Three</option>
+      </Form.Select>
+    </FloatingLabel>
+  );
+}
+
+export default FormFloatingSelectExample;

--- a/www/src/examples/Form/FormFloatingTextarea.js
+++ b/www/src/examples/Form/FormFloatingTextarea.js
@@ -1,12 +1,25 @@
-<>
-  <FloatingLabel controlId="floatingTextarea" label="Comments" className="mb-3">
-    <Form.Control as="textarea" placeholder="Leave a comment here" />
-  </FloatingLabel>
-  <FloatingLabel controlId="floatingTextarea2" label="Comments">
-    <Form.Control
-      as="textarea"
-      placeholder="Leave a comment here"
-      style={{ height: '100px' }}
-    />
-  </FloatingLabel>
-</>;
+import FloatingLabel from 'react-bootstrap/FloatingLabel';
+import Form from 'react-bootstrap/Form';
+
+function FormFloatingTextareaExample() {
+  return (
+    <>
+      <FloatingLabel
+        controlId="floatingTextarea"
+        label="Comments"
+        className="mb-3"
+      >
+        <Form.Control as="textarea" placeholder="Leave a comment here" />
+      </FloatingLabel>
+      <FloatingLabel controlId="floatingTextarea2" label="Comments">
+        <Form.Control
+          as="textarea"
+          placeholder="Leave a comment here"
+          style={{ height: '100px' }}
+        />
+      </FloatingLabel>
+    </>
+  );
+}
+
+export default FormFloatingTextareaExample;

--- a/www/src/examples/Form/FormGroup.js
+++ b/www/src/examples/Form/FormGroup.js
@@ -1,10 +1,18 @@
-<Form>
-  <Form.Group className="mb-3" controlId="formGroupEmail">
-    <Form.Label>Email address</Form.Label>
-    <Form.Control type="email" placeholder="Enter email" />
-  </Form.Group>
-  <Form.Group className="mb-3" controlId="formGroupPassword">
-    <Form.Label>Password</Form.Label>
-    <Form.Control type="password" placeholder="Password" />
-  </Form.Group>
-</Form>;
+import Form from 'react-bootstrap/Form';
+
+function FormGroupExample() {
+  return (
+    <Form>
+      <Form.Group className="mb-3" controlId="formGroupEmail">
+        <Form.Label>Email address</Form.Label>
+        <Form.Control type="email" placeholder="Enter email" />
+      </Form.Group>
+      <Form.Group className="mb-3" controlId="formGroupPassword">
+        <Form.Label>Password</Form.Label>
+        <Form.Control type="password" placeholder="Password" />
+      </Form.Group>
+    </Form>
+  );
+}
+
+export default FormGroupExample;

--- a/www/src/examples/Form/FormLabelSizing.js
+++ b/www/src/examples/Form/FormLabelSizing.js
@@ -1,28 +1,38 @@
-<>
-  <Row>
-    <Form.Label column="lg" lg={2}>
-      Large Text
-    </Form.Label>
-    <Col>
-      <Form.Control size="lg" type="text" placeholder="Large text" />
-    </Col>
-  </Row>
-  <br />
-  <Row>
-    <Form.Label column lg={2}>
-      Normal Text
-    </Form.Label>
-    <Col>
-      <Form.Control type="text" placeholder="Normal text" />
-    </Col>
-  </Row>
-  <br />
-  <Row>
-    <Form.Label column="sm" lg={2}>
-      Small Text
-    </Form.Label>
-    <Col>
-      <Form.Control size="sm" type="text" placeholder="Small text" />
-    </Col>
-  </Row>
-</>;
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
+
+function FormLabelSizingExample() {
+  return (
+    <>
+      <Row>
+        <Form.Label column="lg" lg={2}>
+          Large Text
+        </Form.Label>
+        <Col>
+          <Form.Control size="lg" type="text" placeholder="Large text" />
+        </Col>
+      </Row>
+      <br />
+      <Row>
+        <Form.Label column lg={2}>
+          Normal Text
+        </Form.Label>
+        <Col>
+          <Form.Control type="text" placeholder="Normal text" />
+        </Col>
+      </Row>
+      <br />
+      <Row>
+        <Form.Label column="sm" lg={2}>
+          Small Text
+        </Form.Label>
+        <Col>
+          <Form.Control size="sm" type="text" placeholder="Small text" />
+        </Col>
+      </Row>
+    </>
+  );
+}
+
+export default FormLabelSizingExample;

--- a/www/src/examples/Form/FormText.js
+++ b/www/src/examples/Form/FormText.js
@@ -1,12 +1,20 @@
-<>
-  <Form.Label htmlFor="inputPassword5">Password</Form.Label>
-  <Form.Control
-    type="password"
-    id="inputPassword5"
-    aria-describedby="passwordHelpBlock"
-  />
-  <Form.Text id="passwordHelpBlock" muted>
-    Your password must be 8-20 characters long, contain letters and numbers, and
-    must not contain spaces, special characters, or emoji.
-  </Form.Text>
-</>;
+import Form from 'react-bootstrap/Form';
+
+function FormTextExample() {
+  return (
+    <>
+      <Form.Label htmlFor="inputPassword5">Password</Form.Label>
+      <Form.Control
+        type="password"
+        id="inputPassword5"
+        aria-describedby="passwordHelpBlock"
+      />
+      <Form.Text id="passwordHelpBlock" muted>
+        Your password must be 8-20 characters long, contain letters and numbers,
+        and must not contain spaces, special characters, or emoji.
+      </Form.Text>
+    </>
+  );
+}
+
+export default FormTextExample;

--- a/www/src/examples/Form/GridAutoSizing.js
+++ b/www/src/examples/Form/GridAutoSizing.js
@@ -1,36 +1,48 @@
-<Form>
-  <Row className="align-items-center">
-    <Col xs="auto">
-      <Form.Label htmlFor="inlineFormInput" visuallyHidden>
-        Name
-      </Form.Label>
-      <Form.Control
-        className="mb-2"
-        id="inlineFormInput"
-        placeholder="Jane Doe"
-      />
-    </Col>
-    <Col xs="auto">
-      <Form.Label htmlFor="inlineFormInputGroup" visuallyHidden>
-        Username
-      </Form.Label>
-      <InputGroup className="mb-2">
-        <InputGroup.Text>@</InputGroup.Text>
-        <FormControl id="inlineFormInputGroup" placeholder="Username" />
-      </InputGroup>
-    </Col>
-    <Col xs="auto">
-      <Form.Check
-        type="checkbox"
-        id="autoSizingCheck"
-        className="mb-2"
-        label="Remember me"
-      />
-    </Col>
-    <Col xs="auto">
-      <Button type="submit" className="mb-2">
-        Submit
-      </Button>
-    </Col>
-  </Row>
-</Form>;
+import Button from 'react-bootstrap/Button';
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
+import Row from 'react-bootstrap/Row';
+
+function GridAutoSizingExample() {
+  return (
+    <Form>
+      <Row className="align-items-center">
+        <Col xs="auto">
+          <Form.Label htmlFor="inlineFormInput" visuallyHidden>
+            Name
+          </Form.Label>
+          <Form.Control
+            className="mb-2"
+            id="inlineFormInput"
+            placeholder="Jane Doe"
+          />
+        </Col>
+        <Col xs="auto">
+          <Form.Label htmlFor="inlineFormInputGroup" visuallyHidden>
+            Username
+          </Form.Label>
+          <InputGroup className="mb-2">
+            <InputGroup.Text>@</InputGroup.Text>
+            <Form.Control id="inlineFormInputGroup" placeholder="Username" />
+          </InputGroup>
+        </Col>
+        <Col xs="auto">
+          <Form.Check
+            type="checkbox"
+            id="autoSizingCheck"
+            className="mb-2"
+            label="Remember me"
+          />
+        </Col>
+        <Col xs="auto">
+          <Button type="submit" className="mb-2">
+            Submit
+          </Button>
+        </Col>
+      </Row>
+    </Form>
+  );
+}
+
+export default GridAutoSizingExample;

--- a/www/src/examples/Form/GridAutoSizingColMix.js
+++ b/www/src/examples/Form/GridAutoSizingColMix.js
@@ -1,25 +1,44 @@
-<Form>
-  <Row className="align-items-center">
-    <Col sm={3} className="my-1">
-      <Form.Label htmlFor="inlineFormInputName" visuallyHidden>
-        Name
-      </Form.Label>
-      <Form.Control id="inlineFormInputName" placeholder="Jane Doe" />
-    </Col>
-    <Col sm={3} className="my-1">
-      <Form.Label htmlFor="inlineFormInputGroupUsername" visuallyHidden>
-        Username
-      </Form.Label>
-      <InputGroup>
-        <InputGroup.Text>@</InputGroup.Text>
-        <FormControl id="inlineFormInputGroupUsername" placeholder="Username" />
-      </InputGroup>
-    </Col>
-    <Col xs="auto" className="my-1">
-      <Form.Check type="checkbox" id="autoSizingCheck2" label="Remember me" />
-    </Col>
-    <Col xs="auto" className="my-1">
-      <Button type="submit">Submit</Button>
-    </Col>
-  </Row>
-</Form>;
+import Button from 'react-bootstrap/Button';
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
+import Row from 'react-bootstrap/Row';
+
+function GridAutoSizingColMixExample() {
+  return (
+    <Form>
+      <Row className="align-items-center">
+        <Col sm={3} className="my-1">
+          <Form.Label htmlFor="inlineFormInputName" visuallyHidden>
+            Name
+          </Form.Label>
+          <Form.Control id="inlineFormInputName" placeholder="Jane Doe" />
+        </Col>
+        <Col sm={3} className="my-1">
+          <Form.Label htmlFor="inlineFormInputGroupUsername" visuallyHidden>
+            Username
+          </Form.Label>
+          <InputGroup>
+            <InputGroup.Text>@</InputGroup.Text>
+            <Form.Control
+              id="inlineFormInputGroupUsername"
+              placeholder="Username"
+            />
+          </InputGroup>
+        </Col>
+        <Col xs="auto" className="my-1">
+          <Form.Check
+            type="checkbox"
+            id="autoSizingCheck2"
+            label="Remember me"
+          />
+        </Col>
+        <Col xs="auto" className="my-1">
+          <Button type="submit">Submit</Button>
+        </Col>
+      </Row>
+    </Form>
+  );
+}
+
+export default GridAutoSizingColMixExample;

--- a/www/src/examples/Form/GridBasic.js
+++ b/www/src/examples/Form/GridBasic.js
@@ -1,10 +1,20 @@
-<Form>
-  <Row>
-    <Col>
-      <Form.Control placeholder="First name" />
-    </Col>
-    <Col>
-      <Form.Control placeholder="Last name" />
-    </Col>
-  </Row>
-</Form>;
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
+
+function GridBasicExample() {
+  return (
+    <Form>
+      <Row>
+        <Col>
+          <Form.Control placeholder="First name" />
+        </Col>
+        <Col>
+          <Form.Control placeholder="Last name" />
+        </Col>
+      </Row>
+    </Form>
+  );
+}
+
+export default GridBasicExample;

--- a/www/src/examples/Form/GridColSizes.js
+++ b/www/src/examples/Form/GridColSizes.js
@@ -1,13 +1,23 @@
-<Form>
-  <Row>
-    <Col xs={7}>
-      <Form.Control placeholder="City" />
-    </Col>
-    <Col>
-      <Form.Control placeholder="State" />
-    </Col>
-    <Col>
-      <Form.Control placeholder="Zip" />
-    </Col>
-  </Row>
-</Form>;
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
+
+function GridColSizesExample() {
+  return (
+    <Form>
+      <Row>
+        <Col xs={7}>
+          <Form.Control placeholder="City" />
+        </Col>
+        <Col>
+          <Form.Control placeholder="State" />
+        </Col>
+        <Col>
+          <Form.Control placeholder="Zip" />
+        </Col>
+      </Row>
+    </Form>
+  );
+}
+
+export default GridColSizesExample;

--- a/www/src/examples/Form/GridComplex.js
+++ b/www/src/examples/Form/GridComplex.js
@@ -1,51 +1,62 @@
-<Form>
-  <Row className="mb-3">
-    <Form.Group as={Col} controlId="formGridEmail">
-      <Form.Label>Email</Form.Label>
-      <Form.Control type="email" placeholder="Enter email" />
-    </Form.Group>
+import Button from 'react-bootstrap/Button';
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
 
-    <Form.Group as={Col} controlId="formGridPassword">
-      <Form.Label>Password</Form.Label>
-      <Form.Control type="password" placeholder="Password" />
-    </Form.Group>
-  </Row>
+function GridComplexExample() {
+  return (
+    <Form>
+      <Row className="mb-3">
+        <Form.Group as={Col} controlId="formGridEmail">
+          <Form.Label>Email</Form.Label>
+          <Form.Control type="email" placeholder="Enter email" />
+        </Form.Group>
 
-  <Form.Group className="mb-3" controlId="formGridAddress1">
-    <Form.Label>Address</Form.Label>
-    <Form.Control placeholder="1234 Main St" />
-  </Form.Group>
+        <Form.Group as={Col} controlId="formGridPassword">
+          <Form.Label>Password</Form.Label>
+          <Form.Control type="password" placeholder="Password" />
+        </Form.Group>
+      </Row>
 
-  <Form.Group className="mb-3" controlId="formGridAddress2">
-    <Form.Label>Address 2</Form.Label>
-    <Form.Control placeholder="Apartment, studio, or floor" />
-  </Form.Group>
+      <Form.Group className="mb-3" controlId="formGridAddress1">
+        <Form.Label>Address</Form.Label>
+        <Form.Control placeholder="1234 Main St" />
+      </Form.Group>
 
-  <Row className="mb-3">
-    <Form.Group as={Col} controlId="formGridCity">
-      <Form.Label>City</Form.Label>
-      <Form.Control />
-    </Form.Group>
+      <Form.Group className="mb-3" controlId="formGridAddress2">
+        <Form.Label>Address 2</Form.Label>
+        <Form.Control placeholder="Apartment, studio, or floor" />
+      </Form.Group>
 
-    <Form.Group as={Col} controlId="formGridState">
-      <Form.Label>State</Form.Label>
-      <Form.Select defaultValue="Choose...">
-        <option>Choose...</option>
-        <option>...</option>
-      </Form.Select>
-    </Form.Group>
+      <Row className="mb-3">
+        <Form.Group as={Col} controlId="formGridCity">
+          <Form.Label>City</Form.Label>
+          <Form.Control />
+        </Form.Group>
 
-    <Form.Group as={Col} controlId="formGridZip">
-      <Form.Label>Zip</Form.Label>
-      <Form.Control />
-    </Form.Group>
-  </Row>
+        <Form.Group as={Col} controlId="formGridState">
+          <Form.Label>State</Form.Label>
+          <Form.Select defaultValue="Choose...">
+            <option>Choose...</option>
+            <option>...</option>
+          </Form.Select>
+        </Form.Group>
 
-  <Form.Group className="mb-3" id="formGridCheckbox">
-    <Form.Check type="checkbox" label="Check me out" />
-  </Form.Group>
+        <Form.Group as={Col} controlId="formGridZip">
+          <Form.Label>Zip</Form.Label>
+          <Form.Control />
+        </Form.Group>
+      </Row>
 
-  <Button variant="primary" type="submit">
-    Submit
-  </Button>
-</Form>;
+      <Form.Group className="mb-3" id="formGridCheckbox">
+        <Form.Check type="checkbox" label="Check me out" />
+      </Form.Group>
+
+      <Button variant="primary" type="submit">
+        Submit
+      </Button>
+    </Form>
+  );
+}
+
+export default GridComplexExample;

--- a/www/src/examples/Form/Horizontal.js
+++ b/www/src/examples/Form/Horizontal.js
@@ -1,57 +1,68 @@
-<Form>
-  <Form.Group as={Row} className="mb-3" controlId="formHorizontalEmail">
-    <Form.Label column sm={2}>
-      Email
-    </Form.Label>
-    <Col sm={10}>
-      <Form.Control type="email" placeholder="Email" />
-    </Col>
-  </Form.Group>
+import Button from 'react-bootstrap/Button';
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
 
-  <Form.Group as={Row} className="mb-3" controlId="formHorizontalPassword">
-    <Form.Label column sm={2}>
-      Password
-    </Form.Label>
-    <Col sm={10}>
-      <Form.Control type="password" placeholder="Password" />
-    </Col>
-  </Form.Group>
-  <fieldset>
-    <Form.Group as={Row} className="mb-3">
-      <Form.Label as="legend" column sm={2}>
-        Radios
-      </Form.Label>
-      <Col sm={10}>
-        <Form.Check
-          type="radio"
-          label="first radio"
-          name="formHorizontalRadios"
-          id="formHorizontalRadios1"
-        />
-        <Form.Check
-          type="radio"
-          label="second radio"
-          name="formHorizontalRadios"
-          id="formHorizontalRadios2"
-        />
-        <Form.Check
-          type="radio"
-          label="third radio"
-          name="formHorizontalRadios"
-          id="formHorizontalRadios3"
-        />
-      </Col>
-    </Form.Group>
-  </fieldset>
-  <Form.Group as={Row} className="mb-3" controlId="formHorizontalCheck">
-    <Col sm={{ span: 10, offset: 2 }}>
-      <Form.Check label="Remember me" />
-    </Col>
-  </Form.Group>
+function HorizontalExample() {
+  return (
+    <Form>
+      <Form.Group as={Row} className="mb-3" controlId="formHorizontalEmail">
+        <Form.Label column sm={2}>
+          Email
+        </Form.Label>
+        <Col sm={10}>
+          <Form.Control type="email" placeholder="Email" />
+        </Col>
+      </Form.Group>
 
-  <Form.Group as={Row} className="mb-3">
-    <Col sm={{ span: 10, offset: 2 }}>
-      <Button type="submit">Sign in</Button>
-    </Col>
-  </Form.Group>
-</Form>;
+      <Form.Group as={Row} className="mb-3" controlId="formHorizontalPassword">
+        <Form.Label column sm={2}>
+          Password
+        </Form.Label>
+        <Col sm={10}>
+          <Form.Control type="password" placeholder="Password" />
+        </Col>
+      </Form.Group>
+      <fieldset>
+        <Form.Group as={Row} className="mb-3">
+          <Form.Label as="legend" column sm={2}>
+            Radios
+          </Form.Label>
+          <Col sm={10}>
+            <Form.Check
+              type="radio"
+              label="first radio"
+              name="formHorizontalRadios"
+              id="formHorizontalRadios1"
+            />
+            <Form.Check
+              type="radio"
+              label="second radio"
+              name="formHorizontalRadios"
+              id="formHorizontalRadios2"
+            />
+            <Form.Check
+              type="radio"
+              label="third radio"
+              name="formHorizontalRadios"
+              id="formHorizontalRadios3"
+            />
+          </Col>
+        </Form.Group>
+      </fieldset>
+      <Form.Group as={Row} className="mb-3" controlId="formHorizontalCheck">
+        <Col sm={{ span: 10, offset: 2 }}>
+          <Form.Check label="Remember me" />
+        </Col>
+      </Form.Group>
+
+      <Form.Group as={Row} className="mb-3">
+        <Col sm={{ span: 10, offset: 2 }}>
+          <Button type="submit">Sign in</Button>
+        </Col>
+      </Form.Group>
+    </Form>
+  );
+}
+
+export default HorizontalExample;

--- a/www/src/examples/Form/InputReadOnly.js
+++ b/www/src/examples/Form/InputReadOnly.js
@@ -1,1 +1,9 @@
-<Form.Control type="text" placeholder="Readonly input here..." readOnly />;
+import Form from 'react-bootstrap/Form';
+
+function InputReadOnlyExample() {
+  return (
+    <Form.Control type="text" placeholder="Readonly input here..." readOnly />
+  );
+}
+
+export default InputReadOnlyExample;

--- a/www/src/examples/Form/InputSizes.js
+++ b/www/src/examples/Form/InputSizes.js
@@ -1,7 +1,15 @@
-<>
-  <Form.Control size="lg" type="text" placeholder="Large text" />
-  <br />
-  <Form.Control type="text" placeholder="Normal text" />
-  <br />
-  <Form.Control size="sm" type="text" placeholder="Small text" />
-</>;
+import Form from 'react-bootstrap/Form';
+
+function InputSizesExample() {
+  return (
+    <>
+      <Form.Control size="lg" type="text" placeholder="Large text" />
+      <br />
+      <Form.Control type="text" placeholder="Normal text" />
+      <br />
+      <Form.Control size="sm" type="text" placeholder="Small text" />
+    </>
+  );
+}
+
+export default InputSizesExample;

--- a/www/src/examples/Form/NoLabels.js
+++ b/www/src/examples/Form/NoLabels.js
@@ -1,4 +1,12 @@
-<>
-  <Form.Check aria-label="option 1" />
-  <Form.Check type="radio" aria-label="radio 1" />
-</>;
+import Form from 'react-bootstrap/Form';
+
+function NoLabelExample() {
+  return (
+    <>
+      <Form.Check aria-label="option 1" />
+      <Form.Check type="radio" aria-label="radio 1" />
+    </>
+  );
+}
+
+export default NoLabelExample;

--- a/www/src/examples/Form/Plaintext.js
+++ b/www/src/examples/Form/Plaintext.js
@@ -1,19 +1,29 @@
-<Form>
-  <Form.Group as={Row} className="mb-3" controlId="formPlaintextEmail">
-    <Form.Label column sm="2">
-      Email
-    </Form.Label>
-    <Col sm="10">
-      <Form.Control plaintext readOnly defaultValue="email@example.com" />
-    </Col>
-  </Form.Group>
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import Row from 'react-bootstrap/Row';
 
-  <Form.Group as={Row} className="mb-3" controlId="formPlaintextPassword">
-    <Form.Label column sm="2">
-      Password
-    </Form.Label>
-    <Col sm="10">
-      <Form.Control type="password" placeholder="Password" />
-    </Col>
-  </Form.Group>
-</Form>;
+function PlaintextExample() {
+  return (
+    <Form>
+      <Form.Group as={Row} className="mb-3" controlId="formPlaintextEmail">
+        <Form.Label column sm="2">
+          Email
+        </Form.Label>
+        <Col sm="10">
+          <Form.Control plaintext readOnly defaultValue="email@example.com" />
+        </Col>
+      </Form.Group>
+
+      <Form.Group as={Row} className="mb-3" controlId="formPlaintextPassword">
+        <Form.Label column sm="2">
+          Password
+        </Form.Label>
+        <Col sm="10">
+          <Form.Control type="password" placeholder="Password" />
+        </Col>
+      </Form.Group>
+    </Form>
+  );
+}
+
+export default PlaintextExample;

--- a/www/src/examples/Form/Range.js
+++ b/www/src/examples/Form/Range.js
@@ -1,4 +1,12 @@
-<>
-  <Form.Label>Range</Form.Label>
-  <Form.Range />
-</>;
+import Form from 'react-bootstrap/Form';
+
+function RangeExample() {
+  return (
+    <>
+      <Form.Label>Range</Form.Label>
+      <Form.Range />
+    </>
+  );
+}
+
+export default RangeExample;

--- a/www/src/examples/Form/SelectBasic.js
+++ b/www/src/examples/Form/SelectBasic.js
@@ -1,6 +1,14 @@
-<Form.Select aria-label="Default select example">
-  <option>Open this select menu</option>
-  <option value="1">One</option>
-  <option value="2">Two</option>
-  <option value="3">Three</option>
-</Form.Select>;
+import Form from 'react-bootstrap/Form';
+
+function SelectBasicExample() {
+  return (
+    <Form.Select aria-label="Default select example">
+      <option>Open this select menu</option>
+      <option value="1">One</option>
+      <option value="2">Two</option>
+      <option value="3">Three</option>
+    </Form.Select>
+  );
+}
+
+export default SelectBasicExample;

--- a/www/src/examples/Form/SelectSizes.js
+++ b/www/src/examples/Form/SelectSizes.js
@@ -1,13 +1,21 @@
-<>
-  <Form.Select size="lg">
-    <option>Large select</option>
-  </Form.Select>
-  <br />
-  <Form.Select>
-    <option>Default select</option>
-  </Form.Select>
-  <br />
-  <Form.Select size="sm">
-    <option>Small select</option>
-  </Form.Select>
-</>;
+import Form from 'react-bootstrap/Form';
+
+function SelectSizesExample() {
+  return (
+    <>
+      <Form.Select size="lg">
+        <option>Large select</option>
+      </Form.Select>
+      <br />
+      <Form.Select>
+        <option>Default select</option>
+      </Form.Select>
+      <br />
+      <Form.Select size="sm">
+        <option>Small select</option>
+      </Form.Select>
+    </>
+  );
+}
+
+export default SelectSizesExample;

--- a/www/src/examples/Form/Switch.js
+++ b/www/src/examples/Form/Switch.js
@@ -1,13 +1,21 @@
-<Form>
-  <Form.Check // prettier-ignore
-    type="switch"
-    id="custom-switch"
-    label="Check this switch"
-  />
-  <Form.Check // prettier-ignore
-    disabled
-    type="switch"
-    label="disabled switch"
-    id="disabled-custom-switch"
-  />
-</Form>;
+import Form from 'react-bootstrap/Form';
+
+function SwitchExample() {
+  return (
+    <Form>
+      <Form.Check // prettier-ignore
+        type="switch"
+        id="custom-switch"
+        label="Check this switch"
+      />
+      <Form.Check // prettier-ignore
+        disabled
+        type="switch"
+        label="disabled switch"
+        id="disabled-custom-switch"
+      />
+    </Form>
+  );
+}
+
+export default SwitchExample;

--- a/www/src/examples/Form/TextControls.js
+++ b/www/src/examples/Form/TextControls.js
@@ -1,10 +1,18 @@
-<Form>
-  <Form.Group className="mb-3" controlId="exampleForm.ControlInput1">
-    <Form.Label>Email address</Form.Label>
-    <Form.Control type="email" placeholder="name@example.com" />
-  </Form.Group>
-  <Form.Group className="mb-3" controlId="exampleForm.ControlTextarea1">
-    <Form.Label>Example textarea</Form.Label>
-    <Form.Control as="textarea" rows={3} />
-  </Form.Group>
-</Form>;
+import Form from 'react-bootstrap/Form';
+
+function TextControlsExample() {
+  return (
+    <Form>
+      <Form.Group className="mb-3" controlId="exampleForm.ControlInput1">
+        <Form.Label>Email address</Form.Label>
+        <Form.Control type="email" placeholder="name@example.com" />
+      </Form.Group>
+      <Form.Group className="mb-3" controlId="exampleForm.ControlTextarea1">
+        <Form.Label>Example textarea</Form.Label>
+        <Form.Control as="textarea" rows={3} />
+      </Form.Group>
+    </Form>
+  );
+}
+
+export default TextControlsExample;

--- a/www/src/examples/Form/ValidationFormik.js
+++ b/www/src/examples/Form/ValidationFormik.js
@@ -1,3 +1,9 @@
+import Button from 'react-bootstrap/Button';
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
+import Row from 'react-bootstrap/Row';
+
 const { Formik } = formik;
 
 const schema = yup.object().shape({

--- a/www/src/examples/Form/ValidationInputGroup.js
+++ b/www/src/examples/Form/ValidationInputGroup.js
@@ -1,7 +1,16 @@
-<InputGroup hasValidation>
-  <InputGroup.Text>@</InputGroup.Text>
-  <Form.Control type="text" required isInvalid />
-  <Form.Control.Feedback type="invalid">
-    Please choose a username.
-  </Form.Control.Feedback>
-</InputGroup>;
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
+
+function ValidationInputGroupExample() {
+  return (
+    <InputGroup hasValidation>
+      <InputGroup.Text>@</InputGroup.Text>
+      <Form.Control type="text" required isInvalid />
+      <Form.Control.Feedback type="invalid">
+        Please choose a username.
+      </Form.Control.Feedback>
+    </InputGroup>
+  );
+}
+
+export default ValidationInputGroupExample;

--- a/www/src/examples/Form/ValidationNative.js
+++ b/www/src/examples/Form/ValidationNative.js
@@ -1,3 +1,10 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
+import Row from 'react-bootstrap/Row';
+
 function FormExample() {
   const [validated, setValidated] = useState(false);
 

--- a/www/src/examples/Form/ValidationTooltips.js
+++ b/www/src/examples/Form/ValidationTooltips.js
@@ -1,3 +1,9 @@
+import Button from 'react-bootstrap/Button';
+import Col from 'react-bootstrap/Col';
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
+import Row from 'react-bootstrap/Row';
+
 const { Formik } = formik;
 
 const schema = yup.object().shape({

--- a/www/src/examples/Grid/AutoLayout.js
+++ b/www/src/examples/Grid/AutoLayout.js
@@ -1,11 +1,21 @@
-<Container>
-  <Row>
-    <Col>1 of 2</Col>
-    <Col>2 of 2</Col>
-  </Row>
-  <Row>
-    <Col>1 of 3</Col>
-    <Col>2 of 3</Col>
-    <Col>3 of 3</Col>
-  </Row>
-</Container>;
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+function AutoLayoutExample() {
+  return (
+    <Container>
+      <Row>
+        <Col>1 of 2</Col>
+        <Col>2 of 2</Col>
+      </Row>
+      <Row>
+        <Col>1 of 3</Col>
+        <Col>2 of 3</Col>
+        <Col>3 of 3</Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default AutoLayoutExample;

--- a/www/src/examples/Grid/AutoLayoutSizing.js
+++ b/www/src/examples/Grid/AutoLayoutSizing.js
@@ -1,12 +1,22 @@
-<Container>
-  <Row>
-    <Col>1 of 3</Col>
-    <Col xs={6}>2 of 3 (wider)</Col>
-    <Col>3 of 3</Col>
-  </Row>
-  <Row>
-    <Col>1 of 3</Col>
-    <Col xs={5}>2 of 3 (wider)</Col>
-    <Col>3 of 3</Col>
-  </Row>
-</Container>;
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+function AutoLayoutSizingExample() {
+  return (
+    <Container>
+      <Row>
+        <Col>1 of 3</Col>
+        <Col xs={6}>2 of 3 (wider)</Col>
+        <Col>3 of 3</Col>
+      </Row>
+      <Row>
+        <Col>1 of 3</Col>
+        <Col xs={5}>2 of 3 (wider)</Col>
+        <Col>3 of 3</Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default AutoLayoutSizingExample;

--- a/www/src/examples/Grid/AutoLayoutVariable.js
+++ b/www/src/examples/Grid/AutoLayoutVariable.js
@@ -1,18 +1,28 @@
-<Container>
-  <Row className="justify-content-md-center">
-    <Col xs lg="2">
-      1 of 3
-    </Col>
-    <Col md="auto">Variable width content</Col>
-    <Col xs lg="2">
-      3 of 3
-    </Col>
-  </Row>
-  <Row>
-    <Col>1 of 3</Col>
-    <Col md="auto">Variable width content</Col>
-    <Col xs lg="2">
-      3 of 3
-    </Col>
-  </Row>
-</Container>;
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+function AutoLayoutVariableExample() {
+  return (
+    <Container>
+      <Row className="justify-content-md-center">
+        <Col xs lg="2">
+          1 of 3
+        </Col>
+        <Col md="auto">Variable width content</Col>
+        <Col xs lg="2">
+          3 of 3
+        </Col>
+      </Row>
+      <Row>
+        <Col>1 of 3</Col>
+        <Col md="auto">Variable width content</Col>
+        <Col xs lg="2">
+          3 of 3
+        </Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default AutoLayoutVariableExample;

--- a/www/src/examples/Grid/Container.js
+++ b/www/src/examples/Grid/Container.js
@@ -1,5 +1,15 @@
-<Container>
-  <Row>
-    <Col>1 of 1</Col>
-  </Row>
-</Container>;
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+function ContainerExample() {
+  return (
+    <Container>
+      <Row>
+        <Col>1 of 1</Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default ContainerExample;

--- a/www/src/examples/Grid/ContainerFluid.js
+++ b/www/src/examples/Grid/ContainerFluid.js
@@ -1,5 +1,15 @@
-<Container fluid>
-  <Row>
-    <Col>1 of 1</Col>
-  </Row>
-</Container>;
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+function ContainerFluidExample() {
+  return (
+    <Container fluid>
+      <Row>
+        <Col>1 of 1</Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default ContainerFluidExample;

--- a/www/src/examples/Grid/ContainerFluidBreakpoint.js
+++ b/www/src/examples/Grid/ContainerFluidBreakpoint.js
@@ -1,5 +1,15 @@
-<Container fluid="md">
-  <Row>
-    <Col>1 of 1</Col>
-  </Row>
-</Container>;
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+function ContainerFluidBreakpointExample() {
+  return (
+    <Container fluid="md">
+      <Row>
+        <Col>1 of 1</Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default ContainerFluidBreakpointExample;

--- a/www/src/examples/Grid/Offsetting.js
+++ b/www/src/examples/Grid/Offsetting.js
@@ -1,13 +1,23 @@
-<Container>
-  <Row>
-    <Col md={4}>md=4</Col>
-    <Col md={{ span: 4, offset: 4 }}>{`md={{ span: 4, offset: 4 }}`}</Col>
-  </Row>
-  <Row>
-    <Col md={{ span: 3, offset: 3 }}>{`md={{ span: 3, offset: 3 }}`}</Col>
-    <Col md={{ span: 3, offset: 3 }}>{`md={{ span: 3, offset: 3 }}`}</Col>
-  </Row>
-  <Row>
-    <Col md={{ span: 6, offset: 3 }}>{`md={{ span: 6, offset: 3 }}`}</Col>
-  </Row>
-</Container>;
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+function OffsettingExample() {
+  return (
+    <Container>
+      <Row>
+        <Col md={4}>md=4</Col>
+        <Col md={{ span: 4, offset: 4 }}>{`md={{ span: 4, offset: 4 }}`}</Col>
+      </Row>
+      <Row>
+        <Col md={{ span: 3, offset: 3 }}>{`md={{ span: 3, offset: 3 }}`}</Col>
+        <Col md={{ span: 3, offset: 3 }}>{`md={{ span: 3, offset: 3 }}`}</Col>
+      </Row>
+      <Row>
+        <Col md={{ span: 6, offset: 3 }}>{`md={{ span: 6, offset: 3 }}`}</Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default OffsettingExample;

--- a/www/src/examples/Grid/Ordering.js
+++ b/www/src/examples/Grid/Ordering.js
@@ -1,7 +1,17 @@
-<Container>
-  <Row>
-    <Col xs>First, but unordered</Col>
-    <Col xs={{ order: 12 }}>Second, but last</Col>
-    <Col xs={{ order: 1 }}>Third, but second</Col>
-  </Row>
-</Container>;
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+function OrderingExample() {
+  return (
+    <Container>
+      <Row>
+        <Col xs>First, but unordered</Col>
+        <Col xs={{ order: 12 }}>Second, but last</Col>
+        <Col xs={{ order: 1 }}>Third, but second</Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default OrderingExample;

--- a/www/src/examples/Grid/OrderingFirstLast.js
+++ b/www/src/examples/Grid/OrderingFirstLast.js
@@ -1,7 +1,17 @@
-<Container>
-  <Row>
-    <Col xs={{ order: 'last' }}>First, but last</Col>
-    <Col xs>Second, but unordered</Col>
-    <Col xs={{ order: 'first' }}>Third, but first</Col>
-  </Row>
-</Container>;
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+function OrderingFirstLastExample() {
+  return (
+    <Container>
+      <Row>
+        <Col xs={{ order: 'last' }}>First, but last</Col>
+        <Col xs>Second, but unordered</Col>
+        <Col xs={{ order: 'first' }}>Third, but first</Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default OrderingFirstLastExample;

--- a/www/src/examples/Grid/Responsive.js
+++ b/www/src/examples/Grid/Responsive.js
@@ -1,30 +1,40 @@
-<Container>
-  {/* Stack the columns on mobile by making one full-width and the other half-width */}
-  <Row>
-    <Col xs={12} md={8}>
-      xs=12 md=8
-    </Col>
-    <Col xs={6} md={4}>
-      xs=6 md=4
-    </Col>
-  </Row>
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
 
-  {/* Columns start at 50% wide on mobile and bump up to 33.3% wide on desktop */}
-  <Row>
-    <Col xs={6} md={4}>
-      xs=6 md=4
-    </Col>
-    <Col xs={6} md={4}>
-      xs=6 md=4
-    </Col>
-    <Col xs={6} md={4}>
-      xs=6 md=4
-    </Col>
-  </Row>
+function ResponsiveExample() {
+  return (
+    <Container>
+      {/* Stack the columns on mobile by making one full-width and the other half-width */}
+      <Row>
+        <Col xs={12} md={8}>
+          xs=12 md=8
+        </Col>
+        <Col xs={6} md={4}>
+          xs=6 md=4
+        </Col>
+      </Row>
 
-  {/* Columns are always 50% wide, on mobile and desktop */}
-  <Row>
-    <Col xs={6}>xs=6</Col>
-    <Col xs={6}>xs=6</Col>
-  </Row>
-</Container>;
+      {/* Columns start at 50% wide on mobile and bump up to 33.3% wide on desktop */}
+      <Row>
+        <Col xs={6} md={4}>
+          xs=6 md=4
+        </Col>
+        <Col xs={6} md={4}>
+          xs=6 md=4
+        </Col>
+        <Col xs={6} md={4}>
+          xs=6 md=4
+        </Col>
+      </Row>
+
+      {/* Columns are always 50% wide, on mobile and desktop */}
+      <Row>
+        <Col xs={6}>xs=6</Col>
+        <Col xs={6}>xs=6</Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default ResponsiveExample;

--- a/www/src/examples/Grid/ResponsiveAuto.js
+++ b/www/src/examples/Grid/ResponsiveAuto.js
@@ -1,11 +1,21 @@
-<Container>
-  <Row>
-    <Col sm={8}>sm=8</Col>
-    <Col sm={4}>sm=4</Col>
-  </Row>
-  <Row>
-    <Col sm>sm=true</Col>
-    <Col sm>sm=true</Col>
-    <Col sm>sm=true</Col>
-  </Row>
-</Container>;
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+function ResponsiveAutoExample() {
+  return (
+    <Container>
+      <Row>
+        <Col sm={8}>sm=8</Col>
+        <Col sm={4}>sm=4</Col>
+      </Row>
+      <Row>
+        <Col sm>sm=true</Col>
+        <Col sm>sm=true</Col>
+        <Col sm>sm=true</Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default ResponsiveAutoExample;

--- a/www/src/examples/Grid/RowColLayout.js
+++ b/www/src/examples/Grid/RowColLayout.js
@@ -1,16 +1,26 @@
-<Container>
-  <Row xs={2} md={4} lg={6}>
-    <Col>1 of 2</Col>
-    <Col>2 of 2</Col>
-  </Row>
-  <Row xs={1} md={2}>
-    <Col>1 of 3</Col>
-    <Col>2 of 3</Col>
-    <Col>3 of 3</Col>
-  </Row>
-  <Row xs="auto">
-    <Col>1 of 3</Col>
-    <Col>2 of 3</Col>
-    <Col>3 of 3</Col>
-  </Row>
-</Container>;
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+function RowColLayoutExample() {
+  return (
+    <Container>
+      <Row xs={2} md={4} lg={6}>
+        <Col>1 of 2</Col>
+        <Col>2 of 2</Col>
+      </Row>
+      <Row xs={1} md={2}>
+        <Col>1 of 3</Col>
+        <Col>2 of 3</Col>
+        <Col>3 of 3</Col>
+      </Row>
+      <Row xs="auto">
+        <Col>1 of 3</Col>
+        <Col>2 of 3</Col>
+        <Col>3 of 3</Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default RowColLayoutExample;

--- a/www/src/examples/Grid/RowColLayoutColWidthBreakpoint.js
+++ b/www/src/examples/Grid/RowColLayoutColWidthBreakpoint.js
@@ -1,7 +1,17 @@
-<Container>
-  <Row md={4}>
-    <Col>1 of 3</Col>
-    <Col xs={6}>2 of 3</Col>
-    <Col>3 of 3</Col>
-  </Row>
-</Container>;
+import Container from 'react-bootstrap/Container';
+import Row from 'react-bootstrap/Row';
+import Col from 'react-bootstrap/Col';
+
+function RowColLayoutColWidthBreakpointExample() {
+  return (
+    <Container>
+      <Row md={4}>
+        <Col>1 of 3</Col>
+        <Col xs={6}>2 of 3</Col>
+        <Col>3 of 3</Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default RowColLayoutColWidthBreakpointExample;

--- a/www/src/examples/Image/Fluid.js
+++ b/www/src/examples/Image/Fluid.js
@@ -1,1 +1,7 @@
-<Image src="holder.js/100px250" fluid />;
+import Image from 'react-bootstrap/Image';
+
+function FluidExample() {
+  return <Image src="holder.js/100px250" fluid />;
+}
+
+export default FluidExample;

--- a/www/src/examples/Image/Shape.js
+++ b/www/src/examples/Image/Shape.js
@@ -1,13 +1,24 @@
-<Container>
-  <Row>
-    <Col xs={6} md={4}>
-      <Image src="holder.js/171x180" rounded />
-    </Col>
-    <Col xs={6} md={4}>
-      <Image src="holder.js/171x180" roundedCircle />
-    </Col>
-    <Col xs={6} md={4}>
-      <Image src="holder.js/171x180" thumbnail />
-    </Col>
-  </Row>
-</Container>;
+import Col from 'react-bootstrap/Col';
+import Container from 'react-bootstrap/Container';
+import Image from 'react-bootstrap/Image';
+import Row from 'react-bootstrap/Row';
+
+function ShapeExample() {
+  return (
+    <Container>
+      <Row>
+        <Col xs={6} md={4}>
+          <Image src="holder.js/171x180" rounded />
+        </Col>
+        <Col xs={6} md={4}>
+          <Image src="holder.js/171x180" roundedCircle />
+        </Col>
+        <Col xs={6} md={4}>
+          <Image src="holder.js/171x180" thumbnail />
+        </Col>
+      </Row>
+    </Container>
+  );
+}
+
+export default ShapeExample;

--- a/www/src/examples/InputGroup/Basic.js
+++ b/www/src/examples/InputGroup/Basic.js
@@ -1,38 +1,47 @@
-<>
-  <InputGroup className="mb-3">
-    <InputGroup.Text id="basic-addon1">@</InputGroup.Text>
-    <FormControl
-      placeholder="Username"
-      aria-label="Username"
-      aria-describedby="basic-addon1"
-    />
-  </InputGroup>
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
 
-  <InputGroup className="mb-3">
-    <FormControl
-      placeholder="Recipient's username"
-      aria-label="Recipient's username"
-      aria-describedby="basic-addon2"
-    />
-    <InputGroup.Text id="basic-addon2">@example.com</InputGroup.Text>
-  </InputGroup>
+function BasicExample() {
+  return (
+    <>
+      <InputGroup className="mb-3">
+        <InputGroup.Text id="basic-addon1">@</InputGroup.Text>
+        <Form.Control
+          placeholder="Username"
+          aria-label="Username"
+          aria-describedby="basic-addon1"
+        />
+      </InputGroup>
 
-  <Form.Label htmlFor="basic-url">Your vanity URL</Form.Label>
-  <InputGroup className="mb-3">
-    <InputGroup.Text id="basic-addon3">
-      https://example.com/users/
-    </InputGroup.Text>
-    <FormControl id="basic-url" aria-describedby="basic-addon3" />
-  </InputGroup>
+      <InputGroup className="mb-3">
+        <Form.Control
+          placeholder="Recipient's username"
+          aria-label="Recipient's username"
+          aria-describedby="basic-addon2"
+        />
+        <InputGroup.Text id="basic-addon2">@example.com</InputGroup.Text>
+      </InputGroup>
 
-  <InputGroup className="mb-3">
-    <InputGroup.Text>$</InputGroup.Text>
-    <FormControl aria-label="Amount (to the nearest dollar)" />
-    <InputGroup.Text>.00</InputGroup.Text>
-  </InputGroup>
+      <Form.Label htmlFor="basic-url">Your vanity URL</Form.Label>
+      <InputGroup className="mb-3">
+        <InputGroup.Text id="basic-addon3">
+          https://example.com/users/
+        </InputGroup.Text>
+        <Form.Control id="basic-url" aria-describedby="basic-addon3" />
+      </InputGroup>
 
-  <InputGroup>
-    <InputGroup.Text>With textarea</InputGroup.Text>
-    <FormControl as="textarea" aria-label="With textarea" />
-  </InputGroup>
-</>;
+      <InputGroup className="mb-3">
+        <InputGroup.Text>$</InputGroup.Text>
+        <Form.Control aria-label="Amount (to the nearest dollar)" />
+        <InputGroup.Text>.00</InputGroup.Text>
+      </InputGroup>
+
+      <InputGroup>
+        <InputGroup.Text>With textarea</InputGroup.Text>
+        <Form.Control as="textarea" aria-label="With textarea" />
+      </InputGroup>
+    </>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/InputGroup/ButtonDropdowns.js
+++ b/www/src/examples/InputGroup/ButtonDropdowns.js
@@ -1,60 +1,71 @@
-<>
-  <InputGroup className="mb-3">
-    <DropdownButton
-      variant="outline-secondary"
-      title="Dropdown"
-      id="input-group-dropdown-1"
-    >
-      <Dropdown.Item href="#">Action</Dropdown.Item>
-      <Dropdown.Item href="#">Another action</Dropdown.Item>
-      <Dropdown.Item href="#">Something else here</Dropdown.Item>
-      <Dropdown.Divider />
-      <Dropdown.Item href="#">Separated link</Dropdown.Item>
-    </DropdownButton>
-    <FormControl aria-label="Text input with dropdown button" />
-  </InputGroup>
+import Dropdown from 'react-bootstrap/Dropdown';
+import DropdownButton from 'react-bootstrap/DropdownButton';
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
 
-  <InputGroup className="mb-3">
-    <FormControl aria-label="Text input with dropdown button" />
+function ButtonDropdownsExample() {
+  return (
+    <>
+      <InputGroup className="mb-3">
+        <DropdownButton
+          variant="outline-secondary"
+          title="Dropdown"
+          id="input-group-dropdown-1"
+        >
+          <Dropdown.Item href="#">Action</Dropdown.Item>
+          <Dropdown.Item href="#">Another action</Dropdown.Item>
+          <Dropdown.Item href="#">Something else here</Dropdown.Item>
+          <Dropdown.Divider />
+          <Dropdown.Item href="#">Separated link</Dropdown.Item>
+        </DropdownButton>
+        <Form.Control aria-label="Text input with dropdown button" />
+      </InputGroup>
 
-    <DropdownButton
-      variant="outline-secondary"
-      title="Dropdown"
-      id="input-group-dropdown-2"
-      align="end"
-    >
-      <Dropdown.Item href="#">Action</Dropdown.Item>
-      <Dropdown.Item href="#">Another action</Dropdown.Item>
-      <Dropdown.Item href="#">Something else here</Dropdown.Item>
-      <Dropdown.Divider />
-      <Dropdown.Item href="#">Separated link</Dropdown.Item>
-    </DropdownButton>
-  </InputGroup>
+      <InputGroup className="mb-3">
+        <Form.Control aria-label="Text input with dropdown button" />
 
-  <InputGroup>
-    <DropdownButton
-      variant="outline-secondary"
-      title="Dropdown"
-      id="input-group-dropdown-3"
-    >
-      <Dropdown.Item href="#">Action</Dropdown.Item>
-      <Dropdown.Item href="#">Another action</Dropdown.Item>
-      <Dropdown.Item href="#">Something else here</Dropdown.Item>
-      <Dropdown.Divider />
-      <Dropdown.Item href="#">Separated link</Dropdown.Item>
-    </DropdownButton>
-    <FormControl aria-label="Text input with 2 dropdown buttons" />
-    <DropdownButton
-      variant="outline-secondary"
-      title="Dropdown"
-      id="input-group-dropdown-4"
-      align="end"
-    >
-      <Dropdown.Item href="#">Action</Dropdown.Item>
-      <Dropdown.Item href="#">Another action</Dropdown.Item>
-      <Dropdown.Item href="#">Something else here</Dropdown.Item>
-      <Dropdown.Divider />
-      <Dropdown.Item href="#">Separated link</Dropdown.Item>
-    </DropdownButton>
-  </InputGroup>
-</>;
+        <DropdownButton
+          variant="outline-secondary"
+          title="Dropdown"
+          id="input-group-dropdown-2"
+          align="end"
+        >
+          <Dropdown.Item href="#">Action</Dropdown.Item>
+          <Dropdown.Item href="#">Another action</Dropdown.Item>
+          <Dropdown.Item href="#">Something else here</Dropdown.Item>
+          <Dropdown.Divider />
+          <Dropdown.Item href="#">Separated link</Dropdown.Item>
+        </DropdownButton>
+      </InputGroup>
+
+      <InputGroup>
+        <DropdownButton
+          variant="outline-secondary"
+          title="Dropdown"
+          id="input-group-dropdown-3"
+        >
+          <Dropdown.Item href="#">Action</Dropdown.Item>
+          <Dropdown.Item href="#">Another action</Dropdown.Item>
+          <Dropdown.Item href="#">Something else here</Dropdown.Item>
+          <Dropdown.Divider />
+          <Dropdown.Item href="#">Separated link</Dropdown.Item>
+        </DropdownButton>
+        <Form.Control aria-label="Text input with 2 dropdown buttons" />
+        <DropdownButton
+          variant="outline-secondary"
+          title="Dropdown"
+          id="input-group-dropdown-4"
+          align="end"
+        >
+          <Dropdown.Item href="#">Action</Dropdown.Item>
+          <Dropdown.Item href="#">Another action</Dropdown.Item>
+          <Dropdown.Item href="#">Something else here</Dropdown.Item>
+          <Dropdown.Divider />
+          <Dropdown.Item href="#">Separated link</Dropdown.Item>
+        </DropdownButton>
+      </InputGroup>
+    </>
+  );
+}
+
+export default ButtonDropdownsExample;

--- a/www/src/examples/InputGroup/Buttons.js
+++ b/www/src/examples/InputGroup/Buttons.js
@@ -1,37 +1,47 @@
-<>
-  <InputGroup className="mb-3">
-    <Button variant="outline-secondary" id="button-addon1">
-      Button
-    </Button>
-    <FormControl
-      aria-label="Example text with button addon"
-      aria-describedby="basic-addon1"
-    />
-  </InputGroup>
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
 
-  <InputGroup className="mb-3">
-    <FormControl
-      placeholder="Recipient's username"
-      aria-label="Recipient's username"
-      aria-describedby="basic-addon2"
-    />
-    <Button variant="outline-secondary" id="button-addon2">
-      Button
-    </Button>
-  </InputGroup>
+function ButtonsExample() {
+  return (
+    <>
+      <InputGroup className="mb-3">
+        <Button variant="outline-secondary" id="button-addon1">
+          Button
+        </Button>
+        <Form.Control
+          aria-label="Example text with button addon"
+          aria-describedby="basic-addon1"
+        />
+      </InputGroup>
 
-  <InputGroup className="mb-3">
-    <Button variant="outline-secondary">Button</Button>
-    <Button variant="outline-secondary">Button</Button>
-    <FormControl aria-label="Example text with two button addons" />
-  </InputGroup>
+      <InputGroup className="mb-3">
+        <Form.Control
+          placeholder="Recipient's username"
+          aria-label="Recipient's username"
+          aria-describedby="basic-addon2"
+        />
+        <Button variant="outline-secondary" id="button-addon2">
+          Button
+        </Button>
+      </InputGroup>
 
-  <InputGroup>
-    <FormControl
-      placeholder="Recipient's username"
-      aria-label="Recipient's username with two button addons"
-    />
-    <Button variant="outline-secondary">Button</Button>
-    <Button variant="outline-secondary">Button</Button>
-  </InputGroup>
-</>;
+      <InputGroup className="mb-3">
+        <Button variant="outline-secondary">Button</Button>
+        <Button variant="outline-secondary">Button</Button>
+        <Form.Control aria-label="Example text with two button addons" />
+      </InputGroup>
+
+      <InputGroup>
+        <Form.Control
+          placeholder="Recipient's username"
+          aria-label="Recipient's username with two button addons"
+        />
+        <Button variant="outline-secondary">Button</Button>
+        <Button variant="outline-secondary">Button</Button>
+      </InputGroup>
+    </>
+  );
+}
+
+export default ButtonsExample;

--- a/www/src/examples/InputGroup/Checkboxes.js
+++ b/www/src/examples/InputGroup/Checkboxes.js
@@ -1,10 +1,19 @@
-<>
-  <InputGroup className="mb-3">
-    <InputGroup.Checkbox aria-label="Checkbox for following text input" />
-    <FormControl aria-label="Text input with checkbox" />
-  </InputGroup>
-  <InputGroup>
-    <InputGroup.Radio aria-label="Radio button for following text input" />
-    <FormControl aria-label="Text input with radio button" />
-  </InputGroup>
-</>;
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
+
+function CheckboxesExample() {
+  return (
+    <>
+      <InputGroup className="mb-3">
+        <InputGroup.Checkbox aria-label="Checkbox for following text input" />
+        <Form.Control aria-label="Text input with checkbox" />
+      </InputGroup>
+      <InputGroup>
+        <InputGroup.Radio aria-label="Radio button for following text input" />
+        <Form.Control aria-label="Text input with radio button" />
+      </InputGroup>
+    </>
+  );
+}
+
+export default CheckboxesExample;

--- a/www/src/examples/InputGroup/MultipleAddons.js
+++ b/www/src/examples/InputGroup/MultipleAddons.js
@@ -1,12 +1,21 @@
-<>
-  <InputGroup className="mb-3">
-    <InputGroup.Text>$</InputGroup.Text>
-    <InputGroup.Text>0.00</InputGroup.Text>
-    <FormControl aria-label="Dollar amount (with dot and two decimal places)" />
-  </InputGroup>
-  <InputGroup>
-    <FormControl aria-label="Dollar amount (with dot and two decimal places)" />
-    <InputGroup.Text>$</InputGroup.Text>
-    <InputGroup.Text>0.00</InputGroup.Text>
-  </InputGroup>
-</>;
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
+
+function MultipleAddonsExample() {
+  return (
+    <>
+      <InputGroup className="mb-3">
+        <InputGroup.Text>$</InputGroup.Text>
+        <InputGroup.Text>0.00</InputGroup.Text>
+        <Form.Control aria-label="Dollar amount (with dot and two decimal places)" />
+      </InputGroup>
+      <InputGroup>
+        <Form.Control aria-label="Dollar amount (with dot and two decimal places)" />
+        <InputGroup.Text>$</InputGroup.Text>
+        <InputGroup.Text>0.00</InputGroup.Text>
+      </InputGroup>
+    </>
+  );
+}
+
+export default MultipleAddonsExample;

--- a/www/src/examples/InputGroup/MultipleInputs.js
+++ b/www/src/examples/InputGroup/MultipleInputs.js
@@ -1,5 +1,14 @@
-<InputGroup className="mb-3">
-  <InputGroup.Text>First and last name</InputGroup.Text>
-  <FormControl aria-label="First name" />
-  <FormControl aria-label="Last name" />
-</InputGroup>;
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
+
+function MultipleInputsExample() {
+  return (
+    <InputGroup className="mb-3">
+      <InputGroup.Text>First and last name</InputGroup.Text>
+      <Form.Control aria-label="First name" />
+      <Form.Control aria-label="Last name" />
+    </InputGroup>
+  );
+}
+
+export default MultipleInputsExample;

--- a/www/src/examples/InputGroup/SegmentedButtonDropdowns.js
+++ b/www/src/examples/InputGroup/SegmentedButtonDropdowns.js
@@ -1,32 +1,43 @@
-<>
-  <InputGroup className="mb-3">
-    <SplitButton
-      variant="outline-secondary"
-      title="Action"
-      id="segmented-button-dropdown-1"
-    >
-      <Dropdown.Item href="#">Action</Dropdown.Item>
-      <Dropdown.Item href="#">Another action</Dropdown.Item>
-      <Dropdown.Item href="#">Something else here</Dropdown.Item>
-      <Dropdown.Divider />
-      <Dropdown.Item href="#">Separated link</Dropdown.Item>
-    </SplitButton>
-    <FormControl aria-label="Text input with dropdown button" />
-  </InputGroup>
+import Dropdown from 'react-bootstrap/Dropdown';
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
+import SplitButton from 'react-bootstrap/SplitButton';
 
-  <InputGroup className="mb-3">
-    <FormControl aria-label="Text input with dropdown button" />
-    <SplitButton
-      variant="outline-secondary"
-      title="Action"
-      id="segmented-button-dropdown-2"
-      alignRight
-    >
-      <Dropdown.Item href="#">Action</Dropdown.Item>
-      <Dropdown.Item href="#">Another action</Dropdown.Item>
-      <Dropdown.Item href="#">Something else here</Dropdown.Item>
-      <Dropdown.Divider />
-      <Dropdown.Item href="#">Separated link</Dropdown.Item>
-    </SplitButton>
-  </InputGroup>
-</>;
+function SegmentedButtonDropdownsExample() {
+  return (
+    <>
+      <InputGroup className="mb-3">
+        <SplitButton
+          variant="outline-secondary"
+          title="Action"
+          id="segmented-button-dropdown-1"
+        >
+          <Dropdown.Item href="#">Action</Dropdown.Item>
+          <Dropdown.Item href="#">Another action</Dropdown.Item>
+          <Dropdown.Item href="#">Something else here</Dropdown.Item>
+          <Dropdown.Divider />
+          <Dropdown.Item href="#">Separated link</Dropdown.Item>
+        </SplitButton>
+        <Form.Control aria-label="Text input with dropdown button" />
+      </InputGroup>
+
+      <InputGroup className="mb-3">
+        <Form.Control aria-label="Text input with dropdown button" />
+        <SplitButton
+          variant="outline-secondary"
+          title="Action"
+          id="segmented-button-dropdown-2"
+          alignRight
+        >
+          <Dropdown.Item href="#">Action</Dropdown.Item>
+          <Dropdown.Item href="#">Another action</Dropdown.Item>
+          <Dropdown.Item href="#">Something else here</Dropdown.Item>
+          <Dropdown.Divider />
+          <Dropdown.Item href="#">Separated link</Dropdown.Item>
+        </SplitButton>
+      </InputGroup>
+    </>
+  );
+}
+
+export default SegmentedButtonDropdownsExample;

--- a/www/src/examples/InputGroup/Sizes.js
+++ b/www/src/examples/InputGroup/Sizes.js
@@ -1,19 +1,36 @@
-<>
-  <InputGroup size="sm" className="mb-3">
-    <InputGroup.Text id="inputGroup-sizing-sm">Small</InputGroup.Text>
-    <FormControl aria-label="Small" aria-describedby="inputGroup-sizing-sm" />
-  </InputGroup>
-  <br />
-  <InputGroup className="mb-3">
-    <InputGroup.Text id="inputGroup-sizing-default">Default</InputGroup.Text>
-    <FormControl
-      aria-label="Default"
-      aria-describedby="inputGroup-sizing-default"
-    />
-  </InputGroup>
-  <br />
-  <InputGroup size="lg">
-    <InputGroup.Text id="inputGroup-sizing-lg">Large</InputGroup.Text>
-    <FormControl aria-label="Large" aria-describedby="inputGroup-sizing-sm" />
-  </InputGroup>
-</>;
+import Form from 'react-bootstrap/Form';
+import InputGroup from 'react-bootstrap/InputGroup';
+
+function SizesExample() {
+  return (
+    <>
+      <InputGroup size="sm" className="mb-3">
+        <InputGroup.Text id="inputGroup-sizing-sm">Small</InputGroup.Text>
+        <Form.Control
+          aria-label="Small"
+          aria-describedby="inputGroup-sizing-sm"
+        />
+      </InputGroup>
+      <br />
+      <InputGroup className="mb-3">
+        <InputGroup.Text id="inputGroup-sizing-default">
+          Default
+        </InputGroup.Text>
+        <Form.Control
+          aria-label="Default"
+          aria-describedby="inputGroup-sizing-default"
+        />
+      </InputGroup>
+      <br />
+      <InputGroup size="lg">
+        <InputGroup.Text id="inputGroup-sizing-lg">Large</InputGroup.Text>
+        <Form.Control
+          aria-label="Large"
+          aria-describedby="inputGroup-sizing-sm"
+        />
+      </InputGroup>
+    </>
+  );
+}
+
+export default SizesExample;

--- a/www/src/examples/ListGroup/Active.js
+++ b/www/src/examples/ListGroup/Active.js
@@ -1,10 +1,18 @@
-<ListGroup as="ul">
-  <ListGroup.Item as="li" active>
-    Cras justo odio
-  </ListGroup.Item>
-  <ListGroup.Item as="li">Dapibus ac facilisis in</ListGroup.Item>
-  <ListGroup.Item as="li" disabled>
-    Morbi leo risus
-  </ListGroup.Item>
-  <ListGroup.Item as="li">Porta ac consectetur ac</ListGroup.Item>
-</ListGroup>;
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function ActiveExample() {
+  return (
+    <ListGroup as="ul">
+      <ListGroup.Item as="li" active>
+        Cras justo odio
+      </ListGroup.Item>
+      <ListGroup.Item as="li">Dapibus ac facilisis in</ListGroup.Item>
+      <ListGroup.Item as="li" disabled>
+        Morbi leo risus
+      </ListGroup.Item>
+      <ListGroup.Item as="li">Porta ac consectetur ac</ListGroup.Item>
+    </ListGroup>
+  );
+}
+
+export default ActiveExample;

--- a/www/src/examples/ListGroup/Buttons.js
+++ b/www/src/examples/ListGroup/Buttons.js
@@ -1,13 +1,19 @@
-function alertClicked() {
-  alert('You clicked the third ListGroupItem');
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function ButtonExample() {
+  const alertClicked = () => {
+    alert('You clicked the third ListGroupItem');
+  };
+
+  return (
+    <ListGroup>
+      <ListGroup.Item action>Link 1</ListGroup.Item>
+      <ListGroup.Item action>Link 2</ListGroup.Item>
+      <ListGroup.Item action onClick={alertClicked}>
+        Trigger an alert
+      </ListGroup.Item>
+    </ListGroup>
+  );
 }
 
-render(
-  <ListGroup>
-    <ListGroup.Item action>Link 1</ListGroup.Item>
-    <ListGroup.Item action>Link 2</ListGroup.Item>
-    <ListGroup.Item action onClick={alertClicked}>
-      Trigger an alert
-    </ListGroup.Item>
-  </ListGroup>,
-);
+export default ButtonExample;

--- a/www/src/examples/ListGroup/Default.js
+++ b/www/src/examples/ListGroup/Default.js
@@ -1,7 +1,15 @@
-<ListGroup>
-  <ListGroup.Item>Cras justo odio</ListGroup.Item>
-  <ListGroup.Item>Dapibus ac facilisis in</ListGroup.Item>
-  <ListGroup.Item>Morbi leo risus</ListGroup.Item>
-  <ListGroup.Item>Porta ac consectetur ac</ListGroup.Item>
-  <ListGroup.Item>Vestibulum at eros</ListGroup.Item>
-</ListGroup>;
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function DefaultExample() {
+  return (
+    <ListGroup>
+      <ListGroup.Item>Cras justo odio</ListGroup.Item>
+      <ListGroup.Item>Dapibus ac facilisis in</ListGroup.Item>
+      <ListGroup.Item>Morbi leo risus</ListGroup.Item>
+      <ListGroup.Item>Porta ac consectetur ac</ListGroup.Item>
+      <ListGroup.Item>Vestibulum at eros</ListGroup.Item>
+    </ListGroup>
+  );
+}
+
+export default DefaultExample;

--- a/www/src/examples/ListGroup/Disabled.js
+++ b/www/src/examples/ListGroup/Disabled.js
@@ -1,6 +1,14 @@
-<ListGroup>
-  <ListGroup.Item disabled>Cras justo odio</ListGroup.Item>
-  <ListGroup.Item>Dapibus ac facilisis in</ListGroup.Item>
-  <ListGroup.Item>Morbi leo risus</ListGroup.Item>
-  <ListGroup.Item>Porta ac consectetur ac</ListGroup.Item>
-</ListGroup>;
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function DisabledExample() {
+  return (
+    <ListGroup>
+      <ListGroup.Item disabled>Cras justo odio</ListGroup.Item>
+      <ListGroup.Item>Dapibus ac facilisis in</ListGroup.Item>
+      <ListGroup.Item>Morbi leo risus</ListGroup.Item>
+      <ListGroup.Item>Porta ac consectetur ac</ListGroup.Item>
+    </ListGroup>
+  );
+}
+
+export default DisabledExample;

--- a/www/src/examples/ListGroup/Flush.js
+++ b/www/src/examples/ListGroup/Flush.js
@@ -1,6 +1,14 @@
-<ListGroup variant="flush">
-  <ListGroup.Item>Cras justo odio</ListGroup.Item>
-  <ListGroup.Item>Dapibus ac facilisis in</ListGroup.Item>
-  <ListGroup.Item>Morbi leo risus</ListGroup.Item>
-  <ListGroup.Item>Porta ac consectetur ac</ListGroup.Item>
-</ListGroup>;
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function FlushExample() {
+  return (
+    <ListGroup variant="flush">
+      <ListGroup.Item>Cras justo odio</ListGroup.Item>
+      <ListGroup.Item>Dapibus ac facilisis in</ListGroup.Item>
+      <ListGroup.Item>Morbi leo risus</ListGroup.Item>
+      <ListGroup.Item>Porta ac consectetur ac</ListGroup.Item>
+    </ListGroup>
+  );
+}
+
+export default FlushExample;

--- a/www/src/examples/ListGroup/Header.js
+++ b/www/src/examples/ListGroup/Header.js
@@ -1,9 +1,17 @@
-<ListGroup>
-  <ListGroupItem header="Heading 1">Some body text</ListGroupItem>
-  <ListGroupItem header="Heading 2" href="#">
-    Linked item
-  </ListGroupItem>
-  <ListGroupItem header="Heading 3" bsStyle="danger">
-    Danger styling
-  </ListGroupItem>
-</ListGroup>;
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function HeaderExample() {
+  return (
+    <ListGroup>
+      <ListGroup.Item header="Heading 1">Some body text</ListGroup.Item>
+      <ListGroup.Item header="Heading 2" href="#">
+        Linked item
+      </ListGroup.Item>
+      <ListGroup.Item header="Heading 3" bsStyle="danger">
+        Danger styling
+      </ListGroup.Item>
+    </ListGroup>
+  );
+}
+
+export default HeaderExample;

--- a/www/src/examples/ListGroup/Horizontal.js
+++ b/www/src/examples/ListGroup/Horizontal.js
@@ -1,6 +1,14 @@
-<ListGroup horizontal>
-  <ListGroup.Item>This</ListGroup.Item>
-  <ListGroup.Item>ListGroup</ListGroup.Item>
-  <ListGroup.Item>renders</ListGroup.Item>
-  <ListGroup.Item>horizontally!</ListGroup.Item>
-</ListGroup>;
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function HorizontalExample() {
+  return (
+    <ListGroup horizontal>
+      <ListGroup.Item>This</ListGroup.Item>
+      <ListGroup.Item>ListGroup</ListGroup.Item>
+      <ListGroup.Item>renders</ListGroup.Item>
+      <ListGroup.Item>horizontally!</ListGroup.Item>
+    </ListGroup>
+  );
+}
+
+export default HorizontalExample;

--- a/www/src/examples/ListGroup/HorizontalResponsive.js
+++ b/www/src/examples/ListGroup/HorizontalResponsive.js
@@ -1,10 +1,18 @@
-<>
-  {['sm', 'md', 'lg', 'xl', 'xxl'].map((breakpoint) => (
-    <ListGroup key={breakpoint} horizontal={breakpoint} className="my-2">
-      <ListGroup.Item>This ListGroup</ListGroup.Item>
-      <ListGroup.Item>renders horizontally</ListGroup.Item>
-      <ListGroup.Item>on {breakpoint}</ListGroup.Item>
-      <ListGroup.Item>and above!</ListGroup.Item>
-    </ListGroup>
-  ))}
-</>;
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function HorizontalResponsiveExample() {
+  return (
+    <>
+      {['sm', 'md', 'lg', 'xl', 'xxl'].map((breakpoint) => (
+        <ListGroup key={breakpoint} horizontal={breakpoint} className="my-2">
+          <ListGroup.Item>This ListGroup</ListGroup.Item>
+          <ListGroup.Item>renders horizontally</ListGroup.Item>
+          <ListGroup.Item>on {breakpoint}</ListGroup.Item>
+          <ListGroup.Item>and above!</ListGroup.Item>
+        </ListGroup>
+      ))}
+    </>
+  );
+}
+
+export default HorizontalResponsiveExample;

--- a/www/src/examples/ListGroup/Linked.js
+++ b/www/src/examples/ListGroup/Linked.js
@@ -1,17 +1,23 @@
-function alertClicked() {
-  alert('You clicked the third ListGroupItem');
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function LinkedExample() {
+  const alertClicked = () => {
+    alert('You clicked the third ListGroupItem');
+  };
+
+  return (
+    <ListGroup defaultActiveKey="#link1">
+      <ListGroup.Item action href="#link1">
+        Link 1
+      </ListGroup.Item>
+      <ListGroup.Item action href="#link2" disabled>
+        Link 2
+      </ListGroup.Item>
+      <ListGroup.Item action onClick={alertClicked}>
+        This one is a button
+      </ListGroup.Item>
+    </ListGroup>
+  );
 }
 
-render(
-  <ListGroup defaultActiveKey="#link1">
-    <ListGroup.Item action href="#link1">
-      Link 1
-    </ListGroup.Item>
-    <ListGroup.Item action href="#link2" disabled>
-      Link 2
-    </ListGroup.Item>
-    <ListGroup.Item action onClick={alertClicked}>
-      This one is a button
-    </ListGroup.Item>
-  </ListGroup>,
-);
+export default LinkedExample;

--- a/www/src/examples/ListGroup/Numbered.js
+++ b/www/src/examples/ListGroup/Numbered.js
@@ -1,5 +1,13 @@
-<ListGroup as="ol" numbered>
-  <ListGroup.Item as="li">Cras justo odio</ListGroup.Item>
-  <ListGroup.Item as="li">Cras justo odio</ListGroup.Item>
-  <ListGroup.Item as="li">Cras justo odio</ListGroup.Item>
-</ListGroup>;
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function NumberedExample() {
+  return (
+    <ListGroup as="ol" numbered>
+      <ListGroup.Item as="li">Cras justo odio</ListGroup.Item>
+      <ListGroup.Item as="li">Cras justo odio</ListGroup.Item>
+      <ListGroup.Item as="li">Cras justo odio</ListGroup.Item>
+    </ListGroup>
+  );
+}
+
+export default NumberedExample;

--- a/www/src/examples/ListGroup/NumberedCustom.js
+++ b/www/src/examples/ListGroup/NumberedCustom.js
@@ -1,38 +1,47 @@
-<ListGroup as="ol" numbered>
-  <ListGroup.Item
-    as="li"
-    className="d-flex justify-content-between align-items-start"
-  >
-    <div className="ms-2 me-auto">
-      <div className="fw-bold">Subheading</div>
-      Cras justo odio
-    </div>
-    <Badge bg="primary" pill>
-      14
-    </Badge>
-  </ListGroup.Item>
-  <ListGroup.Item
-    as="li"
-    className="d-flex justify-content-between align-items-start"
-  >
-    <div className="ms-2 me-auto">
-      <div className="fw-bold">Subheading</div>
-      Cras justo odio
-    </div>
-    <Badge bg="primary" pill>
-      14
-    </Badge>
-  </ListGroup.Item>
-  <ListGroup.Item
-    as="li"
-    className="d-flex justify-content-between align-items-start"
-  >
-    <div className="ms-2 me-auto">
-      <div className="fw-bold">Subheading</div>
-      Cras justo odio
-    </div>
-    <Badge bg="primary" pill>
-      14
-    </Badge>
-  </ListGroup.Item>
-</ListGroup>;
+import Badge from 'react-bootstrap/Badge';
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function DefaultExample() {
+  return (
+    <ListGroup as="ol" numbered>
+      <ListGroup.Item
+        as="li"
+        className="d-flex justify-content-between align-items-start"
+      >
+        <div className="ms-2 me-auto">
+          <div className="fw-bold">Subheading</div>
+          Cras justo odio
+        </div>
+        <Badge bg="primary" pill>
+          14
+        </Badge>
+      </ListGroup.Item>
+      <ListGroup.Item
+        as="li"
+        className="d-flex justify-content-between align-items-start"
+      >
+        <div className="ms-2 me-auto">
+          <div className="fw-bold">Subheading</div>
+          Cras justo odio
+        </div>
+        <Badge bg="primary" pill>
+          14
+        </Badge>
+      </ListGroup.Item>
+      <ListGroup.Item
+        as="li"
+        className="d-flex justify-content-between align-items-start"
+      >
+        <div className="ms-2 me-auto">
+          <div className="fw-bold">Subheading</div>
+          Cras justo odio
+        </div>
+        <Badge bg="primary" pill>
+          14
+        </Badge>
+      </ListGroup.Item>
+    </ListGroup>
+  );
+}
+
+export default DefaultExample;

--- a/www/src/examples/ListGroup/Style.js
+++ b/www/src/examples/ListGroup/Style.js
@@ -1,11 +1,19 @@
-<ListGroup>
-  <ListGroup.Item>No style</ListGroup.Item>
-  <ListGroup.Item variant="primary">Primary</ListGroup.Item>
-  <ListGroup.Item variant="secondary">Secondary</ListGroup.Item>
-  <ListGroup.Item variant="success">Success</ListGroup.Item>
-  <ListGroup.Item variant="danger">Danger</ListGroup.Item>
-  <ListGroup.Item variant="warning">Warning</ListGroup.Item>
-  <ListGroup.Item variant="info">Info</ListGroup.Item>
-  <ListGroup.Item variant="light">Light</ListGroup.Item>
-  <ListGroup.Item variant="dark">Dark</ListGroup.Item>
-</ListGroup>;
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function StyleExample() {
+  return (
+    <ListGroup>
+      <ListGroup.Item>No style</ListGroup.Item>
+      <ListGroup.Item variant="primary">Primary</ListGroup.Item>
+      <ListGroup.Item variant="secondary">Secondary</ListGroup.Item>
+      <ListGroup.Item variant="success">Success</ListGroup.Item>
+      <ListGroup.Item variant="danger">Danger</ListGroup.Item>
+      <ListGroup.Item variant="warning">Warning</ListGroup.Item>
+      <ListGroup.Item variant="info">Info</ListGroup.Item>
+      <ListGroup.Item variant="light">Light</ListGroup.Item>
+      <ListGroup.Item variant="dark">Dark</ListGroup.Item>
+    </ListGroup>
+  );
+}
+
+export default StyleExample;

--- a/www/src/examples/ListGroup/StyleActions.js
+++ b/www/src/examples/ListGroup/StyleActions.js
@@ -1,25 +1,33 @@
-<ListGroup>
-  <ListGroup.Item>No style</ListGroup.Item>
-  <ListGroup.Item variant="primary">Primary</ListGroup.Item>
-  <ListGroup.Item action variant="secondary">
-    Secondary
-  </ListGroup.Item>
-  <ListGroup.Item action variant="success">
-    Success
-  </ListGroup.Item>
-  <ListGroup.Item action variant="danger">
-    Danger
-  </ListGroup.Item>
-  <ListGroup.Item action variant="warning">
-    Warning
-  </ListGroup.Item>
-  <ListGroup.Item action variant="info">
-    Info
-  </ListGroup.Item>
-  <ListGroup.Item action variant="light">
-    Light
-  </ListGroup.Item>
-  <ListGroup.Item action variant="dark">
-    Dark
-  </ListGroup.Item>
-</ListGroup>;
+import ListGroup from 'react-bootstrap/ListGroup';
+
+function StyleActionsExample() {
+  return (
+    <ListGroup>
+      <ListGroup.Item>No style</ListGroup.Item>
+      <ListGroup.Item variant="primary">Primary</ListGroup.Item>
+      <ListGroup.Item action variant="secondary">
+        Secondary
+      </ListGroup.Item>
+      <ListGroup.Item action variant="success">
+        Success
+      </ListGroup.Item>
+      <ListGroup.Item action variant="danger">
+        Danger
+      </ListGroup.Item>
+      <ListGroup.Item action variant="warning">
+        Warning
+      </ListGroup.Item>
+      <ListGroup.Item action variant="info">
+        Info
+      </ListGroup.Item>
+      <ListGroup.Item action variant="light">
+        Light
+      </ListGroup.Item>
+      <ListGroup.Item action variant="dark">
+        Dark
+      </ListGroup.Item>
+    </ListGroup>
+  );
+}
+
+export default StyleActionsExample;

--- a/www/src/examples/ListGroup/Tabs.js
+++ b/www/src/examples/ListGroup/Tabs.js
@@ -1,24 +1,35 @@
-<Tab.Container id="list-group-tabs-example" defaultActiveKey="#link1">
-  <Row>
-    <Col sm={4}>
-      <ListGroup>
-        <ListGroup.Item action href="#link1">
-          Link 1
-        </ListGroup.Item>
-        <ListGroup.Item action href="#link2">
-          Link 2
-        </ListGroup.Item>
-      </ListGroup>
-    </Col>
-    <Col sm={8}>
-      <Tab.Content>
-        <Tab.Pane eventKey="#link1">
-          <Sonnet />
-        </Tab.Pane>
-        <Tab.Pane eventKey="#link2">
-          <Sonnet />
-        </Tab.Pane>
-      </Tab.Content>
-    </Col>
-  </Row>
-</Tab.Container>;
+import Col from 'react-bootstrap/Col';
+import ListGroup from 'react-bootstrap/ListGroup';
+import Row from 'react-bootstrap/Row';
+import Tab from 'react-bootstrap/Tab';
+
+function TabsExample() {
+  return (
+    <Tab.Container id="list-group-tabs-example" defaultActiveKey="#link1">
+      <Row>
+        <Col sm={4}>
+          <ListGroup>
+            <ListGroup.Item action href="#link1">
+              Link 1
+            </ListGroup.Item>
+            <ListGroup.Item action href="#link2">
+              Link 2
+            </ListGroup.Item>
+          </ListGroup>
+        </Col>
+        <Col sm={8}>
+          <Tab.Content>
+            <Tab.Pane eventKey="#link1">
+              <Sonnet />
+            </Tab.Pane>
+            <Tab.Pane eventKey="#link2">
+              <Sonnet />
+            </Tab.Pane>
+          </Tab.Content>
+        </Col>
+      </Row>
+    </Tab.Container>
+  );
+}
+
+export default TabsExample;

--- a/www/src/examples/Modal/Basic.js
+++ b/www/src/examples/Modal/Basic.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
+
 function Example() {
   const [show, setShow] = useState(false);
 

--- a/www/src/examples/Modal/CustomSizing.js
+++ b/www/src/examples/Modal/CustomSizing.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
+
 function Example() {
   const [show, setShow] = useState(false);
 

--- a/www/src/examples/Modal/DefaultSizing.js
+++ b/www/src/examples/Modal/DefaultSizing.js
@@ -1,10 +1,16 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
+
 function Example() {
   const [smShow, setSmShow] = useState(false);
   const [lgShow, setLgShow] = useState(false);
 
   return (
     <>
-      <Button onClick={() => setSmShow(true)} className="me-2">Small modal</Button>
+      <Button onClick={() => setSmShow(true)} className="me-2">
+        Small modal
+      </Button>
       <Button onClick={() => setLgShow(true)}>Large modal</Button>
       <Modal
         size="sm"

--- a/www/src/examples/Modal/Focus.js
+++ b/www/src/examples/Modal/Focus.js
@@ -1,3 +1,8 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import Modal from 'react-bootstrap/Modal';
+
 function Example() {
   const [show, setShow] = useState(false);
 

--- a/www/src/examples/Modal/FullScreen.js
+++ b/www/src/examples/Modal/FullScreen.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
+
 function Example() {
   const values = [true, 'sm-down', 'md-down', 'lg-down', 'xl-down', 'xxl-down'];
   const [fullscreen, setFullscreen] = useState(true);

--- a/www/src/examples/Modal/Grid.js
+++ b/www/src/examples/Modal/Grid.js
@@ -1,3 +1,10 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Col from 'react-bootstrap/Col';
+import Container from 'react-bootstrap/Container';
+import Modal from 'react-bootstrap/Modal';
+import Row from 'react-bootstrap/Row';
+
 function MydModalWithGrid(props) {
   return (
     <Modal {...props} aria-labelledby="contained-modal-title-vcenter">

--- a/www/src/examples/Modal/Static.js
+++ b/www/src/examples/Modal/Static.js
@@ -1,14 +1,23 @@
-<Modal.Dialog>
-  <Modal.Header closeButton>
-    <Modal.Title>Modal title</Modal.Title>
-  </Modal.Header>
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
 
-  <Modal.Body>
-    <p>Modal body text goes here.</p>
-  </Modal.Body>
+function StaticExample() {
+  return (
+    <Modal.Dialog>
+      <Modal.Header closeButton>
+        <Modal.Title>Modal title</Modal.Title>
+      </Modal.Header>
 
-  <Modal.Footer>
-    <Button variant="secondary">Close</Button>
-    <Button variant="primary">Save changes</Button>
-  </Modal.Footer>
-</Modal.Dialog>;
+      <Modal.Body>
+        <p>Modal body text goes here.</p>
+      </Modal.Body>
+
+      <Modal.Footer>
+        <Button variant="secondary">Close</Button>
+        <Button variant="primary">Save changes</Button>
+      </Modal.Footer>
+    </Modal.Dialog>
+  );
+}
+
+export default StaticExample;

--- a/www/src/examples/Modal/StaticBackdrop.js
+++ b/www/src/examples/Modal/StaticBackdrop.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
+
 function Example() {
   const [show, setShow] = useState(false);
 

--- a/www/src/examples/Modal/VerticallyCentered.js
+++ b/www/src/examples/Modal/VerticallyCentered.js
@@ -1,3 +1,6 @@
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
+
 function MyVerticallyCenteredModal(props) {
   return (
     <Modal

--- a/www/src/examples/Modal/WithoutAnimation.js
+++ b/www/src/examples/Modal/WithoutAnimation.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Modal from 'react-bootstrap/Modal';
+
 function Example() {
   const [show, setShow] = useState(false);
 

--- a/www/src/examples/Nav/Alignment.js
+++ b/www/src/examples/Nav/Alignment.js
@@ -1,35 +1,43 @@
-<>
-  <Nav className="justify-content-center" activeKey="/home">
-    <Nav.Item>
-      <Nav.Link href="/home">Active</Nav.Link>
-    </Nav.Item>
-    <Nav.Item>
-      <Nav.Link eventKey="link-1">Link</Nav.Link>
-    </Nav.Item>
-    <Nav.Item>
-      <Nav.Link eventKey="link-2">Link</Nav.Link>
-    </Nav.Item>
-    <Nav.Item>
-      <Nav.Link eventKey="disabled" disabled>
-        Disabled
-      </Nav.Link>
-    </Nav.Item>
-  </Nav>
-  <p className="text-center mt-4 mb-4">Or right-aligned</p>
-  <Nav className="justify-content-end" activeKey="/home">
-    <Nav.Item>
-      <Nav.Link href="/home">Active</Nav.Link>
-    </Nav.Item>
-    <Nav.Item>
-      <Nav.Link eventKey="link-1">Link</Nav.Link>
-    </Nav.Item>
-    <Nav.Item>
-      <Nav.Link eventKey="link-2">Link</Nav.Link>
-    </Nav.Item>
-    <Nav.Item>
-      <Nav.Link eventKey="disabled" disabled>
-        Disabled
-      </Nav.Link>
-    </Nav.Item>
-  </Nav>
-</>;
+import Nav from 'react-bootstrap/Nav';
+
+function AlignmentExample() {
+  return (
+    <>
+      <Nav className="justify-content-center" activeKey="/home">
+        <Nav.Item>
+          <Nav.Link href="/home">Active</Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="link-1">Link</Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="link-2">Link</Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="disabled" disabled>
+            Disabled
+          </Nav.Link>
+        </Nav.Item>
+      </Nav>
+      <p className="text-center mt-4 mb-4">Or right-aligned</p>
+      <Nav className="justify-content-end" activeKey="/home">
+        <Nav.Item>
+          <Nav.Link href="/home">Active</Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="link-1">Link</Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="link-2">Link</Nav.Link>
+        </Nav.Item>
+        <Nav.Item>
+          <Nav.Link eventKey="disabled" disabled>
+            Disabled
+          </Nav.Link>
+        </Nav.Item>
+      </Nav>
+    </>
+  );
+}
+
+export default AlignmentExample;

--- a/www/src/examples/Nav/Basic.js
+++ b/www/src/examples/Nav/Basic.js
@@ -1,19 +1,27 @@
-<Nav
-  activeKey="/home"
-  onSelect={(selectedKey) => alert(`selected ${selectedKey}`)}
->
-  <Nav.Item>
-    <Nav.Link href="/home">Active</Nav.Link>
-  </Nav.Item>
-  <Nav.Item>
-    <Nav.Link eventKey="link-1">Link</Nav.Link>
-  </Nav.Item>
-  <Nav.Item>
-    <Nav.Link eventKey="link-2">Link</Nav.Link>
-  </Nav.Item>
-  <Nav.Item>
-    <Nav.Link eventKey="disabled" disabled>
-      Disabled
-    </Nav.Link>
-  </Nav.Item>
-</Nav>;
+import Nav from 'react-bootstrap/Nav';
+
+function BasicExample() {
+  return (
+    <Nav
+      activeKey="/home"
+      onSelect={(selectedKey) => alert(`selected ${selectedKey}`)}
+    >
+      <Nav.Item>
+        <Nav.Link href="/home">Active</Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="link-1">Link</Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="link-2">Link</Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="disabled" disabled>
+          Disabled
+        </Nav.Link>
+      </Nav.Item>
+    </Nav>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/Nav/Dropdown.js
+++ b/www/src/examples/Nav/Dropdown.js
@@ -1,3 +1,6 @@
+import Nav from 'react-bootstrap/Nav';
+import NavDropdown from 'react-bootstrap/NavDropdown';
+
 function NavDropdownExample() {
   const handleSelect = (eventKey) => alert(`selected ${eventKey}`);
 

--- a/www/src/examples/Nav/DropdownImpl.js
+++ b/www/src/examples/Nav/DropdownImpl.js
@@ -1,6 +1,16 @@
-<Dropdown as={NavItem}>
-  <Dropdown.Toggle as={NavLink}>Click to see more…</Dropdown.Toggle>
-  <Dropdown.Menu>
-    <Dropdown.Item>Hello there!</Dropdown.Item>
-  </Dropdown.Menu>
-</Dropdown>;
+import Dropdown from 'react-bootstrap/Dropdown';
+import NavItem from 'react-bootstrap/NavItem';
+import NavLink from 'react-bootstrap/NavLink';
+
+function DropdownImplExample() {
+  return (
+    <Dropdown as={NavItem}>
+      <Dropdown.Toggle as={NavLink}>Click to see more…</Dropdown.Toggle>
+      <Dropdown.Menu>
+        <Dropdown.Item>Hello there!</Dropdown.Item>
+      </Dropdown.Menu>
+    </Dropdown>
+  );
+}
+
+export default DropdownImplExample;

--- a/www/src/examples/Nav/Fill.js
+++ b/www/src/examples/Nav/Fill.js
@@ -1,16 +1,24 @@
-<Nav fill variant="tabs" defaultActiveKey="/home">
-  <Nav.Item>
-    <Nav.Link href="/home">Active</Nav.Link>
-  </Nav.Item>
-  <Nav.Item>
-    <Nav.Link eventKey="link-1">Loooonger NavLink</Nav.Link>
-  </Nav.Item>
-  <Nav.Item>
-    <Nav.Link eventKey="link-2">Link</Nav.Link>
-  </Nav.Item>
-  <Nav.Item>
-    <Nav.Link eventKey="disabled" disabled>
-      Disabled
-    </Nav.Link>
-  </Nav.Item>
-</Nav>;
+import Nav from 'react-bootstrap/Nav';
+
+function FillExample() {
+  return (
+    <Nav fill variant="tabs" defaultActiveKey="/home">
+      <Nav.Item>
+        <Nav.Link href="/home">Active</Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="link-1">Loooonger NavLink</Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="link-2">Link</Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="disabled" disabled>
+          Disabled
+        </Nav.Link>
+      </Nav.Item>
+    </Nav>
+  );
+}
+
+export default FillExample;

--- a/www/src/examples/Nav/Justified.js
+++ b/www/src/examples/Nav/Justified.js
@@ -1,16 +1,24 @@
-<Nav justify variant="tabs" defaultActiveKey="/home">
-  <Nav.Item>
-    <Nav.Link href="/home">Active</Nav.Link>
-  </Nav.Item>
-  <Nav.Item>
-    <Nav.Link eventKey="link-1">Loooonger NavLink</Nav.Link>
-  </Nav.Item>
-  <Nav.Item>
-    <Nav.Link eventKey="link-2">Link</Nav.Link>
-  </Nav.Item>
-  <Nav.Item>
-    <Nav.Link eventKey="disabled" disabled>
-      Disabled
-    </Nav.Link>
-  </Nav.Item>
-</Nav>;
+import Nav from 'react-bootstrap/Nav';
+
+function JustifiedExample() {
+  return (
+    <Nav justify variant="tabs" defaultActiveKey="/home">
+      <Nav.Item>
+        <Nav.Link href="/home">Active</Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="link-1">Loooonger NavLink</Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="link-2">Link</Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="disabled" disabled>
+          Disabled
+        </Nav.Link>
+      </Nav.Item>
+    </Nav>
+  );
+}
+
+export default JustifiedExample;

--- a/www/src/examples/Nav/List.js
+++ b/www/src/examples/Nav/List.js
@@ -1,11 +1,19 @@
-<Nav defaultActiveKey="/home" as="ul">
-  <Nav.Item as="li">
-    <Nav.Link href="/home">Active</Nav.Link>
-  </Nav.Item>
-  <Nav.Item as="li">
-    <Nav.Link eventKey="link-1">Link</Nav.Link>
-  </Nav.Item>
-  <Nav.Item as="li">
-    <Nav.Link eventKey="link-2">Link</Nav.Link>
-  </Nav.Item>
-</Nav>;
+import Nav from 'react-bootstrap/Nav';
+
+function ListExample() {
+  return (
+    <Nav defaultActiveKey="/home" as="ul">
+      <Nav.Item as="li">
+        <Nav.Link href="/home">Active</Nav.Link>
+      </Nav.Item>
+      <Nav.Item as="li">
+        <Nav.Link eventKey="link-1">Link</Nav.Link>
+      </Nav.Item>
+      <Nav.Item as="li">
+        <Nav.Link eventKey="link-2">Link</Nav.Link>
+      </Nav.Item>
+    </Nav>
+  );
+}
+
+export default ListExample;

--- a/www/src/examples/Nav/Pills.js
+++ b/www/src/examples/Nav/Pills.js
@@ -1,13 +1,21 @@
-<Nav variant="pills" defaultActiveKey="/home">
-  <Nav.Item>
-    <Nav.Link href="/home">Active</Nav.Link>
-  </Nav.Item>
-  <Nav.Item>
-    <Nav.Link eventKey="link-1">Option 2</Nav.Link>
-  </Nav.Item>
-  <Nav.Item>
-    <Nav.Link eventKey="disabled" disabled>
-      Disabled
-    </Nav.Link>
-  </Nav.Item>
-</Nav>;
+import Nav from 'react-bootstrap/Nav';
+
+function PillsExample() {
+  return (
+    <Nav variant="pills" defaultActiveKey="/home">
+      <Nav.Item>
+        <Nav.Link href="/home">Active</Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="link-1">Option 2</Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="disabled" disabled>
+          Disabled
+        </Nav.Link>
+      </Nav.Item>
+    </Nav>
+  );
+}
+
+export default PillsExample;

--- a/www/src/examples/Nav/Stacked.js
+++ b/www/src/examples/Nav/Stacked.js
@@ -1,8 +1,16 @@
-<Nav defaultActiveKey="/home" className="flex-column">
-  <Nav.Link href="/home">Active</Nav.Link>
-  <Nav.Link eventKey="link-1">Link</Nav.Link>
-  <Nav.Link eventKey="link-2">Link</Nav.Link>
-  <Nav.Link eventKey="disabled" disabled>
-    Disabled
-  </Nav.Link>
-</Nav>;
+import Nav from 'react-bootstrap/Nav';
+
+function StackedExample() {
+  return (
+    <Nav defaultActiveKey="/home" className="flex-column">
+      <Nav.Link href="/home">Active</Nav.Link>
+      <Nav.Link eventKey="link-1">Link</Nav.Link>
+      <Nav.Link eventKey="link-2">Link</Nav.Link>
+      <Nav.Link eventKey="disabled" disabled>
+        Disabled
+      </Nav.Link>
+    </Nav>
+  );
+}
+
+export default StackedExample;

--- a/www/src/examples/Nav/Tabs.js
+++ b/www/src/examples/Nav/Tabs.js
@@ -1,13 +1,21 @@
-<Nav variant="tabs" defaultActiveKey="/home">
-  <Nav.Item>
-    <Nav.Link href="/home">Active</Nav.Link>
-  </Nav.Item>
-  <Nav.Item>
-    <Nav.Link eventKey="link-1">Option 2</Nav.Link>
-  </Nav.Item>
-  <Nav.Item>
-    <Nav.Link eventKey="disabled" disabled>
-      Disabled
-    </Nav.Link>
-  </Nav.Item>
-</Nav>;
+import Nav from 'react-bootstrap/Nav';
+
+function TabsExample() {
+  return (
+    <Nav variant="tabs" defaultActiveKey="/home">
+      <Nav.Item>
+        <Nav.Link href="/home">Active</Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="link-1">Option 2</Nav.Link>
+      </Nav.Item>
+      <Nav.Item>
+        <Nav.Link eventKey="disabled" disabled>
+          Disabled
+        </Nav.Link>
+      </Nav.Item>
+    </Nav>
+  );
+}
+
+export default TabsExample;

--- a/www/src/examples/Navbar/Basic.js
+++ b/www/src/examples/Navbar/Basic.js
@@ -1,19 +1,34 @@
-<Navbar bg="light" expand="lg">
-  <Container>
-    <Navbar.Brand href="#home">React-Bootstrap</Navbar.Brand>
-    <Navbar.Toggle aria-controls="basic-navbar-nav" />
-    <Navbar.Collapse id="basic-navbar-nav">
-      <Nav className="me-auto">
-        <Nav.Link href="#home">Home</Nav.Link>
-        <Nav.Link href="#link">Link</Nav.Link>
-        <NavDropdown title="Dropdown" id="basic-nav-dropdown">
-          <NavDropdown.Item href="#action/3.1">Action</NavDropdown.Item>
-          <NavDropdown.Item href="#action/3.2">Another action</NavDropdown.Item>
-          <NavDropdown.Item href="#action/3.3">Something</NavDropdown.Item>
-          <NavDropdown.Divider />
-          <NavDropdown.Item href="#action/3.4">Separated link</NavDropdown.Item>
-        </NavDropdown>
-      </Nav>
-    </Navbar.Collapse>
-  </Container>
-</Navbar>;
+import Container from 'react-bootstrap/Container';
+import Nav from 'react-bootstrap/Nav';
+import Navbar from 'react-bootstrap/Navbar';
+import NavDropdown from 'react-bootstrap/NavDropdown';
+
+function BasicExample() {
+  return (
+    <Navbar bg="light" expand="lg">
+      <Container>
+        <Navbar.Brand href="#home">React-Bootstrap</Navbar.Brand>
+        <Navbar.Toggle aria-controls="basic-navbar-nav" />
+        <Navbar.Collapse id="basic-navbar-nav">
+          <Nav className="me-auto">
+            <Nav.Link href="#home">Home</Nav.Link>
+            <Nav.Link href="#link">Link</Nav.Link>
+            <NavDropdown title="Dropdown" id="basic-nav-dropdown">
+              <NavDropdown.Item href="#action/3.1">Action</NavDropdown.Item>
+              <NavDropdown.Item href="#action/3.2">
+                Another action
+              </NavDropdown.Item>
+              <NavDropdown.Item href="#action/3.3">Something</NavDropdown.Item>
+              <NavDropdown.Divider />
+              <NavDropdown.Item href="#action/3.4">
+                Separated link
+              </NavDropdown.Item>
+            </NavDropdown>
+          </Nav>
+        </Navbar.Collapse>
+      </Container>
+    </Navbar>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/Navbar/Brand.js
+++ b/www/src/examples/Navbar/Brand.js
@@ -1,42 +1,51 @@
-<>
-  <Navbar bg="light">
-    <Container>
-      <Navbar.Brand href="#home">Brand link</Navbar.Brand>
-    </Container>
-  </Navbar>
-  <br />
-  <Navbar bg="light">
-    <Container>
-      <Navbar.Brand>Brand text</Navbar.Brand>
-    </Container>
-  </Navbar>
-  <br />
-  <Navbar bg="dark">
-  <Container>
-    <Navbar.Brand href="#home">
-      <img
-        src="/logo.svg"
-        width="30"
-        height="30"
-        className="d-inline-block align-top"
-        alt="React Bootstrap logo"
-      />
-    </Navbar.Brand>
-  </Container>
-  </Navbar>
-  <br />
-  <Navbar bg="dark" variant="dark">
-    <Container>
-      <Navbar.Brand href="#home">
-        <img
-          alt=""
-          src="/logo.svg"
-          width="30"
-          height="30"
-          className="d-inline-block align-top"
-        />{' '}
-      React Bootstrap
-      </Navbar.Brand>
-    </Container>
-  </Navbar>
-</>;
+import Container from 'react-bootstrap/Container';
+import Navbar from 'react-bootstrap/Navbar';
+
+function BrandExample() {
+  return (
+    <>
+      <Navbar bg="light">
+        <Container>
+          <Navbar.Brand href="#home">Brand link</Navbar.Brand>
+        </Container>
+      </Navbar>
+      <br />
+      <Navbar bg="light">
+        <Container>
+          <Navbar.Brand>Brand text</Navbar.Brand>
+        </Container>
+      </Navbar>
+      <br />
+      <Navbar bg="dark">
+        <Container>
+          <Navbar.Brand href="#home">
+            <img
+              src="/logo.svg"
+              width="30"
+              height="30"
+              className="d-inline-block align-top"
+              alt="React Bootstrap logo"
+            />
+          </Navbar.Brand>
+        </Container>
+      </Navbar>
+      <br />
+      <Navbar bg="dark" variant="dark">
+        <Container>
+          <Navbar.Brand href="#home">
+            <img
+              alt=""
+              src="/logo.svg"
+              width="30"
+              height="30"
+              className="d-inline-block align-top"
+            />{' '}
+            React Bootstrap
+          </Navbar.Brand>
+        </Container>
+      </Navbar>
+    </>
+  );
+}
+
+export default BrandExample;

--- a/www/src/examples/Navbar/Collapsible.js
+++ b/www/src/examples/Navbar/Collapsible.js
@@ -1,25 +1,40 @@
-<Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">
-  <Container>
-  <Navbar.Brand href="#home">React-Bootstrap</Navbar.Brand>
-  <Navbar.Toggle aria-controls="responsive-navbar-nav" />
-  <Navbar.Collapse id="responsive-navbar-nav">
-    <Nav className="me-auto">
-      <Nav.Link href="#features">Features</Nav.Link>
-      <Nav.Link href="#pricing">Pricing</Nav.Link>
-      <NavDropdown title="Dropdown" id="collasible-nav-dropdown">
-        <NavDropdown.Item href="#action/3.1">Action</NavDropdown.Item>
-        <NavDropdown.Item href="#action/3.2">Another action</NavDropdown.Item>
-        <NavDropdown.Item href="#action/3.3">Something</NavDropdown.Item>
-        <NavDropdown.Divider />
-        <NavDropdown.Item href="#action/3.4">Separated link</NavDropdown.Item>
-      </NavDropdown>
-    </Nav>
-    <Nav>
-      <Nav.Link href="#deets">More deets</Nav.Link>
-      <Nav.Link eventKey={2} href="#memes">
-        Dank memes
-      </Nav.Link>
-    </Nav>
-  </Navbar.Collapse>
-  </Container>
-</Navbar>;
+import Container from 'react-bootstrap/Container';
+import Nav from 'react-bootstrap/Nav';
+import Navbar from 'react-bootstrap/Navbar';
+import NavDropdown from 'react-bootstrap/NavDropdown';
+
+function CollapsibleExample() {
+  return (
+    <Navbar collapseOnSelect expand="lg" bg="dark" variant="dark">
+      <Container>
+        <Navbar.Brand href="#home">React-Bootstrap</Navbar.Brand>
+        <Navbar.Toggle aria-controls="responsive-navbar-nav" />
+        <Navbar.Collapse id="responsive-navbar-nav">
+          <Nav className="me-auto">
+            <Nav.Link href="#features">Features</Nav.Link>
+            <Nav.Link href="#pricing">Pricing</Nav.Link>
+            <NavDropdown title="Dropdown" id="collasible-nav-dropdown">
+              <NavDropdown.Item href="#action/3.1">Action</NavDropdown.Item>
+              <NavDropdown.Item href="#action/3.2">
+                Another action
+              </NavDropdown.Item>
+              <NavDropdown.Item href="#action/3.3">Something</NavDropdown.Item>
+              <NavDropdown.Divider />
+              <NavDropdown.Item href="#action/3.4">
+                Separated link
+              </NavDropdown.Item>
+            </NavDropdown>
+          </Nav>
+          <Nav>
+            <Nav.Link href="#deets">More deets</Nav.Link>
+            <Nav.Link eventKey={2} href="#memes">
+              Dank memes
+            </Nav.Link>
+          </Nav>
+        </Navbar.Collapse>
+      </Container>
+    </Navbar>
+  );
+}
+
+export default CollapsibleExample;

--- a/www/src/examples/Navbar/ColorSchemes.js
+++ b/www/src/examples/Navbar/ColorSchemes.js
@@ -1,35 +1,45 @@
-<>
-  <Navbar bg="dark" variant="dark">
-    <Container>
-    <Navbar.Brand href="#home">Navbar</Navbar.Brand>
-    <Nav className="me-auto">
-      <Nav.Link href="#home">Home</Nav.Link>
-      <Nav.Link href="#features">Features</Nav.Link>
-      <Nav.Link href="#pricing">Pricing</Nav.Link>
-    </Nav>
-    </Container>
-  </Navbar>
-  <br />
-  <Navbar bg="primary" variant="dark">
-    <Container>
-    <Navbar.Brand href="#home">Navbar</Navbar.Brand>
-    <Nav className="me-auto">
-      <Nav.Link href="#home">Home</Nav.Link>
-      <Nav.Link href="#features">Features</Nav.Link>
-      <Nav.Link href="#pricing">Pricing</Nav.Link>
-    </Nav>
-    </Container>
-  </Navbar>
+import Container from 'react-bootstrap/Container';
+import Nav from 'react-bootstrap/Nav';
+import Navbar from 'react-bootstrap/Navbar';
 
-  <br />
-  <Navbar bg="light" variant="light">
-    <Container>
-    <Navbar.Brand href="#home">Navbar</Navbar.Brand>
-    <Nav className="me-auto">
-      <Nav.Link href="#home">Home</Nav.Link>
-      <Nav.Link href="#features">Features</Nav.Link>
-      <Nav.Link href="#pricing">Pricing</Nav.Link>
-    </Nav>
-    </Container>
-  </Navbar>
-</>;
+function ColorSchemesExample() {
+  return (
+    <>
+      <Navbar bg="dark" variant="dark">
+        <Container>
+          <Navbar.Brand href="#home">Navbar</Navbar.Brand>
+          <Nav className="me-auto">
+            <Nav.Link href="#home">Home</Nav.Link>
+            <Nav.Link href="#features">Features</Nav.Link>
+            <Nav.Link href="#pricing">Pricing</Nav.Link>
+          </Nav>
+        </Container>
+      </Navbar>
+      <br />
+      <Navbar bg="primary" variant="dark">
+        <Container>
+          <Navbar.Brand href="#home">Navbar</Navbar.Brand>
+          <Nav className="me-auto">
+            <Nav.Link href="#home">Home</Nav.Link>
+            <Nav.Link href="#features">Features</Nav.Link>
+            <Nav.Link href="#pricing">Pricing</Nav.Link>
+          </Nav>
+        </Container>
+      </Navbar>
+
+      <br />
+      <Navbar bg="light" variant="light">
+        <Container>
+          <Navbar.Brand href="#home">Navbar</Navbar.Brand>
+          <Nav className="me-auto">
+            <Nav.Link href="#home">Home</Nav.Link>
+            <Nav.Link href="#features">Features</Nav.Link>
+            <Nav.Link href="#pricing">Pricing</Nav.Link>
+          </Nav>
+        </Container>
+      </Navbar>
+    </>
+  );
+}
+
+export default ColorSchemesExample;

--- a/www/src/examples/Navbar/ContainerInside.js
+++ b/www/src/examples/Navbar/ContainerInside.js
@@ -1,5 +1,14 @@
-<Navbar expand="lg" variant="light" bg="light">
-  <Container>
-    <Navbar.Brand href="#">Navbar</Navbar.Brand>
-  </Container>
-</Navbar>;
+import Container from 'react-bootstrap/Container';
+import Navbar from 'react-bootstrap/Navbar';
+
+function ContainerInsideExample() {
+  return (
+    <Navbar expand="lg" variant="light" bg="light">
+      <Container>
+        <Navbar.Brand href="#">Navbar</Navbar.Brand>
+      </Container>
+    </Navbar>
+  );
+}
+
+export default ContainerInsideExample;

--- a/www/src/examples/Navbar/ContainerOutside.js
+++ b/www/src/examples/Navbar/ContainerOutside.js
@@ -1,7 +1,16 @@
-<Container>
-  <Navbar expand="lg" variant="light" bg="light">
+import Container from 'react-bootstrap/Container';
+import Navbar from 'react-bootstrap/Navbar';
+
+function ContainerOutsideExample() {
+  return (
     <Container>
-      <Navbar.Brand href="#">Navbar</Navbar.Brand>
+      <Navbar expand="lg" variant="light" bg="light">
+        <Container>
+          <Navbar.Brand href="#">Navbar</Navbar.Brand>
+        </Container>
+      </Navbar>
     </Container>
-  </Navbar>
-</Container>;
+  );
+}
+
+export default ContainerOutsideExample;

--- a/www/src/examples/Navbar/NavScroll.js
+++ b/www/src/examples/Navbar/NavScroll.js
@@ -1,36 +1,51 @@
-<Navbar bg="light" expand="lg">
-  <Container fluid>
-    <Navbar.Brand href="#">Navbar scroll</Navbar.Brand>
-    <Navbar.Toggle aria-controls="navbarScroll" />
-    <Navbar.Collapse id="navbarScroll">
-      <Nav
-        className="me-auto my-2 my-lg-0"
-        style={{ maxHeight: '100px' }}
-        navbarScroll
-      >
-        <Nav.Link href="#action1">Home</Nav.Link>
-        <Nav.Link href="#action2">Link</Nav.Link>
-        <NavDropdown title="Link" id="navbarScrollingDropdown">
-          <NavDropdown.Item href="#action3">Action</NavDropdown.Item>
-          <NavDropdown.Item href="#action4">Another action</NavDropdown.Item>
-          <NavDropdown.Divider />
-          <NavDropdown.Item href="#action5">
-            Something else here
-          </NavDropdown.Item>
-        </NavDropdown>
-        <Nav.Link href="#" disabled>
-          Link
-        </Nav.Link>
-      </Nav>
-      <Form className="d-flex">
-        <FormControl
-          type="search"
-          placeholder="Search"
-          className="me-2"
-          aria-label="Search"
-        />
-        <Button variant="outline-success">Search</Button>
-      </Form>
-    </Navbar.Collapse>
-  </Container>
-</Navbar>;
+import Button from 'react-bootstrap/Button';
+import Container from 'react-bootstrap/Container';
+import Form from 'react-bootstrap/Form';
+import Nav from 'react-bootstrap/Nav';
+import Navbar from 'react-bootstrap/Navbar';
+import NavDropdown from 'react-bootstrap/NavDropdown';
+
+function NavScrollExample() {
+  return (
+    <Navbar bg="light" expand="lg">
+      <Container fluid>
+        <Navbar.Brand href="#">Navbar scroll</Navbar.Brand>
+        <Navbar.Toggle aria-controls="navbarScroll" />
+        <Navbar.Collapse id="navbarScroll">
+          <Nav
+            className="me-auto my-2 my-lg-0"
+            style={{ maxHeight: '100px' }}
+            navbarScroll
+          >
+            <Nav.Link href="#action1">Home</Nav.Link>
+            <Nav.Link href="#action2">Link</Nav.Link>
+            <NavDropdown title="Link" id="navbarScrollingDropdown">
+              <NavDropdown.Item href="#action3">Action</NavDropdown.Item>
+              <NavDropdown.Item href="#action4">
+                Another action
+              </NavDropdown.Item>
+              <NavDropdown.Divider />
+              <NavDropdown.Item href="#action5">
+                Something else here
+              </NavDropdown.Item>
+            </NavDropdown>
+            <Nav.Link href="#" disabled>
+              Link
+            </Nav.Link>
+          </Nav>
+          <Form className="d-flex">
+            <Form.Control
+              type="search"
+              placeholder="Search"
+              className="me-2"
+              aria-label="Search"
+            />
+            <Button variant="outline-success">Search</Button>
+          </Form>
+        </Navbar.Collapse>
+      </Container>
+    </Navbar>
+  );
+}
+
+export default NavScrollExample;

--- a/www/src/examples/Navbar/Offcanvas.js
+++ b/www/src/examples/Navbar/Offcanvas.js
@@ -1,49 +1,63 @@
-<>
-  {[false, 'sm', 'md', 'lg', 'xl', 'xxl'].map((expand) => (
-    <Navbar key={expand} bg="light" expand={expand} className="mb-3">
-      <Container fluid>
-        <Navbar.Brand href="#">Navbar Offcanvas</Navbar.Brand>
-        <Navbar.Toggle aria-controls={`offcanvasNavbar-expand-${expand}`} />
-        <Navbar.Offcanvas
-          id={`offcanvasNavbar-expand-${expand}`}
-          aria-labelledby={`offcanvasNavbarLabel-expand-${expand}`}
-          placement="end"
-        >
-          <Offcanvas.Header closeButton>
-            <Offcanvas.Title id={`offcanvasNavbarLabel-expand-${expand}`}>
-              Offcanvas
-            </Offcanvas.Title>
-          </Offcanvas.Header>
-          <Offcanvas.Body>
-            <Nav className="justify-content-end flex-grow-1 pe-3">
-              <Nav.Link href="#action1">Home</Nav.Link>
-              <Nav.Link href="#action2">Link</Nav.Link>
-              <NavDropdown
-                title="Dropdown"
-                id={`offcanvasNavbarDropdown-expand-${expand}`}
-              >
-                <NavDropdown.Item href="#action3">Action</NavDropdown.Item>
-                <NavDropdown.Item href="#action4">
-                  Another action
-                </NavDropdown.Item>
-                <NavDropdown.Divider />
-                <NavDropdown.Item href="#action5">
-                  Something else here
-                </NavDropdown.Item>
-              </NavDropdown>
-            </Nav>
-            <Form className="d-flex">
-              <FormControl
-                type="search"
-                placeholder="Search"
-                className="me-2"
-                aria-label="Search"
-              />
-              <Button variant="outline-success">Search</Button>
-            </Form>
-          </Offcanvas.Body>
-        </Navbar.Offcanvas>
-      </Container>
-    </Navbar>
-  ))}
-</>;
+import Button from 'react-bootstrap/Button';
+import Container from 'react-bootstrap/Container';
+import Form from 'react-bootstrap/Form';
+import Nav from 'react-bootstrap/Nav';
+import Navbar from 'react-bootstrap/Navbar';
+import NavDropdown from 'react-bootstrap/NavDropdown';
+import Offcanvas from 'react-bootstrap/Offcanvas';
+
+function OffcanvasExample() {
+  return (
+    <>
+      {[false, 'sm', 'md', 'lg', 'xl', 'xxl'].map((expand) => (
+        <Navbar key={expand} bg="light" expand={expand} className="mb-3">
+          <Container fluid>
+            <Navbar.Brand href="#">Navbar Offcanvas</Navbar.Brand>
+            <Navbar.Toggle aria-controls={`offcanvasNavbar-expand-${expand}`} />
+            <Navbar.Offcanvas
+              id={`offcanvasNavbar-expand-${expand}`}
+              aria-labelledby={`offcanvasNavbarLabel-expand-${expand}`}
+              placement="end"
+            >
+              <Offcanvas.Header closeButton>
+                <Offcanvas.Title id={`offcanvasNavbarLabel-expand-${expand}`}>
+                  Offcanvas
+                </Offcanvas.Title>
+              </Offcanvas.Header>
+              <Offcanvas.Body>
+                <Nav className="justify-content-end flex-grow-1 pe-3">
+                  <Nav.Link href="#action1">Home</Nav.Link>
+                  <Nav.Link href="#action2">Link</Nav.Link>
+                  <NavDropdown
+                    title="Dropdown"
+                    id={`offcanvasNavbarDropdown-expand-${expand}`}
+                  >
+                    <NavDropdown.Item href="#action3">Action</NavDropdown.Item>
+                    <NavDropdown.Item href="#action4">
+                      Another action
+                    </NavDropdown.Item>
+                    <NavDropdown.Divider />
+                    <NavDropdown.Item href="#action5">
+                      Something else here
+                    </NavDropdown.Item>
+                  </NavDropdown>
+                </Nav>
+                <Form className="d-flex">
+                  <Form.Control
+                    type="search"
+                    placeholder="Search"
+                    className="me-2"
+                    aria-label="Search"
+                  />
+                  <Button variant="outline-success">Search</Button>
+                </Form>
+              </Offcanvas.Body>
+            </Navbar.Offcanvas>
+          </Container>
+        </Navbar>
+      ))}
+    </>
+  );
+}
+
+export default OffcanvasExample;

--- a/www/src/examples/Navbar/TextLink.js
+++ b/www/src/examples/Navbar/TextLink.js
@@ -1,11 +1,20 @@
-<Navbar>
-  <Container>
-    <Navbar.Brand href="#home">Navbar with text</Navbar.Brand>
-    <Navbar.Toggle />
-    <Navbar.Collapse className="justify-content-end">
-      <Navbar.Text>
-        Signed in as: <a href="#login">Mark Otto</a>
-      </Navbar.Text>
-    </Navbar.Collapse>
-  </Container>
-</Navbar>;
+import Container from 'react-bootstrap/Container';
+import Navbar from 'react-bootstrap/Navbar';
+
+function TextLinkExample() {
+  return (
+    <Navbar>
+      <Container>
+        <Navbar.Brand href="#home">Navbar with text</Navbar.Brand>
+        <Navbar.Toggle />
+        <Navbar.Collapse className="justify-content-end">
+          <Navbar.Text>
+            Signed in as: <a href="#login">Mark Otto</a>
+          </Navbar.Text>
+        </Navbar.Collapse>
+      </Container>
+    </Navbar>
+  );
+}
+
+export default TextLinkExample;

--- a/www/src/examples/Offcanvas/Backdrop.js
+++ b/www/src/examples/Offcanvas/Backdrop.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Offcanvas from 'react-bootstrap/Offcanvas';
+
 const options = [
   {
     name: 'Enable backdrop (default)',

--- a/www/src/examples/Offcanvas/Basic.js
+++ b/www/src/examples/Offcanvas/Basic.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Offcanvas from 'react-bootstrap/Offcanvas';
+
 function Example() {
   const [show, setShow] = useState(false);
 

--- a/www/src/examples/Offcanvas/Placement.js
+++ b/www/src/examples/Offcanvas/Placement.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Offcanvas from 'react-bootstrap/Offcanvas';
+
 function OffCanvasExample({ name, ...props }) {
   const [show, setShow] = useState(false);
 

--- a/www/src/examples/Offcanvas/StaticBackdrop.js
+++ b/www/src/examples/Offcanvas/StaticBackdrop.js
@@ -1,3 +1,7 @@
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Offcanvas from 'react-bootstrap/Offcanvas';
+
 function Example() {
   const [show, setShow] = useState(false);
 

--- a/www/src/examples/Overlay.js
+++ b/www/src/examples/Overlay.js
@@ -1,21 +1,25 @@
+import Button from 'react-bootstrap/Button';
+import Overlay from 'react-bootstrap/Overlay';
+import Tooltip from 'react-bootstrap/Tooltip';
+
 class Example extends React.Component {
   constructor(props, context) {
     super(props, context);
 
-    this.getTarget = this.getTarget.bind(this);
     this.handleToggle = this.handleToggle.bind(this);
+    this.getTarget = this.getTarget.bind(this);
 
     this.state = {
       show: true,
     };
   }
 
-  getTarget() {
-    return ReactDOM.findDOMNode(this.target);
-  }
-
   handleToggle() {
     this.setState((s) => ({ show: !s.show }));
+  }
+
+  getTarget() {
+    return ReactDOM.findDOMNode(this.target);
   }
 
   render() {

--- a/www/src/examples/Overlays/Disabled.js
+++ b/www/src/examples/Overlays/Disabled.js
@@ -1,7 +1,17 @@
-<OverlayTrigger overlay={<Tooltip id="tooltip-disabled">Tooltip!</Tooltip>}>
-  <span className="d-inline-block">
-    <Button disabled style={{ pointerEvents: 'none' }}>
-      Disabled button
-    </Button>
-  </span>
-</OverlayTrigger>;
+import Button from 'react-bootstrap/Button';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+
+function DisabledExample() {
+  return (
+    <OverlayTrigger overlay={<Tooltip id="tooltip-disabled">Tooltip!</Tooltip>}>
+      <span className="d-inline-block">
+        <Button disabled style={{ pointerEvents: 'none' }}>
+          Disabled button
+        </Button>
+      </span>
+    </OverlayTrigger>
+  );
+}
+
+export default DisabledExample;

--- a/www/src/examples/Overlays/Overlay.js
+++ b/www/src/examples/Overlays/Overlay.js
@@ -1,3 +1,7 @@
+import React, { useState, useRef } from 'react';
+import Button from 'react-bootstrap/Button';
+import Overlay from 'react-bootstrap/Overlay';
+
 function Example() {
   const [show, setShow] = useState(false);
   const target = useRef(null);

--- a/www/src/examples/Overlays/PopoverBasic.js
+++ b/www/src/examples/Overlays/PopoverBasic.js
@@ -1,3 +1,7 @@
+import Button from 'react-bootstrap/Button';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Popover from 'react-bootstrap/Popover';
+
 const popover = (
   <Popover id="popover-basic">
     <Popover.Header as="h3">Popover right</Popover.Header>

--- a/www/src/examples/Overlays/PopoverContained.js
+++ b/www/src/examples/Overlays/PopoverContained.js
@@ -1,3 +1,8 @@
+import React, { useState, useRef } from 'react';
+import Button from 'react-bootstrap/Button';
+import Overlay from 'react-bootstrap/Overlay';
+import Popover from 'react-bootstrap/Popover';
+
 function Example() {
   const [show, setShow] = useState(false);
   const [target, setTarget] = useState(null);

--- a/www/src/examples/Overlays/PopoverPositioned.js
+++ b/www/src/examples/Overlays/PopoverPositioned.js
@@ -1,19 +1,29 @@
-<>
-  {['top', 'right', 'bottom', 'left'].map((placement) => (
-    <OverlayTrigger
-      trigger="click"
-      key={placement}
-      placement={placement}
-      overlay={
-        <Popover id={`popover-positioned-${placement}`}>
-          <Popover.Header as="h3">{`Popover ${placement}`}</Popover.Header>
-          <Popover.Body>
-            <strong>Holy guacamole!</strong> Check this info.
-          </Popover.Body>
-        </Popover>
-      }
-    >
-      <Button variant="secondary">Popover on {placement}</Button>
-    </OverlayTrigger>
-  ))}
-</>;
+import Button from 'react-bootstrap/Button';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Popover from 'react-bootstrap/Popover';
+
+function PopoverPositionedExample() {
+  return (
+    <>
+      {['top', 'right', 'bottom', 'left'].map((placement) => (
+        <OverlayTrigger
+          trigger="click"
+          key={placement}
+          placement={placement}
+          overlay={
+            <Popover id={`popover-positioned-${placement}`}>
+              <Popover.Header as="h3">{`Popover ${placement}`}</Popover.Header>
+              <Popover.Body>
+                <strong>Holy guacamole!</strong> Check this info.
+              </Popover.Body>
+            </Popover>
+          }
+        >
+          <Button variant="secondary">Popover on {placement}</Button>
+        </OverlayTrigger>
+      ))}
+    </>
+  );
+}
+
+export default PopoverPositionedExample;

--- a/www/src/examples/Overlays/PopoverPositionedScrolling.js
+++ b/www/src/examples/Overlays/PopoverPositionedScrolling.js
@@ -1,59 +1,61 @@
-const popover = (position) => (
-  <Popover id={`popover-positioned-scrolling-${position}`}>
-    <Popover.Header as="h3">{`Popover ${position}`}</Popover.Header>
-    <Popover.Body>
-      <strong>Holy guacamole!</strong> Check this info.
-    </Popover.Body>
-  </Popover>
-);
+import Button from 'react-bootstrap/Button';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Popover from 'react-bootstrap/Popover';
 
-const popoverLeft = <popover position="left" />;
+function PopoverPositionedScrollingExample() {
+  const popover = (position) => (
+    <Popover id={`popover-positioned-scrolling-${position}`}>
+      <Popover.Header as="h3">{`Popover ${position}`}</Popover.Header>
+      <Popover.Body>
+        <strong>Holy guacamole!</strong> Check this info.
+      </Popover.Body>
+    </Popover>
+  );
 
-const popoverTop = <popover position="top" />;
+  const popoverLeft = <popover position="left" />;
 
-const popoverBottom = <popover position="bottom" />;
+  const popoverTop = <popover position="top" />;
 
-const popoverRight = <popover position="right" />;
+  const popoverBottom = <popover position="bottom" />;
 
-class Positioner extends React.Component {
-  render() {
-    return (
-      <div style={{ padding: '100px 0' }}>
-        <OverlayTrigger
-          container={this}
-          trigger="click"
-          placement="left"
-          overlay={popoverLeft}
-        >
-          <Button>Holy guacamole!</Button>
-        </OverlayTrigger>{' '}
-        <OverlayTrigger
-          container={this}
-          trigger="click"
-          placement="top"
-          overlay={popoverTop}
-        >
-          <Button>Holy guacamole!</Button>
-        </OverlayTrigger>{' '}
-        <OverlayTrigger
-          container={this}
-          trigger="click"
-          placement="bottom"
-          overlay={popoverBottom}
-        >
-          <Button>Holy guacamole!</Button>
-        </OverlayTrigger>{' '}
-        <OverlayTrigger
-          container={this}
-          trigger="click"
-          placement="right"
-          overlay={popoverRight}
-        >
-          <Button>Holy guacamole!</Button>
-        </OverlayTrigger>
-      </div>
-    );
-  }
+  const popoverRight = <popover position="right" />;
+
+  return (
+    <div style={{ padding: '100px 0' }}>
+      <OverlayTrigger
+        container={this}
+        trigger="click"
+        placement="left"
+        overlay={popoverLeft}
+      >
+        <Button>Holy guacamole!</Button>
+      </OverlayTrigger>{' '}
+      <OverlayTrigger
+        container={this}
+        trigger="click"
+        placement="top"
+        overlay={popoverTop}
+      >
+        <Button>Holy guacamole!</Button>
+      </OverlayTrigger>{' '}
+      <OverlayTrigger
+        container={this}
+        trigger="click"
+        placement="bottom"
+        overlay={popoverBottom}
+      >
+        <Button>Holy guacamole!</Button>
+      </OverlayTrigger>{' '}
+      <OverlayTrigger
+        container={this}
+        trigger="click"
+        placement="right"
+        overlay={popoverRight}
+      >
+        <Button>Holy guacamole!</Button>
+      </OverlayTrigger>
+    </div>
+  );
 }
 
-render(<Positioner />);
+export default PopoverPositionedScrollingExample;

--- a/www/src/examples/Overlays/PopoverTriggerBehaviors.js
+++ b/www/src/examples/Overlays/PopoverTriggerBehaviors.js
@@ -1,42 +1,50 @@
-const popover = (triggerBehavior) => (
-  <Popover id={`popover-trigger-${triggerBehavior}`}>
-    <Popover.Header as="h3">Popover bottom</Popover.Header>
-    <Popover.Body>
-      <strong>Holy guacamole!</strong> Check this info.
-    </Popover.Body>
-  </Popover>
-);
+import Button from 'react-bootstrap/Button';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Popover from 'react-bootstrap/Popover';
 
-const popoverClick = <popover triggerBehavior="click" />;
+function PopoverTriggerBehaviorsExample() {
+  const popover = (triggerBehavior) => (
+    <Popover id={`popover-trigger-${triggerBehavior}`}>
+      <Popover.Header as="h3">Popover bottom</Popover.Header>
+      <Popover.Body>
+        <strong>Holy guacamole!</strong> Check this info.
+      </Popover.Body>
+    </Popover>
+  );
 
-const popoverHoverFocus = <popover triggerBehavior="hover-focus" />;
+  const popoverClick = <popover triggerBehavior="click" />;
 
-const popoverFocus = <popover triggerBehavior="focus" />;
+  const popoverHoverFocus = <popover triggerBehavior="hover-focus" />;
 
-const popoverClickRootClose = <popover triggerBehavior="click-root-close" />;
+  const popoverFocus = <popover triggerBehavior="focus" />;
 
-render(
-  <>
-    <OverlayTrigger trigger="click" placement="bottom" overlay={popoverClick}>
-      <Button>Click</Button>
-    </OverlayTrigger>{' '}
-    <OverlayTrigger
-      trigger={['hover', 'focus']}
-      placement="bottom"
-      overlay={popoverHoverFocus}
-    >
-      <Button>Hover + Focus</Button>
-    </OverlayTrigger>{' '}
-    <OverlayTrigger trigger="focus" placement="bottom" overlay={popoverFocus}>
-      <Button>Focus</Button>
-    </OverlayTrigger>{' '}
-    <OverlayTrigger
-      trigger="click"
-      rootClose
-      placement="bottom"
-      overlay={popoverClickRootClose}
-    >
-      <Button>Click w/rootClose</Button>
-    </OverlayTrigger>
-  </>,
-);
+  const popoverClickRootClose = <popover triggerBehavior="click-root-close" />;
+
+  return (
+    <>
+      <OverlayTrigger trigger="click" placement="bottom" overlay={popoverClick}>
+        <Button>Click</Button>
+      </OverlayTrigger>{' '}
+      <OverlayTrigger
+        trigger={['hover', 'focus']}
+        placement="bottom"
+        overlay={popoverHoverFocus}
+      >
+        <Button>Hover + Focus</Button>
+      </OverlayTrigger>{' '}
+      <OverlayTrigger trigger="focus" placement="bottom" overlay={popoverFocus}>
+        <Button>Focus</Button>
+      </OverlayTrigger>{' '}
+      <OverlayTrigger
+        trigger="click"
+        rootClose
+        placement="bottom"
+        overlay={popoverClickRootClose}
+      >
+        <Button>Click w/rootClose</Button>
+      </OverlayTrigger>
+    </>
+  );
+}
+
+export default PopoverTriggerBehaviorsExample;

--- a/www/src/examples/Overlays/ScheduleUpdate.js
+++ b/www/src/examples/Overlays/ScheduleUpdate.js
@@ -1,3 +1,8 @@
+import React, { useEffect, useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Popover from 'react-bootstrap/Popover';
+
 const UpdatingPopover = React.forwardRef(
   ({ popper, children, show: _, ...props }, ref) => {
     useEffect(() => {

--- a/www/src/examples/Overlays/TooltipInCopy.js
+++ b/www/src/examples/Overlays/TooltipInCopy.js
@@ -1,30 +1,37 @@
-const Link = ({ id, children, title }) => (
-  <OverlayTrigger overlay={<Tooltip id={id}>{title}</Tooltip>}>
-    <a href="#">{children}</a>
-  </OverlayTrigger>
-);
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
 
-render(
-  <p>
-    Tight pants next level keffiyeh{' '}
-    <Link title="Default title" id="t-1">
-      you probably
-    </Link>{' '}
-    haven't heard of them. Farm-to-table seitan, mcsweeney's fixie sustainable
-    quinoa 8-bit american apparel{' '}
-    <Link id="t-2" title="Another one">
-      have a
-    </Link>{' '}
-    terry richardson vinyl chambray. Beard stumptown, cardigans banh mi lomo
-    thundercats. Tofu biodiesel williamsburg marfa, four loko mcsweeney's
-    cleanse vegan chambray. A really ironic artisan{' '}
-    <Link title="Another one here too" id="t-3">
-      whatever keytar
-    </Link>
-    , scenester farm-to-table banksy Austin{' '}
-    <Link title="The last tip!" id="t-4">
-      twitter handle
-    </Link>{' '}
-    freegan cred raw denim single-origin coffee viral.
-  </p>,
-);
+function TooltipInCopyExample() {
+  const Link = ({ id, children, title }) => (
+    <OverlayTrigger overlay={<Tooltip id={id}>{title}</Tooltip>}>
+      <a href="#">{children}</a>
+    </OverlayTrigger>
+  );
+
+  return (
+    <p>
+      Tight pants next level keffiyeh{' '}
+      <Link title="Default title" id="t-1">
+        you probably
+      </Link>{' '}
+      haven't heard of them. Farm-to-table seitan, mcsweeney's fixie sustainable
+      quinoa 8-bit american apparel{' '}
+      <Link id="t-2" title="Another one">
+        have a
+      </Link>{' '}
+      terry richardson vinyl chambray. Beard stumptown, cardigans banh mi lomo
+      thundercats. Tofu biodiesel williamsburg marfa, four loko mcsweeney's
+      cleanse vegan chambray. A really ironic artisan{' '}
+      <Link title="Another one here too" id="t-3">
+        whatever keytar
+      </Link>
+      , scenester farm-to-table banksy Austin{' '}
+      <Link title="The last tip!" id="t-4">
+        twitter handle
+      </Link>{' '}
+      freegan cred raw denim single-origin coffee viral.
+    </p>
+  );
+}
+
+export default TooltipInCopyExample;

--- a/www/src/examples/Overlays/TooltipOverlay.js
+++ b/www/src/examples/Overlays/TooltipOverlay.js
@@ -1,3 +1,8 @@
+import React, { useState, useRef } from 'react';
+import Button from 'react-bootstrap/Button';
+import Overlay from 'react-bootstrap/Overlay';
+import Tooltip from 'react-bootstrap/Tooltip';
+
 function Example() {
   const [show, setShow] = useState(false);
   const target = useRef(null);

--- a/www/src/examples/Overlays/TooltipPositioned.js
+++ b/www/src/examples/Overlays/TooltipPositioned.js
@@ -1,15 +1,25 @@
-<>
-  {['top', 'right', 'bottom', 'left'].map((placement) => (
-    <OverlayTrigger
-      key={placement}
-      placement={placement}
-      overlay={
-        <Tooltip id={`tooltip-${placement}`}>
-          Tooltip on <strong>{placement}</strong>.
-        </Tooltip>
-      }
-    >
-      <Button variant="secondary">Tooltip on {placement}</Button>
-    </OverlayTrigger>
-  ))}
-</>;
+import Button from 'react-bootstrap/Button';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
+
+function TooltipPositionedExample() {
+  return (
+    <>
+      {['top', 'right', 'bottom', 'left'].map((placement) => (
+        <OverlayTrigger
+          key={placement}
+          placement={placement}
+          overlay={
+            <Tooltip id={`tooltip-${placement}`}>
+              Tooltip on <strong>{placement}</strong>.
+            </Tooltip>
+          }
+        >
+          <Button variant="secondary">Tooltip on {placement}</Button>
+        </OverlayTrigger>
+      ))}
+    </>
+  );
+}
+
+export default TooltipPositionedExample;

--- a/www/src/examples/Overlays/Trigger.js
+++ b/www/src/examples/Overlays/Trigger.js
@@ -1,15 +1,23 @@
-const renderTooltip = (props) => (
-  <Tooltip id="button-tooltip" {...props}>
-    Simple tooltip
-  </Tooltip>
-);
+import Button from 'react-bootstrap/Button';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+import Tooltip from 'react-bootstrap/Tooltip';
 
-render(
-  <OverlayTrigger
-    placement="right"
-    delay={{ show: 250, hide: 400 }}
-    overlay={renderTooltip}
-  >
-    <Button variant="success">Hover me to see</Button>
-  </OverlayTrigger>,
-);
+function TriggerExample() {
+  const renderTooltip = (props) => (
+    <Tooltip id="button-tooltip" {...props}>
+      Simple tooltip
+    </Tooltip>
+  );
+
+  return (
+    <OverlayTrigger
+      placement="right"
+      delay={{ show: 250, hide: 400 }}
+      overlay={renderTooltip}
+    >
+      <Button variant="success">Hover me to see</Button>
+    </OverlayTrigger>
+  );
+}
+
+export default TriggerExample;

--- a/www/src/examples/Overlays/TriggerRenderProp.js
+++ b/www/src/examples/Overlays/TriggerRenderProp.js
@@ -1,21 +1,29 @@
-render(
-  <OverlayTrigger
-    placement="bottom"
-    overlay={<Tooltip id="button-tooltip-2">Check out this avatar</Tooltip>}
-  >
-    {({ ref, ...triggerHandler }) => (
-      <Button
-        variant="light"
-        {...triggerHandler}
-        className="d-inline-flex align-items-center"
-      >
-        <Image
-          ref={ref}
-          roundedCircle
-          src="holder.js/20x20?text=J&bg=28a745&fg=FFF"
-        />
-        <span className="ms-1">Hover to see</span>
-      </Button>
-    )}
-  </OverlayTrigger>,
-);
+import Button from 'react-bootstrap/Button';
+import Image from 'react-bootstrap/Image';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
+
+function TriggerRendererProp() {
+  return (
+    <OverlayTrigger
+      placement="bottom"
+      overlay={<Tooltip id="button-tooltip-2">Check out this avatar</Tooltip>}
+    >
+      {({ ref, ...triggerHandler }) => (
+        <Button
+          variant="light"
+          {...triggerHandler}
+          className="d-inline-flex align-items-center"
+        >
+          <Image
+            ref={ref}
+            roundedCircle
+            src="holder.js/20x20?text=J&bg=28a745&fg=FFF"
+          />
+          <span className="ms-1">Hover to see</span>
+        </Button>
+      )}
+    </OverlayTrigger>
+  );
+}
+
+export default TriggerRendererProp;

--- a/www/src/examples/Pagination/Advanced.js
+++ b/www/src/examples/Pagination/Advanced.js
@@ -1,17 +1,25 @@
-<Pagination>
-  <Pagination.First />
-  <Pagination.Prev />
-  <Pagination.Item>{1}</Pagination.Item>
-  <Pagination.Ellipsis />
+import Pagination from 'react-bootstrap/Pagination';
 
-  <Pagination.Item>{10}</Pagination.Item>
-  <Pagination.Item>{11}</Pagination.Item>
-  <Pagination.Item active>{12}</Pagination.Item>
-  <Pagination.Item>{13}</Pagination.Item>
-  <Pagination.Item disabled>{14}</Pagination.Item>
+function AdvancedExample() {
+  return (
+    <Pagination>
+      <Pagination.First />
+      <Pagination.Prev />
+      <Pagination.Item>{1}</Pagination.Item>
+      <Pagination.Ellipsis />
 
-  <Pagination.Ellipsis />
-  <Pagination.Item>{20}</Pagination.Item>
-  <Pagination.Next />
-  <Pagination.Last />
-</Pagination>;
+      <Pagination.Item>{10}</Pagination.Item>
+      <Pagination.Item>{11}</Pagination.Item>
+      <Pagination.Item active>{12}</Pagination.Item>
+      <Pagination.Item>{13}</Pagination.Item>
+      <Pagination.Item disabled>{14}</Pagination.Item>
+
+      <Pagination.Ellipsis />
+      <Pagination.Item>{20}</Pagination.Item>
+      <Pagination.Next />
+      <Pagination.Last />
+    </Pagination>
+  );
+}
+
+export default AdvancedExample;

--- a/www/src/examples/Pagination/Basic.js
+++ b/www/src/examples/Pagination/Basic.js
@@ -1,3 +1,5 @@
+import Pagination from 'react-bootstrap/Pagination';
+
 let active = 2;
 let items = [];
 for (let number = 1; number <= 5; number++) {

--- a/www/src/examples/Placeholder/Animation.js
+++ b/www/src/examples/Placeholder/Animation.js
@@ -1,8 +1,16 @@
-<>
-  <Placeholder as="p" animation="glow">
-    <Placeholder xs={12} />
-  </Placeholder>
-  <Placeholder as="p" animation="wave">
-    <Placeholder xs={12} />
-  </Placeholder>
-</>;
+import Placeholder from 'react-bootstrap/Placeholder';
+
+function AnimationExample() {
+  return (
+    <>
+      <Placeholder as="p" animation="glow">
+        <Placeholder xs={12} />
+      </Placeholder>
+      <Placeholder as="p" animation="wave">
+        <Placeholder xs={12} />
+      </Placeholder>
+    </>
+  );
+}
+
+export default AnimationExample;

--- a/www/src/examples/Placeholder/Card.js
+++ b/www/src/examples/Placeholder/Card.js
@@ -1,27 +1,37 @@
-<div className="d-flex justify-content-around">
-  <Card style={{ width: '18rem' }}>
-    <Card.Img variant="top" src="holder.js/100px180" />
-    <Card.Body>
-      <Card.Title>Card Title</Card.Title>
-      <Card.Text>
-        Some quick example text to build on the card title and make up the bulk
-        of the card's content.
-      </Card.Text>
-      <Button variant="primary">Go somewhere</Button>
-    </Card.Body>
-  </Card>
+import Button from 'react-bootstrap/Button';
+import Card from 'react-bootstrap/Card';
+import Placeholder from 'react-bootstrap/Placeholder';
 
-  <Card style={{ width: '18rem' }}>
-    <Card.Img variant="top" src="holder.js/100px180" />
-    <Card.Body>
-      <Placeholder as={Card.Title} animation="glow">
-        <Placeholder xs={6} />
-      </Placeholder>
-      <Placeholder as={Card.Text} animation="glow">
-        <Placeholder xs={7} /> <Placeholder xs={4} /> <Placeholder xs={4} />{' '}
-        <Placeholder xs={6} /> <Placeholder xs={8} />
-      </Placeholder>
-      <Placeholder.Button variant="primary" xs={6} />
-    </Card.Body>
-  </Card>
-</div>;
+function CardExample() {
+  return (
+    <div className="d-flex justify-content-around">
+      <Card style={{ width: '18rem' }}>
+        <Card.Img variant="top" src="holder.js/100px180" />
+        <Card.Body>
+          <Card.Title>Card Title</Card.Title>
+          <Card.Text>
+            Some quick example text to build on the card title and make up the
+            bulk of the card's content.
+          </Card.Text>
+          <Button variant="primary">Go somewhere</Button>
+        </Card.Body>
+      </Card>
+
+      <Card style={{ width: '18rem' }}>
+        <Card.Img variant="top" src="holder.js/100px180" />
+        <Card.Body>
+          <Placeholder as={Card.Title} animation="glow">
+            <Placeholder xs={6} />
+          </Placeholder>
+          <Placeholder as={Card.Text} animation="glow">
+            <Placeholder xs={7} /> <Placeholder xs={4} /> <Placeholder xs={4} />{' '}
+            <Placeholder xs={6} /> <Placeholder xs={8} />
+          </Placeholder>
+          <Placeholder.Button variant="primary" xs={6} />
+        </Card.Body>
+      </Card>
+    </div>
+  );
+}
+
+export default CardExample;

--- a/www/src/examples/Placeholder/Color.js
+++ b/www/src/examples/Placeholder/Color.js
@@ -1,12 +1,20 @@
-<>
-  <Placeholder xs={12} />
+import Placeholder from 'react-bootstrap/Placeholder';
 
-  <Placeholder xs={12} bg="primary" />
-  <Placeholder xs={12} bg="secondary" />
-  <Placeholder xs={12} bg="success" />
-  <Placeholder xs={12} bg="danger" />
-  <Placeholder xs={12} bg="warning" />
-  <Placeholder xs={12} bg="info" />
-  <Placeholder xs={12} bg="light" />
-  <Placeholder xs={12} bg="dark" />
-</>;
+function ColorExample() {
+  return (
+    <>
+      <Placeholder xs={12} />
+
+      <Placeholder xs={12} bg="primary" />
+      <Placeholder xs={12} bg="secondary" />
+      <Placeholder xs={12} bg="success" />
+      <Placeholder xs={12} bg="danger" />
+      <Placeholder xs={12} bg="warning" />
+      <Placeholder xs={12} bg="info" />
+      <Placeholder xs={12} bg="light" />
+      <Placeholder xs={12} bg="dark" />
+    </>
+  );
+}
+
+export default ColorExample;

--- a/www/src/examples/Placeholder/Example.js
+++ b/www/src/examples/Placeholder/Example.js
@@ -1,7 +1,15 @@
-<>
-  <p aria-hidden="true">
-    <Placeholder xs={6} />
-  </p>
+import Placeholder from 'react-bootstrap/Placeholder';
 
-  <Placeholder.Button xs={4} aria-hidden="true" />
-</>;
+function BasicExample() {
+  return (
+    <>
+      <p aria-hidden="true">
+        <Placeholder xs={6} />
+      </p>
+
+      <Placeholder.Button xs={4} aria-hidden="true" />
+    </>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/Placeholder/Size.js
+++ b/www/src/examples/Placeholder/Size.js
@@ -1,6 +1,14 @@
-<>
-  <Placeholder xs={12} size="lg" />
-  <Placeholder xs={12} />
-  <Placeholder xs={12} size="sm" />
-  <Placeholder xs={12} size="xs" />
-</>;
+import Placeholder from 'react-bootstrap/Placeholder';
+
+function SizeExample() {
+  return (
+    <>
+      <Placeholder xs={12} size="lg" />
+      <Placeholder xs={12} />
+      <Placeholder xs={12} size="sm" />
+      <Placeholder xs={12} size="xs" />
+    </>
+  );
+}
+
+export default SizeExample;

--- a/www/src/examples/Placeholder/Width.js
+++ b/www/src/examples/Placeholder/Width.js
@@ -1,4 +1,12 @@
-<>
-  <Placeholder xs={6} />
-  <Placeholder className="w-75" /> <Placeholder style={{ width: '25%' }} />
-</>;
+import Placeholder from 'react-bootstrap/Placeholder';
+
+function WidthExample() {
+  return (
+    <>
+      <Placeholder xs={6} />
+      <Placeholder className="w-75" /> <Placeholder style={{ width: '25%' }} />
+    </>
+  );
+}
+
+export default WidthExample;

--- a/www/src/examples/ProgressBar/Animated.js
+++ b/www/src/examples/ProgressBar/Animated.js
@@ -1,1 +1,7 @@
-<ProgressBar animated now={45} />;
+import ProgressBar from 'react-bootstrap/ProgressBar';
+
+function AnimatedExample() {
+  return <ProgressBar animated now={45} />;
+}
+
+export default AnimatedExample;

--- a/www/src/examples/ProgressBar/Basic.js
+++ b/www/src/examples/ProgressBar/Basic.js
@@ -1,1 +1,7 @@
-<ProgressBar now={60} />;
+import ProgressBar from 'react-bootstrap/ProgressBar';
+
+function BasicExample() {
+  return <ProgressBar now={60} />;
+}
+
+export default BasicExample;

--- a/www/src/examples/ProgressBar/Contextual.js
+++ b/www/src/examples/ProgressBar/Contextual.js
@@ -1,6 +1,14 @@
-<div>
-  <ProgressBar variant="success" now={40} />
-  <ProgressBar variant="info" now={20} />
-  <ProgressBar variant="warning" now={60} />
-  <ProgressBar variant="danger" now={80} />
-</div>;
+import ProgressBar from 'react-bootstrap/ProgressBar';
+
+function ContextualExample() {
+  return (
+    <div>
+      <ProgressBar variant="success" now={40} />
+      <ProgressBar variant="info" now={20} />
+      <ProgressBar variant="warning" now={60} />
+      <ProgressBar variant="danger" now={80} />
+    </div>
+  );
+}
+
+export default ContextualExample;

--- a/www/src/examples/ProgressBar/ScreenreaderLabel.js
+++ b/www/src/examples/ProgressBar/ScreenreaderLabel.js
@@ -1,7 +1,8 @@
-const now = 60;
+import ProgressBar from 'react-bootstrap/ProgressBar';
 
-const progressInstance = (
-  <ProgressBar now={now} label={`${now}%`} visuallyHidden />
-);
+function ScreenreaderLabelExample() {
+  const now = 60;
+  return <ProgressBar now={now} label={`${now}%`} visuallyHidden />;
+}
 
-render(progressInstance);
+export default ScreenreaderLabelExample;

--- a/www/src/examples/ProgressBar/Stacked.js
+++ b/www/src/examples/ProgressBar/Stacked.js
@@ -1,5 +1,13 @@
-<ProgressBar>
-  <ProgressBar striped variant="success" now={35} key={1} />
-  <ProgressBar variant="warning" now={20} key={2} />
-  <ProgressBar striped variant="danger" now={10} key={3} />
-</ProgressBar>;
+import ProgressBar from 'react-bootstrap/ProgressBar';
+
+function StackedExample() {
+  return (
+    <ProgressBar>
+      <ProgressBar striped variant="success" now={35} key={1} />
+      <ProgressBar variant="warning" now={20} key={2} />
+      <ProgressBar striped variant="danger" now={10} key={3} />
+    </ProgressBar>
+  );
+}
+
+export default StackedExample;

--- a/www/src/examples/ProgressBar/Striped.js
+++ b/www/src/examples/ProgressBar/Striped.js
@@ -1,6 +1,14 @@
-<div>
-  <ProgressBar striped variant="success" now={40} />
-  <ProgressBar striped variant="info" now={20} />
-  <ProgressBar striped variant="warning" now={60} />
-  <ProgressBar striped variant="danger" now={80} />
-</div>;
+import ProgressBar from 'react-bootstrap/ProgressBar';
+
+function StripedExample() {
+  return (
+    <div>
+      <ProgressBar striped variant="success" now={40} />
+      <ProgressBar striped variant="info" now={20} />
+      <ProgressBar striped variant="warning" now={60} />
+      <ProgressBar striped variant="danger" now={80} />
+    </div>
+  );
+}
+
+export default StripedExample;

--- a/www/src/examples/ProgressBar/WithLabel.js
+++ b/www/src/examples/ProgressBar/WithLabel.js
@@ -1,5 +1,8 @@
-const now = 60;
+import ProgressBar from 'react-bootstrap/ProgressBar';
 
-const progressInstance = <ProgressBar now={now} label={`${now}%`} />;
+function WithLabelExample() {
+  const now = 60;
+  return <ProgressBar now={now} label={`${now}%`} />;
+}
 
-render(progressInstance);
+export default WithLabelExample;

--- a/www/src/examples/Ratio/Custom.js
+++ b/www/src/examples/Ratio/Custom.js
@@ -1,8 +1,16 @@
-<>
-  <Ratio aspectRatio={1 / 2}>
-    <div>2x1</div>
-  </Ratio>
-  <Ratio aspectRatio={50}>
-    <div>2x1</div>
-  </Ratio>
-</>;
+import Ratio from 'react-bootstrap/Ratio';
+
+function CustomExample() {
+  return (
+    <>
+      <Ratio aspectRatio={1 / 2}>
+        <div>2x1</div>
+      </Ratio>
+      <Ratio aspectRatio={50}>
+        <div>2x1</div>
+      </Ratio>
+    </>
+  );
+}
+
+export default CustomExample;

--- a/www/src/examples/Ratio/Default.js
+++ b/www/src/examples/Ratio/Default.js
@@ -1,7 +1,15 @@
-<>
-  {['1x1', '4x3', '16x9', '21x9'].map((ratio) => (
-    <Ratio aspectRatio={ratio}>
-      <div>{ratio}</div>
-    </Ratio>
-  ))}
-</>;
+import Ratio from 'react-bootstrap/Ratio';
+
+function DefaultExample() {
+  return (
+    <>
+      {['1x1', '4x3', '16x9', '21x9'].map((ratio) => (
+        <Ratio aspectRatio={ratio}>
+          <div>{ratio}</div>
+        </Ratio>
+      ))}
+    </>
+  );
+}
+
+export default DefaultExample;

--- a/www/src/examples/Ratio/Example.js
+++ b/www/src/examples/Ratio/Example.js
@@ -1,5 +1,13 @@
-<div style={{ width: 660, height: 'auto' }}>
-  <Ratio aspectRatio="16x9">
-    <embed type="image/svg+xml" src="/TheresaKnott_castle.svg" />
-  </Ratio>
-</div>;
+import Ratio from 'react-bootstrap/Ratio';
+
+function BasicExample() {
+  return (
+    <div style={{ width: 660, height: 'auto' }}>
+      <Ratio aspectRatio="16x9">
+        <embed type="image/svg+xml" src="/TheresaKnott_castle.svg" />
+      </Ratio>
+    </div>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/Spinner/Basic.js
+++ b/www/src/examples/Spinner/Basic.js
@@ -1,3 +1,11 @@
-<Spinner animation="border" role="status">
-  <span className="visually-hidden">Loading...</span>
-</Spinner>;
+import Spinner from 'react-bootstrap/Spinner';
+
+function BasicExample() {
+  return (
+    <Spinner animation="border" role="status">
+      <span className="visually-hidden">Loading...</span>
+    </Spinner>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/Spinner/Border.js
+++ b/www/src/examples/Spinner/Border.js
@@ -1,1 +1,7 @@
-<Spinner animation="border" />;
+import Spinner from 'react-bootstrap/Spinner';
+
+function BorderExample() {
+  return <Spinner animation="border" />;
+}
+
+export default BorderExample;

--- a/www/src/examples/Spinner/Buttons.js
+++ b/www/src/examples/Spinner/Buttons.js
@@ -1,22 +1,31 @@
-<>
-  <Button variant="primary" disabled>
-    <Spinner
-      as="span"
-      animation="border"
-      size="sm"
-      role="status"
-      aria-hidden="true"
-    />
-    <span className="visually-hidden">Loading...</span>
-  </Button>{' '}
-  <Button variant="primary" disabled>
-    <Spinner
-      as="span"
-      animation="grow"
-      size="sm"
-      role="status"
-      aria-hidden="true"
-    />
-    Loading...
-  </Button>
-</>;
+import Button from 'react-bootstrap/Button';
+import Spinner from 'react-bootstrap/Spinner';
+
+function ButtonExample() {
+  return (
+    <>
+      <Button variant="primary" disabled>
+        <Spinner
+          as="span"
+          animation="border"
+          size="sm"
+          role="status"
+          aria-hidden="true"
+        />
+        <span className="visually-hidden">Loading...</span>
+      </Button>{' '}
+      <Button variant="primary" disabled>
+        <Spinner
+          as="span"
+          animation="grow"
+          size="sm"
+          role="status"
+          aria-hidden="true"
+        />
+        Loading...
+      </Button>
+    </>
+  );
+}
+
+export default ButtonExample;

--- a/www/src/examples/Spinner/Grow.js
+++ b/www/src/examples/Spinner/Grow.js
@@ -1,1 +1,7 @@
-<Spinner animation="grow" />;
+import Spinner from 'react-bootstrap/Spinner';
+
+function GrowExample() {
+  return <Spinner animation="grow" />;
+}
+
+export default GrowExample;

--- a/www/src/examples/Spinner/Sizes.js
+++ b/www/src/examples/Spinner/Sizes.js
@@ -1,6 +1,14 @@
-<>
-  <Spinner animation="border" size="sm" />
-  <Spinner animation="border" />
-  <Spinner animation="grow" size="sm" />
-  <Spinner animation="grow" />
-</>;
+import Spinner from 'react-bootstrap/Spinner';
+
+function SizesExample() {
+  return (
+    <>
+      <Spinner animation="border" size="sm" />
+      <Spinner animation="border" />
+      <Spinner animation="grow" size="sm" />
+      <Spinner animation="grow" />
+    </>
+  );
+}
+
+export default SizesExample;

--- a/www/src/examples/Spinner/Variants.js
+++ b/www/src/examples/Spinner/Variants.js
@@ -1,18 +1,26 @@
-<>
-  <Spinner animation="border" variant="primary" />
-  <Spinner animation="border" variant="secondary" />
-  <Spinner animation="border" variant="success" />
-  <Spinner animation="border" variant="danger" />
-  <Spinner animation="border" variant="warning" />
-  <Spinner animation="border" variant="info" />
-  <Spinner animation="border" variant="light" />
-  <Spinner animation="border" variant="dark" />
-  <Spinner animation="grow" variant="primary" />
-  <Spinner animation="grow" variant="secondary" />
-  <Spinner animation="grow" variant="success" />
-  <Spinner animation="grow" variant="danger" />
-  <Spinner animation="grow" variant="warning" />
-  <Spinner animation="grow" variant="info" />
-  <Spinner animation="grow" variant="light" />
-  <Spinner animation="grow" variant="dark" />
-</>;
+import Spinner from 'react-bootstrap/Spinner';
+
+function VariantsExample() {
+  return (
+    <>
+      <Spinner animation="border" variant="primary" />
+      <Spinner animation="border" variant="secondary" />
+      <Spinner animation="border" variant="success" />
+      <Spinner animation="border" variant="danger" />
+      <Spinner animation="border" variant="warning" />
+      <Spinner animation="border" variant="info" />
+      <Spinner animation="border" variant="light" />
+      <Spinner animation="border" variant="dark" />
+      <Spinner animation="grow" variant="primary" />
+      <Spinner animation="grow" variant="secondary" />
+      <Spinner animation="grow" variant="success" />
+      <Spinner animation="grow" variant="danger" />
+      <Spinner animation="grow" variant="warning" />
+      <Spinner animation="grow" variant="info" />
+      <Spinner animation="grow" variant="light" />
+      <Spinner animation="grow" variant="dark" />
+    </>
+  );
+}
+
+export default VariantsExample;

--- a/www/src/examples/Stack/Buttons.js
+++ b/www/src/examples/Stack/Buttons.js
@@ -1,4 +1,13 @@
-<Stack gap={2} className="col-md-5 mx-auto">
-  <Button variant="secondary">Save changes</Button>
-  <Button variant="outline-secondary">Cancel</Button>
-</Stack>;
+import Button from 'react-bootstrap/Button';
+import Stack from 'react-bootstrap/Stack';
+
+function ButtonsExample() {
+  return (
+    <Stack gap={2} className="col-md-5 mx-auto">
+      <Button variant="secondary">Save changes</Button>
+      <Button variant="outline-secondary">Cancel</Button>
+    </Stack>
+  );
+}
+
+export default ButtonsExample;

--- a/www/src/examples/Stack/Form.js
+++ b/www/src/examples/Stack/Form.js
@@ -1,6 +1,16 @@
-<Stack direction="horizontal" gap={3}>
-  <Form.Control className="me-auto" placeholder="Add your item here..." />
-  <Button variant="secondary">Submit</Button>
-  <div className="vr" />
-  <Button variant="outline-danger">Reset</Button>
-</Stack>;
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+import Stack from 'react-bootstrap/Stack';
+
+function FormExample() {
+  return (
+    <Stack direction="horizontal" gap={3}>
+      <Form.Control className="me-auto" placeholder="Add your item here..." />
+      <Button variant="secondary">Submit</Button>
+      <div className="vr" />
+      <Button variant="outline-danger">Reset</Button>
+    </Stack>
+  );
+}
+
+export default FormExample;

--- a/www/src/examples/Stack/Horizontal.js
+++ b/www/src/examples/Stack/Horizontal.js
@@ -1,5 +1,13 @@
-<Stack direction="horizontal" gap={3}>
-  <div className="bg-light border">First item</div>
-  <div className="bg-light border">Second item</div>
-  <div className="bg-light border">Third item</div>
-</Stack>;
+import Stack from 'react-bootstrap/Stack';
+
+function HorizontalExample() {
+  return (
+    <Stack direction="horizontal" gap={3}>
+      <div className="bg-light border">First item</div>
+      <div className="bg-light border">Second item</div>
+      <div className="bg-light border">Third item</div>
+    </Stack>
+  );
+}
+
+export default HorizontalExample;

--- a/www/src/examples/Stack/HorizontalMarginStart.js
+++ b/www/src/examples/Stack/HorizontalMarginStart.js
@@ -1,5 +1,13 @@
-<Stack direction="horizontal" gap={3}>
-  <div className="bg-light border">First item</div>
-  <div className="bg-light border ms-auto">Second item</div>
-  <div className="bg-light border">Third item</div>
-</Stack>;
+import Stack from 'react-bootstrap/Stack';
+
+function HorizontalMarginStartExample() {
+  return (
+    <Stack direction="horizontal" gap={3}>
+      <div className="bg-light border">First item</div>
+      <div className="bg-light border ms-auto">Second item</div>
+      <div className="bg-light border">Third item</div>
+    </Stack>
+  );
+}
+
+export default HorizontalMarginStartExample;

--- a/www/src/examples/Stack/HorizontalVerticalRules.js
+++ b/www/src/examples/Stack/HorizontalVerticalRules.js
@@ -1,6 +1,14 @@
-<Stack direction="horizontal" gap={3}>
-  <div className="bg-light border">First item</div>
-  <div className="bg-light border ms-auto">Second item</div>
-  <div className="vr" />
-  <div className="bg-light border">Third item</div>
-</Stack>;
+import Stack from 'react-bootstrap/Stack';
+
+function HorizontalVerticalRulesExample() {
+  return (
+    <Stack direction="horizontal" gap={3}>
+      <div className="bg-light border">First item</div>
+      <div className="bg-light border ms-auto">Second item</div>
+      <div className="vr" />
+      <div className="bg-light border">Third item</div>
+    </Stack>
+  );
+}
+
+export default HorizontalVerticalRulesExample;

--- a/www/src/examples/Stack/Vertical.js
+++ b/www/src/examples/Stack/Vertical.js
@@ -1,5 +1,13 @@
-<Stack gap={3}>
-  <div className="bg-light border">First item</div>
-  <div className="bg-light border">Second item</div>
-  <div className="bg-light border">Third item</div>
-</Stack>;
+import Stack from 'react-bootstrap/Stack';
+
+function VerticalExample() {
+  return (
+    <Stack gap={3}>
+      <div className="bg-light border">First item</div>
+      <div className="bg-light border">Second item</div>
+      <div className="bg-light border">Third item</div>
+    </Stack>
+  );
+}
+
+export default VerticalExample;

--- a/www/src/examples/Table/Basic.js
+++ b/www/src/examples/Table/Basic.js
@@ -1,29 +1,37 @@
-<Table striped bordered hover>
-  <thead>
-    <tr>
-      <th>#</th>
-      <th>First Name</th>
-      <th>Last Name</th>
-      <th>Username</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>1</td>
-      <td>Mark</td>
-      <td>Otto</td>
-      <td>@mdo</td>
-    </tr>
-    <tr>
-      <td>2</td>
-      <td>Jacob</td>
-      <td>Thornton</td>
-      <td>@fat</td>
-    </tr>
-    <tr>
-      <td>3</td>
-      <td colSpan={2}>Larry the Bird</td>
-      <td>@twitter</td>
-    </tr>
-  </tbody>
-</Table>;
+import Table from 'react-bootstrap/Table';
+
+function BasicExample() {
+  return (
+    <Table striped bordered hover>
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Username</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>1</td>
+          <td>Mark</td>
+          <td>Otto</td>
+          <td>@mdo</td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>Jacob</td>
+          <td>Thornton</td>
+          <td>@fat</td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td colSpan={2}>Larry the Bird</td>
+          <td>@twitter</td>
+        </tr>
+      </tbody>
+    </Table>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/Table/Dark.js
+++ b/www/src/examples/Table/Dark.js
@@ -1,29 +1,37 @@
-<Table striped bordered hover variant="dark">
-  <thead>
-    <tr>
-      <th>#</th>
-      <th>First Name</th>
-      <th>Last Name</th>
-      <th>Username</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>1</td>
-      <td>Mark</td>
-      <td>Otto</td>
-      <td>@mdo</td>
-    </tr>
-    <tr>
-      <td>2</td>
-      <td>Jacob</td>
-      <td>Thornton</td>
-      <td>@fat</td>
-    </tr>
-    <tr>
-      <td>3</td>
-      <td colSpan={2}>Larry the Bird</td>
-      <td>@twitter</td>
-    </tr>
-  </tbody>
-</Table>;
+import Table from 'react-bootstrap/Table';
+
+function DarkExample() {
+  return (
+    <Table striped bordered hover variant="dark">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Username</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>1</td>
+          <td>Mark</td>
+          <td>Otto</td>
+          <td>@mdo</td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>Jacob</td>
+          <td>Thornton</td>
+          <td>@fat</td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td colSpan={2}>Larry the Bird</td>
+          <td>@twitter</td>
+        </tr>
+      </tbody>
+    </Table>
+  );
+}
+
+export default DarkExample;

--- a/www/src/examples/Table/Responsive.js
+++ b/www/src/examples/Table/Responsive.js
@@ -1,30 +1,38 @@
-<Table responsive>
-  <thead>
-    <tr>
-      <th>#</th>
-      {Array.from({ length: 12 }).map((_, index) => (
-        <th key={index}>Table heading</th>
-      ))}
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>1</td>
-      {Array.from({ length: 12 }).map((_, index) => (
-        <td key={index}>Table cell {index}</td>
-      ))}
-    </tr>
-    <tr>
-      <td>2</td>
-      {Array.from({ length: 12 }).map((_, index) => (
-        <td key={index}>Table cell {index}</td>
-      ))}
-    </tr>
-    <tr>
-      <td>3</td>
-      {Array.from({ length: 12 }).map((_, index) => (
-        <td key={index}>Table cell {index}</td>
-      ))}
-    </tr>
-  </tbody>
-</Table>;
+import Table from 'react-bootstrap/Table';
+
+function ResponsiveExample() {
+  return (
+    <Table responsive>
+      <thead>
+        <tr>
+          <th>#</th>
+          {Array.from({ length: 12 }).map((_, index) => (
+            <th key={index}>Table heading</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>1</td>
+          {Array.from({ length: 12 }).map((_, index) => (
+            <td key={index}>Table cell {index}</td>
+          ))}
+        </tr>
+        <tr>
+          <td>2</td>
+          {Array.from({ length: 12 }).map((_, index) => (
+            <td key={index}>Table cell {index}</td>
+          ))}
+        </tr>
+        <tr>
+          <td>3</td>
+          {Array.from({ length: 12 }).map((_, index) => (
+            <td key={index}>Table cell {index}</td>
+          ))}
+        </tr>
+      </tbody>
+    </Table>
+  );
+}
+
+export default ResponsiveExample;

--- a/www/src/examples/Table/ResponsiveBreakpoints.js
+++ b/www/src/examples/Table/ResponsiveBreakpoints.js
@@ -1,170 +1,178 @@
-<div>
-  <Table responsive="sm">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-    </tbody>
-  </Table>
-  <Table responsive="md">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-    </tbody>
-  </Table>
-  <Table responsive="lg">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-    </tbody>
-  </Table>
-  <Table responsive="xl">
-    <thead>
-      <tr>
-        <th>#</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-        <th>Table heading</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>1</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-      <tr>
-        <td>2</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-      <tr>
-        <td>3</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-        <td>Table cell</td>
-      </tr>
-    </tbody>
-  </Table>
-</div>;
+import Table from 'react-bootstrap/Table';
+
+function ResponsiveBreakpointsExample() {
+  return (
+    <div>
+      <Table responsive="sm">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>1</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+          </tr>
+          <tr>
+            <td>2</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+          </tr>
+          <tr>
+            <td>3</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+          </tr>
+        </tbody>
+      </Table>
+      <Table responsive="md">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>1</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+          </tr>
+          <tr>
+            <td>2</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+          </tr>
+          <tr>
+            <td>3</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+          </tr>
+        </tbody>
+      </Table>
+      <Table responsive="lg">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>1</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+          </tr>
+          <tr>
+            <td>2</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+          </tr>
+          <tr>
+            <td>3</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+          </tr>
+        </tbody>
+      </Table>
+      <Table responsive="xl">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+            <th>Table heading</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>1</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+          </tr>
+          <tr>
+            <td>2</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+          </tr>
+          <tr>
+            <td>3</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+            <td>Table cell</td>
+          </tr>
+        </tbody>
+      </Table>
+    </div>
+  );
+}
+
+export default ResponsiveBreakpointsExample;

--- a/www/src/examples/Table/Small.js
+++ b/www/src/examples/Table/Small.js
@@ -1,29 +1,37 @@
-<Table striped bordered hover size="sm">
-  <thead>
-    <tr>
-      <th>#</th>
-      <th>First Name</th>
-      <th>Last Name</th>
-      <th>Username</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>1</td>
-      <td>Mark</td>
-      <td>Otto</td>
-      <td>@mdo</td>
-    </tr>
-    <tr>
-      <td>2</td>
-      <td>Jacob</td>
-      <td>Thornton</td>
-      <td>@fat</td>
-    </tr>
-    <tr>
-      <td>3</td>
-      <td colSpan={2}>Larry the Bird</td>
-      <td>@twitter</td>
-    </tr>
-  </tbody>
-</Table>;
+import Table from 'react-bootstrap/Table';
+
+function SmallExample() {
+  return (
+    <Table striped bordered hover size="sm">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Username</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>1</td>
+          <td>Mark</td>
+          <td>Otto</td>
+          <td>@mdo</td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>Jacob</td>
+          <td>Thornton</td>
+          <td>@fat</td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td colSpan={2}>Larry the Bird</td>
+          <td>@twitter</td>
+        </tr>
+      </tbody>
+    </Table>
+  );
+}
+
+export default SmallExample;

--- a/www/src/examples/Table/StripedColumns.js
+++ b/www/src/examples/Table/StripedColumns.js
@@ -1,29 +1,37 @@
-<Table striped="columns">
-  <thead>
-    <tr>
-      <th>#</th>
-      <th>First Name</th>
-      <th>Last Name</th>
-      <th>Username</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>1</td>
-      <td>Mark</td>
-      <td>Otto</td>
-      <td>@mdo</td>
-    </tr>
-    <tr>
-      <td>2</td>
-      <td>Jacob</td>
-      <td>Thornton</td>
-      <td>@fat</td>
-    </tr>
-    <tr>
-      <td>3</td>
-      <td colSpan={2}>Larry the Bird</td>
-      <td>@twitter</td>
-    </tr>
-  </tbody>
-</Table>;
+import Table from 'react-bootstrap/Table';
+
+function StripedColumnsExample() {
+  return (
+    <Table striped="columns">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Username</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>1</td>
+          <td>Mark</td>
+          <td>Otto</td>
+          <td>@mdo</td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>Jacob</td>
+          <td>Thornton</td>
+          <td>@fat</td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td colSpan={2}>Larry the Bird</td>
+          <td>@twitter</td>
+        </tr>
+      </tbody>
+    </Table>
+  );
+}
+
+export default StripedColumnsExample;

--- a/www/src/examples/Table/StripedRow.js
+++ b/www/src/examples/Table/StripedRow.js
@@ -1,29 +1,37 @@
-<Table striped>
-  <thead>
-    <tr>
-      <th>#</th>
-      <th>First Name</th>
-      <th>Last Name</th>
-      <th>Username</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>1</td>
-      <td>Mark</td>
-      <td>Otto</td>
-      <td>@mdo</td>
-    </tr>
-    <tr>
-      <td>2</td>
-      <td>Jacob</td>
-      <td>Thornton</td>
-      <td>@fat</td>
-    </tr>
-    <tr>
-      <td>3</td>
-      <td colSpan={2}>Larry the Bird</td>
-      <td>@twitter</td>
-    </tr>
-  </tbody>
-</Table>;
+import Table from 'react-bootstrap/Table';
+
+function StripedRowExample() {
+  return (
+    <Table striped>
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>First Name</th>
+          <th>Last Name</th>
+          <th>Username</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>1</td>
+          <td>Mark</td>
+          <td>Otto</td>
+          <td>@mdo</td>
+        </tr>
+        <tr>
+          <td>2</td>
+          <td>Jacob</td>
+          <td>Thornton</td>
+          <td>@fat</td>
+        </tr>
+        <tr>
+          <td>3</td>
+          <td colSpan={2}>Larry the Bird</td>
+          <td>@twitter</td>
+        </tr>
+      </tbody>
+    </Table>
+  );
+}
+
+export default StripedRowExample;

--- a/www/src/examples/Tabs/Controlled.js
+++ b/www/src/examples/Tabs/Controlled.js
@@ -1,4 +1,10 @@
-function ControlledTabs() {
+import React, { useState } from 'react';
+import Tab from 'react-bootstrap/Tab';
+import Tabs from 'react-bootstrap/Tabs';
+
+import { Sonnet } from '../../components/Sonnet';
+
+function ControlledTabsExample() {
   const [key, setKey] = useState('home');
 
   return (
@@ -21,4 +27,4 @@ function ControlledTabs() {
   );
 }
 
-render(<ControlledTabs />);
+export default ControlledTabsExample;

--- a/www/src/examples/Tabs/LeftTabs.js
+++ b/www/src/examples/Tabs/LeftTabs.js
@@ -1,24 +1,37 @@
-<Tab.Container id="left-tabs-example" defaultActiveKey="first">
-  <Row>
-    <Col sm={3}>
-      <Nav variant="pills" className="flex-column">
-        <Nav.Item>
-          <Nav.Link eventKey="first">Tab 1</Nav.Link>
-        </Nav.Item>
-        <Nav.Item>
-          <Nav.Link eventKey="second">Tab 2</Nav.Link>
-        </Nav.Item>
-      </Nav>
-    </Col>
-    <Col sm={9}>
-      <Tab.Content>
-        <Tab.Pane eventKey="first">
-          <Sonnet />
-        </Tab.Pane>
-        <Tab.Pane eventKey="second">
-          <Sonnet />
-        </Tab.Pane>
-      </Tab.Content>
-    </Col>
-  </Row>
-</Tab.Container>;
+import Col from 'react-bootstrap/Col';
+import Nav from 'react-bootstrap/Nav';
+import Row from 'react-bootstrap/Row';
+import Tab from 'react-bootstrap/Tab';
+
+import { Sonnet } from '../../components/Sonnet';
+
+function LeftTabsExample() {
+  return (
+    <Tab.Container id="left-tabs-example" defaultActiveKey="first">
+      <Row>
+        <Col sm={3}>
+          <Nav variant="pills" className="flex-column">
+            <Nav.Item>
+              <Nav.Link eventKey="first">Tab 1</Nav.Link>
+            </Nav.Item>
+            <Nav.Item>
+              <Nav.Link eventKey="second">Tab 2</Nav.Link>
+            </Nav.Item>
+          </Nav>
+        </Col>
+        <Col sm={9}>
+          <Tab.Content>
+            <Tab.Pane eventKey="first">
+              <Sonnet />
+            </Tab.Pane>
+            <Tab.Pane eventKey="second">
+              <Sonnet />
+            </Tab.Pane>
+          </Tab.Content>
+        </Col>
+      </Row>
+    </Tab.Container>
+  );
+}
+
+export default LeftTabsExample;

--- a/www/src/examples/Tabs/NoAnimation.js
+++ b/www/src/examples/Tabs/NoAnimation.js
@@ -1,16 +1,27 @@
-<Tabs
-  defaultActiveKey="home"
-  transition={false}
-  id="noanim-tab-example"
-  className="mb-3"
->
-  <Tab eventKey="home" title="Home">
-    <Sonnet />
-  </Tab>
-  <Tab eventKey="profile" title="Profile">
-    <Sonnet />
-  </Tab>
-  <Tab eventKey="contact" title="Contact" disabled>
-    <Sonnet />
-  </Tab>
-</Tabs>;
+import Tab from 'react-bootstrap/Tab';
+import Tabs from 'react-bootstrap/Tabs';
+
+import { Sonnet } from '../../components/Sonnet';
+
+function NoAnimationExample() {
+  return (
+    <Tabs
+      defaultActiveKey="home"
+      transition={false}
+      id="noanim-tab-example"
+      className="mb-3"
+    >
+      <Tab eventKey="home" title="Home">
+        <Sonnet />
+      </Tab>
+      <Tab eventKey="profile" title="Profile">
+        <Sonnet />
+      </Tab>
+      <Tab eventKey="contact" title="Contact" disabled>
+        <Sonnet />
+      </Tab>
+    </Tabs>
+  );
+}
+
+export default NoAnimationExample;

--- a/www/src/examples/Tabs/Uncontrolled.js
+++ b/www/src/examples/Tabs/Uncontrolled.js
@@ -1,11 +1,26 @@
-<Tabs defaultActiveKey="profile" id="uncontrolled-tab-example" className="mb-3">
-  <Tab eventKey="home" title="Home">
-    <Sonnet />
-  </Tab>
-  <Tab eventKey="profile" title="Profile">
-    <Sonnet />
-  </Tab>
-  <Tab eventKey="contact" title="Contact" disabled>
-    <Sonnet />
-  </Tab>
-</Tabs>;
+import Tab from 'react-bootstrap/Tab';
+import Tabs from 'react-bootstrap/Tabs';
+
+import { Sonnet } from '../../components/Sonnet';
+
+function UncontrolledExample() {
+  return (
+    <Tabs
+      defaultActiveKey="profile"
+      id="uncontrolled-tab-example"
+      className="mb-3"
+    >
+      <Tab eventKey="home" title="Home">
+        <Sonnet />
+      </Tab>
+      <Tab eventKey="profile" title="Profile">
+        <Sonnet />
+      </Tab>
+      <Tab eventKey="contact" title="Contact" disabled>
+        <Sonnet />
+      </Tab>
+    </Tabs>
+  );
+}
+
+export default UncontrolledExample;

--- a/www/src/examples/Theming/Prefixes.js
+++ b/www/src/examples/Theming/Prefixes.js
@@ -1,9 +1,18 @@
-<>
-  {/* Hint: inspect the markup to see how the classes differ */}
-  <ThemeProvider prefixes={{ btn: 'my-btn' }}>
-    <Button variant="primary">My Button</Button>
-  </ThemeProvider>{' '}
-  <Button bsPrefix="super-btn" variant="primary">
-    Super button
-  </Button>
-</>;
+import ThemeProvider from 'react-bootstrap/ThemeProvider';
+import Button from 'react-bootstrap/Button';
+
+function PrefixesExample() {
+  return (
+    <>
+      {/* Hint: inspect the markup to see how the classes differ */}
+      <ThemeProvider prefixes={{ btn: 'my-btn' }}>
+        <Button variant="primary">My Button</Button>
+      </ThemeProvider>{' '}
+      <Button bsPrefix="super-btn" variant="primary">
+        Super button
+      </Button>
+    </>
+  );
+}
+
+export default PrefixesExample;

--- a/www/src/examples/Theming/Variants.js
+++ b/www/src/examples/Theming/Variants.js
@@ -1,6 +1,10 @@
-<>
-  <style type="text/css">
-    {`
+import Button from 'react-bootstrap/Button';
+
+function VariantsExample() {
+  return (
+    <>
+      <style type="text/css">
+        {`
     .btn-flat {
       background-color: purple;
       color: white;
@@ -11,9 +15,13 @@
       font-size: 1.5rem;
     }
     `}
-  </style>
+      </style>
 
-  <Button variant="flat" size="xxl">
-    flat button
-  </Button>
-</>;
+      <Button variant="flat" size="xxl">
+        flat button
+      </Button>
+    </>
+  );
+}
+
+export default VariantsExample;

--- a/www/src/examples/Toast/Autohide.js
+++ b/www/src/examples/Toast/Autohide.js
@@ -1,4 +1,10 @@
-function Example() {
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Col from 'react-bootstrap/Col';
+import Row from 'react-bootstrap/Row';
+import Toast from 'react-bootstrap/Toast';
+
+function AutohideExample() {
   const [show, setShow] = useState(false);
 
   return (
@@ -24,4 +30,4 @@ function Example() {
   );
 }
 
-render(<Example />);
+export default AutohideExample;

--- a/www/src/examples/Toast/Basic.js
+++ b/www/src/examples/Toast/Basic.js
@@ -1,8 +1,16 @@
-<Toast>
-  <Toast.Header>
-    <img src="holder.js/20x20?text=%20" className="rounded me-2" alt="" />
-    <strong className="me-auto">Bootstrap</strong>
-    <small>11 mins ago</small>
-  </Toast.Header>
-  <Toast.Body>Hello, world! This is a toast message.</Toast.Body>
-</Toast>;
+import Toast from 'react-bootstrap/Toast';
+
+function BasicExample() {
+  return (
+    <Toast>
+      <Toast.Header>
+        <img src="holder.js/20x20?text=%20" className="rounded me-2" alt="" />
+        <strong className="me-auto">Bootstrap</strong>
+        <small>11 mins ago</small>
+      </Toast.Header>
+      <Toast.Body>Hello, world! This is a toast message.</Toast.Body>
+    </Toast>
+  );
+}
+
+export default BasicExample;

--- a/www/src/examples/Toast/Contextual.js
+++ b/www/src/examples/Toast/Contextual.js
@@ -1,23 +1,39 @@
-<>
-  {[
-    'Primary',
-    'Secondary',
-    'Success',
-    'Danger',
-    'Warning',
-    'Info',
-    'Light',
-    'Dark',
-  ].map((variant, idx) => (
-    <Toast className="d-inline-block m-1" bg={variant.toLowerCase()} key={idx}>
-      <Toast.Header>
-        <img src="holder.js/20x20?text=%20" className="rounded me-2" alt="" />
-        <strong className="me-auto">Bootstrap</strong>
-        <small>11 mins ago</small>
-      </Toast.Header>
-      <Toast.Body className={variant === 'Dark' && 'text-white'}>
-        Hello, world! This is a toast message.
-      </Toast.Body>
-    </Toast>
-  ))}
-</>;
+import Toast from 'react-bootstrap/Toast';
+
+function ContextualExample() {
+  return (
+    <>
+      {[
+        'Primary',
+        'Secondary',
+        'Success',
+        'Danger',
+        'Warning',
+        'Info',
+        'Light',
+        'Dark',
+      ].map((variant, idx) => (
+        <Toast
+          className="d-inline-block m-1"
+          bg={variant.toLowerCase()}
+          key={idx}
+        >
+          <Toast.Header>
+            <img
+              src="holder.js/20x20?text=%20"
+              className="rounded me-2"
+              alt=""
+            />
+            <strong className="me-auto">Bootstrap</strong>
+            <small>11 mins ago</small>
+          </Toast.Header>
+          <Toast.Body className={variant === 'Dark' && 'text-white'}>
+            Hello, world! This is a toast message.
+          </Toast.Body>
+        </Toast>
+      ))}
+    </>
+  );
+}
+
+export default ContextualExample;

--- a/www/src/examples/Toast/Dismissible.js
+++ b/www/src/examples/Toast/Dismissible.js
@@ -1,4 +1,10 @@
-function Example() {
+import React, { useState } from 'react';
+import Button from 'react-bootstrap/Button';
+import Col from 'react-bootstrap/Col';
+import Row from 'react-bootstrap/Row';
+import Toast from 'react-bootstrap/Toast';
+
+function DismissibleExample() {
   const [showA, setShowA] = useState(true);
   const [showB, setShowB] = useState(true);
 
@@ -45,4 +51,4 @@ function Example() {
   );
 }
 
-render(<Example />);
+export default DismissibleExample;

--- a/www/src/examples/Toast/Placement.js
+++ b/www/src/examples/Toast/Placement.js
@@ -1,4 +1,9 @@
-function Example() {
+import React, { useState } from 'react';
+import Form from 'react-bootstrap/Form';
+import Toast from 'react-bootstrap/Toast';
+import ToastContainer from 'react-bootstrap/ToastContainer';
+
+function PlacementExample() {
   const [position, setPosition] = useState('top-start');
 
   return (
@@ -52,3 +57,5 @@ function Example() {
     </>
   );
 }
+
+export default PlacementExample;

--- a/www/src/examples/Toast/PlacementMulti.js
+++ b/www/src/examples/Toast/PlacementMulti.js
@@ -1,25 +1,45 @@
-<div
-  aria-live="polite"
-  aria-atomic="true"
-  className="bg-dark position-relative"
-  style={{ minHeight: '240px' }}
->
-  <ToastContainer position="top-end" className="p-3">
-    <Toast>
-      <Toast.Header>
-        <img src="holder.js/20x20?text=%20" className="rounded me-2" alt="" />
-        <strong className="me-auto">Bootstrap</strong>
-        <small className="text-muted">just now</small>
-      </Toast.Header>
-      <Toast.Body>See? Just like this.</Toast.Body>
-    </Toast>
-    <Toast>
-      <Toast.Header>
-        <img src="holder.js/20x20?text=%20" className="rounded me-2" alt="" />
-        <strong className="me-auto">Bootstrap</strong>
-        <small className="text-muted">2 seconds ago</small>
-      </Toast.Header>
-      <Toast.Body>Heads up, toasts will stack automatically</Toast.Body>
-    </Toast>
-  </ToastContainer>
-</div>;
+import React, { useState } from 'react';
+import Toast from 'react-bootstrap/Toast';
+import ToastContainer from 'react-bootstrap/ToastContainer';
+
+function PlacementMultiExample() {
+  const [position, setPosition] = useState('top-start');
+
+  return (
+    <div
+      aria-live="polite"
+      aria-atomic="true"
+      className="bg-dark position-relative"
+      style={{ minHeight: '240px' }}
+    >
+      <ToastContainer position="top-end" className="p-3">
+        <Toast>
+          <Toast.Header>
+            <img
+              src="holder.js/20x20?text=%20"
+              className="rounded me-2"
+              alt=""
+            />
+            <strong className="me-auto">Bootstrap</strong>
+            <small className="text-muted">just now</small>
+          </Toast.Header>
+          <Toast.Body>See? Just like this.</Toast.Body>
+        </Toast>
+        <Toast>
+          <Toast.Header>
+            <img
+              src="holder.js/20x20?text=%20"
+              className="rounded me-2"
+              alt=""
+            />
+            <strong className="me-auto">Bootstrap</strong>
+            <small className="text-muted">2 seconds ago</small>
+          </Toast.Header>
+          <Toast.Body>Heads up, toasts will stack automatically</Toast.Body>
+        </Toast>
+      </ToastContainer>
+    </div>
+  );
+}
+
+export default PlacementMultiExample;

--- a/www/src/examples/Toast/Stacking.js
+++ b/www/src/examples/Toast/Stacking.js
@@ -1,18 +1,30 @@
-<ToastContainer>
-  <Toast>
-    <Toast.Header>
-      <img src="holder.js/20x20?text=%20" className="rounded me-2" alt="" />
-      <strong className="me-auto">Bootstrap</strong>
-      <small className="text-muted">just now</small>
-    </Toast.Header>
-    <Toast.Body>See? Just like this.</Toast.Body>
-  </Toast>
-  <Toast>
-    <Toast.Header>
-      <img src="holder.js/20x20?text=%20" className="rounded me-2" alt="" />
-      <strong className="me-auto">Bootstrap</strong>
-      <small className="text-muted">2 seconds ago</small>
-    </Toast.Header>
-    <Toast.Body>Heads up, toasts will stack automatically</Toast.Body>
-  </Toast>
-</ToastContainer>;
+import React, { useState } from 'react';
+import Toast from 'react-bootstrap/Toast';
+import ToastContainer from 'react-bootstrap/ToastContainer';
+
+function StackingExample() {
+  const [position, setPosition] = useState('top-start');
+
+  return (
+    <ToastContainer>
+      <Toast>
+        <Toast.Header>
+          <img src="holder.js/20x20?text=%20" className="rounded me-2" alt="" />
+          <strong className="me-auto">Bootstrap</strong>
+          <small className="text-muted">just now</small>
+        </Toast.Header>
+        <Toast.Body>See? Just like this.</Toast.Body>
+      </Toast>
+      <Toast>
+        <Toast.Header>
+          <img src="holder.js/20x20?text=%20" className="rounded me-2" alt="" />
+          <strong className="me-auto">Bootstrap</strong>
+          <small className="text-muted">2 seconds ago</small>
+        </Toast.Header>
+        <Toast.Body>Heads up, toasts will stack automatically</Toast.Body>
+      </Toast>
+    </ToastContainer>
+  );
+}
+
+export default StackingExample;


### PR DESCRIPTION
This PR addresses issue #4952 by adding the imports for components used in the code examples in the user documentation. `react-live` provides a way to do this using a transform function passed as a prop to `LIveProvider`. In this case, the simple transform function added in `ReactPlayground.js` uses some regex to strip the import and export statements added to the example code before sending it to be rendered in the Live Preview. I only added the imports and exports to code examples that have the `Copy` button. 