### PR TITLE
Docs: Added Example For React Bootstrap Component in As Prop API

### DIFF
--- a/www/src/examples/AsPropAccordion.js
+++ b/www/src/examples/AsPropAccordion.js
@@ -1,0 +1,14 @@
+<div>
+  <h1>
+    Example heading{' '}
+    <Badge bg="secondary" as="Button">
+      New
+    </Badge>
+  </h1>
+  <h2>
+    Example heading{' '}
+    <Button bg="secondary" as="Badge">
+      New
+    </Button>
+  </h2>
+</div>;

--- a/www/src/examples/AsPropComponent.js
+++ b/www/src/examples/AsPropComponent.js
@@ -5,10 +5,4 @@
       New
     </Badge>
   </h1>
-  <h2>
-    Example heading{' '}
-    <Button bg="secondary" as="Badge">
-      New
-    </Button>
-  </h2>
 </div>;

--- a/www/src/pages/getting-started/introduction.mdx
+++ b/www/src/pages/getting-started/introduction.mdx
@@ -5,7 +5,7 @@ import CssCodeBlock from '../../components/CssCodeBlock';
 import DocLink from '../../components/DocLink';
 import ReactPlayground from '../../components/ReactPlayground';
 import AsPropButtonExample from '../../examples/AsProp';
-import AsPropAccordionExample from '../../examples/AsPropAccordion';
+import AsPropAccordionExample from '../../examples/AsPropComponent';
 
 <PageHeader
   title="Introduction"

--- a/www/src/pages/getting-started/introduction.mdx
+++ b/www/src/pages/getting-started/introduction.mdx
@@ -5,6 +5,7 @@ import CssCodeBlock from '../../components/CssCodeBlock';
 import DocLink from '../../components/DocLink';
 import ReactPlayground from '../../components/ReactPlayground';
 import AsPropButtonExample from '../../examples/AsProp';
+import AsPropAccordionExample from '../../examples/AsPropAccordion';
 
 <PageHeader
   title="Introduction"
@@ -136,6 +137,13 @@ ultimately causes a `a` tag to be rendered but with the same styles as a `Button
 component.
 
 <ReactPlayground codeText={AsPropButtonExample} />
+
+Below is an illustration of passing a React Bootstrap component. It contains a `Badge` component and a `Button` 
+component that have been supplied to the `as` prop, respectively, as `Button` and `Badge`. This finally results 
+in the rendering of a `Button` component with the same styles as a `Badge` component and a `Badge` component with 
+the same styles as a `Button`.
+
+<ReactPlayground codeText={AsPropAccordionExample} />
 
 ## Themes
 

--- a/www/src/pages/getting-started/introduction.mdx
+++ b/www/src/pages/getting-started/introduction.mdx
@@ -139,9 +139,8 @@ component.
 <ReactPlayground codeText={AsPropButtonExample} />
 
 Below is an illustration of passing a React Bootstrap component. It contains a `Badge` component and a `Button` 
-component that have been supplied to the `as` prop, respectively, as `Button` and `Badge`. This finally results 
-in the rendering of a `Button` component with the same styles as a `Badge` component and a `Badge` component with 
-the same styles as a `Button`.
+component that have been supplied to the `as` prop. This finally results in the rendering of a `Button` component 
+with the same styles as a `Badge` component.
 
 <ReactPlayground codeText={AsPropAccordionExample} />
 

--- a/www/src/pages/getting-started/introduction.mdx
+++ b/www/src/pages/getting-started/introduction.mdx
@@ -5,7 +5,7 @@ import CssCodeBlock from '../../components/CssCodeBlock';
 import DocLink from '../../components/DocLink';
 import ReactPlayground from '../../components/ReactPlayground';
 import AsPropButtonExample from '../../examples/AsProp';
-import AsPropAccordionExample from '../../examples/AsPropComponent';
+import AsPropComponent from '../../examples/AsPropComponent';
 
 <PageHeader
   title="Introduction"
@@ -142,7 +142,7 @@ Below is an illustration of passing a React Bootstrap component. It contains a `
 component that have been supplied to the `as` prop. This finally results in the rendering of a `Button` component 
 with the same styles as a `Badge` component.
 
-<ReactPlayground codeText={AsPropAccordionExample} />
+<ReactPlayground codeText={AsPropComponent} />
 
 ## Themes
 


### PR DESCRIPTION
This is the pull request for Issue  #6430 
Please review the changes and let me know if any other modifications are necessary.