### PR TITLE
feat(types): Allow fill and justify settings for tabs

### DIFF
--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import { useUncontrolled } from 'uncontrollable';
 import BaseTabs, { TabsProps as BaseTabsProps } from '@restart/ui/Tabs';
-import Nav from './Nav';
+import Nav, { NavProps } from './Nav';
 import NavLink from './NavLink';
 import NavItem from './NavItem';
 import TabContent from './TabContent';
@@ -14,7 +14,8 @@ import { TransitionType } from './helpers';
 
 export interface TabsProps
   extends Omit<BaseTabsProps, 'transition'>,
-    Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'> {
+    Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'>,
+    NavProps {
   variant?: 'tabs' | 'pills';
   transition?: TransitionType;
 }
@@ -82,6 +83,16 @@ const propTypes = {
    * Unmount tabs (remove it from the DOM) when it is no longer visible
    */
   unmountOnExit: PropTypes.bool,
+
+  /**
+   * Have all `Tabs`s proportionately fill all available width.
+   */
+  fill: PropTypes.bool,
+
+  /**
+   * Have all `Tab`s evenly fill all available width.
+   */
+  justify: PropTypes.bool,
 };
 
 const defaultProps = {

--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -16,7 +16,6 @@ export interface TabsProps
   extends Omit<BaseTabsProps, 'transition'>,
     Omit<React.HTMLAttributes<HTMLElement>, 'onSelect'>,
     NavProps {
-  variant?: 'tabs' | 'pills';
   transition?: TransitionType;
 }
 

--- a/test/TabsSpec.tsx
+++ b/test/TabsSpec.tsx
@@ -218,6 +218,36 @@ describe('<Tabs>', () => {
     firstTabContent.classList.contains('fade').should.be.false;
     secondTabContent.classList.contains('fade').should.be.true;
   });
+
+  it('Should pass fill to Nav', () => {
+    const { getByTestId } = render(
+      <Tabs data-testid="test" defaultActiveKey={1} transition={false} fill>
+        <Tab title="Tab 1" eventKey={1}>
+          Tab 1 content
+        </Tab>
+        <Tab title="Tab 2" eventKey={2}>
+          Tab 2 content
+        </Tab>
+      </Tabs>,
+    );
+
+    getByTestId('test').classList.contains('nav-fill').should.be.true;
+  });
+
+  it('Should pass justified to Nav', () => {
+    const { getByTestId } = render(
+      <Tabs data-testid="test" defaultActiveKey={1} transition={false} justify>
+        <Tab title="Tab 1" eventKey={1}>
+          Tab 1 content
+        </Tab>
+        <Tab title="Tab 2" eventKey={2}>
+          Tab 2 content
+        </Tab>
+      </Tabs>,
+    );
+
+    getByTestId('test').classList.contains('nav-justified').should.be.true;
+  });
 });
 
 // describe('<Tab>', () => {

--- a/www/src/examples/Tabs/Fill.js
+++ b/www/src/examples/Tabs/Fill.js
@@ -1,0 +1,30 @@
+import Tab from 'react-bootstrap/Tab';
+import Tabs from 'react-bootstrap/Tabs';
+
+import Sonnet from '../../components/Sonnet';
+
+function FillExample() {
+  return (
+    <Tabs
+      defaultActiveKey="profile"
+      id="fill-tab-example"
+      className="mb-3"
+      fill
+    >
+      <Tab eventKey="home" title="Home">
+        <Sonnet />
+      </Tab>
+      <Tab eventKey="profile" title="Profile">
+        <Sonnet />
+      </Tab>
+      <Tab eventKey="longer-tab" title="Loooonger Tab">
+        <Sonnet />
+      </Tab>
+      <Tab eventKey="contact" title="Contact" disabled>
+        <Sonnet />
+      </Tab>
+    </Tabs>
+  );
+}
+
+export default FillExample;

--- a/www/src/examples/Tabs/Justified.js
+++ b/www/src/examples/Tabs/Justified.js
@@ -1,0 +1,30 @@
+import Tab from 'react-bootstrap/Tab';
+import Tabs from 'react-bootstrap/Tabs';
+
+import Sonnet from '../../components/Sonnet';
+
+function JustifiedExample() {
+  return (
+    <Tabs
+      defaultActiveKey="profile"
+      id="justify-tab-example"
+      className="mb-3"
+      justify
+    >
+      <Tab eventKey="home" title="Home">
+        <Sonnet />
+      </Tab>
+      <Tab eventKey="profile" title="Profile">
+        <Sonnet />
+      </Tab>
+      <Tab eventKey="longer-tab" title="Loooonger Tab">
+        <Sonnet />
+      </Tab>
+      <Tab eventKey="contact" title="Contact" disabled>
+        <Sonnet />
+      </Tab>
+    </Tabs>
+  );
+}
+
+export default JustifiedExample;

--- a/www/src/pages/components/tabs.mdx
+++ b/www/src/pages/components/tabs.mdx
@@ -42,7 +42,7 @@ Set the `transition` prop to `false`.
 
 ## Fill and justify
 
-Similar to the `Navs` component, you can force the contents of your `Tabs` to extend the full available width. To
+Similar to the `Nav` component, you can force the contents of your `Tabs` to extend the full available width. To
 proportionately fill the space use `fill`. Notice that the
 `Tabs` is the entire width but each `Tab` item is a different size.
 

--- a/www/src/pages/components/tabs.mdx
+++ b/www/src/pages/components/tabs.mdx
@@ -7,6 +7,8 @@ import TabsControlled from '../../examples/Tabs/Controlled';
 import LeftTabs from '../../examples/Tabs/LeftTabs';
 import TabsNoAnimation from '../../examples/Tabs/NoAnimation';
 import TabsUncontrolled from '../../examples/Tabs/Uncontrolled';
+import TabsFill from '../../examples/Tabs/Fill';
+import TabsJustified from '../../examples/Tabs/Justified';
 
 <PageHeader title="Tabbed components" subTitle="Dynamic tabbed interfaces" />
 
@@ -37,6 +39,18 @@ Set the `transition` prop to `false`.
   codeText={TabsNoAnimation}
   exampleClassName="bs-example-tabs"
 />
+
+## Fill and justify
+
+Similar to the `Navs` component, you can force the contents of your `Tabs` to extend the full available width. To
+proportionately fill the space use `fill`. Notice that the
+`Tabs` is the entire width but each `Tab` item is a different size.
+
+<ReactPlayground codeText={TabsFill} />
+
+If you want each `Tab` to be the same size use `justify`.
+
+<ReactPlayground codeText={TabsJustified} />
 
 ## Dropdowns?
 


### PR DESCRIPTION
Allows the `fill` and `justify` props to be passed to `<Tabs>`

resolves: #6382 