### PR TITLE
docs: adds Carousel no transition example

### DIFF
--- a/www/src/examples/Carousel/NoTransition.js
+++ b/www/src/examples/Carousel/NoTransition.js
@@ -1,0 +1,47 @@
+import Carousel from 'react-bootstrap/Carousel';
+
+function NoTransitionExample() {
+  return (
+    <Carousel slide={false}>
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=First slide&bg=373940"
+          alt="First slide"
+        />
+        <Carousel.Caption>
+          <h3>First slide label</h3>
+          <p>Nulla vitae elit libero, a pharetra augue mollis interdum.</p>
+        </Carousel.Caption>
+      </Carousel.Item>
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=Second slide&bg=282c34"
+          alt="Second slide"
+        />
+
+        <Carousel.Caption>
+          <h3>Second slide label</h3>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        </Carousel.Caption>
+      </Carousel.Item>
+      <Carousel.Item>
+        <img
+          className="d-block w-100"
+          src="holder.js/800x400?text=Third slide&bg=20232a"
+          alt="Third slide"
+        />
+
+        <Carousel.Caption>
+          <h3>Third slide label</h3>
+          <p>
+            Praesent commodo cursus magna, vel scelerisque nisl consectetur.
+          </p>
+        </Carousel.Caption>
+      </Carousel.Item>
+    </Carousel>
+  );
+}
+
+export default NoTransitionExample;

--- a/www/src/pages/components/carousel.mdx
+++ b/www/src/pages/components/carousel.mdx
@@ -7,6 +7,7 @@ import CarouselUncontrolled from '../../examples/Carousel/Uncontrolled';
 import CarouselFade from '../../examples/Carousel/CarouselFade';
 import IndividualIntervals from '../../examples/Carousel/IndividualIntervals';
 import DarkVariant from '../../examples/Carousel/DarkVariant';
+import NoTransition from '../../examples/Carousel/NoTransition';
 
 <PageHeader
   title="Carousels"
@@ -36,6 +37,12 @@ You can also _control_ the Carousel state, via the
 Add the `fade` prop to your carousel to animate slides with a fade transition instead of a slide.
 
 <ReactPlayground codeText={CarouselFade} />
+
+## No transation animation
+
+Set the `slide` prop to false to disable the transation animation between slides.
+
+<ReactPlayground codeText={NoTransition} />
 
 ## Individual Item Intervals
 

--- a/www/src/pages/components/carousel.mdx
+++ b/www/src/pages/components/carousel.mdx
@@ -38,9 +38,9 @@ Add the `fade` prop to your carousel to animate slides with a fade transition in
 
 <ReactPlayground codeText={CarouselFade} />
 
-## No transation animation
+## No transition animation
 
-Set the `slide` prop to false to disable the transation animation between slides.
+Set the `slide` prop to false to disable the transition animation between slides.
 
 <ReactPlayground codeText={NoTransition} />
 


### PR DESCRIPTION
Ref: #6266 

Adds a `No animation transition` carousel example to the docs.