### PR TITLE
Fix(Unable to add custom styles to PageItem Component)

### DIFF
--- a/src/PageItem.tsx
+++ b/src/PageItem.tsx
@@ -13,6 +13,8 @@ export interface PageItemProps
   active?: boolean;
   activeLabel?: string;
   href?: string;
+  innerStyle?: React.CSSProperties;
+  innerClassName?: string;
 }
 
 const propTypes = {
@@ -42,6 +44,8 @@ const PageItem: BsPrefixRefForwardingComponent<'li', PageItemProps> =
         style,
         activeLabel = '(current)',
         children,
+        innerClassName,
+        innerStyle,
         ...props
       }: PageItemProps,
       ref,
@@ -53,7 +57,11 @@ const PageItem: BsPrefixRefForwardingComponent<'li', PageItemProps> =
           style={style}
           className={classNames(className, 'page-item', { active, disabled })}
         >
-          <Component className="page-link" {...props}>
+          <Component
+            className={classNames('page-link', innerClassName)}
+            style={innerStyle}
+            {...props}
+          >
             {children}
             {active && activeLabel && (
               <span className="visually-hidden">{activeLabel}</span>

--- a/src/PageItem.tsx
+++ b/src/PageItem.tsx
@@ -13,8 +13,8 @@ export interface PageItemProps
   active?: boolean;
   activeLabel?: string;
   href?: string;
-  innerStyle?: React.CSSProperties;
-  innerClassName?: string;
+  linkStyle?: React.CSSProperties;
+  linkClassName?: string;
 }
 
 const propTypes = {
@@ -34,10 +34,10 @@ const propTypes = {
   onClick: PropTypes.func,
 
   /** custom style for the inner component of the PageItem */
-  innerStyle: PropTypes.object,
+  linkStyle: PropTypes.object,
 
   /** custom className for the inner component of the PageItem */
-  innerClassName: PropTypes.string,
+  linkClassName: PropTypes.string,
 };
 
 const PageItem: BsPrefixRefForwardingComponent<'li', PageItemProps> =
@@ -50,8 +50,8 @@ const PageItem: BsPrefixRefForwardingComponent<'li', PageItemProps> =
         style,
         activeLabel = '(current)',
         children,
-        innerClassName,
-        innerStyle,
+        linkStyle,
+        linkClassName,
         ...props
       }: PageItemProps,
       ref,
@@ -64,8 +64,8 @@ const PageItem: BsPrefixRefForwardingComponent<'li', PageItemProps> =
           className={classNames(className, 'page-item', { active, disabled })}
         >
           <Component
-            className={classNames('page-link', innerClassName)}
-            style={innerStyle}
+            className={classNames('page-link', linkClassName)}
+            style={linkStyle}
             {...props}
           >
             {children}

--- a/src/PageItem.tsx
+++ b/src/PageItem.tsx
@@ -32,6 +32,12 @@ const propTypes = {
 
   /** A callback function for when this component is clicked. */
   onClick: PropTypes.func,
+
+  /** custom style for the inner component of the PageItem */
+  innerStyle: PropTypes.object,
+
+  /** custom className for the inner component of the PageItem */
+  innerClassName: PropTypes.string,
 };
 
 const PageItem: BsPrefixRefForwardingComponent<'li', PageItemProps> =

--- a/test/PageItemSpec.tsx
+++ b/test/PageItemSpec.tsx
@@ -49,5 +49,23 @@ describe('<PageItem>', () => {
 
       pageItemInnerElem.classList.contains('page-link').should.be.true;
     });
+
+    it('should apply className to the inner component if linkClassName is set', () => {
+      const { container } = render(
+        <PageItem linkClassName="custom-class-name" />,
+      );
+      const pageItemElem = container.firstElementChild!;
+      const pageItemInnerElem = pageItemElem.firstElementChild!;
+
+      pageItemInnerElem.classList.contains('custom-class-name').should.be.true;
+    });
+
+    it('should apply style to the inner component if linkStyle is set', () => {
+      const { container } = render(<PageItem linkStyle={{ color: 'red' }} />);
+      const pageItemElem = container.firstElementChild!;
+      const pageItemInnerElem = pageItemElem.firstElementChild!;
+
+      pageItemInnerElem.getAttribute('style')!.should.equal('color: red;');
+    });
   });
 });


### PR DESCRIPTION
This fixes #5950 

When using Bootstrap Pagination, There is an incomplete API to allow adding custom styles to the ``<Component>`` inside the ``<PageItem>``. there is no className or style prop that is passed to the <Component> to allow for custom styles to be applied, so The developer can't change the color of the ``<a>``  tag inside of the ``<PageItem>`` for example!

I have solved the issue by creating a new two props ( innerStyle and innerClassName ), they are passed to the ``<Component>`` inside of ``<PageItem>``

Thanks.

PART OF GTC OPEN SOURCE INTIATIVE