### PR TITLE
Added support for portrait size ratios

### DIFF
--- a/src/Ratio.tsx
+++ b/src/Ratio.tsx
@@ -38,7 +38,7 @@ const defaultProps = {
 
 function toPercent(num: number): string {
   if (num <= 0 || num > 100) return '100%';
-  if (num < 1) return `${num * 100}%`;
+  if (num < 5) return `${num * 100}%`;
   return `${num}%`;
 }
 

--- a/src/Ratio.tsx
+++ b/src/Ratio.tsx
@@ -37,8 +37,8 @@ const defaultProps = {
 };
 
 function toPercent(num: number): string {
-  if (num <= 0 || num > 100) return '100%';
-  if (num < 5) return `${num * 100}%`;
+  if (num <= 0) return '100%';
+  if (num < 1) return `${num * 100}%`;
   return `${num}%`;
 }
 

--- a/test/RatioSpec.tsx
+++ b/test/RatioSpec.tsx
@@ -49,7 +49,7 @@ describe('Ratio', () => {
     styleAttr.should.match(/--bs-aspect-ratio:[ ]*100%;/);
   });
 
-  it('should support use 100% as custom ratio if aspectRatio is greater than 100', () => {
+  it('should support aspectRatio greater than 100', () => {
     const { getByTestId } = render(
       <Ratio data-testid="test" aspectRatio={200}>
         <div />
@@ -57,6 +57,6 @@ describe('Ratio', () => {
     );
     const ratioElem = getByTestId('test');
     const styleAttr = ratioElem.getAttribute('style')!;
-    styleAttr.should.match(/--bs-aspect-ratio:[ ]*100%;/);
+    styleAttr.should.match(/--bs-aspect-ratio:[ ]*200%;/);
   });
 });


### PR DESCRIPTION
Regarding this issue: https://github.com/react-bootstrap/react-bootstrap/issues/6495, suggesting allowing ratios above 100% of the width to allow for portrait style presentation. 

Currently, in the `toPercent()` function, any number above 1 converts to a percent, ensuring that width is always greater than or equal to height. Perhaps, for small numbers above 1 we could infer that the developer wants a portrait style layout. I've suggested 5 somewhat arbitrarily, but it seems absurdly small for a percent height/width ratio so seems safe to me. Suggestions?