### PR TITLE
Replace direction:String prop with horizontal:Bool

### DIFF
--- a/src/Stack.tsx
+++ b/src/Stack.tsx
@@ -32,6 +32,11 @@ const propTypes = {
   bsPrefix: PropTypes.string,
 
   /**
+   * Arranges the elements of the stack horizontally.
+   */
+  horizontal: PropTypes.bool,
+
+  /**
    * Sets the spacing between each item. Valid values are `0-5`.
    */
   gap: responsivePropType(PropTypes.number),
@@ -43,10 +48,7 @@ const Stack: BsPrefixRefForwardingComponent<'span', StackProps> =
       { as: Component = 'div', bsPrefix, className, horizontal, gap, ...props },
       ref,
     ) => {
-      bsPrefix = useBootstrapPrefix(
-        bsPrefix,
-        horizontal ? 'hstack' : 'vstack',
-      );
+      bsPrefix = useBootstrapPrefix(bsPrefix, horizontal ? 'hstack' : 'vstack');
       const breakpoints = useBootstrapBreakpoints();
       const minBreakpoint = useBootstrapMinBreakpoint();
 

--- a/src/Stack.tsx
+++ b/src/Stack.tsx
@@ -13,12 +13,10 @@ import createUtilityClassName, {
   responsivePropType,
 } from './createUtilityClasses';
 
-export type StackDirection = 'horizontal' | 'vertical';
-
 export interface StackProps
   extends BsPrefixProps,
     React.HTMLAttributes<HTMLElement> {
-  direction?: StackDirection;
+  horizontal?: boolean;
   gap?: ResponsiveUtilityValue<GapValue>;
 }
 
@@ -27,8 +25,7 @@ const propTypes = {
    * Change the underlying component CSS base class name and modifier class names prefix.
    * **This is an escape hatch** for working with heavily customized bootstrap css.
    *
-   * Defaults to `hstack` if direction is `horizontal` or `vstack` if direction
-   * is `vertical`.
+   * Defaults to `hstack` if horizontal is present or true, or `vstack` if horizontal is absent or false.
    *
    * @default 'hstack | vstack'
    */
@@ -43,12 +40,12 @@ const propTypes = {
 const Stack: BsPrefixRefForwardingComponent<'span', StackProps> =
   React.forwardRef<HTMLElement, StackProps>(
     (
-      { as: Component = 'div', bsPrefix, className, direction, gap, ...props },
+      { as: Component = 'div', bsPrefix, className, horizontal, gap, ...props },
       ref,
     ) => {
       bsPrefix = useBootstrapPrefix(
         bsPrefix,
-        direction === 'horizontal' ? 'hstack' : 'vstack',
+        horizontal ? 'hstack' : 'vstack',
       );
       const breakpoints = useBootstrapBreakpoints();
       const minBreakpoint = useBootstrapMinBreakpoint();

--- a/test/StackSpec.tsx
+++ b/test/StackSpec.tsx
@@ -9,7 +9,7 @@ describe('<Stack>', () => {
   });
 
   it('should render direction', () => {
-    const { container } = render(<Stack direction="horizontal" />);
+    const { container } = render(<Stack horizontal />);
     container.firstElementChild!.className.should.contain('hstack');
   });
 


### PR DESCRIPTION
This makes it easier to set a stack to horizontal.

If a Stack defaults to vertical anyways, why require a specific string to be provided instead of a boolean? There are only two directions, unless there are plans for a depth-stack, using z-index.

I removed references to a prop called 'direction', and replaced it with a prop called horizontal.