### PR TITLE
docs: fix playground tabbing and add copy button

### DIFF
--- a/www/src/theme/Playground/EditorInfoMessage.tsx
+++ b/www/src/theme/Playground/EditorInfoMessage.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.css';
+
+const EditorInfoMessage: React.FC<React.HTMLAttributes<HTMLDivElement>> = (
+  props,
+) => (
+  <div
+    className={clsx('alert alert-info p-2', styles.editorInfoMessage)}
+    {...props}
+  />
+);
+
+EditorInfoMessage.displayName = 'EditorInfoMessage';
+
+export default EditorInfoMessage;

--- a/www/src/theme/Playground/styles.module.css
+++ b/www/src/theme/Playground/styles.module.css
@@ -31,3 +31,30 @@
   padding: 1rem;
   background-color: var(--ifm-pre-background);
 }
+
+.editorToolbar {
+  position: absolute;
+  right: calc(var(--ifm-pre-padding) / 2);
+  top: calc(var(--ifm-pre-padding) / 2);
+  display: flex;
+  column-gap: 0.2rem;
+}
+
+.editorInfoMessage {
+  font-size: 70%;
+  pointer-events: none;
+}
+
+/* https://github.com/facebook/docusaurus/blob/main/packages/docusaurus-theme-classic/src/theme/CodeBlock/Content/styles.module.css */
+.buttonGroup button {
+  display: flex;
+  align-items: center;
+  background: var(--prism-background-color);
+  color: var(--prism-color);
+  border: 1px solid var(--ifm-color-emphasis-300);
+  border-radius: var(--ifm-global-radius);
+  padding: 0.4rem;
+  line-height: 0;
+  transition: opacity var(--ifm-transition-fast) ease-in-out;
+  opacity: 1;
+}


### PR DESCRIPTION
Brings back the copy button (styled like the other codeblocks) and fixes the tabbing behavior for live code like it was in the old docs.