### PR TITLE
Deleting the placeholder to solve the issue #6616

### DIFF
--- a/www/docs/examples/Form/FormFloatingTextarea.js
+++ b/www/docs/examples/Form/FormFloatingTextarea.js
@@ -9,12 +9,12 @@ function FormFloatingTextareaExample() {
         label="Comments"
         className="mb-3"
       >
-        <Form.Control as="textarea" placeholder="Leave a comment here" />
+        <Form.Control as="textarea"  />
       </FloatingLabel>
       <FloatingLabel controlId="floatingTextarea2" label="Comments">
         <Form.Control
           as="textarea"
-          placeholder="Leave a comment here"
+       
           style={{ height: '100px' }}
         />
       </FloatingLabel>


### PR DESCRIPTION
Erased the placeholder in the 'Floating label' tag so only the Label is appearing 