### PR TITLE
Added a note in the documentation for OverlayTrigger

### DIFF
--- a/src/OverlayTrigger.tsx
+++ b/src/OverlayTrigger.tsx
@@ -74,8 +74,6 @@ const propTypes = {
   /**
    * Specify which action or actions trigger Overlay visibility
    *
-   * The `click` trigger ignores the configured `delay`.
-   *
    * @type {'hover' | 'click' |'focus' | Array<'hover' | 'click' |'focus'>}
    */
   trigger: PropTypes.oneOfType([triggerType, PropTypes.arrayOf(triggerType)]),

--- a/src/OverlayTrigger.tsx
+++ b/src/OverlayTrigger.tsx
@@ -74,6 +74,8 @@ const propTypes = {
   /**
    * Specify which action or actions trigger Overlay visibility
    *
+   * The `click` trigger ignores the configured `delay`.
+   *
    * @type {'hover' | 'click' |'focus' | Array<'hover' | 'click' |'focus'>}
    */
   trigger: PropTypes.oneOfType([triggerType, PropTypes.arrayOf(triggerType)]),

--- a/src/OverlayTrigger.tsx
+++ b/src/OverlayTrigger.tsx
@@ -250,7 +250,6 @@ function OverlayTrigger({
   const handleClick = useCallback(
     (...args: any[]) => {
       setShow(!show);
-      if (delay.hide) handleHide();
       onClick?.(...args);
     },
     [onClick, setShow, show],


### PR DESCRIPTION
Regarding this issue: https://github.com/react-bootstrap/react-bootstrap/issues/6288

Added a note to the documentation for `OverlayTrigger` that the `click` trigger ignores the `delay` to avoid this confusion. 
