### PR TITLE
Dropdown flip changes

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -35,7 +35,6 @@ export interface DropdownProps
     Omit<React.HTMLAttributes<HTMLElement>, 'onSelect' | 'children'> {
   drop?: DropDirection;
   align?: AlignType;
-  flip?: boolean;
   focusFirstItemOnShow?: boolean | 'keyboard';
   navbar?: boolean;
   autoClose?: boolean | 'outside' | 'inside';
@@ -68,13 +67,6 @@ const propTypes = {
    * @controllable onToggle
    */
   show: PropTypes.bool,
-
-  /**
-   * Allow Dropdown to flip in case of an overlapping on the reference element. For more information refer to
-   * Popper.js's flip [docs](https://popper.js.org/docs/v2/modifiers/flip/).
-   *
-   */
-  flip: PropTypes.bool,
 
   /**
    * A callback fired when the Dropdown wishes to change visibility. Called with the requested

--- a/src/DropdownButton.tsx
+++ b/src/DropdownButton.tsx
@@ -16,6 +16,7 @@ export interface DropdownButtonProps
   renderMenuOnMount?: boolean;
   rootCloseEvent?: 'click' | 'mousedown';
   menuVariant?: DropdownMenuVariant;
+  flip?: boolean;
 }
 
 const propTypes = {
@@ -66,6 +67,13 @@ const propTypes = {
    */
   menuVariant: PropTypes.oneOf<DropdownMenuVariant>(['dark']),
 
+  /**
+   * Allow Dropdown to flip in case of an overlapping on the reference element. For more information refer to
+   * Popper.js's flip [docs](https://popper.js.org/docs/v2/modifiers/flip/).
+   *
+   */
+  flip: PropTypes.bool,
+
   /** @ignore */
   bsPrefix: PropTypes.string,
   /** @ignore */
@@ -101,6 +109,7 @@ const DropdownButton: BsPrefixRefForwardingComponent<
       href,
       id,
       menuVariant,
+      flip,
       ...props
     },
     ref,
@@ -121,6 +130,7 @@ const DropdownButton: BsPrefixRefForwardingComponent<
         renderOnMount={renderMenuOnMount}
         rootCloseEvent={rootCloseEvent}
         variant={menuVariant}
+        flip={flip}
       >
         {children}
       </DropdownMenu>

--- a/src/SplitButton.tsx
+++ b/src/SplitButton.tsx
@@ -19,6 +19,7 @@ export interface SplitButtonProps
   title: React.ReactNode;
   toggleLabel?: string;
   type?: ButtonType;
+  flip?: boolean;
 }
 
 const propTypes = {
@@ -74,6 +75,13 @@ const propTypes = {
    */
   rootCloseEvent: PropTypes.string,
 
+  /**
+   * Allow Dropdown to flip in case of an overlapping on the reference element. For more information refer to
+   * Popper.js's flip [docs](https://popper.js.org/docs/v2/modifiers/flip/).
+   *
+   */
+  flip: PropTypes.bool,
+
   /** @ignore */
   bsPrefix: PropTypes.string,
   /** @ignore */
@@ -114,6 +122,7 @@ const SplitButton = React.forwardRef<HTMLElement, SplitButtonProps>(
       menuRole,
       renderMenuOnMount,
       rootCloseEvent,
+      flip,
       ...props
     },
     ref,
@@ -146,6 +155,7 @@ const SplitButton = React.forwardRef<HTMLElement, SplitButtonProps>(
         role={menuRole}
         renderOnMount={renderMenuOnMount}
         rootCloseEvent={rootCloseEvent}
+        flip={flip}
       >
         {children}
       </Dropdown.Menu>


### PR DESCRIPTION
Closes #3589

Adds `flip` prop to `SplitButton` and `DropdownButton`.  Removes `flip` prop from `Dropdown`.