### PR TITLE
Propose: use Sandpack as code playground

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -30,6 +30,8 @@
     }
   },
   "devDependencies": {
+    "@codesandbox/sandpack-react": "1.20.9",
+    "@codesandbox/sandpack-themes": "latest",
     "@docsearch/css": "^3.3.3",
     "@docsearch/react": "^3.3.3",
     "@fortawesome/fontawesome-svg-core": "^6.3.0",

--- a/www/src/components/ReactPlayground.js
+++ b/www/src/components/ReactPlayground.js
@@ -1,346 +1,100 @@
-import styled, { css } from 'astroturf';
-import classNames from 'classnames';
-import qsa from 'dom-helpers/querySelectorAll';
-import * as formik from 'formik';
 import PropTypes from 'prop-types';
+import { useEffect, useState } from 'react';
+
 import {
-  forwardRef,
-  useCallback,
-  useContext,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
-import * as ReactBootstrap from 'react-bootstrap';
-import { Button, OverlayTrigger, Tooltip } from 'react-bootstrap';
-import ReactDOM from 'react-dom';
-import {
-  LiveContext,
-  LiveEditor,
-  LiveError,
-  LivePreview,
-  LiveProvider,
-} from 'react-live';
-import * as yup from 'yup';
-import useEventCallback from '@restart/hooks/useEventCallback';
-import useIsomorphicEffect from '@restart/hooks/useIsomorphicEffect';
-import useMutationObserver from '@restart/hooks/useMutationObserver';
-import PlaceholderImage from './PlaceholderImage';
-import Sonnet from './Sonnet';
-
-const scope = {
-  useEffect,
-  useRef,
-  useState,
-  useContext,
-  ...ReactBootstrap,
-  ReactDOM,
-  classNames,
-  PropTypes,
-  Sonnet,
-  formik,
-  yup,
-  PlaceholderImage,
-};
-
-const StyledContainer = styled('div')`
-  @import '../css/theme';
-
-  position: relative;
-  margin-bottom: 3rem;
-  background-color: $body-bg;
-`;
-
-const StyledExample = styled('div')`
-  @import '../css/theme';
-
-  composes: bs-example from global;
-
-  position: relative;
-  padding: 1rem;
-  border-style: solid;
-  border-color: rgb(236, 236, 236);
-  border-width: 0.2rem;
-  border-radius: 8px;
-  margin-right: 0;
-  margin-left: 0;
-  color: $body-color;
-
-  &.show-code {
-    border-width: 0.2rem 0.2rem 0 0.2rem;
-    border-radius: 8px 8px 0 0;
-  }
-
-  :global {
-    .react-live-preview::after {
-      display: block;
-      clear: both;
-      content: '';
-    }
-  }
-`;
-
-const StyledError = styled(LiveError)`
-  composes: alert alert-danger text-monospace from global;
-
-  border-radius: 0;
-  border-width: 0.2rem;
-  margin-bottom: 0;
-  white-space: pre;
-`;
-
-const { background, foreground, fontFamily } = css`
-  @import '../css/theme';
-
-  :export {
-    background: $lighter;
-    foreground: $subtle-on-dark;
-    font-family: $font-family-base;
-  }
-`;
-
-function Preview({ showCode, className }) {
-  const exampleRef = useRef();
-  const [hjs, setHjs] = useState(null);
-  const live = useContext(LiveContext);
-
-  useEffect(() => {
-    import('holderjs').then(({ default: hjs_ }) => {
-      hjs_.addTheme('gray', {
-        bg: background,
-        fg: foreground,
-        font: fontFamily,
-        fontweight: 'normal',
-      });
-
-      setHjs(hjs_);
-    });
-  }, []);
-
-  useIsomorphicEffect(() => {
-    if (!hjs) {
-      return;
-    }
-
-    hjs.run({
-      theme: 'gray',
-      images: qsa(exampleRef.current, 'img'),
-    });
-  }, [hjs, live.element]);
-
-  useMutationObserver(
-    exampleRef.current,
-    {
-      childList: true,
-      subtree: true,
-    },
-    (mutations) => {
-      mutations.forEach((mutation) => {
-        if (hjs && mutation.addedNodes.length > 0) {
-          hjs.run({
-            theme: 'gray',
-            images: qsa(exampleRef.current, 'img'),
-          });
-        }
-      });
-    },
-  );
-
-  const handleClick = useCallback((e) => {
-    if (e.target.tagName === 'A') {
-      e.preventDefault();
-    }
-  }, []);
-
-  return (
-    <>
-      <StyledExample
-        ref={exampleRef}
-        role="region"
-        aria-label="Code Example"
-        showCode={showCode}
-        className={className}
-        onClick={handleClick}
-      >
-        <LivePreview />
-      </StyledExample>
-      <StyledError />
-    </>
-  );
-}
-
-const StyledEditor = styled(LiveEditor)`
-  composes: prism from '../css/prism.module.scss';
-
-  border-radius: 0 0 8px 8px !important;
-`;
-
-const EditorInfoMessage = styled.div`
-  composes: p-2 alert alert-info from global;
-
-  font-size: 70%;
-  pointer-events: none;
-  margin-bottom: 0;
-  margin-right: 0.5rem;
-`;
-
-const EditorToolbar = styled.div`
-  position: absolute;
-  top: 0.5rem;
-  right: 0.5rem;
-  display: flex;
-  align-items: start;
-`;
-
-let uid = 0;
-
-const CopyTooltip = forwardRef(
-  ({ popper, children, show: _, ...props }, ref) => {
-    useEffect(() => {
-      popper.scheduleUpdate();
-    }, [children, popper]);
-
-    return (
-      <Tooltip ref={ref} {...props}>
-        {children}
-      </Tooltip>
-    );
-  },
-);
-
-function Editor() {
-  const live = useContext(LiveContext);
-
-  const [focused, setFocused] = useState(false);
-  const [ignoreTab, setIgnoreTab] = useState(false);
-  const [keyboardFocused, setKeyboardFocused] = useState(false);
-  const [copyStatus, setCopyStatus] = useState('Copy to clipboard');
-  const [code, setCode] = useState('');
-
-  const mouseDownRef = useRef(false);
-
-  const idRef = useRef(null);
-  if (idRef.current === null) idRef.current = `described-by-${++uid}`;
-  const id = idRef.current;
-
-  const handleKeyDown = useEventCallback((e) => {
-    if (ignoreTab) {
-      if (e.key !== 'Tab' && e.key !== 'Shift') {
-        if (e.key === 'Enter') e.preventDefault();
-        setIgnoreTab(false);
-      }
-    } else if (e.key === 'Escape') {
-      setIgnoreTab(true);
-    }
-  });
-
-  const handleFocus = useEventCallback(() => {
-    setFocused(true);
-    setIgnoreTab(!mouseDownRef.current);
-    setKeyboardFocused(!mouseDownRef.current);
-  });
-
-  const handleBlur = useEventCallback(() => {
-    setFocused(false);
-  });
-
-  const handleMouseDown = useEventCallback(() => {
-    mouseDownRef.current = true;
-    window.setTimeout(() => {
-      mouseDownRef.current = false;
-    });
-  });
-
-  const handleTooltipExited = useEventCallback(() => {
-    setCopyStatus('Copy to clipboard');
-  });
-
-  const handleCopy = useEventCallback(() => {
-    navigator.clipboard.writeText(code).then(setCopyStatus('Copied!'));
-  });
-
-  const handleCodeChange = useEventCallback((codeText) => {
-    live.onChange(codeText);
-    setCode(codeText);
-  });
-
-  const showMessage = keyboardFocused || (focused && !ignoreTab);
-
-  return (
-    <div className="position-relative">
-      <StyledEditor
-        onChange={handleCodeChange}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        onKeyDown={handleKeyDown}
-        onMouseDown={handleMouseDown}
-        ignoreTabKey={ignoreTab}
-        aria-describedby={showMessage ? id : null}
-        aria-label="Example code editor"
-        padding={20}
-      />
-
-      <EditorToolbar>
-        {showMessage && (
-          <EditorInfoMessage id={id} aria-live="polite">
-            {ignoreTab ? (
-              <>
-                Press <kbd>enter</kbd> or type a key to enable tab-to-indent
-              </>
-            ) : (
-              <>
-                Press <kbd>esc</kbd> to disable tab trapping
-              </>
-            )}
-          </EditorInfoMessage>
-        )}
-
-        <OverlayTrigger
-          onExited={handleTooltipExited}
-          trigger={['hover', 'focus']}
-          overlay={<CopyTooltip id="copy-tooltip">{copyStatus}</CopyTooltip>}
-        >
-          <Button onClick={handleCopy} variant="outline-light" size="sm">
-            Copy
-          </Button>
-        </OverlayTrigger>
-      </EditorToolbar>
-    </div>
-  );
-}
-
-const PRETTIER_IGNORE_REGEX =
-  /({\s*\/\*\s+prettier-ignore\s+\*\/\s*})|(\/\/\s+prettier-ignore)/gim;
-
-const IGNORE_IMPORTS_EXPORTS_REGEX = /^.*\b(import|export)\b.*$/gim;
+  SandpackCodeEditor,
+  SandpackLayout,
+  SandpackPreview,
+  SandpackProvider,
+  useSandpack,
+} from '@codesandbox/sandpack-react';
+import { githubLight } from '@codesandbox/sandpack-themes';
 
 const propTypes = {
   codeText: PropTypes.string.isRequired,
 };
 
-function Playground({ codeText, exampleClassName, showCode = true }) {
-  // Remove Prettier comments and trailing semicolons in JSX in displayed code.
-  const code = codeText
-    .replace(PRETTIER_IGNORE_REGEX, '')
-    .trim()
-    .replace(/>;$/, '>');
+const ListenerResize = ({ onResize }) => {
+  const { listen } = useSandpack();
 
-  const transformCode = (rawCode) =>
-    rawCode.replace(IGNORE_IMPORTS_EXPORTS_REGEX, '');
+  useEffect(() => {
+    const unsubs = listen((message) => {
+      if (message.type === 'resize') {
+        onResize(message.height);
+      }
+    });
+
+    return unsubs;
+  }, []);
+
+  return null;
+};
+
+function Playground({ codeText, exampleClassName, showCode = true }) {
+  const [height, setHeight] = useState(200);
+
+  const exportedFile = (function () {
+    if (codeText.indexOf('export default') !== -1) {
+      return codeText.replace(new RegExp('render(.+);'), '').trim();
+    }
+
+    const functionName = codeText
+      .match(new RegExp('render(.+);'))[1]
+      .replace(/[()/<>]/g, '');
+
+    return `${codeText
+      .replace(new RegExp('render(.+);'), '')
+      .trim()}\n\nexport default ${functionName}`;
+  })();
 
   return (
-    <StyledContainer>
-      <LiveProvider
-        scope={scope}
-        code={code}
-        mountStylesheet={false}
-        noInline={codeText.includes('render(')}
-        transformCode={transformCode}
-      >
-        <Preview showCode={showCode} className={exampleClassName} />
-        {showCode && <Editor />}
-      </LiveProvider>
-    </StyledContainer>
+    <SandpackProvider
+      className={exampleClassName}
+      theme={githubLight}
+      customSetup={{
+        dependencies: { 'react-bootstrap': '2.7.2', bootstrap: 'latest' },
+      }}
+      template="react"
+      files={{
+        'App.js': exportedFile,
+        'styles.css': { code: `body {padding: 1em}`, hidden: true },
+        'index.js': {
+          hidden: true,
+          code: `
+import React, { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import "bootstrap/dist/css/bootstrap.min.css";
+import "./styles.css"
+
+import App from "./App";
+
+const root = createRoot(document.getElementById("root"));
+root.render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);`,
+        },
+      }}
+    >
+      <ListenerResize
+        onResize={(resizeHeight) =>
+          setHeight(resizeHeight > height ? resizeHeight : height)
+        }
+      />
+      <SandpackLayout style={{ height }}>
+        <SandpackPreview style={{ height }} />
+      </SandpackLayout>
+
+      {showCode && (
+        <>
+          <br />
+          <SandpackLayout>
+            <SandpackCodeEditor />
+          </SandpackLayout>
+        </>
+      )}
+    </SandpackProvider>
   );
 }
 

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -1212,6 +1212,142 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@code-hike/classer@^0.0.0-aa6efee":
+  version "0.0.0-e48fa74"
+  resolved "https://registry.yarnpkg.com/@code-hike/classer/-/classer-0.0.0-e48fa74.tgz#17243ca84d5af303c51e62b378e8db65e01cd3f4"
+  integrity sha512-CyPYvfl4K5Hp9uyhLhUemul56eiGOF0FNXh5ALzzK9VNhRmRmj1O0mKtLDpoccI8W90r9kQES/nW2FC8jVVieg==
+
+"@codemirror/autocomplete@^6.0.0", "@codemirror/autocomplete@^6.4.0":
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.4.2.tgz#938b25223bd21f97b2a6d85474643355f98b505b"
+  integrity sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.6.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/commands@^6.1.3":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.2.1.tgz#ab5e979ad1458bbe395bf69ac601f461ac73cf08"
+  integrity sha512-FFiNKGuHA5O8uC6IJE5apI5rT9gyjlw4whqy4vlcX0wE/myxL6P1s0upwDhY4HtMWLOwzwsp0ap3bjdQhvfDOA==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.2.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/lang-css@^6.0.0", "@codemirror/lang-css@^6.0.1":
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-css/-/lang-css-6.0.2.tgz#b286d0226755a751f60599e1e2969d351aebbd4c"
+  integrity sha512-4V4zmUOl2Glx0GWw0HiO1oGD4zvMlIQ3zx5hXOE6ipCjhohig2bhWRAasrZylH9pRNTcl1VMa59Lsl8lZWlTzw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@lezer/css" "^1.0.0"
+
+"@codemirror/lang-html@^6.4.0":
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-html/-/lang-html-6.4.2.tgz#3c7117e45bae009bc7bc08eef8a79b5d05930d83"
+  integrity sha512-bqCBASkteKySwtIbiV/WCtGnn/khLRbbiV5TE+d9S9eQJD7BA4c5dTRm2b3bVmSpilff5EYxvB4PQaZzM/7cNw==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/lang-css" "^6.0.0"
+    "@codemirror/lang-javascript" "^6.0.0"
+    "@codemirror/language" "^6.4.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.2.2"
+    "@lezer/common" "^1.0.0"
+    "@lezer/css" "^1.1.0"
+    "@lezer/html" "^1.3.0"
+
+"@codemirror/lang-javascript@^6.0.0", "@codemirror/lang-javascript@^6.1.2":
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-javascript/-/lang-javascript-6.1.4.tgz#8a41f4d213e1143b4eef6f65f8b77b349aaf894c"
+  integrity sha512-OxLf7OfOZBTMRMi6BO/F72MNGmgOd9B0vetOLvHsDACFXayBzW8fm8aWnDM0yuy68wTK03MBf4HbjSBNRG5q7A==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/language" "^6.6.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/javascript" "^1.0.0"
+
+"@codemirror/language@^6.0.0", "@codemirror/language@^6.3.2", "@codemirror/language@^6.4.0", "@codemirror/language@^6.6.0":
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.6.0.tgz#2204407174a38a68053715c19e28ad61f491779f"
+  integrity sha512-cwUd6lzt3MfNYOobdjf14ZkLbJcnv4WtndYaoBkbor/vF+rCNguMPK0IRtvZJG4dsWiaWPcK8x1VijhvSxnstg==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+    style-mod "^4.0.0"
+
+"@codemirror/lint@^6.0.0":
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.1.1.tgz#b30741e714a43a11cb78feb2c220b4971ad175f3"
+  integrity sha512-e+M543x0NVHGayNHQzLP4XByJsvbu/ojY6+0VF2Y4Uu66Rt1nADuxNflZwECLf7gS009smIsptSUa6bUj/U/rw==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    crelt "^1.0.5"
+
+"@codemirror/state@^6.0.0", "@codemirror/state@^6.1.4", "@codemirror/state@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.2.0.tgz#a0fb08403ced8c2a68d1d0acee926bd20be922f2"
+  integrity sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA==
+
+"@codemirror/view@^6.0.0", "@codemirror/view@^6.2.2", "@codemirror/view@^6.6.0", "@codemirror/view@^6.7.1":
+  version "6.9.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.9.1.tgz#2ce4c528974b6172a5a4a738b7b0a0f04a4c1140"
+  integrity sha512-bzfSjJn9dAADVpabLKWKNmMG4ibyTV2e3eOGowjElNPTdTkSbi6ixPYHm2u0ADcETfKsi2/R84Rkmi91dH9yEg==
+  dependencies:
+    "@codemirror/state" "^6.1.4"
+    style-mod "^4.0.0"
+    w3c-keyname "^2.2.4"
+
+"@codesandbox/sandpack-client@^1.20.9":
+  version "1.20.9"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-client/-/sandpack-client-1.20.9.tgz#206cb2226f23d0292ce67218186fd0b4f0b09cf1"
+  integrity sha512-Z/SXVRFzO8BOagLg6+6WQfBpAio3AZNjeposYPyoI7fxT8L9urS+G5uG/oG4vV/YkK5nmIuT7pKdTL66wMUsxA==
+  dependencies:
+    codesandbox-import-utils "^1.2.3"
+    lodash.isequal "^4.5.0"
+
+"@codesandbox/sandpack-react@1.20.9":
+  version "1.20.9"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-react/-/sandpack-react-1.20.9.tgz#d19ab0143dee5fd79104da0066909dcd3bc6e78a"
+  integrity sha512-bUfp+JjKBEwY6RDMnhjQ0qbSj2V6P+3n5Avk7AJ7eJ0uYV1ZS2v8Q8PDQw2d9RX27xgyQQ6OklY+XXrlnQZfjw==
+  dependencies:
+    "@code-hike/classer" "^0.0.0-aa6efee"
+    "@codemirror/autocomplete" "^6.4.0"
+    "@codemirror/commands" "^6.1.3"
+    "@codemirror/lang-css" "^6.0.1"
+    "@codemirror/lang-html" "^6.4.0"
+    "@codemirror/lang-javascript" "^6.1.2"
+    "@codemirror/language" "^6.3.2"
+    "@codemirror/state" "^6.2.0"
+    "@codemirror/view" "^6.7.1"
+    "@codesandbox/sandpack-client" "^1.20.9"
+    "@lezer/highlight" "^1.1.3"
+    "@react-hook/intersection-observer" "^3.1.1"
+    "@stitches/core" "^1.2.6"
+    clean-set "^1.1.2"
+    codesandbox-import-util-types "^2.2.3"
+    lodash.isequal "^4.5.0"
+    lz-string "^1.4.4"
+    react-devtools-inline "4.4.0"
+    react-is "^17.0.2"
+
+"@codesandbox/sandpack-themes@latest":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@codesandbox/sandpack-themes/-/sandpack-themes-2.0.1.tgz#4533cf04d0e7da49b055573f93263aa13eef84b8"
+  integrity sha512-Tpo2ycdfGfAYt9TtMuMZSq+su6VbwouHoLTaeT+ZAVp+gXuHXCAx6QkMVb+Iu/ux7TWXUgXO5lCpqpLNfDNTLA==
+
 "@docsearch/css@3.3.3", "@docsearch/css@^3.3.3":
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/@docsearch/css/-/css-3.3.3.tgz#f9346c9e24602218341f51b8ba91eb9109add434"
@@ -1500,6 +1636,50 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
+"@lezer/common@^1.0.0":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.0.2.tgz#8fb9b86bdaa2ece57e7d59e5ffbcb37d71815087"
+  integrity sha512-SVgiGtMnMnW3ActR8SXgsDhw7a0w0ChHSYAyAUxxrOiJ1OqYWEKk/xJd84tTSPo1mo6DXLObAJALNnd0Hrv7Ng==
+
+"@lezer/css@^1.0.0", "@lezer/css@^1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@lezer/css/-/css-1.1.1.tgz#c36dcb0789317cb80c3740767dd3b85e071ad082"
+  integrity sha512-mSjx+unLLapEqdOYDejnGBokB5+AiJKZVclmud0MKQOKx3DLJ5b5VTCstgDDknR6iIV4gVrN6euzsCnj0A2gQA==
+  dependencies:
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/highlight@^1.0.0", "@lezer/highlight@^1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.1.3.tgz#bf5a36c2ee227f526d74997ac91f7777e29bd25d"
+  integrity sha512-3vLKLPThO4td43lYRBygmMY18JN3CPh9w+XS2j8WC30vR4yZeFG4z1iFe4jXE43NtGqe//zHW5q8ENLlHvz9gw==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@lezer/html@^1.3.0":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@lezer/html/-/html-1.3.3.tgz#2eddae2ad000f9b184d9fc4686394d0fa0849993"
+  integrity sha512-04Fyvu66DjV2EjhDIG1kfDdktn5Pfw56SXPrzKNQH5B2m7BDfc6bDsz+ZJG8dLS3kIPEKbyyq1Sm2/kjeG0+AA==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/javascript@^1.0.0":
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/@lezer/javascript/-/javascript-1.4.1.tgz#97a15042c76b5979af6a069fac83cf6485628cbf"
+  integrity sha512-Hqx36DJeYhKtdpc7wBYPR0XF56ZzIp0IkMO/zNNj80xcaFOV4Oj/P7TQc/8k2TxNhzl7tV5tXS8ZOCPbT4L3nA==
+  dependencies:
+    "@lezer/highlight" "^1.1.3"
+    "@lezer/lr" "^1.3.0"
+
+"@lezer/lr@^1.0.0", "@lezer/lr@^1.3.0":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.3.3.tgz#0ac6c889f1235874f33c45a1b9785d7054f60708"
+  integrity sha512-JPQe3mwJlzEVqy67iQiiGozhcngbO8QBgpqZM6oL1Wj/dXckrEexpBLeFkq0edtW5IqnPRFxA24BHJni8Js69w==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
 "@mdx-js/mdx@^1.6.22":
   version "1.6.22"
   resolved "https://registry.yarnpkg.com/@mdx-js/mdx/-/mdx-1.6.22.tgz#8a723157bf90e78f17dc0f27995398e6c731f1ba"
@@ -1611,6 +1791,19 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@react-hook/intersection-observer@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@react-hook/intersection-observer/-/intersection-observer-3.1.1.tgz#6b8fdb80d133c9c28bc8318368ecb3a1f8befc50"
+  integrity sha512-OTDx8/wFaRvzFtKl1dEUEXSOqK2zVJHporiTTdC2xO++0e9FEx9wIrPis5q3lqtXeZH9zYGLbk+aB75qNFbbuw==
+  dependencies:
+    "@react-hook/passive-layout-effect" "^1.2.0"
+    intersection-observer "^0.10.0"
+
+"@react-hook/passive-layout-effect@^1.2.0":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz#c06dac2d011f36d61259aa1c6df4f0d5e28bc55e"
+  integrity sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==
+
 "@restart/context@^2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@restart/context/-/context-2.1.4.tgz#a99d87c299a34c28bd85bb489cb07bfd23149c02"
@@ -1648,6 +1841,11 @@
   dependencies:
     escape-string-regexp "^2.0.0"
     lodash.deburr "^4.1.0"
+
+"@stitches/core@^1.2.6":
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/@stitches/core/-/core-1.2.8.tgz#dce3b8fdc764fbc6dbea30c83b73bfb52cf96173"
+  integrity sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -2808,6 +3006,11 @@ binary-extensions@^2.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.0.0.tgz#23c0df14f6a88077f5f986c0d167ec03c3d5537c"
   integrity sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==
 
+binaryextensions@2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.3.0.tgz#1d269cbf7e6243ea886aa41453c3651ccbe13c22"
+  integrity sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==
+
 bl@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.2.tgz#52b71e9088515d0606d9dd9cc7aa48dc1f98e73a"
@@ -3439,6 +3642,11 @@ classnames@^2.3.2:
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
   integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
 
+clean-set@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/clean-set/-/clean-set-1.1.2.tgz#76d8bf238c3e27827bfa73073ecdfdc767187070"
+  integrity sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==
+
 clean-stack@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/clean-stack/-/clean-stack-2.2.0.tgz#ee8472dbb129e727b31e8a10a427dee9dfe4008b"
@@ -3533,6 +3741,25 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
+codesandbox-import-util-types@^1.3.7:
+  version "1.3.7"
+  resolved "https://registry.yarnpkg.com/codesandbox-import-util-types/-/codesandbox-import-util-types-1.3.7.tgz#7a6097e248a75424d13b06b74368cd76bd2b3e10"
+  integrity sha512-8oP3emA0jyEuVOM2FBTpo/AF4C9vxHn14saVWZf2CQ/QhMtonBlNPE98ElrHkW+PFNXiO7Ad52Qr73b03n8qlA==
+
+codesandbox-import-util-types@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/codesandbox-import-util-types/-/codesandbox-import-util-types-2.2.3.tgz#b354b2f732ad130e119ebd9ead3bda3be5981a54"
+  integrity sha512-Qj00p60oNExthP2oR3vvXmUGjukij+rxJGuiaKM6tyUmSyimdZsqHI/TUvFFClAffk9s7hxGnQgWQ8KCce27qQ==
+
+codesandbox-import-utils@^1.2.3:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/codesandbox-import-utils/-/codesandbox-import-utils-1.3.8.tgz#5576786439c5f37ebd3fee5751e06027a1edef84"
+  integrity sha512-S12zO49QEkldoYLGh5KbkHRLOacg5BCNTue2vlyZXSpuK3oQdArwC/G1hCLKryV460bW3Ecn5xdkpfkUcFeOwQ==
+  dependencies:
+    codesandbox-import-util-types "^1.3.7"
+    istextorbinary "2.2.1"
+    lz-string "^1.4.4"
 
 collapse-white-space@^1.0.0, collapse-white-space@^1.0.2:
   version "1.0.5"
@@ -3911,6 +4138,11 @@ create-react-context@0.3.0:
   dependencies:
     gud "^1.0.0"
     warning "^4.0.3"
+
+crelt@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.5.tgz#57c0d52af8c859e354bace1883eb2e1eb182bb94"
+  integrity sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==
 
 cross-fetch@3.0.6:
   version "3.0.6"
@@ -4685,6 +4917,11 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
+editions@^1.3.3:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/editions/-/editions-1.3.4.tgz#3662cb592347c3168eb8e498a0ff73271d67f50b"
+  integrity sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==
+
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
@@ -4880,7 +5117,7 @@ es6-iterator@^2.0.3, es6-iterator@~2.0.3:
     es5-ext "^0.10.35"
     es6-symbol "^3.1.1"
 
-es6-symbol@^3.1.1, es6-symbol@~3.1.3:
+es6-symbol@^3, es6-symbol@^3.1.1, es6-symbol@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
   integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
@@ -7539,6 +7776,11 @@ internal-slot@^1.0.2:
     has "^1.0.3"
     side-channel "^1.0.2"
 
+intersection-observer@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/intersection-observer/-/intersection-observer-0.10.0.tgz#4d11d63c1ff67e21e62987be24d55218da1a1a69"
+  integrity sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==
+
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
@@ -8106,6 +8348,15 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
+istextorbinary@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/istextorbinary/-/istextorbinary-2.2.1.tgz#a5231a08ef6dd22b268d0895084cf8d58b5bec53"
+  integrity sha512-TS+hoFl8Z5FAFMK38nhBkdLt44CclNRgDHWeMgsV8ko3nDlr/9UI2Sf839sW7enijf8oKsZYXRvM8g0it9Zmcw==
+  dependencies:
+    binaryextensions "2"
+    editions "^1.3.3"
+    textextensions "2"
+
 isurl@^1.0.0-alpha5:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isurl/-/isurl-1.0.0.tgz#b27f4f49f3cdaa3ea44a0a5b7f3462e6edc39d67"
@@ -8499,6 +8750,11 @@ lodash.foreach@^4.3.0, lodash.foreach@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
   integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
@@ -8646,6 +8902,11 @@ lru-queue@^0.1.0:
   integrity sha1-Jzi9nw089PhEkMVzbEhpmsYyzaM=
   dependencies:
     es5-ext "~0.10.2"
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
 
 magic-string@^0.25.0, magic-string@^0.25.1, magic-string@^0.25.7:
   version "0.25.7"
@@ -11002,6 +11263,13 @@ react-dev-utils@^4.2.3:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
+react-devtools-inline@4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/react-devtools-inline/-/react-devtools-inline-4.4.0.tgz#e032a6eb17a9977b682306f84b46e683adf4bf68"
+  integrity sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==
+  dependencies:
+    es6-symbol "^3"
+
 react-docgen@^5.3.1, react-docgen@^5.4.3:
   version "5.4.3"
   resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-5.4.3.tgz#7d297f73b977d0c7611402e5fc2a168acf332b26"
@@ -11071,6 +11339,11 @@ react-is@^16.12.0, react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 react-lifecycles-compat@^3.0.4:
   version "3.0.4"
@@ -12688,6 +12961,11 @@ style-loader@^0.23.1:
     loader-utils "^1.1.0"
     schema-utils "^1.0.0"
 
+style-mod@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.0.0.tgz#97e7c2d68b592975f2ca7a63d0dd6fcacfe35a01"
+  integrity sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==
+
 style-to-object@0.3.0, style-to-object@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/style-to-object/-/style-to-object-0.3.0.tgz#b1b790d205991cc783801967214979ee19a76e46"
@@ -12882,6 +13160,11 @@ text-table@0.2.0, text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
+textextensions@2:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/textextensions/-/textextensions-2.6.0.tgz#d7e4ab13fe54e32e08873be40d51b74229b00fc4"
+  integrity sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ==
 
 through2@^2.0.0, through2@^2.0.1:
   version "2.0.5"
@@ -13731,6 +14014,11 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+w3c-keyname@^2.2.4:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.6.tgz#8412046116bc16c5d73d4e612053ea10a189c85f"
+  integrity sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==
 
 warning@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
<img width="1021" alt="Screenshot 2023-02-23 at 14 45 02" src="https://user-images.githubusercontent.com/4838076/220940013-629348c6-c931-4fea-b178-e26beffc4367.png">

Hey there! I want to propose that react-bootstrap starts using Sandpack to run interactive live code examples in the documentation.

Sandpack is a component toolkit for creating live code editing experiences powered by the online bundler used on CodeSandbox. It provides an open ecosystem of components and utilities that allow you to compile and run modern frameworks in the browser, making it perfect for documenting components, bug reports, and playgrounds. Many open-source documentations, such as [React docs](https://beta.reactjs.org/), [Chakra UI](https://play.chakra-ui.com/playground?code=), [Amplify](https://ui.docs.amplify.aws/), and others, use Sandpack in various ways to make their documentation more interactive.

Here's an example of the [alerts component page](https://2ouhld-8000.preview.csb.app/components/alerts) running in Sandpack. I believe this could be very useful to show on all the documentation, as it lets users play around with code and see the example live.

**Why Sandpack?**
- Security: The bundler evaluates and transpiles all files in an iframe under a different subdomain. This is important because it prevents attackers from tampering with cookies of the host domain when evaluating code.

- User-experience: With built-in npm dependency support, hot module reloading, error overlaying, caching, and Node.js support, Sandpack can provide an environment closer to the user development experience. Sandpack uses CodeMirror as its code editor, which supports touch devices and a lightweight bundler.

- Offline Support: Sandpack uses Service Workers to download all transpilers in the background so that the next time a user visits the react-bootstrap Docs, they don't have to download the bundler anymore, and it can be used offline. This is possible because Sandpack hosts the service worker externally.

- Keep coding with a click: With Sandpack, you're always one click away from opening your code snippet in CodeSandbox. This way, end-users can easily share bug reports or examples behind a unique URL.


If you find Sandpack exciting and agree with this integration, I would be happy to collaborate and bring Sandpack to React-bootstrap documentation. This is just a start, and there are many ways we can improve the integration, including making sure the Sandpack layout fits the documentation layout, using Sandpack as a code highlighter to match the snippets of codes and the editor, and updating examples to ensure they are working correctly.

Let me know if you have any questions or feedback!
