### PR TITLE
Bug/breakpoints smaller than xs

### DIFF
--- a/src/Col.tsx
+++ b/src/Col.tsx
@@ -2,7 +2,11 @@ import classNames from 'classnames';
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
-import { useBootstrapPrefix, useBootstrapBreakpoints } from './ThemeProvider';
+import {
+  useBootstrapPrefix,
+  useBootstrapBreakpoints,
+  useBootstrapMinBreakpoint,
+} from './ThemeProvider';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 type NumberAttr =
@@ -125,6 +129,7 @@ export function useCol({
 }: ColProps): [any, UseColMetadata] {
   bsPrefix = useBootstrapPrefix(bsPrefix, 'col');
   const breakpoints = useBootstrapBreakpoints();
+  const minBreakpoint = useBootstrapMinBreakpoint();
 
   const spans: string[] = [];
   const classes: string[] = [];
@@ -143,7 +148,7 @@ export function useCol({
       span = propValue;
     }
 
-    const infix = brkPoint !== 'xs' ? `-${brkPoint}` : '';
+    const infix = brkPoint !== minBreakpoint ? `-${brkPoint}` : '';
 
     if (span)
       spans.push(

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types';
 
 import * as React from 'react';
 
-import { useBootstrapPrefix, useBootstrapBreakpoints } from './ThemeProvider';
+import {
+  useBootstrapPrefix,
+  useBootstrapBreakpoints,
+  useBootstrapMinBreakpoint,
+} from './ThemeProvider';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 type RowColWidth =
@@ -117,6 +121,7 @@ const Row: BsPrefixRefForwardingComponent<'div', RowProps> = React.forwardRef<
   ) => {
     const decoratedBsPrefix = useBootstrapPrefix(bsPrefix, 'row');
     const breakpoints = useBootstrapBreakpoints();
+    const minBreakpoint = useBootstrapMinBreakpoint();
 
     const sizePrefix = `${decoratedBsPrefix}-cols`;
     const classes: string[] = [];
@@ -132,7 +137,7 @@ const Row: BsPrefixRefForwardingComponent<'div', RowProps> = React.forwardRef<
         cols = propValue;
       }
 
-      const infix = brkPoint !== 'xs' ? `-${brkPoint}` : '';
+      const infix = brkPoint !== minBreakpoint ? `-${brkPoint}` : '';
 
       if (cols != null) classes.push(`${sizePrefix}${infix}-${cols}`);
     });

--- a/src/Stack.tsx
+++ b/src/Stack.tsx
@@ -1,7 +1,11 @@
 import classNames from 'classnames';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { useBootstrapPrefix, useBootstrapBreakpoints } from './ThemeProvider';
+import {
+  useBootstrapPrefix,
+  useBootstrapBreakpoints,
+  useBootstrapMinBreakpoint,
+} from './ThemeProvider';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 import { GapValue } from './types';
 import createUtilityClassName, {
@@ -47,6 +51,7 @@ const Stack: BsPrefixRefForwardingComponent<'span', StackProps> =
         direction === 'horizontal' ? 'hstack' : 'vstack',
       );
       const breakpoints = useBootstrapBreakpoints();
+      const minBreakpoint = useBootstrapMinBreakpoint();
 
       return (
         <Component
@@ -58,6 +63,7 @@ const Stack: BsPrefixRefForwardingComponent<'span', StackProps> =
             ...createUtilityClassName({
               gap,
               breakpoints,
+              minBreakpoint,
             }),
           )}
         />

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -3,10 +3,12 @@ import * as React from 'react';
 import { useContext, useMemo } from 'react';
 
 export const DEFAULT_BREAKPOINTS = ['xxl', 'xl', 'lg', 'md', 'sm', 'xs'];
+export const DEFAULT_MIN_BREAKPOINT = 'xs';
 
 export interface ThemeContextValue {
   prefixes: Record<string, string>;
   breakpoints: string[];
+  minBreakpoint?: string;
   dir?: string;
 }
 
