### PR TITLE
fix(ci): fix ubuntu firefox build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install Firefox (macOS)
         if: matrix.os == 'macOS-latest' && matrix.browser == 'FirefoxHeadless'
         run: brew install --cask firefox
+      - name: Install Firefox (ubuntu)
+        if: matrix.os == 'ubuntu-latest' && matrix.browser == 'FirefoxHeadless'
+        run: sudo apt install firefox
       - name: Install Dependencies
         run: yarn bootstrap
         env:


### PR DESCRIPTION
Newest ubuntu image comes w/o firefox installed: https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20221027.1

(previous version had it: https://github.com/actions/runner-images/blob/ubuntu22/20221027.1/images/linux/Ubuntu2004-Readme.md)