### PR TITLE
make the spinner animation default to border

### DIFF
--- a/src/Spinner.tsx
+++ b/src/Spinner.tsx
@@ -9,7 +9,7 @@ import { Variant } from './types';
 export interface SpinnerProps
   extends React.HTMLAttributes<HTMLElement>,
     BsPrefixProps {
-  animation: 'border' | 'grow';
+  animation?: 'border' | 'grow';
   size?: 'sm';
   variant?: Variant;
 }
@@ -74,8 +74,8 @@ const Spinner: BsPrefixRefForwardingComponent<'div', SpinnerProps> =
       ref,
     ) => {
       bsPrefix = useBootstrapPrefix(bsPrefix, 'spinner');
-      const bsSpinnerPrefix = `${bsPrefix}-${animation}`;
-
+      const animationName = animation || 'border';
+      const bsSpinnerPrefix = `${bsPrefix}-${animationName}`;
       return (
         <Component
           ref={ref}

--- a/src/Spinner.tsx
+++ b/src/Spinner.tsx
@@ -64,7 +64,7 @@ const Spinner: BsPrefixRefForwardingComponent<'div', SpinnerProps> =
       {
         bsPrefix,
         variant,
-        animation,
+        animation = 'border',
         size,
         // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
         as: Component = 'div',
@@ -74,8 +74,7 @@ const Spinner: BsPrefixRefForwardingComponent<'div', SpinnerProps> =
       ref,
     ) => {
       bsPrefix = useBootstrapPrefix(bsPrefix, 'spinner');
-      const animationName = animation || 'border';
-      const bsSpinnerPrefix = `${bsPrefix}-${animationName}`;
+      const bsSpinnerPrefix = `${bsPrefix}-${animation}`;
       return (
         <Component
           ref={ref}


### PR DESCRIPTION
There's no good reason to always type out the animation for the spinner. There are only two choices, and the "border" option is the obvious choice as a default.

This should be a non-breaking change.