### PR TITLE
docs(Modal): fix static example

### DIFF
--- a/www/src/examples/Modal/Static.js
+++ b/www/src/examples/Modal/Static.js
@@ -3,20 +3,25 @@ import Modal from 'react-bootstrap/Modal';
 
 function StaticExample() {
   return (
-    <Modal.Dialog>
-      <Modal.Header closeButton>
-        <Modal.Title>Modal title</Modal.Title>
-      </Modal.Header>
+    <div
+      className="modal show"
+      style={{ display: 'block', position: 'initial' }}
+    >
+      <Modal.Dialog>
+        <Modal.Header closeButton>
+          <Modal.Title>Modal title</Modal.Title>
+        </Modal.Header>
 
-      <Modal.Body>
-        <p>Modal body text goes here.</p>
-      </Modal.Body>
+        <Modal.Body>
+          <p>Modal body text goes here.</p>
+        </Modal.Body>
 
-      <Modal.Footer>
-        <Button variant="secondary">Close</Button>
-        <Button variant="primary">Save changes</Button>
-      </Modal.Footer>
-    </Modal.Dialog>
+        <Modal.Footer>
+          <Button variant="secondary">Close</Button>
+          <Button variant="primary">Save changes</Button>
+        </Modal.Footer>
+      </Modal.Dialog>
+    </div>
   );
 }
 


### PR DESCRIPTION
Fixes #6491

Some of the styles are defined as css variables in `.modal`, so had to add a wrapper with that and change the position from `sticky` to `initial`