### PR TITLE
feat: support indeterminate checkbox state

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "invariant": "^2.2.4",
     "prop-types": "^15.8.1",
     "prop-types-extra": "^1.1.0",
+    "react-is": "^18.2.0",
     "react-transition-group": "^4.4.2",
     "uncontrollable": "^7.2.1",
     "warning": "^4.0.3"
@@ -89,6 +90,7 @@
     "@types/mocha": "^9.1.1",
     "@types/prop-types": "^15.7.5",
     "@types/react-dom": "^16.9.17",
+    "@types/react-is": "^17.0.3",
     "@types/sinon": "^10.0.13",
     "@types/sinon-chai": "^3.2.9",
     "@types/warning": "^3.0.0",

--- a/src/FormCheck.tsx
+++ b/src/FormCheck.tsx
@@ -26,6 +26,7 @@ export interface FormCheckProps
   feedback?: React.ReactNode;
   feedbackType?: FeedbackType;
   bsSwitchPrefix?: string;
+  indeterminate?: boolean;
 }
 
 const propTypes = {
@@ -145,6 +146,7 @@ const FormCheck: BsPrefixRefForwardingComponent<'input', FormCheckProps> =
         children,
         // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
         as = 'input',
+        indeterminate = false,
         ...props
       },
       ref,
@@ -173,6 +175,7 @@ const FormCheck: BsPrefixRefForwardingComponent<'input', FormCheckProps> =
           isInvalid={isInvalid}
           disabled={disabled}
           as={as}
+          indeterminate={indeterminate}
         />
       );
 

--- a/src/FormCheckInput.tsx
+++ b/src/FormCheckInput.tsx
@@ -2,9 +2,14 @@ import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import * as React from 'react';
 import { useContext } from 'react';
+import { isForwardRef } from 'react-is';
 import FormContext from './FormContext';
 import { useBootstrapPrefix } from './ThemeProvider';
-import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
+import {
+  BsPrefixProps,
+  BsPrefixRefForwardingComponent,
+  isDOMElement,
+} from './helpers';
 
 type FormCheckInputType = 'checkbox' | 'radio';
 
@@ -69,27 +74,24 @@ const FormCheckInput: BsPrefixRefForwardingComponent<
     bsPrefix = useBootstrapPrefix(bsPrefix, 'form-check-input');
 
     const inputRef = React.useRef<HTMLInputElement>();
