### PR TITLE
docs: add missing Accordion and AccordionCollapse props

### DIFF
--- a/src/Accordion.tsx
+++ b/src/Accordion.tsx
@@ -38,6 +38,17 @@ const propTypes = {
   /** The default active key that is expanded on start */
   defaultActiveKey: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
 
+  /**
+   * Callback fired when the active item changes.
+   *
+   * ```js
+   * (eventKey: string | string[] | null, event: Object) => void
+   * ```
+   *
+   * @controllable activeIndex
+   */
+  onSelect: PropTypes.func,
+
   /** Renders accordion edge-to-edge with its parent container */
   flush: PropTypes.bool,
 

--- a/src/AccordionCollapse.tsx
+++ b/src/AccordionCollapse.tsx
@@ -25,6 +25,9 @@ const propTypes = {
   children: PropTypes.element.isRequired,
 };
 
+/**
+ * This component accepts all of [`Collapse`'s props](/utilities/transitions/#collapse-props).
+ */
 const AccordionCollapse: BsPrefixRefForwardingComponent<
   'div',
   AccordionCollapseProps


### PR DESCRIPTION
Addresses missing parts of docs from #6400