### PR TITLE
docs: move ads into page below title/lead

### DIFF
--- a/www/src/components/CarbonAds.js
+++ b/www/src/components/CarbonAds.js
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-const CarbonAds = () => {
+const CarbonAds = (props) => {
   const ref = useRef();
 
   useEffect(() => {
@@ -22,7 +22,7 @@ const CarbonAds = () => {
     };
   }, []);
 
-  return <div ref={ref} />;
+  return <div ref={ref} {...props} />;
 };
 
 export default CarbonAds;

--- a/www/src/components/PageHeader.js
+++ b/www/src/components/PageHeader.js
@@ -1,11 +1,14 @@
+import Heading from './Heading';
+import CarbonAds from './CarbonAds';
+
 function PageHeader({ title, subTitle }) {
   return (
-    <div className="bs-docs-header" id="content">
-      <div className="container">
-        <h1>{title}</h1>
-        <p>{subTitle}</p>
-      </div>
-    </div>
+    <>
+      <Heading h="1">{title}</Heading>
+      {subTitle && <p className="lead">{subTitle}</p>}
+
+      <CarbonAds className="my-4" />
+    </>
   );
 }
 

--- a/www/src/components/SideNav.js
+++ b/www/src/components/SideNav.js
@@ -7,7 +7,6 @@ import FormControl from 'react-bootstrap/FormControl';
 import styled from 'astroturf';
 import Button from 'react-bootstrap/Button';
 import Collapse from 'react-bootstrap/Collapse';
-import CarbonAds from './CarbonAds';
 
 const MenuButton = styled(Button).attrs({ variant: 'link' })`
   composes: p-0 d-md-none ms-3 from global;
@@ -285,7 +284,6 @@ class SideNav extends React.Component {
               />
               <NavSection heading="About" location={location} path="/about" />
             </TableOfContents>
-            <CarbonAds />
           </OverflowWrapper>
         </Collapse>
       </SidePanel>

--- a/www/src/layouts/index.js
+++ b/www/src/layouts/index.js
@@ -7,6 +7,7 @@ import Heading from '../components/Heading';
 import CodeBlock from '../components/CodeBlock';
 import LinkedHeading from '../components/LinkedHeading';
 import DocsAlert from '../components/DocsAlert';
+import PageHeader from '../components/PageHeader';
 import SEO from '../seo';
 import ThemeProvider from '../../../src/ThemeProvider';
 
@@ -31,6 +32,7 @@ const components = {
     ) : (
       <pre {...props} />
     ),
+  PageHeader,
 };
 
 const propTypes = {

--- a/www/src/pages/about.mdx
+++ b/www/src/pages/about.mdx
@@ -1,23 +1,27 @@
-# About
-<p className="lead">
-	Get to know more about the team maintaining React Bootstrap. Learn a 
+<PageHeader
+  title="About"
+  subTitle="Get to know more about the team maintaining React Bootstrap. Learn a 
 	little history of how, why and when the project started and how
-	you can be a part of it.
-</p>
+	you can be a part of it."
+/>
 
 ### Team
+
 React Bootstrap is maintained by a [team of developers](https://github.com/orgs/react-bootstrap/people) on Github. We have a growing team
 and if you are interested in re-building the most popular front-end framework with React we would love to hear from you.
 
 ### Contributors
+
 We welcome community support with both feature and bug reporting. Please don't hesitate to jump in.
 Join our growing list of [contributors](https://github.com/react-bootstrap/react-bootstrap/graphs/contributors).
 
 ### Get Involved
+
 Get involved with React Bootstrap [by opening an issue](https://github.com/react-bootstrap/react-bootstrap/issues/new) or submitting a pull request.
 See our [contributing guidelines](https://github.com/react-bootstrap/react-bootstrap/blob/master/CONTRIBUTING.md) here.
 
 ### External Links
+
 - [Bootstrap](https://getbootstrap.com/)
 - [React](https://reactjs.org/)
 - [React Router Bootstrap](https://github.com/react-bootstrap/react-router-bootstrap)

--- a/www/src/pages/components/accordion.mdx
+++ b/www/src/pages/components/accordion.mdx
@@ -11,12 +11,10 @@ import AlwaysOpen from '../../examples/Accordion/AlwaysOpen';
 import CustomToggle from '../../examples/Accordion/CustomToggle.js';
 import ContextAwareToggle from '../../examples/Accordion/ContextAwareToggle.js';
 
-# Accordion
-
-<p className="lead">
-  Build vertically collapsing accordions in combination with the Collapse
-  component.
-</p>
+<PageHeader
+  title="Accordion"
+  subTitle="Build vertically collapsing accordions in combination with the Collapse component"
+/>
 
 ## Examples
 
@@ -47,7 +45,7 @@ control the component, you must use an array of strings for `activeKey` or `defa
 
 ## Custom Accordions
 
-You can still create card-based accordions like those in Bootstrap 4. You can hook 
+You can still create card-based accordions like those in Bootstrap 4. You can hook
 into the Accordion toggle functionality via `useAccordionButton` to make custom
 toggle components.
 

--- a/www/src/pages/components/alerts.mdx
+++ b/www/src/pages/components/alerts.mdx
@@ -10,12 +10,10 @@ import Dismissible from '../../examples/Alert/Dismissible';
 import DismissibleControlled from '../../examples/Alert/DismissibleControlled';
 import Link from '../../examples/Alert/Link';
 
-# Alerts
-
-<p className="lead">
-  Provide contextual feedback messages for typical user actions with the handful
-  of available and flexible alert messages.
-</p>
+<PageHeader
+  title="Alerts"
+  subTitle="Provide contextual feedback messages for typical user actions with the handful of available and flexible alert messages."
+/>
 
 ## Examples
 
@@ -27,9 +25,10 @@ dismiss button. For proper styling, use one of the eight `variant`s.
 <Callout title="Conveying meaning to assistive technologies">
   Using color to add meaning only provides a visual indication, which will not
   be conveyed to users of assistive technologies – such as screen readers.
-  Ensure that information denoted by the color is either obvious from the content
-  itself (e.g. the visible text), or is included through alternative means,
-  such as additional text hidden with the <code>.visually-hidden</code> class.
+  Ensure that information denoted by the color is either obvious from the
+  content itself (e.g. the visible text), or is included through alternative
+  means, such as additional text hidden with the <code>.visually-hidden</code>{' '}
+  class.
 </Callout>
 
 ### Links
@@ -60,7 +59,10 @@ want to build more complicated alerts.
 ## API
 
 <ComponentApi metadata={props.data.Alert} />
-<ComponentApi metadata={props.data.AlertHeading} exportedBy={props.data.Alert} />
+<ComponentApi
+  metadata={props.data.AlertHeading}
+  exportedBy={props.data.Alert}
+/>
 <ComponentApi metadata={props.data.AlertLink} exportedBy={props.data.Alert} />
 
 export const query = graphql`

--- a/www/src/pages/components/badge.mdx
+++ b/www/src/pages/components/badge.mdx
@@ -7,7 +7,12 @@ import BadgeButton from '../../examples/Badge/Button';
 import BadgePill from '../../examples/Badge/Pill';
 import BadgeVariations from '../../examples/Badge/Variations';
 
-# Badges
+<PageHeader
+  title="Badges"
+  subTitle="Documentation and examples for badges, our small count and labeling component."
+/>
+
+## Examples
 
 Badges scale to match the size of the immediate parent element by
 using relative font sizing and em units.
@@ -45,7 +50,6 @@ Useful if you miss the badges from v3.
 ## API
 
 <ComponentApi metadata={props.data.metadata} />
-
 
 export const query = graphql`
   query BadgeQuery {

--- a/www/src/pages/components/breadcrumb.mdx
+++ b/www/src/pages/components/breadcrumb.mdx
@@ -4,16 +4,14 @@ import ComponentApi from '../../components/ComponentApi';
 import ReactPlayground from '../../components/ReactPlayground';
 import Breadcrumb from '../../examples/Breadcrumb';
 
+<PageHeader
+  title="Breadcrumbs"
+  subTitle="Indicate the current page’s location within a navigational hierarchy that automatically adds separators via CSS."
+/>
 
-## Breadcrumbs
+## Example
 
-Indicate the current page’s location within a navigational
-hierarchy that automatically adds separators via CSS. Add `active `
-prop to active  `Breadcrumb.Item `. Do not
-set both  `active ` and  `href ` attributes. `active ` overrides  `href ` and  `span `
-element is rendered instead of  `a `.
-
-### Example
+Add `active` prop to the active `Breadcrumb.Item`. Do not set both `active` and `href` attributes. `active` overrides `href` and `span` element is rendered instead of `a`.
 
 <ReactPlayground codeText={Breadcrumb} />
 
@@ -25,7 +23,6 @@ element is rendered instead of  `a `.
   metadata={props.data.BreadcrumbItem}
   exportedBy={props.data.Breadcrumb}
 />
-
 
 export const query = graphql`
   query BreadcrumbQuery {

--- a/www/src/pages/components/button-group.mdx
+++ b/www/src/pages/components/button-group.mdx
@@ -9,25 +9,10 @@ import ButtonToolbar from '../../examples/ButtonGroup/Toolbar';
 import ButtonToolbarBasic from '../../examples/ButtonGroup/ToolbarBasic';
 import ButtonGroupVertical from '../../examples/ButtonGroup/Vertical';
 
-export const query = graphql`
-  query ButtonGroupQuery {
-    ButtonGroup: componentMetadata(displayName: { eq: "ButtonGroup" }) {
-      displayName
-      ...ComponentApi_metadata
-    }
-    ButtonToolbar: componentMetadata(displayName: { eq: "ButtonToolbar" }) {
-      displayName
-      ...ComponentApi_metadata
-    }
-  }
-`;
-
-# Button groups
-
-<p className="lead">
-  Group a series of buttons together on a single line with the button
-  group.
-</p>
+<PageHeader
+  title="Button group"
+  subTitle="Group a series of buttons together on a single line or stack them in a vertical column."
+/>
 
 ## Basic example
 
@@ -37,7 +22,7 @@ Wrap a series of `<Button>`s in a `<ButtonGroup>`.
 
 ## Button toolbar
 
-Combine sets of  `<ButtonGroup>`s into a `<ButtonToolbar>` for more complex components.
+Combine sets of `<ButtonGroup>`s into a `<ButtonToolbar>` for more complex components.
 
 <ReactPlayground codeText={ButtonToolbarBasic} />
 
@@ -50,7 +35,7 @@ to space things properly.
 ## Sizing
 
 Instead of applying button sizing props to every button in a group, just
-add  `size ` prop to the  `<ButtonGroup>`.
+add `size` prop to the `<ButtonGroup>`.
 
 <ReactPlayground codeText={ButtonGroupSizes} />
 
@@ -65,7 +50,7 @@ You can place other button types within the
 
 Make a set of buttons appear vertically stacked rather than
 horizontally, by adding `vertical` to the `<ButtonGroup>`.
- __Split button dropdowns are not supported here.__
+**Split button dropdowns are not supported here.**
 
 <ReactPlayground codeText={ButtonGroupVertical} />
 
@@ -74,4 +59,17 @@ horizontally, by adding `vertical` to the `<ButtonGroup>`.
 <ComponentApi metadata={props.data.ButtonGroup} />
 <ComponentApi metadata={props.data.ButtonToolbar} />
 
+export const query = graphql`
+  query ButtonGroupQuery {
+    ButtonGroup: componentMetadata(displayName: { eq: "ButtonGroup" }) {
+      displayName
+      ...ComponentApi_metadata
+    }
+    ButtonToolbar: componentMetadata(displayName: { eq: "ButtonToolbar" }) {
+      displayName
+      ...ComponentApi_metadata
+    }
+  }
+`;
 
+;

--- a/www/src/pages/components/buttons.mdx
+++ b/www/src/pages/components/buttons.mdx
@@ -15,12 +15,10 @@ import ToggleButtonGroupControlled from '../../examples/Button/ToggleButtonGroup
 import ToggleButtonGroupUncontrolled from '../../examples/Button/ToggleButtonGroupUncontrolled';
 import ButtonTypes from '../../examples/Button/Types';
 
-# Buttons
-
-<p className="lead">
-  Custom button styles for actions in forms, dialogs, and more with
-  support for multiple sizes, states, and more.
-</p>
+<PageHeader
+  title="Buttons"
+  subTitle="Use Bootstrap’s custom button styles for actions in forms, dialogs, and more with support for multiple sizes, states, and more."
+/>
 
 ## Examples
 
@@ -30,7 +28,6 @@ button. Just modify the `variant` prop.
 <ReactPlayground codeText={ButtonTypes} />
 
 ### Outline buttons
-
 
 For a lighter touch, Buttons also come in `outline-*`
 variants with no background color.
@@ -57,13 +54,12 @@ Fancy larger or smaller buttons? Add `size="lg"`,
 
 ## Block buttons
 
-Create responsive stacks of full-width, “block buttons” like those in Bootstrap 4 
-with a mix of our display and gap utilities. 
+Create responsive stacks of full-width, “block buttons” like those in Bootstrap 4
+with a mix of our display and gap utilities.
 
 <ReactPlayground codeText={ButtonBlock} />
 
 ## Active state
-
 
 To set a button's active state simply set the component's
 `active` prop.
@@ -104,7 +100,6 @@ button that works neatly inside an HTML form.
 The above handles styling, But requires manually controlling the
 `checked` state for each radio or checkbox in the group.
 
-
 For a nicer experience with checked state management use the
 `<ToggleButtonGroup>` instead of a `<ButtonGroup>` component.
 The group behaves as a form component, where the `value` is an array of the selected
@@ -124,7 +119,6 @@ The group behaves as a form component, where the `value` is an array of the sele
 <ComponentApi metadata={props.data.Button} />
 <ComponentApi metadata={props.data.ToggleButtonGroup} />
 <ComponentApi metadata={props.data.ToggleButton} />
-
 
 export const query = graphql`
   query ButtonQuery {

--- a/www/src/pages/components/cards.mdx
+++ b/www/src/pages/components/cards.mdx
@@ -23,12 +23,11 @@ import CardWithHeader from '../../examples/Card/WithHeader';
 import CardWithHeaderAndQuote from '../../examples/Card/WithHeaderAndQuote';
 import CardWithHeaderStyled from '../../examples/Card/WithHeaderStyled';
 
-# Cards
-
-<p className="lead">
-  Bootstrap’s cards provide a flexible and extensible content container
-  with multiple variants and options.
-</p>
+<PageHeader
+  title="Cards"
+  subTitle="Bootstrap’s cards provide a flexible and extensible content container
+  with multiple variants and options."
+/>
 
 ## Basic Example
 
@@ -142,14 +141,16 @@ Use `Row`'s [grid column](/layout/grid/#row-layout-col-sizing) props to control 
 <ComponentApi metadata={props.data.CardFooter} exportedBy={props.data.Card} />
 <ComponentApi metadata={props.data.CardHeader} exportedBy={props.data.Card} />
 <ComponentApi metadata={props.data.CardImg} exportedBy={props.data.Card} />
-<ComponentApi metadata={props.data.CardImgOverlay} exportedBy={props.data.Card} />
+<ComponentApi
+  metadata={props.data.CardImgOverlay}
+  exportedBy={props.data.Card}
+/>
 <ComponentApi metadata={props.data.CardLink} exportedBy={props.data.Card} />
 <ComponentApi metadata={props.data.CardSubtitle} exportedBy={props.data.Card} />
 <ComponentApi metadata={props.data.CardText} exportedBy={props.data.Card} />
 <ComponentApi metadata={props.data.CardTitle} exportedBy={props.data.Card} />
 
 <ComponentApi metadata={props.data.CardGroup} />
-
 
 export const query = graphql`
   query CardQuery {

--- a/www/src/pages/components/carousel.mdx
+++ b/www/src/pages/components/carousel.mdx
@@ -8,12 +8,11 @@ import CarouselFade from '../../examples/Carousel/CarouselFade';
 import IndividualIntervals from '../../examples/Carousel/IndividualIntervals';
 import DarkVariant from '../../examples/Carousel/DarkVariant';
 
-# Carousels
-
-<p className="lead">
-  A slideshow component for cycling through elements—images or slides of
-  text—like a carousel.
-</p>
+<PageHeader
+  title="Carousels"
+  subTitle="A slideshow component for cycling through elements—images or slides of
+  text—like a carousel."
+/>
 
 ## Example
 

--- a/www/src/pages/components/close-button.mdx
+++ b/www/src/pages/components/close-button.mdx
@@ -7,10 +7,12 @@ import CloseButtonDisabled from '../../examples/CloseButton/Disabled';
 import CloseButtonVariants from '../../examples/CloseButton/Variants';
 import CloseButtonLabelled from '../../examples/CloseButton/Labelled';
 
+<PageHeader
+  title="Close Button"
+  subTitle="A generic close button for dismissing content such as modals and alerts."
+/>
 
-# Close Button
-
-A generic close button for dismissing content such as modals and alerts.
+## Example
 
 <ReactPlayground codeText={CloseButtonBasic} />
 
@@ -30,7 +32,7 @@ Change the default dark color to white using `variant="white"`.
 ## Accessibility
 
 To ensure the maximum accessibility for Close Button components, it is
-recommended that you provide relevant text for screen readers.  The example
+recommended that you provide relevant text for screen readers. The example
 below provides an example of accessible usage of this component by way of the
 `aria-label` property.
 
@@ -39,7 +41,6 @@ below provides an example of accessible usage of this component by way of the
 ## API
 
 <ComponentApi metadata={props.data.metadata} />
-
 
 export const query = graphql`
   query CloseButton {

--- a/www/src/pages/components/dropdowns.mdx
+++ b/www/src/pages/components/dropdowns.mdx
@@ -24,13 +24,11 @@ import AutoClose from '../../examples/Dropdown/AutoClose';
 
 import styles from '../../css/examples.module.scss';
 
-
-# Dropdowns
-
-<p className="lead">
-  Toggle contextual overlays for displaying lists of links and more with
-  the Bootstrap dropdown plugin
-</p>
+<PageHeader
+  title="Dropdowns"
+  subTitle="Toggle contextual overlays for displaying lists of links and more with
+  the Bootstrap dropdown plugin"
+/>
 
 ## Overview
 
@@ -38,7 +36,6 @@ Dropdowns are toggleable, contextual overlays for displaying lists of
 links and more. Like overlays, Dropdowns are built using a third-party
 library <a href="https://popper.js.org/">Popper.js</a>, which provides
 dynamic positioning and viewport detection.
-
 
 ## Accessibility
 
@@ -69,7 +66,6 @@ the `<DropdownButton>` component to help reduce typing. Provide
 a `title` prop and some `<DropdownItem>`s and you're
 ready to go.
 
-
 <ReactPlayground codeText={DropdownBasicButton} />
 
 DropdownButton will forward Button props to the underlying Toggle
@@ -84,7 +80,6 @@ components with another Button and a ButtonGroup.
 
 <ReactPlayground codeText={SplitBasic} />
 
-
 As with DropdownButton, `SplitButton` is provided as
 convenience component.
 
@@ -98,7 +93,7 @@ Dropdowns work with buttons of all sizes.
 
 ## Dark dropdowns
 
-Opt into darker dropdowns to match a dark navbar or custom style by adding 
+Opt into darker dropdowns to match a dark navbar or custom style by adding
 `variant="dark"` onto an existing `DropdownMenu`. Alternatively, use
 `menuVariant="dark"` when using the `DropdownButton` component.
 
@@ -135,15 +130,14 @@ it by passing `align="end"` to a `<Dropdown>`, `<DropdownButton>`, or `<SplitBut
 
 ### Responsive alignment
 
-If you want to use responsive menu alignment, pass an object containing a breakpoint to the 
-`align` prop on the `<DropdownMenu>`, `<DropdownButton>`, or `<SplitButton>`. 
+If you want to use responsive menu alignment, pass an object containing a breakpoint to the
+`align` prop on the `<DropdownMenu>`, `<DropdownButton>`, or `<SplitButton>`.
 You can specify `start` or `end` for the various breakpoints.
 
 <Callout theme="danger" title="Warning">
-  Using responsive alignment will disable Popper usage so any dynamic positioning 
-  features such as <code>flip</code> will not work.
+  Using responsive alignment will disable Popper usage so any dynamic
+  positioning features such as <code>flip</code> will not work.
 </Callout>
-
 
 <ReactPlayground codeText={MenuAlignResponsive} />
 
@@ -171,10 +165,10 @@ By default, the dropdown menu is closed when selecting a menu item or clicking o
 dropdown menu. This behaviour can be changed by using the `autoClose` property.
 
 By default, `autoClose` is set to the default value `true` and behaves like expected. By choosing `false`, the dropdown
-menu can only be toggled by clicking on the dropdown button. `inside` makes the dropdown disappear __only__
-by choosing a menu item and `outside` closes the dropdown menu __only__ by clicking outside.
+menu can only be toggled by clicking on the dropdown button. `inside` makes the dropdown disappear **only**
+by choosing a menu item and `outside` closes the dropdown menu **only** by clicking outside.
 
-__Notice__ how the dropdown is toggled in each scenario by clicking on the button.
+**Notice** how the dropdown is toggled in each scenario by clicking on the button.
 
 <ReactPlayground codeText={AutoClose} />
 
@@ -195,7 +189,7 @@ Menu components
 For those that want to customize everything, you can forgo the included
 Toggle and Menu components, and create your own. By providing custom
 components to the `as` prop, you can control how each
-component behaves. Custom toggle and menu components __must__ be able to accept refs.
+component behaves. Custom toggle and menu components **must** be able to accept refs.
 
 <ReactPlayground codeText={DropdownButtonCustomMenu} />
 
@@ -207,17 +201,28 @@ component behaves. Custom toggle and menu components __must__ be able to accept 
 
 <ComponentApi metadata={props.data.Dropdown} />
 
-<ComponentApi metadata={props.data.DropdownToggle} exportedBy={props.data.Dropdown} />
-
-<ComponentApi metadata={props.data.DropdownMenu} exportedBy={props.data.Dropdown} />
-
-<ComponentApi metadata={props.data.DropdownItem} exportedBy={props.data.Dropdown} />
-<ComponentApi metadata={props.data.DropdownHeader} exportedBy={props.data.Dropdown} />
 <ComponentApi
-metadata={props.data.DropdownDivider}
-exportedBy={props.data.Dropdown}
+  metadata={props.data.DropdownToggle}
+  exportedBy={props.data.Dropdown}
 />
 
+<ComponentApi
+  metadata={props.data.DropdownMenu}
+  exportedBy={props.data.Dropdown}
+/>
+
+<ComponentApi
+  metadata={props.data.DropdownItem}
+  exportedBy={props.data.Dropdown}
+/>
+<ComponentApi
+  metadata={props.data.DropdownHeader}
+  exportedBy={props.data.Dropdown}
+/>
+<ComponentApi
+  metadata={props.data.DropdownDivider}
+  exportedBy={props.data.Dropdown}
+/>
 
 export const query = graphql`
   query DropdownMDXQuery {

--- a/www/src/pages/components/figures.mdx
+++ b/www/src/pages/components/figures.mdx
@@ -4,10 +4,10 @@ import ComponentApi from '../../components/ComponentApi';
 import ReactPlayground from '../../components/ReactPlayground';
 import Figure from '../../examples/Figure';
 
-# Figures
-
-Anytime you need to display a piece of content, like an image with an
-optional caption, consider using a `Figure`.
+<PageHeader
+  title="Figures"
+  subTitle="Documentation and examples for displaying related images and text with the figure component in Bootstrap."
+/>
 
 ## Figure
 

--- a/www/src/pages/components/images.mdx
+++ b/www/src/pages/components/images.mdx
@@ -5,7 +5,10 @@ import ReactPlayground from '../../components/ReactPlayground';
 import Fluid from '../../examples/Image/Fluid';
 import Shape from '../../examples/Image/Shape';
 
-# Images
+<PageHeader
+  title="Images"
+  subTitle="Documentation and examples for opting images into responsive behavior (so they never become wider than their parent) and add lightweight styles to them—all via classes."
+/>
 
 ## Shape
 

--- a/www/src/pages/components/list-group.mdx
+++ b/www/src/pages/components/list-group.mdx
@@ -20,12 +20,11 @@ import ListGroupTabs from '../../examples/ListGroup/Tabs';
 
 import styles from '../../css/examples.module.scss';
 
-# List groups
-
-<p className="lead">
-  List groups are a flexible and powerful component for displaying a series of
-  content. Modify and extend them to support just about any content within.
-</p>
+<PageHeader
+  title="List groups"
+  subTitle="List groups are a flexible and powerful component for displaying a series of
+  content. Modify and extend them to support just about any content within."
+/>
 
 ## Basic Example
 

--- a/www/src/pages/components/modal.mdx
+++ b/www/src/pages/components/modal.mdx
@@ -16,12 +16,11 @@ import ModalFocus from '../../examples/Modal/Focus';
 
 import styles from '../../css/examples.module.scss';
 
-# Modals
-
-<p className="lead">
-  Add dialogs to your site for lightboxes, user notifications, or completely
-  custom content.
-</p>
+<PageHeader
+  title="Modals"
+  subTitle="Add dialogs to your site for lightboxes, user notifications, or completely
+  custom content."
+/>
 
 ## Overview
 

--- a/www/src/pages/components/navbar.mdx
+++ b/www/src/pages/components/navbar.mdx
@@ -15,12 +15,11 @@ import NavbarTextLink from '../../examples/Navbar/TextLink';
 import ContainerOutside from '../../examples/Navbar/ContainerOutside';
 import ContainerInside from '../../examples/Navbar/ContainerInside';
 
-# Navbars
-
-<p className="lead">
-  A powerful, responsive navigation header, the navbar. Includes support for
-  branding, navigation, and more
-</p>
+<PageHeader
+  title="Navbars"
+  subTitle="A powerful, responsive navigation header, the navbar. Includes support for
+  branding, navigation, and more."
+/>
 
 ## Overview
 
@@ -125,8 +124,8 @@ the collapsing behavior by using the `expanded` and
 `onToggle` props.
 
 <Callout theme="warning">
-  Watch out! You <strong>need</strong> to provide a breakpoint value to <code>expand</code> in
-  order for the Navbar to collapse at all.
+  Watch out! You <strong>need</strong> to provide a breakpoint value to{' '}
+  <code>expand</code> in order for the Navbar to collapse at all.
 </Callout>
 
 <ReactPlayground codeText={NavbarCollapsible} />

--- a/www/src/pages/components/navs.mdx
+++ b/www/src/pages/components/navs.mdx
@@ -15,29 +15,12 @@ import NavStacked from '../../examples/Nav/Stacked';
 import Tabs from '../../examples/Nav/Tabs';
 import Pills from '../../examples/Nav/Pills';
 
+<PageHeader
+  title="Navs and tabs"
+  subTitle="Documentation and examples for how to use Bootstrap’s included navigation components."
+/>
 
-export const query = graphql`
-  query NavQuery {
-    Nav: componentMetadata(displayName: { eq: "Nav" }) {
-      displayName
-      ...ComponentApi_metadata
-    }
-    NavItem: componentMetadata(displayName: { eq: "NavItem" }) {
-      displayName
-      ...ComponentApi_metadata
-    }
-    NavLink: componentMetadata(displayName: { eq: "NavLink" }) {
-      displayName
-      ...ComponentApi_metadata
-    }
-    NavDropdown: componentMetadata(displayName: { eq: "NavDropdown" }) {
-      displayName
-      ...ComponentApi_metadata
-    }
-  }
-`;
-
-# Base Nav
+## Base Nav
 
 Navigation bits in Bootstrap all share a general `Nav`
 component and styles. Swap `variant`s to switch between each
@@ -62,7 +45,6 @@ When a `<ul>` is appropriate you can render one via the `as` prop; be sure to
 also set your items to `<li>` as well!
 
 <ReactPlayground codeText={NavList} />
-
 
 ## Alignment and orientation
 
@@ -129,5 +111,25 @@ straight-forward `<NavDropdown>` that works for most cases.
 <ComponentApi metadata={props.data.NavLink} exportedBy={props.data.Nav} />
 <ComponentApi metadata={props.data.NavDropdown} />
 
+export const query = graphql`
+  query NavQuery {
+    Nav: componentMetadata(displayName: { eq: "Nav" }) {
+      displayName
+      ...ComponentApi_metadata
+    }
+    NavItem: componentMetadata(displayName: { eq: "NavItem" }) {
+      displayName
+      ...ComponentApi_metadata
+    }
+    NavLink: componentMetadata(displayName: { eq: "NavLink" }) {
+      displayName
+      ...ComponentApi_metadata
+    }
+    NavDropdown: componentMetadata(displayName: { eq: "NavDropdown" }) {
+      displayName
+      ...ComponentApi_metadata
+    }
+  }
+`;
 
 [0]: https://getbootstrap.com/docs/4.0/layout/grid/#horizontal-alignment

--- a/www/src/pages/components/offcanvas.mdx
+++ b/www/src/pages/components/offcanvas.mdx
@@ -10,12 +10,11 @@ import StaticBackdrop from '../../examples/Offcanvas/StaticBackdrop';
 import Responsive from '../../examples/Offcanvas/Responsive';
 import Placement from '../../examples/Offcanvas/Placement';
 
-# Offcanvas
-
-<p className="lead">
-  Build hidden sidebars into your project for navigation, shopping carts, and
-  more.
-</p>
+<PageHeader
+  title="Offcanvas"
+  subTitle="Build hidden sidebars into your project for navigation, shopping carts, and
+  more."
+/>
 
 ## Examples
 

--- a/www/src/pages/components/overlays.mdx
+++ b/www/src/pages/components/overlays.mdx
@@ -18,12 +18,11 @@ import TooltipPositioned from '../../examples/Overlays/TooltipPositioned';
 
 import styles from '../../css/examples.module.scss';
 
-# Overlays
-
-<p className="lead">
-  A set of components for positioning beautiful overlays, tooltips, popovers,
-  and anything else you need.
-</p>
+<PageHeader
+  title="Overlays"
+  subTitle="A set of components for positioning beautiful overlays, tooltips, popovers,
+  and anything else you need."
+/>
 
 ## Overview
 

--- a/www/src/pages/components/pagination.mdx
+++ b/www/src/pages/components/pagination.mdx
@@ -5,9 +5,12 @@ import ReactPlayground from '../../components/ReactPlayground';
 import PaginationAdvanced from '../../examples/Pagination/Advanced';
 import PaginationBasic from '../../examples/Pagination/Basic';
 
-# Pagination
+<PageHeader
+  title="Pagination"
+  subTitle="A set of presentational components for building pagination UI."
+/>
 
-A set of _presentational_ components for building pagination UI.
+## Example
 
 <ReactPlayground codeText={PaginationBasic} />
 

--- a/www/src/pages/components/placeholder.mdx
+++ b/www/src/pages/components/placeholder.mdx
@@ -11,12 +11,10 @@ import PlaceholderExample from '../../examples/Placeholder/Example';
 import PlaceholderSize from '../../examples/Placeholder/Size';
 import PlaceholderWidth from '../../examples/Placeholder/Width';
 
-# Placeholders
-
-<p className="lead">
-  Use loading placeholders (otherwise known as "skeletons") for your components
-  or pages to indicate something may still be loading
-</p>
+<PageHeader
+  title="Placeholders"
+  subTitle="Use loading placeholders for your components or pages to indicate something may still be loading."
+/>
 
 ## About
 

--- a/www/src/pages/components/progress.mdx
+++ b/www/src/pages/components/progress.mdx
@@ -10,12 +10,11 @@ import ProgressBarStacked from '../../examples/ProgressBar/Stacked';
 import ProgressBarStriped from '../../examples/ProgressBar/Striped';
 import ProgressBarWithLabel from '../../examples/ProgressBar/WithLabel';
 
-# Progress bars
-
-<p className="lead">
-  Provide up-to-date feedback on the progress of a workflow or action with
-  simple yet flexible progress bars.
-</p>
+<PageHeader
+  title="Progress bars"
+  subTitle="Provide up-to-date feedback on the progress of a workflow or action with
+  simple yet flexible progress bars."
+/>
 
 ## Example
 

--- a/www/src/pages/components/spinners.mdx
+++ b/www/src/pages/components/spinners.mdx
@@ -9,10 +9,12 @@ import SpinnerVariants from '../../examples/Spinner/Variants';
 import SpinnerSizes from '../../examples/Spinner/Sizes';
 import SpinnerButtons from '../../examples/Spinner/Buttons';
 
+<PageHeader
+  title="Spinners"
+  subTitle="Spinners can be used to show the loading state in your projects."
+/>
 
-# Spinners
-
-Spinners can be used to show the loading state in your projects.
+## Example
 
 <ReactPlayground codeText={SpinnerBasic} />
 
@@ -63,14 +65,13 @@ spinner's meaning inside the component using Bootstrap's `visually-hidden`
 class.
 
 The example below provides an example of accessible usage of this
- component.
+component.
 
 <ReactPlayground codeText={SpinnerBasic} />
 
 ## API
 
 <ComponentApi metadata={props.data.metadata} />
-
 
 export const query = graphql`
   query Spinner {

--- a/www/src/pages/components/table.mdx
+++ b/www/src/pages/components/table.mdx
@@ -10,7 +10,9 @@ import TableResponsive from '../../examples/Table/Responsive';
 import TableResponsiveBreakpoints from '../../examples/Table/ResponsiveBreakpoints';
 import TableSmall from '../../examples/Table/Small';
 
-# Tables
+<PageHeader title="Tables" />
+
+## Example
 
 Use the `striped`, `bordered` and `hover` props to customise the table.
 

--- a/www/src/pages/components/tabs.mdx
+++ b/www/src/pages/components/tabs.mdx
@@ -8,9 +8,7 @@ import LeftTabs from '../../examples/Tabs/LeftTabs';
 import TabsNoAnimation from '../../examples/Tabs/NoAnimation';
 import TabsUncontrolled from '../../examples/Tabs/Uncontrolled';
 
-# Tabbed components
-
-<p className="lead">Dynamic tabbed interfaces</p>
+<PageHeader title="Tabbed components" subTitle="Dynamic tabbed interfaces" />
 
 ## Examples
 

--- a/www/src/pages/components/toasts.mdx
+++ b/www/src/pages/components/toasts.mdx
@@ -12,11 +12,10 @@ import ToastPlacementMulti from '../../examples/Toast/PlacementMulti';
 import ToastAutohide from '../../examples/Toast/Autohide';
 import ToastContextual from '../../examples/Toast/Contextual';
 
-# Toasts
-
-<p className="lead">
-  Push notifications to your visitors with a toast, a lightweight and easily customizable alert message.
-</p>
+<PageHeader
+  title="Toasts"
+  subTitle="Push notifications to your visitors with a toast, a lightweight and easily customizable alert message."
+/>
 
 Toasts are lightweight notifications designed to mimic the push notifications that have been popularized by mobile and desktop operating systems. They’re built with flexbox, so they’re easy to align and position.
 
@@ -65,8 +64,8 @@ Add any of the below mentioned modifier classes to change the appearance of a to
 ## API
 
 <ComponentApi metadata={props.data.Toast} />
-<ComponentApi metadata={props.data.ToastHeader}/>
-<ComponentApi metadata={props.data.ToastBody}/>
+<ComponentApi metadata={props.data.ToastHeader} />
+<ComponentApi metadata={props.data.ToastBody} />
 <ComponentApi metadata={props.data.ToastContainer} />
 
 export const query = graphql`

--- a/www/src/pages/forms/checks-radios.mdx
+++ b/www/src/pages/forms/checks-radios.mdx
@@ -11,12 +11,11 @@ import CheckReverse from '../../examples/Form/CheckReverse';
 import NoLabels from '../../examples/Form/NoLabels';
 import Switch from '../../examples/Form/Switch';
 
-# Checks and radios
-
-<p className="lead">
-  Create consistent cross-browser and cross-device checkboxes and radios with
-  our completely rewritten checks component.
-</p>
+<PageHeader
+  title="Checks and radios"
+  subTitle="Create consistent cross-browser and cross-device checkboxes and radios with
+  our completely rewritten checks component."
+/>
 
 For the non-textual checkbox and radio controls, `FormCheck`
 provides a single component for both types that adds some additional

--- a/www/src/pages/forms/floating-labels.mdx
+++ b/www/src/pages/forms/floating-labels.mdx
@@ -9,11 +9,10 @@ import FormFloatingLayout from '../../examples/Form/FormFloatingLayout';
 import FormFloatingSelect from '../../examples/Form/FormFloatingSelect';
 import FormFloatingTextarea from '../../examples/Form/FormFloatingTextarea';
 
-# Floating labels
-
-<p className="lead">
-  Create beautifully simple form labels that float over your input fields.
-</p>
+<PageHeader
+  title="Floating labels"
+  subTitle="Create beautifully simple form labels that float over your input fields."
+/>
 
 ## Example
 

--- a/www/src/pages/forms/form-control.mdx
+++ b/www/src/pages/forms/form-control.mdx
@@ -11,13 +11,10 @@ import Plaintext from '../../examples/Form/Plaintext';
 import FormFile from '../../examples/Form/FormFile';
 import ColorPicker from '../../examples/Form/ColorPicker';
 
-# Form controls
-
-<p className="lead">
-  Give textual form controls like <code>{'<input>'}</code>s and{' '}
-  <code>{'<textarea>'}</code>s an upgrade with custom styles, sizing, focus
-  states, and more.
-</p>
+<PageHeader
+  title="Form controls"
+  subTitle="Give textual form controls like <input>s and <textarea>s an upgrade with custom styles, sizing, focus states, and more."
+/>
 
 ## Example
 

--- a/www/src/pages/forms/form-text.mdx
+++ b/www/src/pages/forms/form-text.mdx
@@ -6,9 +6,10 @@ import ReactPlayground from '../../components/ReactPlayground';
 
 import FormText from '../../examples/Form/FormText';
 
-# Form text
-
-<p className="lead">Create block-level or inline-level form text.</p>
+<PageHeader
+  title="Form text"
+  subTitle="Create block-level or inline-level form text."
+/>
 
 ## Overview
 

--- a/www/src/pages/forms/input-group.mdx
+++ b/www/src/pages/forms/input-group.mdx
@@ -11,7 +11,12 @@ import MultipleInputs from '../../examples/InputGroup/MultipleInputs';
 import SegmentedButtonDropdowns from '../../examples/InputGroup/SegmentedButtonDropdowns';
 import Sizes from '../../examples/InputGroup/Sizes';
 
-# InputGroup
+<PageHeader
+  title="InputGroup"
+  subTitle="Easily extend form controls by adding text, buttons, or button groups on either side of textual inputs, custom selects, and custom file inputs."
+/>
+
+## Example
 
 Place one add-on or button on either side of an input. You may also
 place one on both sides of an input. Remember to place

--- a/www/src/pages/forms/layout.mdx
+++ b/www/src/pages/forms/layout.mdx
@@ -12,12 +12,11 @@ import GridColSizes from '../../examples/Form/GridColSizes';
 import GridComplex from '../../examples/Form/GridComplex';
 import Horizontal from '../../examples/Form/Horizontal';
 
-# Layout
-
-<p className="lead">
-  Give your forms some structure—from inline to horizontal to custom grid
-  implementations—with our form layout options.
-</p>
+<PageHeader
+  title="Layout"
+  subTitle="Give your forms some structure—from inline to horizontal to custom grid
+  implementations—with our form layout options."
+/>
 
 ## Forms
 
@@ -91,8 +90,8 @@ like `<Col xs={7}>`.
 
 ## Auto-sizing
 
-The example below uses a flexbox utility to vertically center the contents and 
-changes `<Col>` to `<Col xs="auto">` so that your columns only take up as much 
+The example below uses a flexbox utility to vertically center the contents and
+changes `<Col>` to `<Col xs="auto">` so that your columns only take up as much
 space as needed. Put another way, the column sizes itself based on on the contents.
 
 <ReactPlayground codeText={GridAutoSizing} />

--- a/www/src/pages/forms/overview.mdx
+++ b/www/src/pages/forms/overview.mdx
@@ -7,12 +7,11 @@ import FormBasic from '../../examples/Form/Basic';
 import FormDisabled from '../../examples/Form/FormDisabled';
 import FormDisabledInputs from '../../examples/Form/FormDisabledInputs';
 
-# Forms
-
-<p className="lead">
-  Examples and usage guidelines for form control styles, layout options, and
-  custom components for creating a wide variety of forms.
-</p>
+<PageHeader
+  title="Forms"
+  subTitle="Examples and usage guidelines for form control styles, layout options, and
+  custom components for creating a wide variety of forms."
+/>
 
 ## Overview
 

--- a/www/src/pages/forms/range.mdx
+++ b/www/src/pages/forms/range.mdx
@@ -5,12 +5,10 @@ import ReactPlayground from '../../components/ReactPlayground';
 
 import Range from '../../examples/Form/Range';
 
-# Range
-
-<p className="lead">
-  Use our custom range inputs for consistent cross-browser styling and built-in
-  customization.
-</p>
+<PageHeader
+  title="Range"
+  subTitle="Use our custom range inputs for consistent cross-browser styling and built-in customization."
+/>
 
 ## Overview
 
@@ -36,3 +34,5 @@ export const query = graphql`
     }
   }
 `;
+
+;

--- a/www/src/pages/forms/select.mdx
+++ b/www/src/pages/forms/select.mdx
@@ -6,12 +6,10 @@ import ReactPlayground from '../../components/ReactPlayground';
 import SelectBasic from '../../examples/Form/SelectBasic';
 import SelectSizes from '../../examples/Form/SelectSizes';
 
-# Select
-
-<p className="lead">
-  Customize the native <code>{'<select>'}</code>s with custom CSS that changes
-  the element’s initial appearance.
-</p>
+<PageHeader
+  title="Select"
+  subTitle="Customize the native <select> with custom CSS that changes the element’s initial appearance."
+/>
 
 ## Default
 

--- a/www/src/pages/forms/validation.mdx
+++ b/www/src/pages/forms/validation.mdx
@@ -9,12 +9,11 @@ import ValidationInputGroup from '../../examples/Form/ValidationInputGroup';
 import ValidationNative from '../../examples/Form/ValidationNative';
 import ValidationTooltips from '../../examples/Form/ValidationTooltips';
 
-# Validation
-
-<p className="lead">
-  Provide valuable, actionable feedback to your users with HTML5 form
-  validation, via browser default behaviors or custom styles and JavaScript.
-</p>
+<PageHeader
+  title="Validation"
+  subTitle="Provide valuable, actionable feedback to your users with HTML5 form
+  validation, via browser default behaviors or custom styles and JavaScript."
+/>
 
 ## Native HTML5 form validation
 

--- a/www/src/pages/getting-started/introduction.mdx
+++ b/www/src/pages/getting-started/introduction.mdx
@@ -6,9 +6,10 @@ import DocLink from '../../components/DocLink';
 import ReactPlayground from '../../components/ReactPlayground';
 import AsPropButtonExample from '../../examples/AsProp';
 
-# Introduction
-
-<p className="lead">Learn how to include React Bootstrap in your project</p>
+<PageHeader
+  title="Introduction"
+  subTitle="Learn how to include React Bootstrap in your project."
+/>
 
 ## Installation
 
@@ -65,6 +66,7 @@ stylesheet **is required** to use these components.
 
 import 'bootstrap/dist/css/bootstrap.min.css';
 ```
+
 How and which Bootstrap styles you include is up to you, but the
 simplest way is to include the latest styles from the CDN. A little
 more information about the benefits of using a CDN can be found
@@ -122,15 +124,15 @@ for more advanced use cases and details about customizing stylesheets.
 
 ## "as" Prop API
 
-With certain React-Bootstrap components, you may want to modify the component or HTML tag 
+With certain React-Bootstrap components, you may want to modify the component or HTML tag
 that is rendered.
 
-If you want to keep all the styling of a particular React-Bootstrap component but switch the 
-component that is finally rendered (whether it's a different React-Bootstrap component, a 
+If you want to keep all the styling of a particular React-Bootstrap component but switch the
+component that is finally rendered (whether it's a different React-Bootstrap component, a
 different custom component, or a different HTML tag) you can use the "as" Prop to do so.
 
-The example below passes a Column component to the "as" Prop in a Button component. This 
-ultimately causes a Column component to be rendered but with the same styles as a Button 
+The example below passes a Column component to the "as" Prop in a Button component. This
+ultimately causes a Column component to be rendered but with the same styles as a Button
 component.
 
 <ReactPlayground codeText={AsPropButtonExample} />
@@ -152,6 +154,7 @@ If you would like to add a custom theme on your app using Create React
 App, they have additional documentation for Create React App and
 Bootstrap
 [here](https://facebook.github.io/create-react-app/docs/adding-bootstrap#using-a-custom-theme)
+
 </Callout>
 
 ## Browser support

--- a/www/src/pages/getting-started/rtl.mdx
+++ b/www/src/pages/getting-started/rtl.mdx
@@ -2,7 +2,7 @@ import DocLink from '../../components/DocLink';
 import DismissibleControlled from '../../examples/Alert/DismissibleControlled';
 import ReactPlayground from '../../components/ReactPlayground';
 
-# RTL
+<PageHeader title="RTL" />
 
 We recommend first reading <DocLink path="/getting-started/rtl">Bootstrap's documentation</DocLink>
 to become familiar with how Bootstrap's RTL support works.

--- a/www/src/pages/getting-started/server-side-rendering.mdx
+++ b/www/src/pages/getting-started/server-side-rendering.mdx
@@ -1,6 +1,6 @@
-# Server-side Rendering
+<PageHeader title="Server-side Rendering" />
 
-React-Bootstrap automatically generates an `id` for some 
+React-Bootstrap automatically generates an `id` for some
 components (such as `DropdownToggle`) if they are not provided.
 This is done for accessibility purposes.
 

--- a/www/src/pages/getting-started/support.mdx
+++ b/www/src/pages/getting-started/support.mdx
@@ -1,9 +1,8 @@
-# Getting help
-
-<p className="lead">
-  Stay up to date on the development of React-Bootstrap and reach out to the
-  community with these helpful resources.
-</p>
+<PageHeader
+  title="Getting help"
+  subTitle="Stay up to date on the development of React-Bootstrap and reach out to the
+  community with these helpful resources."
+/>
 
 ## Stack Overflow
 

--- a/www/src/pages/getting-started/theming.mdx
+++ b/www/src/pages/getting-started/theming.mdx
@@ -3,7 +3,7 @@ import ReactPlayground from '../../components/ReactPlayground';
 import Prefixes from '../../examples/Theming/Prefixes';
 import Variants from '../../examples/Theming/Variants';
 
-# Theming and customizing styles
+<PageHeader title="Theming and customizing styles" />
 
 Generally, if you stick to the Bootstrap defined classes and variants,
 there isn't anything you need to do to use a custom theme with

--- a/www/src/pages/getting-started/why-react-bootstrap.mdx
+++ b/www/src/pages/getting-started/why-react-bootstrap.mdx
@@ -1,36 +1,39 @@
 import DismissibleControlled from '../../examples/Alert/DismissibleControlled';
 import ReactPlayground from '../../components/ReactPlayground';
 
-# Why React-Bootstrap?
+<PageHeader title="Why React-Bootstrap?" />
+
 React-Bootstrap is a complete re-implementation of the
 Bootstrap components using React. It has **no dependency
-on either `bootstrap.js` or jQuery.** If you have React 
-setup and React-Bootstrap installed, you have everything 
-you need. 
+on either `bootstrap.js` or jQuery.** If you have React
+setup and React-Bootstrap installed, you have everything
+you need.
 
 Methods and events using jQuery is done imperatively
 by directly manipulating the DOM. In contrast, React
 uses updates to the state to update the virtual DOM.
 In this way, React-Bootstrap provides a more reliable
-solution by incorporating Bootstrap functionality into 
+solution by incorporating Bootstrap functionality into
 React's virtual DOM. Below are a few examples of how
 React-Bootstrap components differ from Bootstrap.
 
 ## A Simple React Component
+
 The CSS and details of Bootstrap components are rather
 opinionated and lengthy. React-Bootstrap simplifies
 this by condensing the original Bootstrap into React-styled
-components. 
+components.
 
 ### Bootstrap
+
 ```
 import * as React from 'react';
 
 function Example()  {
   return (
     <div class="alert alert-danger alert-dismissible fade show" role="alert">
-      <strong>Oh snap! You got an error!</strong> 
-      <p> 
+      <strong>Oh snap! You got an error!</strong>
+      <p>
         Change this and that and try again.
       </p>
       <button type="button" class="close" data-dismiss="alert" aria-label="Close">
@@ -43,6 +46,7 @@ function Example()  {
 ```
 
 ### React-Bootstrap
+
 ```
 import * as React from 'react';
 import Alert from 'react-bootstrap/Alert';
@@ -60,11 +64,12 @@ function Example() {
 ```
 
 ## Bootstrap with state
+
 Since React-Bootstrap is built with React Javascript, state
 can be passed within React-Bootstrap components as a prop.
 It also makes it easier to manage the state as updates are
 made using React’s state instead of directly manipulating
-the state of the DOM. This also gives a lot of flexibility 
+the state of the DOM. This also gives a lot of flexibility
 when creating more complex components.
 
 ### React-bootstrap
@@ -72,11 +77,12 @@ when creating more complex components.
 <ReactPlayground codeText={DismissibleControlled} />
 
 ### Bootstrap
+
 ```
 // HTML
 <div class="alert alert-success alert-dismissible fade show firstCollapsible" role="alert">
-  <strong>How's it going?!</strong> 
-  <p> 
+  <strong>How's it going?!</strong>
+  <p>
     Duis mollis, est non commodo luctus, nisi erat porttitor ligula,
     eget lacinia odio sem nec elit. Cras mattis consectetur purus sit
     amet fermentum.

--- a/www/src/pages/layout/breakpoints.mdx
+++ b/www/src/pages/layout/breakpoints.mdx
@@ -7,12 +7,10 @@ import ComponentApi from '../../components/ComponentApi';
 import CustomBreakpoints from '../../examples/CustomBreakpoints';
 import DocLink from '../../components/DocLink';
 
-# Breakpoints
-
-<p className="lead">
-  Breakpoints are customizable widths that determine how your responsive layout
-  behaves across device or viewport sizes in Bootstrap.
-</p>
+<PageHeader
+  title="Breakpoints"
+  subTitle="Breakpoints are customizable widths that determine how your responsive layout behaves across device or viewport sizes in Bootstrap."
+/>
 
 ## Available breakpoints
 

--- a/www/src/pages/layout/grid.mdx
+++ b/www/src/pages/layout/grid.mdx
@@ -16,7 +16,7 @@ import GridOrderingFirstLast from '../../examples/Grid/OrderingFirstLast';
 import GridResponsive from '../../examples/Grid/Responsive';
 import GridResponsiveAuto from '../../examples/Grid/ResponsiveAuto';
 
-# Grid system
+<PageHeader title="Grid system" />
 
 Bootstrap’s grid system uses a series of containers, rows, and columns
 to layout and align content. It’s built with

--- a/www/src/pages/layout/stack.mdx
+++ b/www/src/pages/layout/stack.mdx
@@ -4,19 +4,17 @@ import Callout from '../../components/Callout';
 import ComponentApi from '../../components/ComponentApi';
 import ReactPlayground from '../../components/ReactPlayground';
 
-import StackButtons from '../../examples/Stack/Buttons'
-import StackForm from '../../examples/Stack/Form'
+import StackButtons from '../../examples/Stack/Buttons';
+import StackForm from '../../examples/Stack/Form';
 import StackHorizontal from '../../examples/Stack/Horizontal';
 import StackHorizontalMarginStart from '../../examples/Stack/HorizontalMarginStart';
 import StackHorizontalVerticalRules from '../../examples/Stack/HorizontalVerticalRules';
 import StackVertical from '../../examples/Stack/Vertical';
 
-# Stacks
-
-<p className="lead">
-  Shorthand helpers that build on top of our flexbox utilities to make component
-  layout faster and easier than ever.
-</p>
+<PageHeader
+  title="Stacks"
+  subTitle="Shorthand helpers that build on top of our flexbox utilities to make component layout faster and easier than ever."
+/>
 
 ## Vertical
 

--- a/www/src/pages/migrating.mdx
+++ b/www/src/pages/migrating.mdx
@@ -1,4 +1,4 @@
-# Migrating to v2
+<PageHeader title="Migrating to v2" />
 
 React-Bootstrap v2 adds full compatibility with Bootstrap 5. Because Bootstrap 5 is a major rewrite of the project, there
 are significant breaking changes from React-Bootstrap v1.
@@ -40,6 +40,7 @@ Below is a _rough_ account of the breaking API changes as well as the minimal ch
 - `useAccordionToggle` has been renamed to `useAccordionButton`.
 
 ### Badge
+
 - `variant` has been renamed to `bg`.
 
 ### ButtonGroup
@@ -61,11 +62,13 @@ Below is a _rough_ account of the breaking API changes as well as the minimal ch
 - When using objects in breakpoint props, `span` is no longer `true` by default.
 
 ### Dropdown
+
 - dropdown dividers use `hr` by default instead of `div`.
 - Alignment values `left` and `right` changed to `start` and `end` respectively.
 - Removed `alignRight`. Use `align="end"` instead.
 
 ### DropdownButton
+
 - Removed `menuAlign` prop in favor of `align`.
 
 ### DropdownItem
@@ -73,6 +76,7 @@ Below is a _rough_ account of the breaking API changes as well as the minimal ch
 - removed `onSelect`. Use `onSelect` in the parent `Dropdown` instead.
 
 ### DropdownMenu
+
 - Removed `alignRight`. Use `align="end"` instead.
 
 ### Form
@@ -109,9 +113,9 @@ Below is a _rough_ account of the breaking API changes as well as the minimal ch
 
 ### FormGroup
 
-- removed `bsPrefix`. The `.form-group` class is no longer supported in Bootstrap, 
-but this component is useful for passing `controlId` to labels and inputs. To handle
-spacing, use margin utilities instead.
+- removed `bsPrefix`. The `.form-group` class is no longer supported in Bootstrap,
+  but this component is useful for passing `controlId` to labels and inputs. To handle
+  spacing, use margin utilities instead.
 
 ### FormRow
 
@@ -152,7 +156,7 @@ spacing, use margin utilities instead.
 
 ### SplitButton
 
-- Removed `menuAlign` prop in favor of `align`. 
+- Removed `menuAlign` prop in favor of `align`.
 
 ### Toast
 

--- a/www/src/pages/utilities/ratio.mdx
+++ b/www/src/pages/utilities/ratio.mdx
@@ -8,13 +8,11 @@ import RatioExample from '../../examples/Ratio/Example';
 
 import styles from '../../css/examples.module.scss';
 
-# Ratios
-
-<p className="lead">
-  Use generated pseudo elements to make an element maintain the aspect ratio of
-  your choosing. Perfect for responsively handling video or slideshow embeds
-  based on the width of the parent.
-</p>
+<PageHeader
+  title="Ratios"
+  subTitle="Use generated pseudo elements to make an element maintain the aspect ratio of your choosing. Perfect for responsively handling video or slideshow embeds
+  based on the width of the parent."
+/>
 
 ## About
 
@@ -41,7 +39,7 @@ values are provided:
 
 ## Custom
 
-Create custom aspect ratios by passing a number to `aspectRatio` instead of using the above 
+Create custom aspect ratios by passing a number to `aspectRatio` instead of using the above
 pre-defined values. You can use either a fraction or percentage to define the custom ratio.
 
 <ReactPlayground

--- a/www/src/pages/utilities/restart-ui.mdx
+++ b/www/src/pages/utilities/restart-ui.mdx
@@ -1,12 +1,11 @@
-# @restart/ui
-
-<p className="lead">
-  Low-level components and utilities for building beautiful accessible
-  components
-</p>
+<PageHeader
+  title="@restart/ui"
+  subTitle="Low-level components and utilities for building beautiful accessible
+  components"
+/>
 
 Often times you may need a more generic or low-level version of a
 Bootstrap component. Many of the `react-bootstrap` components
-are built on top of components from [@restart/ui](https://github.com/react-restart/ui). 
+are built on top of components from [@restart/ui](https://github.com/react-restart/ui).
 If you find yourself at the limit of a Bootstrap component, consider using
 the `@restart/ui` base component directly.

--- a/www/src/pages/utilities/transitions.mdx
+++ b/www/src/pages/utilities/transitions.mdx
@@ -5,17 +5,17 @@ import ComponentApi from '../../components/ComponentApi';
 import ReactPlayground from '../../components/ReactPlayground';
 
 import Collapse from '../../examples/Collapse';
-import CollapseHorizontal from '../../examples/CollapseHorizontal'
+import CollapseHorizontal from '../../examples/CollapseHorizontal';
 import Fade from '../../examples/Fade';
 
-# Transitions
+<PageHeader title="Transitions" />
 
 Bootstrap includes a few general use CSS transitions that can be applied
 to a number of components. React Bootstrap, bundles them up into a few composable
 `<Transition>` components from [react-transition-group][1], a commonly used animation wrapper for React.
 
-Encapsulating animations into components has the added benefit of making them  more broadly useful,
-as well as portable for using in other libraries.  All React-bootstrap components that can be animated, support pluggable
+Encapsulating animations into components has the added benefit of making them more broadly useful,
+as well as portable for using in other libraries. All React-bootstrap components that can be animated, support pluggable
 `<Transition>` components.
 
 ## Collapse
@@ -25,12 +25,11 @@ as well as portable for using in other libraries.  All React-bootstrap component
 Add a collapse toggle animation to an element or component.
 
 <Callout title="Smooth animations">
-  If you're noticing choppy animations, and the component that's being
-  collapsed has non-zero margin or padding, try wrapping the contents of
-  your <code>{'<Collapse>'}</code> inside a node with no margin or
-  padding, like the <code>{'<div>'}</code> in the example below. This will
-  allow the height to be computed properly, so the animation can proceed
-  smoothly.
+  If you're noticing choppy animations, and the component that's being collapsed
+  has non-zero margin or padding, try wrapping the contents of your{' '}
+  <code>{'<Collapse>'}</code> inside a node with no margin or padding, like the{' '}
+  <code>{'<div>'}</code> in the example below. This will allow the height to be
+  computed properly, so the animation can proceed smoothly.
 </Callout>
 
 <ReactPlayground codeText={Collapse} />
@@ -40,12 +39,11 @@ Add a collapse toggle animation to an element or component.
 Add a collapse toggle animation to an element or component to transition the width instead of height.
 
 <Callout title="Smooth animations">
-  If you're noticing choppy animations, and the component that's being
-  collapsed has non-zero margin or padding, try wrapping the contents of
-  your <code>{'<Collapse>'}</code> inside a node with no margin or
-  padding, like the <code>{'<div>'}</code> in the example below. This will
-  allow the height to be computed properly, so the animation can proceed
-  smoothly.
+  If you're noticing choppy animations, and the component that's being collapsed
+  has non-zero margin or padding, try wrapping the contents of your{' '}
+  <code>{'<Collapse>'}</code> inside a node with no margin or padding, like the{' '}
+  <code>{'<div>'}</code> in the example below. This will allow the height to be
+  computed properly, so the animation can proceed smoothly.
 </Callout>
 
 <ReactPlayground codeText={CollapseHorizontal} />

--- a/www/src/wrap-page.js
+++ b/www/src/wrap-page.js
@@ -7,6 +7,7 @@ const { MDXProvider } = require('@mdx-js/react');
 const Heading = require('./components/Heading');
 const CodeBlock = require('./components/CodeBlock');
 const LinkedHeading = require('./components/LinkedHeading');
+const PageHeader = require('./components/PageHeader');
 
 const getMode = (className = '') => {
   const [, mode] = className.match(/language-(\w+)/) || [];
@@ -29,6 +30,7 @@ const components = {
     ) : (
       <pre {...props} />
     ),
+  PageHeader,
 };
 
 module.exports = ({ element }) => (


### PR DESCRIPTION
Closes #6369

Moves the ads from side nav over to the page below the lead.