-    React.useImperativeHandle(
-      ref,
-      () =>
-        ({
-          current: {
-            ...inputRef.current,
-            indeterminate: !!indeterminate,
-          },
-        } as any),
-    );
-
+    const existingRef =
+      isForwardRef(<Component />) || isDOMElement(<Component />)
+        ? ref || inputRef
+        : undefined;
     React.useEffect(() => {
-      if (inputRef.current && type === 'checkbox' && indeterminate) {
-        inputRef.current.indeterminate = true;
+      if (
+        (existingRef as any)?.current &&
+        type === 'checkbox' &&
+        indeterminate
+      ) {
+        (existingRef as any).current.indeterminate = true;
       }
-    }, [indeterminate, ref, type]);
+    }, [existingRef, indeterminate, ref, type]);
 
     return (
       <Component
         {...props}
-        ref={inputRef}
+        ref={existingRef}
         type={type}
         id={id || controlId}
         className={classNames(

--- a/src/FormCheckInput.tsx
+++ b/src/FormCheckInput.tsx
@@ -14,6 +14,7 @@ export interface FormCheckInputProps
   type?: FormCheckInputType;
   isValid?: boolean;
   isInvalid?: boolean;
+  indeterminate?: boolean;
 }
 
 const propTypes = {
@@ -40,6 +41,9 @@ const propTypes = {
 
   /** Manually style the input as invalid */
   isInvalid: PropTypes.bool,
+
+  /** Set whether the input is of indeterminate state */
+  indeterminate: PropTypes.bool,
 };
 
 const FormCheckInput: BsPrefixRefForwardingComponent<
@@ -54,6 +58,7 @@ const FormCheckInput: BsPrefixRefForwardingComponent<
       type = 'checkbox',
       isValid = false,
       isInvalid = false,
+      indeterminate = false,
       // Need to define the default "as" during prop destructuring to be compatible with styled-components github.com/react-bootstrap/react-bootstrap/issues/3595
       as: Component = 'input',
       ...props
@@ -63,10 +68,28 @@ const FormCheckInput: BsPrefixRefForwardingComponent<
     const { controlId } = useContext(FormContext);
     bsPrefix = useBootstrapPrefix(bsPrefix, 'form-check-input');
 
+    const inputRef = React.useRef<HTMLInputElement>();
+    React.useImperativeHandle(
+      ref,
+      () =>
+        ({
+          current: {
+            ...inputRef.current,
+            indeterminate: !!indeterminate,
+          },
+        } as any),
+    );
+
+    React.useEffect(() => {
+      if (inputRef.current && type === 'checkbox' && indeterminate) {
+        inputRef.current.indeterminate = true;
+      }
+    }, [indeterminate, ref, type]);
+
     return (
       <Component
         {...props}
-        ref={ref}
+        ref={inputRef}
         type={type}
         id={id || controlId}
         className={classNames(

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -57,3 +57,7 @@ export function getOverlayDirection(placement: string, isRTL?: boolean) {
   }
   return bsDirection;
 }
+
+export function isDOMElement(element: JSX.Element) {
+  return typeof element?.type === 'string';
+}

--- a/test/FormCheckSpec.tsx
+++ b/test/FormCheckSpec.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import * as React from 'react';
+import { expect } from 'chai';
 import FormCheck from '../src/FormCheck';
 import Switch from '../src/Switch';
 
@@ -139,6 +140,12 @@ describe('<FormCheck>', () => {
     container.getElementsByClassName('form-check').length.should.equal(0);
   });
 
+  it('should work with indeterminate state', () => {
+    const { getByRole } = render(<FormCheck type="checkbox" indeterminate />);
+
+    expect(getByRole('checkbox').indeterminate).to.be.equal(true);
+  });
+
   it('should support type switch', () => {
     const { getByTestId, container } = render(
       <FormCheck
@@ -199,6 +206,21 @@ describe('<FormCheck>', () => {
   it('should support "as"', () => {
     const Surrogate = ({ className = '', ...rest }) => (
       <input className={`extraClass ${className}'`} {...rest} />
+    );
+    const { getByTestId } = render(
+      <FormCheck as={Surrogate} data-testid="test-id" />,
+    );
+
+    const element = getByTestId('test-id');
+    element.classList.length.should.equal(2);
+    element.classList.contains('extraClass').should.be.true;
+  });
+
+  it('should support "as" that forwardsRef', () => {
+    const Surrogate = React.forwardRef(
+      ({ className = '', ...rest }: any, ref) => (
+        <input ref={ref} className={`extraClass ${className}'`} {...rest} />
+      ),
     );
     const { getByTestId } = render(
       <FormCheck as={Surrogate} data-testid="test-id" />,

--- a/test/InputGroupSpec.tsx
+++ b/test/InputGroupSpec.tsx
@@ -32,6 +32,16 @@ describe('<InputGroup>', () => {
 
       expect(getByRole('checkbox').getAttribute('name')).to.be.equal(name);
     });
+
+    it('should work with indeterminate state', () => {
+      const name = 'foobar';
+
+      const { getByRole } = render(
+        <InputGroup.Checkbox indeterminate name={name} />,
+      );
+
+      expect(getByRole('checkbox').indeterminate).to.be.equal(true);
+    });
   });
 
   describe('<Radio>', () => {

--- a/www/src/examples/Form/CheckIndeterminate.js
+++ b/www/src/examples/Form/CheckIndeterminate.js
@@ -1,0 +1,18 @@
+import Form from 'react-bootstrap/Form';
+
+function CheckIndeterminateExample() {
+  return (
+    <Form>
+      <div key="default-indeterminate" className="mb-3">
+        <Form.Check // prettier-ignore
+          type="checkbox"
+          id="default-indeterminate"
+          label="default indeterminate"
+          indeterminate
+        />
+      </div>
+    </Form>
+  );
+}
+
+export default CheckIndeterminateExample;

--- a/www/src/pages/forms/checks-radios.mdx
+++ b/www/src/pages/forms/checks-radios.mdx
@@ -5,6 +5,7 @@ import ComponentApi from '../../components/ComponentApi';
 import ReactPlayground from '../../components/ReactPlayground';
 
 import Check from '../../examples/Form/Check';
+import CheckIndeterminate from '../../examples/Form/CheckIndeterminate';
 import CheckApi from '../../examples/Form/CheckApi';
 import CheckInline from '../../examples/Form/CheckInline';
 import CheckReverse from '../../examples/Form/CheckReverse';
@@ -28,6 +29,12 @@ sibling will be vertically stacked and appropriately spaced with
 FormCheck.
 
 <ReactPlayground codeText={Check} />
+
+## Indeterminate
+
+There's also a possiblity to render an indeterminate state
+
+<ReactPlayground codeText={CheckIndeterminate} />
 
 ## Switches
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,6 +1574,13 @@
   dependencies:
     "@types/react" "^16"
 
+"@types/react-is@^17.0.3":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
+  integrity sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.4.4":
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.4.tgz#acd4cceaa2be6b757db61ed7b432e103242d163e"
@@ -7384,6 +7391,11 @@ react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
+
+react-is@^18.2.0:
+  version "18.2.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
+  integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
#6496 #6497 Adds `indeterminate` checkbox state support. 

Full disclosure, I've implemented this before I've seen https://github.com/react-bootstrap/react-bootstrap/issues/6497#issuecomment-1317600419 this comment, so I fully understand if we don't wanna merge this(plus it's doing a lot of unelegant logic which also may be troublesome)