### PR TITLE
fix(Modal): apply 'show' class when animation = false

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -458,6 +458,7 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
             className,
             bsPrefix,
             animateStaticModal && `${bsPrefix}-static`,
+            !animation && 'show',
           )}
           onClick={backdrop ? handleClick : undefined}
           onMouseUp={handleMouseUp}


### PR DESCRIPTION
resolves: #6439

Applies `show` class to Modal when `animation={false}`. [Backdrop has the exact same logic](https://github.com/react-bootstrap/react-bootstrap/blob/9ba8c7c341c249b342099685768d7001d5e10b76/src/Modal.tsx#L439) so this should be safe.