### PR TITLE
fix(OverlayTrigger): position overlay properly when defaultShow set

### DIFF
--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -179,10 +179,11 @@ const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
     });
 
     useIsomorphicEffect(() => {
-      if (firstRenderedState) {
+      if (firstRenderedState && outerProps.target) {
+        // Must wait for target element to resolve before updating popper.
         popperRef.current.scheduleUpdate?.();
       }
-    }, [firstRenderedState]);
+    }, [firstRenderedState, outerProps.target]);
 
     useEffect(() => {
       if (!outerShow) {


### PR DESCRIPTION
Fixes #6619

Need to run the popper update once the target element resolves so that it's positioned properly with `defaultShow=true`