### PR TITLE
docs: example uses non-existent property

### DIFF
--- a/www/docs/examples/Tabs/LeftTabs.js
+++ b/www/docs/examples/Tabs/LeftTabs.js
@@ -5,7 +5,7 @@ import Tab from 'react-bootstrap/Tab';
 
 function LeftTabsExample() {
   return (
-    <Tab.Container id="left-tabs-example" defaultActiveKey="first">
+    <Tab.Container id="left-tabs-example">
       <Row>
         <Col sm={3}>
           <Nav variant="pills" className="flex-column">


### PR DESCRIPTION
The API for `<Tab.Container>` does not have the `defaultActiveKey` property.  Removing from this example.

An alternative would be to add `<Tabs  defaultActiveKey="first">...</Tabs>` to the example.