### PR TITLE
docs: Fix typos, remove unnecessary semicolons and blank lines

### DIFF
--- a/src/ListGroupItem.tsx
+++ b/src/ListGroupItem.tsx
@@ -53,7 +53,7 @@ const propTypes = {
 
   /**
    * You can use a custom element type for this component. For none `action` items, items render as `li`.
-   * For actions the default is an achor or button element depending on whether a `href` is provided.
+   * For actions the default is an anchor or button element depending on whether a `href` is provided.
    *
    * @default {'div' | 'a' | 'button'}
    */

--- a/src/Navbar.tsx
+++ b/src/Navbar.tsx
@@ -122,7 +122,7 @@ const propTypes = {
   collapseOnSelect: PropTypes.bool,
 
   /**
-   * Controls the visiblity of the navbar body
+   * Controls the visibility of the navbar body
    *
    * @controllable onToggle
    */

--- a/test/FormRangeSpec.tsx
+++ b/test/FormRangeSpec.tsx
@@ -25,17 +25,17 @@ describe('<FormRange>', () => {
 
   it('should render controlId as id correctly', () => {
     const { getByTestId } = render(
-      <FormGroup controlId="controll-id">
+      <FormGroup controlId="control-id">
         <FormRange data-testid="test-id" />
       </FormGroup>,
     );
     const element = getByTestId('test-id');
-    element.id.should.equal('controll-id');
+    element.id.should.equal('control-id');
   });
 
   it('should override controlId correctly', () => {
     const { getByTestId } = render(
-      <FormGroup controlId="controll-id">
+      <FormGroup controlId="control-id">
         <FormRange id="overridden-id" data-testid="test-id" />
       </FormGroup>,
     );

--- a/test/FormSelectSpec.tsx
+++ b/test/FormSelectSpec.tsx
@@ -58,7 +58,7 @@ describe('<FormSelect>', () => {
 
   it('should render controlId correctly', () => {
     const { getByTestId } = render(
-      <FormGroup controlId="controll-id">
+      <FormGroup controlId="control-id">
         <FormSelect data-testid="test-id">
           <option>1</option>
         </FormSelect>
@@ -66,12 +66,12 @@ describe('<FormSelect>', () => {
     );
 
     const element = getByTestId('test-id');
-    element.id.should.equal('controll-id');
+    element.id.should.equal('control-id');
   });
 
   it('should override controlId correctly', () => {
     const { getByTestId } = render(
-      <FormGroup controlId="controll-id">
+      <FormGroup controlId="control-id">
         <FormSelect id="overridden-id" data-testid="test-id">
           <option>1</option>
         </FormSelect>

--- a/test/PaginationSpec.tsx
+++ b/test/PaginationSpec.tsx
@@ -22,7 +22,7 @@ describe('<Pagination>', () => {
     paginationElem.classList.contains('pagination-sm').should.be.true;
   });
 
-  it('sub-compontents should forward ref correctly', () => {
+  it('sub-components should forward ref correctly', () => {
     const ref = React.createRef<HTMLLIElement>();
     render(
       <Pagination data-testid="test" size="sm">

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -518,7 +518,7 @@ const MegaComponent = () => (
           Horizontal
         </Form.Label>
         <Col sm={10}>
-          <Form.Control type="text" placeholder="Hoizontal" />
+          <Form.Control type="text" placeholder="Horizontal" />
         </Col>
       </Form.Group>
       <Form.Group as={Row} controlId="exampleForm.HorizontalControl">
@@ -526,7 +526,7 @@ const MegaComponent = () => (
           Horizontal
         </Form.Label>
         <Col sm={10}>
-          <Form.Control type="text" placeholder="Hoizontal" />
+          <Form.Control type="text" placeholder="Horizontal" />
         </Col>
       </Form.Group>
       <Form.Switch label="Switch" disabled />

--- a/www/src/pages/components/button-group.mdx
+++ b/www/src/pages/components/button-group.mdx
@@ -71,5 +71,3 @@ export const query = graphql`
     }
   }
 `;
-
-;

--- a/www/src/pages/components/navs.mdx
+++ b/www/src/pages/components/navs.mdx
@@ -4,7 +4,7 @@ import Callout from '../../components/Callout';
 import CodeBlock from '../../components/CodeBlock';
 import ComponentApi from '../../components/ComponentApi';
 import ReactPlayground from '../../components/ReactPlayground';
-import NavAlignement from '../../examples/Nav/Alignment';
+import NavAlignment from '../../examples/Nav/Alignment';
 import NavBasic from '../../examples/Nav/Basic';
 import NavList from '../../examples/Nav/List';
 import NavDropdown from '../../examples/Nav/Dropdown';
@@ -52,7 +52,7 @@ You can control the the direction and orientation of the
 `Nav` by making use of the [flexbox layout][0] utility classes.
 By default, navs are left-aligned, but that is easily changed to center or right-aligned.
 
-<ReactPlayground codeText={NavAlignement} />
+<ReactPlayground codeText={NavAlignment} />
 
 ### Vertical
 

--- a/www/src/pages/components/offcanvas.mdx
+++ b/www/src/pages/components/offcanvas.mdx
@@ -82,5 +82,3 @@ export const query = graphql`
     }
   }
 `;
-
-;

--- a/www/src/pages/components/overlays.mdx
+++ b/www/src/pages/components/overlays.mdx
@@ -26,7 +26,7 @@ import styles from '../../css/examples.module.scss';
 
 ## Overview
 
-Things to know about the React-Boostrap Overlay components.
+Things to know about the React-Bootstrap Overlay components.
 
 - Overlays rely on the third-party library [Popper.js](https://popper.js.org).
   It's included automatically with React-Bootstrap, but you should reference the API

--- a/www/src/pages/components/placeholder.mdx
+++ b/www/src/pages/components/placeholder.mdx
@@ -46,7 +46,7 @@ within the element to reflect the height when actual text is rendered in its pla
   The use of <code>aria-hidden="true"</code> only indicates that the element
   should be hidden to screen readers. The <i>loading</i> behaviour of the
   placeholder depends on how authors will actually use the placeholder styles,
-  how they plan to update things, etc. Some JavasScript code may be needed to{' '}
+  how they plan to update things, etc. Some JavaScript code may be needed to{' '}
   <i>swap</i> the state of the placeholder and inform AT users of the update.
 </Callout>
 

--- a/www/src/pages/components/placeholder.mdx
+++ b/www/src/pages/components/placeholder.mdx
@@ -46,7 +46,7 @@ within the element to reflect the height when actual text is rendered in its pla
   The use of <code>aria-hidden="true"</code> only indicates that the element
   should be hidden to screen readers. The <i>loading</i> behaviour of the
   placeholder depends on how authors will actually use the placeholder styles,
-  how they plan to update things, etc. Some JavasSript code may be needed to{' '}
+  how they plan to update things, etc. Some JavasScript code may be needed to{' '}
   <i>swap</i> the state of the placeholder and inform AT users of the update.
 </Callout>
 
@@ -58,7 +58,7 @@ You can change the `width` through grid column classes, width utilities, or inli
 
 ## Color
 
-By default, the `Placeholder` uses `currentColor`. This can be overriden with a custom color
+By default, the `Placeholder` uses `currentColor`. This can be overridden with a custom color
 or utility class.
 
 <ReactPlayground codeText={PlaceholderColor} />

--- a/www/src/pages/forms/range.mdx
+++ b/www/src/pages/forms/range.mdx
@@ -34,5 +34,3 @@ export const query = graphql`
     }
   }
 `;
-
-;

--- a/www/src/pages/getting-started/why-react-bootstrap.mdx
+++ b/www/src/pages/getting-started/why-react-bootstrap.mdx
@@ -42,7 +42,6 @@ function Example()  {
     </div>
   )
 }
-
 ```
 
 ### React-Bootstrap

--- a/www/src/pages/migrating.mdx
+++ b/www/src/pages/migrating.mdx
@@ -3,7 +3,7 @@
 React-Bootstrap v2 adds full compatibility with Bootstrap 5. Because Bootstrap 5 is a major rewrite of the project, there
 are significant breaking changes from React-Bootstrap v1.
 
-**PLEASE FIRST READ THE UPSTREAM BOOSTRAP MIGRATION GUIDE**
+**PLEASE FIRST READ THE UPSTREAM BOOTSTRAP MIGRATION GUIDE**
 
 > https://v5.getbootstrap.com/docs/5.0/migration
 


### PR DESCRIPTION
- Fix typos in MDX and some codes.
- Remove unnecessary semicolons and blank lines. This PR removes extra semicolons appearing in docs.