### PR TITLE
docs: fix custom tabs example

### DIFF
--- a/www/src/examples/Tabs/LeftTabs.js
+++ b/www/src/examples/Tabs/LeftTabs.js
@@ -12,10 +12,14 @@ function LeftTabsExample() {
         <Col sm={3}>
           <Nav variant="pills" className="flex-column">
             <Nav.Item>
-              <Nav.Link eventKey="first">Tab 1</Nav.Link>
+              <Nav.Link eventKey="first" href="#">
+                Tab 1
+              </Nav.Link>
             </Nav.Item>
             <Nav.Item>
-              <Nav.Link eventKey="second">Tab 2</Nav.Link>
+              <Nav.Link eventKey="second" href="#">
+                Tab 2
+              </Nav.Link>
             </Nav.Item>
           </Nav>
         </Col>


### PR DESCRIPTION
Closes #6393

Fixes keyboard behavior by adding `href="#"` to the anchors