### PR TITLE
fix(types): Fix type of 'safeFindDOMNode' function

### DIFF
--- a/src/OverlayTrigger.tsx
+++ b/src/OverlayTrigger.tsx
@@ -201,7 +201,7 @@ function OverlayTrigger({
       ? React.Children.only(children).props
       : ({} as any);
 
-  const attachRef = (r: React.ComponentClass | Element | null | undefined) => {
+  const attachRef = (r: React.Component | Element | null | undefined) => {
     mergedRef(safeFindDOMNode(r));
   };
 

--- a/src/TransitionWrapper.tsx
+++ b/src/TransitionWrapper.tsx
@@ -39,9 +39,7 @@ const TransitionWrapper = React.forwardRef<
     const nodeRef = useRef<HTMLElement>(null);
     const mergedRef = useMergedRefs(nodeRef, childRef);
 
-    const attachRef = (
-      r: React.ComponentClass | Element | null | undefined,
-    ) => {
+    const attachRef = (r: React.Component | Element | null | undefined) => {
       mergedRef(safeFindDOMNode(r));
     };
 

--- a/src/safeFindDOMNode.ts
+++ b/src/safeFindDOMNode.ts
@@ -1,7 +1,7 @@
 import ReactDOM from 'react-dom';
 
 export default function safeFindDOMNode(
-  componentOrElement: React.ComponentClass | Element | null | undefined,
+  componentOrElement: React.Component | Element | null | undefined,
 ) {
   if (componentOrElement && 'setState' in componentOrElement) {
     return ReactDOM.findDOMNode(componentOrElement);


### PR DESCRIPTION
Based on its body, `safeFindDOMNode` appears to have an incorrect function signature (and TypeScript 4.9 complains about it as a result). The declared type of `React.ComponentClass` refers to *the thing you `new`*, whereas `React.Component` refers to the instance of the class. `setState` is an instance method, not a static method, so will (presumably) never be `in` the former.