### PR TITLE
fix(FormControl): add size support when using plaintext

### DIFF
--- a/src/FormControl.tsx
+++ b/src/FormControl.tsx
@@ -126,16 +126,6 @@ const FormControl: BsPrefixRefForwardingComponent<'input', FormControlProps> =
 
       bsPrefix = useBootstrapPrefix(bsPrefix, 'form-control');
 
-      let classes;
-      if (plaintext) {
-        classes = { [`${bsPrefix}-plaintext`]: true };
-      } else {
-        classes = {
-          [bsPrefix]: true,
-          [`${bsPrefix}-${size}`]: size,
-        };
-      }
-
       warning(
         controlId == null || !id,
         '`controlId` is ignored on `<FormControl>` when `id` is specified.',
@@ -151,10 +141,11 @@ const FormControl: BsPrefixRefForwardingComponent<'input', FormControlProps> =
           id={id || controlId}
           className={classNames(
             className,
-            classes,
-            isValid && `is-valid`,
-            isInvalid && `is-invalid`,
+            plaintext ? `${bsPrefix}-plaintext` : bsPrefix,
+            size && `${bsPrefix}-${size}`,
             type === 'color' && `${bsPrefix}-color`,
+            isValid && 'is-valid',
+            isInvalid && 'is-invalid',
           )}
         />
       );

--- a/test/FormControlSpec.tsx
+++ b/test/FormControlSpec.tsx
@@ -46,6 +46,16 @@ describe('<FormControl>', () => {
     element.classList.contains('form-control-plaintext').should.be.true;
   });
 
+  it('should support plaintext inputs with size', () => {
+    const { getByTestId } = render(
+      <FormControl plaintext size="sm" data-testid="test-id" />,
+    );
+
+    const element = getByTestId('test-id');
+    element.classList.length.should.equal(2);
+    element.classList.contains('form-control-sm').should.be.true;
+  });
+
   it('should support type=color', () => {
     const { getByTestId } = render(
       <FormControl type="color" data-testid="test-id" />,


### PR DESCRIPTION
Currently, when passing `plaintext` alongside with `size` prop, the relevant size class is not set in the input.