### PR TITLE
feat: add initial RSC support

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,7 +1,8 @@
-module.exports = api => {
+module.exports = (api) => {
   const env = api.env();
 
   let dev = false;
+  let setUseClient = false;
   let modules;
 
   switch (env) {
@@ -12,12 +13,17 @@ module.exports = api => {
       modules = false;
       break;
     case 'dist-prod':
+      modules = false;
+      break;
     case 'esm':
       modules = false;
+      setUseClient = true;
       break;
     case 'cjs':
     default:
       modules = 'commonjs';
+      setUseClient = true;
+      break;
   }
 
   return {
@@ -28,6 +34,8 @@ module.exports = api => {
           dev,
           modules,
           removePropTypes: !dev,
+          setUseClient,
+          customClientImports: ['useBootstrapPrefix', 'createWithBsPrefix'],
         },
       ],
       '@babel/preset-typescript',


### PR DESCRIPTION
Closes #6475 

Enables the plugin to add `use client` into all of the components.

Found some issues though:

**1. Cannot use a component that has been created with `createWithBsPrefix`.  For example: `CardGroup`**

```
Error: Attempted to call the default export of createWithBsPrefix.js from the server but it's on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.
```

**Potential solution:**
We would need to stop using this function to create components.

**2. Cannot use a component that's been set as a property. For example `Accordion.Body`**
```
Error: Unsupported Server Component type: undefined
    at stringify (<anonymous>)
```

**Potential solution:**
Users would have to import the component separately `import AccordionBody from 'react-bootstrap/AccordionBody'`