### PR TITLE
fix: update @restart/ui to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@babel/runtime": "^7.17.2",
     "@restart/hooks": "^0.4.6",
-    "@restart/ui": "^1.3.1",
+    "@restart/ui": "^1.4.0",
     "@types/react-transition-group": "^4.4.4",
     "classnames": "^2.3.1",
     "dom-helpers": "^5.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1328,10 +1328,10 @@
   dependencies:
     dequal "^2.0.2"
 
-"@restart/ui@^1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@restart/ui/-/ui-1.3.1.tgz#ae16be26128cc205efb7e0bf93d1f34deb1fe116"
-  integrity sha512-MYvMs2eeZTHu2dBJHOXKx72vxzEZeWbZx2z1QjeXq62iYjpjIyukBC2ZEy8x+sb9Gl0AiOiHkPXrl1wn95aOGQ==
+"@restart/ui@^1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@restart/ui/-/ui-1.4.0.tgz#8333294fefb045f58852d5bb34367c3323e2edb3"
+  integrity sha512-5dDj5uDzUgK1iijWPRg6AnxjkHM04XhTQDJirM1h/8tIc7KyLtF9YyjcCpNEn259hPMXswpkfXKNgiag0skPFg==
   dependencies:
     "@babel/runtime" "^7.18.3"
     "@popperjs/core" "^2.11.5"


### PR DESCRIPTION
Fixes a TypeScript 4.8 error applications using react-bootstrap may have encountered with usePopper's typing through the transitive dependency: https://github.com/react-restart/ui/issues/65