@@ -17,12 +19,14 @@ export interface ThemeProviderProps extends Partial<ThemeContextValue> {
 const ThemeContext = React.createContext<ThemeContextValue>({
   prefixes: {},
   breakpoints: DEFAULT_BREAKPOINTS,
+  minBreakpoint: DEFAULT_MIN_BREAKPOINT,
 });
 const { Consumer, Provider } = ThemeContext;
 
 function ThemeProvider({
   prefixes = {},
   breakpoints = DEFAULT_BREAKPOINTS,
+  minBreakpoint = DEFAULT_MIN_BREAKPOINT,
   dir,
   children,
 }: ThemeProviderProps) {
@@ -30,9 +34,10 @@ function ThemeProvider({
     () => ({
       prefixes: { ...prefixes },
       breakpoints,
+      minBreakpoint,
       dir,
     }),
-    [prefixes, breakpoints, dir],
+    [prefixes, breakpoints, minBreakpoint, dir],
   );
 
   return <Provider value={contextValue}>{children}</Provider>;
@@ -57,6 +62,12 @@ ThemeProvider.propTypes = {
   breakpoints: PropTypes.arrayOf(PropTypes.string),
 
   /**
+   * The minimum breakpoint used by your application.
+   * Defaults to the smallest of the standard Bootstrap breakpoints.
+   */
+  minBreakpoint: PropTypes.string,
+
+  /**
    * Indicates the directionality of the application's text.
    *
    * Use `rtl` to set text as "right to left".
@@ -75,6 +86,11 @@ export function useBootstrapPrefix(
 export function useBootstrapBreakpoints() {
   const { breakpoints } = useContext(ThemeContext);
   return breakpoints;
+}
+
+export function useBootstrapMinBreakpoint() {
+  const { minBreakpoint } = useContext(ThemeContext);
+  return minBreakpoint;
 }
 
 export function useIsRTL() {

--- a/src/createUtilityClasses.ts
+++ b/src/createUtilityClasses.ts
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { DEFAULT_BREAKPOINTS } from './ThemeProvider';
+import { DEFAULT_BREAKPOINTS, DEFAULT_MIN_BREAKPOINT } from './ThemeProvider';
 
 export type ResponsiveUtilityValue<T> =
   | T
@@ -29,6 +29,7 @@ export function responsivePropType(propType: any) {
 export default function createUtilityClassName(
   utilityValues: Record<string, ResponsiveUtilityValue<unknown>>,
   breakpoints = DEFAULT_BREAKPOINTS,
+  minBreakpoint = DEFAULT_MIN_BREAKPOINT,
 ) {
   const classes: string[] = [];
   Object.entries(utilityValues).forEach(([utilName, utilValue]) => {
@@ -37,7 +38,7 @@ export default function createUtilityClassName(
         breakpoints.forEach((brkPoint) => {
           const bpValue = utilValue![brkPoint];
           if (bpValue != null) {
-            const infix = brkPoint !== 'xs' ? `-${brkPoint}` : '';
+            const infix = brkPoint !== minBreakpoint ? `-${brkPoint}` : '';
             classes.push(`${utilName}${infix}-${bpValue}`);
           }
         });

--- a/test/ColSpec.tsx
+++ b/test/ColSpec.tsx
@@ -93,4 +93,17 @@ describe('Col', () => {
     );
     getByText('test').classList.contains('col-custom-3').should.be.true;
   });
+
+  it('should allow custom breakpoints smaller than default "xs"', () => {
+    const { getByText } = render(
+      <ThemeProvider breakpoints={['xxs', 'xs']} minBreakpoint="xxs">
+        <Col xxs="3" xs="2">
+          test
+        </Col>
+      </ThemeProvider>,
+    );
+
+    getByText('test').classList.contains('col-3').should.be.true;
+    getByText('test').classList.contains('col-xs-2').should.be.true;
+  });
 });

--- a/test/RowSpec.tsx
+++ b/test/RowSpec.tsx
@@ -76,4 +76,17 @@ describe('Row', () => {
     );
     getByText('test').classList.contains('row-cols-custom-3').should.be.true;
   });
+
+  it('should allow custom breakpoints smaller than default "xs"', () => {
+    const { getByText } = render(
+      <ThemeProvider breakpoints={['xxs', 'xs']} minBreakpoint="xxs">
+        <Row xxs="3" xs="2">
+          test
+        </Row>
+      </ThemeProvider>,
+    );
+
+    getByText('test').classList.contains('row-cols-3').should.be.true;
+    getByText('test').classList.contains('row-cols-xs-2').should.be.true;
+  });
 });

--- a/www/src/examples/CustomBreakpoints.js
+++ b/www/src/examples/CustomBreakpoints.js
@@ -1,5 +1,6 @@
 <ThemeProvider
   breakpoints={['xxxl', 'xxl', 'xl', 'lg', 'md', 'sm', 'xs', 'xxs']}
+  minBreakpoint="xxs"
 >
   <div>Your app...</div>
 </ThemeProvider>;


### PR DESCRIPTION
Closes #6370 

Adds a `minBreakpoint` prop to ThemeProvider which defaults to "xs". This fixes all occurrences of logic like `brkPoint !== 'xs'` to instead use value from new `minBreakpoint` prop.