### PR TITLE
docs: fix typos in the pagination and pageitem docs

### DIFF
--- a/src/PageItem.tsx
+++ b/src/PageItem.tsx
@@ -22,10 +22,13 @@ const propTypes = {
   /** Styles PageItem as active, and renders a `<span>` instead of an `<a>`. */
   active: PropTypes.bool,
 
-  /** An accessible label indicating the active state.. */
+  /** An accessible label indicating the active state. */
   activeLabel: PropTypes.string,
 
-  /** A callback function for when this component is clicked */
+  /** The HTML href attribute for the `PageItem`. */
+  href: PropTypes.string,
+
+  /** A callback function for when this component is clicked. */
   onClick: PropTypes.func,
 };
 

--- a/src/Pagination.tsx
+++ b/src/Pagination.tsx
@@ -21,7 +21,7 @@ const propTypes = {
   bsPrefix: PropTypes.string,
 
   /**
-   * Set's the size of all PageItems.
+   * Sets the size of all PageItems.
    *
    * @type {('sm'|'lg')}
    */


### PR DESCRIPTION
Fix typo in the pagination api documentation and add missing href description in the page item