### PR TITLE
fix(ListGroupItem): prevent a div with a href

### DIFF
--- a/src/ListGroupItem.tsx
+++ b/src/ListGroupItem.tsx
@@ -100,6 +100,7 @@ const ListGroupItem: BsPrefixRefForwardingComponent<'a', ListGroupItemProps> =
 
       // eslint-disable-next-line no-nested-ternary
       const Component = as || (action ? (props.href ? 'a' : 'button') : 'div');
+      if (Component === 'div') delete props.href;
 
       return (
         <Component

--- a/src/ListGroupItem.tsx
+++ b/src/ListGroupItem.tsx
@@ -100,12 +100,12 @@ const ListGroupItem: BsPrefixRefForwardingComponent<'a', ListGroupItemProps> =
 
       // eslint-disable-next-line no-nested-ternary
       const Component = as || (action ? (props.href ? 'a' : 'button') : 'div');
-      if (Component === 'div') delete props.href;
 
       return (
         <Component
           ref={ref}
           {...props}
+          href={Component === 'div' ? undefined : props.href}
           {...navItemProps}
           onClick={handleClick}
           className={classNames(

--- a/src/ListGroupItem.tsx
+++ b/src/ListGroupItem.tsx
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import warning from 'warning';
 import useEventCallback from '@restart/hooks/useEventCallback';
 import {
   useNavItem,
@@ -101,11 +102,15 @@ const ListGroupItem: BsPrefixRefForwardingComponent<'a', ListGroupItemProps> =
       // eslint-disable-next-line no-nested-ternary
       const Component = as || (action ? (props.href ? 'a' : 'button') : 'div');
 
+      warning(
+        as || !(!action && props.href),
+        '`action=false` and `href` should not be used together.',
+      );
+
       return (
         <Component
           ref={ref}
           {...props}
-          href={Component === 'div' ? undefined : props.href}
           {...navItemProps}
           onClick={handleClick}
           className={classNames(

--- a/test/ListGroupItemSpec.tsx
+++ b/test/ListGroupItemSpec.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render } from '@testing-library/react';
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { shouldWarn } from './helpers';
 
 import ListGroupItem from '../src/ListGroupItem';
 
@@ -87,6 +88,49 @@ describe('<ListGroupItem>', () => {
       const item = getByTestId('test');
       item.tagName.toLowerCase().should.equal('a');
       item.classList.contains('list-group-item-action').should.be.true;
+      expect(item.getAttribute('href')).to.be.equal('/foo');
+    });
+    it('renders a div', () => {
+      const { getByTestId } = render(
+        <ListGroupItem action={false} data-testid="test" />,
+      );
+
+      const item = getByTestId('test');
+      item.tagName.toLowerCase().should.equal('div');
+      item.classList.contains('list-group-item-action').should.be.false;
+    });
+    it('renders a div and show warning', () => {
+      shouldWarn('together');
+      const { getByTestId } = render(
+        <ListGroupItem action={false} href="/foo" data-testid="test" />,
+      );
+
+      const item = getByTestId('test');
+      item.tagName.toLowerCase().should.equal('div');
+      item.classList.contains('list-group-item-action').should.be.false;
+      expect(item.getAttribute('href')).to.be.equal('/foo');
+    });
+    it('renders as div', () => {
+      const { getByTestId } = render(
+        <ListGroupItem as="div" data-testid="test" />,
+      );
+
+      const item = getByTestId('test');
+      item.tagName.toLowerCase().should.equal('div');
+      item.classList.contains('list-group-item-action').should.be.false;
+    });
+    it('renders as div with href', () => {
+      const { getByTestId } = render(
+        <ListGroupItem
+          as="div"
+          action={false}
+          data-testid="test"
+          href="/foo"
+        />,
+      );
+      const item = getByTestId('test');
+      item.tagName.toLowerCase().should.equal('div');
+      item.classList.contains('list-group-item-action').should.be.false;
       expect(item.getAttribute('href')).to.be.equal('/foo');
     });
   });

--- a/test/ListGroupItemSpec.tsx
+++ b/test/ListGroupItemSpec.tsx
@@ -90,15 +90,6 @@ describe('<ListGroupItem>', () => {
       item.classList.contains('list-group-item-action').should.be.true;
       expect(item.getAttribute('href')).to.be.equal('/foo');
     });
-    it('renders a div', () => {
-      const { getByTestId } = render(
-        <ListGroupItem action={false} data-testid="test" />,
-      );
-
-      const item = getByTestId('test');
-      item.tagName.toLowerCase().should.equal('div');
-      item.classList.contains('list-group-item-action').should.be.false;
-    });
     it('renders a div and show warning', () => {
       shouldWarn('together');
       const { getByTestId } = render(
@@ -110,16 +101,7 @@ describe('<ListGroupItem>', () => {
       item.classList.contains('list-group-item-action').should.be.false;
       expect(item.getAttribute('href')).to.be.equal('/foo');
     });
-    it('renders as div', () => {
-      const { getByTestId } = render(
-        <ListGroupItem as="div" data-testid="test" />,
-      );
-
-      const item = getByTestId('test');
-      item.tagName.toLowerCase().should.equal('div');
-      item.classList.contains('list-group-item-action').should.be.false;
-    });
-    it('renders as div with href', () => {
+    it('passes href to custom as components', () => {
       const { getByTestId } = render(
         <ListGroupItem
           as="div"


### PR DESCRIPTION
While adding the docs in #6461 , I realize that if `action=false` and `href` is set, a `<div href="...">` is generated.  I think the `href` attribute should only be for the `<a>` tag or custom component if the `as` is specified.