### PR TITLE
Fix (broken color modes link: Bug)

### DIFF
--- a/www/docs/getting-started/color-modes.mdx
+++ b/www/docs/getting-started/color-modes.mdx
@@ -20,4 +20,4 @@ thanks to the `data-bs-theme` attribute.
 ## Customizing
 
 For more information on how colors modes work or how to customize colors, check out
-the <DocLink path="customize/color-modes">Bootstrap color mode docs</DocLink>.
+the <DocLink path="/customize/color-modes">Bootstrap color mode docs</DocLink>.


### PR DESCRIPTION
This fixes #6637 

There's a simple problem in the docs as mentioned in issue #6637, the passed path to ``<DocLink>`` was missing a slash, in the beginning, to direct to the right page.

Thanks.

``PART OF GTC OPEN SOURCE INTIATIVE``