### PR TITLE
docs: add onclick and href docs to listgroupitem

### DIFF
--- a/src/ListGroupItem.tsx
+++ b/src/ListGroupItem.tsx
@@ -50,7 +50,7 @@ const propTypes = {
   /** A callback function for when this component is clicked.  */
   onClick: PropTypes.func,
 
-  /** Providing a `href` will render the ListGroup.Item as an `<a>` element (unless `as` is provided). */
+  /** Providing a `href` and setting `action` to `true`, it will render the ListGroup.Item as an `<a>` element (unless `as` is provided). */
   href: PropTypes.string,
 
   /**

--- a/src/ListGroupItem.tsx
+++ b/src/ListGroupItem.tsx
@@ -26,7 +26,7 @@ const propTypes = {
   bsPrefix: PropTypes.string,
 
   /**
-   * Sets contextual classes for list item
+   * Sets contextual classes for list item.
    * @type {('primary'|'secondary'|'success'|'danger'|'warning'|'info'|'dark'|'light')}
    */
   variant: PropTypes.string,
@@ -36,19 +36,21 @@ const propTypes = {
    */
   action: PropTypes.bool,
   /**
-   * Sets list item as active
+   * Sets list item as active.
    */
   active: PropTypes.bool,
 
   /**
-   * Sets list item state as disabled
+   * Sets list item state as disabled.
    */
   disabled: PropTypes.bool,
 
   eventKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 
+  /** A callback function for when this component is clicked.  */
   onClick: PropTypes.func,
 
+  /** Providing a `href` will render the ListGroup.Item as an `<a>` element (unless `as` is provided). */
   href: PropTypes.string,
 
   /**


### PR DESCRIPTION
I noticed that the onClick and href is missing for the ListGroupItem api, so I added it in this PR.