### PR TITLE
docs (Form Text): fixed docs with incorrect documentation.

### DIFF
--- a/www/src/pages/forms/form-text.mdx
+++ b/www/src/pages/forms/form-text.mdx
@@ -26,7 +26,7 @@ like `.text-muted`.
 </Callout>
 
 Form text below inputs can be styled with `<Form.Text>`. This component includes
-`display: block` and adds some top margin for easy spacing from the inputs above.
+`display: inline` and uses `<small>` element.
 
 <ReactPlayground codeText={FormText} />
 


### PR DESCRIPTION
## This PR addresses the issue https://github.com/react-bootstrap/react-bootstrap/issues/6546.

I have made the required changes to the documentation. Any alternative choice of words for the changed documentation is appreciated and welcomed.