### PR TITLE
Accordion additional event oncomplete and additional properties for onselect

### DIFF
--- a/src/Accordion.tsx
+++ b/src/Accordion.tsx
@@ -10,6 +10,7 @@ import AccordionCollapse from './AccordionCollapse';
 import AccordionContext, {
   AccordionSelectCallback,
   AccordionEventKey,
+  AccordionCompleteCallback,
 } from './AccordionContext';
 import AccordionHeader from './AccordionHeader';
 import AccordionItem from './AccordionItem';
@@ -23,6 +24,7 @@ export interface AccordionProps
   onSelect?: AccordionSelectCallback;
   flush?: boolean;
   alwaysOpen?: boolean;
+  onComplete?: AccordionCompleteCallback;
 }
 
 const propTypes = {
@@ -56,6 +58,7 @@ const Accordion: BsPrefixRefForwardingComponent<'div', AccordionProps> =
       onSelect,
       flush,
       alwaysOpen,
+      onComplete,
       ...controlledProps
     } = useUncontrolled(props, {
       activeKey: 'onSelect',
@@ -67,8 +70,9 @@ const Accordion: BsPrefixRefForwardingComponent<'div', AccordionProps> =
         activeEventKey: activeKey,
         onSelect,
         alwaysOpen,
+        onComplete,
       }),
-      [activeKey, onSelect, alwaysOpen],
+      [activeKey, onSelect, alwaysOpen, onComplete],
     );
 
     return (

--- a/src/AccordionButton.tsx
+++ b/src/AccordionButton.tsx
@@ -38,22 +38,27 @@ export function useAccordionButton(
       Compare the event key in context with the given event key.
       If they are the same, then collapse the component.
     */
+    const currentKey = eventKey;
+    let isExpanded = false;
     let eventKeyPassed: AccordionEventKey =
       eventKey === activeEventKey ? null : eventKey;
+    if (eventKeyPassed && !alwaysOpen) {
+      isExpanded = true;
+    }
     if (alwaysOpen) {
       if (Array.isArray(activeEventKey)) {
         if (activeEventKey.includes(eventKey)) {
           eventKeyPassed = activeEventKey.filter((k) => k !== eventKey);
         } else {
+          isExpanded = true;
           eventKeyPassed = [...activeEventKey, eventKey];
         }
       } else {
-        // activeEventKey is undefined.
         eventKeyPassed = [eventKey];
       }
     }
 
-    onSelect?.(eventKeyPassed, e);
+    onSelect?.(eventKeyPassed, e, currentKey, isExpanded);
     onClick?.(e);
   };
 }

--- a/src/AccordionCollapse.tsx
+++ b/src/AccordionCollapse.tsx
@@ -40,13 +40,22 @@ const AccordionCollapse: BsPrefixRefForwardingComponent<
     },
     ref,
   ) => {
-    const { activeEventKey } = useContext(AccordionContext);
+    const { activeEventKey, onComplete } = useContext(AccordionContext);
     bsPrefix = useBootstrapPrefix(bsPrefix, 'accordion-collapse');
 
+    const onCollapseComplete = () => {
+      onComplete?.(
+        activeEventKey,
+        eventKey,
+        isAccordionItemSelected(activeEventKey, eventKey),
+      );
+    };
     return (
       <Collapse
         ref={ref}
         in={isAccordionItemSelected(activeEventKey, eventKey)}
+        onEntered={onCollapseComplete}
+        onExited={onCollapseComplete}
         {...props}
         className={classNames(className, bsPrefix)}
       >

--- a/src/AccordionContext.ts
+++ b/src/AccordionContext.ts
@@ -5,12 +5,21 @@ export type AccordionEventKey = string | string[] | null | undefined;
 export declare type AccordionSelectCallback = (
   eventKey: AccordionEventKey,
   e: React.SyntheticEvent<unknown>,
+  currentEventKey: AccordionEventKey,
+  isExpanded?: boolean,
+) => void;
+
+export declare type AccordionCompleteCallback = (
+  eventKey: AccordionEventKey,
+  currentEventKey: AccordionEventKey,
+  isExpanded?: boolean,
 ) => void;
 
 export interface AccordionContextValue {
   activeEventKey?: AccordionEventKey;
   onSelect?: AccordionSelectCallback;
   alwaysOpen?: boolean;
+  onComplete?: AccordionCompleteCallback;
 }
 
 export function isAccordionItemSelected(


### PR DESCRIPTION
Accordion additional event oncomplete and additional properties for onselect

- OnComplete will be fired after collapse or expand completes
- OnSelect will have additional two properties which is currentkey and IsExpanded. currentkey is to know which key has been clicked and IsExpanded is to know the current operation without doing any additional operation