### PR TITLE
docs: add docs to close button

### DIFF
--- a/src/CloseButton.tsx
+++ b/src/CloseButton.tsx
@@ -10,7 +10,10 @@ export interface CloseButtonProps
 }
 
 const propTypes = {
+  /** An accessible label indicating the relevant information about the Close Button. */
   'aria-label': PropTypes.string,
+
+  /** A callback fired after the Close Button is clicked. */
   onClick: PropTypes.func,
 
   /**


### PR DESCRIPTION
I noticed that the api docs had the onclick and aria-label fields missing, so I added it in.