### PR TITLE
docs: Fix consistent code style in Badge examples

### DIFF
--- a/www/src/examples/Badge/Variations.js
+++ b/www/src/examples/Badge/Variations.js
@@ -3,17 +3,30 @@ import Badge from 'react-bootstrap/Badge';
 function VariationsExample() {
   return (
     <div>
-      <Badge bg="primary">Primary</Badge>{' '}
-      <Badge bg="secondary">Secondary</Badge>{' '}
-      <Badge bg="success">Success</Badge> <Badge bg="danger">Danger</Badge>{' '}
+      <Badge bg="primary">
+        Primary
+      </Badge>{' '}
+      <Badge bg="secondary">
+        Secondary
+      </Badge>{' '}
+      <Badge bg="success">
+        Success
+      </Badge>{' '}
+      <Badge bg="danger">
+        Danger
+      </Badge>{' '}
       <Badge bg="warning" text="dark">
         Warning
       </Badge>{' '}
-      <Badge bg="info">Info</Badge>{' '}
+      <Badge bg="info">
+        Info
+      </Badge>{' '}
       <Badge bg="light" text="dark">
         Light
       </Badge>{' '}
-      <Badge bg="dark">Dark</Badge>
+      <Badge bg="dark">
+        Dark
+      </Badge>
     </div>
   );
 }


### PR DESCRIPTION
- Fix inconsistent code style for "Contextual variations" example. "Pill" is taken as a reference of code style.

<details>
  <summary>Current view (screenshot)</summary>

  ![image](https://user-images.githubusercontent.com/11060914/201904437-99eba8e2-f597-4b80-89df-4866a8ceac3a.png)
</details>