### PR TITLE
docs: fix typo in grid.mdx

### DIFF
--- a/www/src/pages/layout/grid.mdx
+++ b/www/src/pages/layout/grid.mdx
@@ -123,7 +123,7 @@ widths.
 
 Note that `Row` column widths will override `Col` widths
 set on lower breakpoints when viewed on larger screens. The
-`<Col xs={6} />` size will be overriden by `<Row md={4} />`
+`<Col xs={6} />` size will be overridden by `<Row md={4} />`
 on medium and larger screens.
 
 <ReactPlayground


### PR DESCRIPTION
overriden -> overridden