### PR TITLE
docs: switch cdn to jsDelivr

### DIFF
--- a/www/src/components/BrowserGlobalsCodeBlock.js
+++ b/www/src/components/BrowserGlobalsCodeBlock.js
@@ -7,14 +7,14 @@ function BrowserGlobalsCodeBlock() {
     <CodeBlock
       mode="html"
       codeText={`
-<script src="https://unpkg.com/react/umd/react.production.min.js" crossorigin></script>
+<script src="https://cdn.jsdelivr.net/npm/react/umd/react.production.min.js" crossorigin></script>
 
 <script
-  src="https://unpkg.com/react-dom/umd/react-dom.production.min.js"
+  src="https://cdn.jsdelivr.net/npm/react-dom/umd/react-dom.production.min.js"
   crossorigin></script>
 
 <script
-  src="https://unpkg.com/react-bootstrap@next/dist/react-bootstrap.min.js"
+  src="https://cdn.jsdelivr.net/npm/react-bootstrap@next/dist/react-bootstrap.min.js"
   crossorigin></script>
 
 <script>var Alert = ReactBootstrap.Alert;</script>

--- a/www/src/pages/getting-started/introduction.mdx
+++ b/www/src/pages/getting-started/introduction.mdx
@@ -43,7 +43,7 @@ import { Button } from 'react-bootstrap';
 We provide `react-bootstrap.js` and
 `react-bootstrap.min.js` bundles with all components
 exported on the `window.ReactBootstrap` object. These
-bundles are available on [unpkg](https://unpkg.com/react-bootstrap/), as
+bundles are available on [jsDelivr](https://www.jsdelivr.com/package/npm/react-bootstrap), as
 well as in the npm package.
 
 <BrowserGlobalsCodeBlock />


### PR DESCRIPTION
The current docs endorse `unpkg` as the CDN of choice for developers to use. However, that project is currently unmaintained and [full of issues](https://github.com/mjackson/unpkg/issues).

Full disclosure that I work at [jsDelivr](www.jsdelivr.com), but I think it would be awesome if you React Bootstrap considers endorsing it! It's been actively maintained for the past 10 years and uses a [multi-CDN fallback system](https://www.jsdelivr.com/network/infographic) to prevent any downtime from occurring regardless of provider outages.

Happy to answer any questions or concerns you may have!