### PR TITLE
docs: fix sidenav padding

### DIFF
--- a/www/src/components/SideNav.js
+++ b/www/src/components/SideNav.js
@@ -49,16 +49,17 @@ const OverflowWrapper = styled('div')`
   }
 `;
 
-const TableOfContents = styled('nav')`
+const TableOfContents = styled(Nav)`
   @import '../css/theme';
 
-  composes: pt-2 pb-4 from global;
+  composes: pt-2 pb-4 flex-column from global;
 
   @include media-breakpoint-up(md) {
     height: 100% !important;
     overflow: auto;
     margin-right: -15px;
     padding-right: calc(15px + 1rem);
+    flex-wrap: nowrap;
   }
 `;
 


### PR DESCRIPTION
The padding disappeared with BS 5.2 due to padding css vars being defined in `.nav`