### PR TITLE
fix(Stack): fix incorrect classes being generated

### DIFF
--- a/src/Stack.tsx
+++ b/src/Stack.tsx
@@ -60,11 +60,13 @@ const Stack: BsPrefixRefForwardingComponent<'span', StackProps> =
           className={classNames(
             className,
             bsPrefix,
-            ...createUtilityClassName({
-              gap,
+            ...createUtilityClassName(
+              {
+                gap,
+              },
               breakpoints,
               minBreakpoint,
-            }),
+            ),
           )}
         />
       );


### PR DESCRIPTION
Breakpoint params were placed in the wrong spot.  They shouldn't be inside the utility values map.