### PR TITLE
fix: fix RSC error with createWithBsPrefix components

### DIFF
--- a/src/Alert.tsx
+++ b/src/Alert.tsx
@@ -4,13 +4,12 @@ import PropTypes from 'prop-types';
 import { elementType } from 'prop-types-extra';
 import { useUncontrolled } from 'uncontrollable';
 import useEventCallback from '@restart/hooks/useEventCallback';
-import Anchor from '@restart/ui/Anchor';
 import { useBootstrapPrefix } from './ThemeProvider';
+import AlertHeading from './AlertHeading';
+import AlertLink from './AlertLink';
 import Fade from './Fade';
 import CloseButton, { CloseButtonVariant } from './CloseButton';
 import { Variant } from './types';
-import divWithClassName from './divWithClassName';
-import createWithBsPrefix from './createWithBsPrefix';
 import { TransitionType } from './helpers';
 
 export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
@@ -23,17 +22,6 @@ export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   closeVariant?: CloseButtonVariant;
   transition?: TransitionType;
 }
-
-const DivStyledAsH4 = divWithClassName('h4');
-DivStyledAsH4.displayName = 'DivStyledAsH4';
-
-const AlertHeading = createWithBsPrefix('alert-heading', {
-  Component: DivStyledAsH4,
-});
-
-const AlertLink = createWithBsPrefix('alert-link', {
-  Component: Anchor,
-});
 
 const propTypes = {
   /**

--- a/src/AlertHeading.tsx
+++ b/src/AlertHeading.tsx
@@ -1,19 +1,20 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import divWithClassName from './divWithClassName';
 import { useBootstrapPrefix } from './ThemeProvider';
+import divWithClassName from './divWithClassName';
 import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 const DivStyledAsH4 = divWithClassName('h4');
+DivStyledAsH4.displayName = 'DivStyledAsH4';
 
-export interface ModalTitleProps
+export interface AlertHeadingProps
   extends BsPrefixProps,
     React.HTMLAttributes<HTMLElement> {}
 
-const ModalTitle: BsPrefixRefForwardingComponent<'span', ModalTitleProps> =
-  React.forwardRef<HTMLElement, ModalTitleProps>(
+const AlertHeading: BsPrefixRefForwardingComponent<'div', AlertHeadingProps> =
+  React.forwardRef<HTMLElement, AlertHeadingProps>(
     ({ className, bsPrefix, as: Component = DivStyledAsH4, ...props }, ref) => {
-      bsPrefix = useBootstrapPrefix(bsPrefix, 'modal-title');
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'alert-heading');
       return (
         <Component
           ref={ref}
@@ -24,6 +25,6 @@ const ModalTitle: BsPrefixRefForwardingComponent<'span', ModalTitleProps> =
     },
   );
 
-ModalTitle.displayName = 'ModalTitle';
+AlertHeading.displayName = 'AlertHeading';
 
-export default ModalTitle;
+export default AlertHeading;

--- a/src/AlertLink.tsx
+++ b/src/AlertLink.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import Anchor from '@restart/ui/Anchor';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
+
+export interface AlertLinkProps
+  extends BsPrefixProps,
+    React.AnchorHTMLAttributes<HTMLElement> {}
+
+const AlertLink: BsPrefixRefForwardingComponent<'a', AlertLinkProps> =
+  React.forwardRef<HTMLElement, AlertLinkProps>(
+    ({ className, bsPrefix, as: Component = Anchor, ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'alert-link');
+      return (
+        <Component
+          ref={ref}
+          className={classNames(className, bsPrefix)}
+          {...props}
+        />
+      );
+    },
+  );
+
+AlertLink.displayName = 'AlertLink';
+
+export default AlertLink;

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -3,26 +3,17 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 
 import { useBootstrapPrefix } from './ThemeProvider';
-import createWithBsPrefix from './createWithBsPrefix';
-import divWithClassName from './divWithClassName';
-import CardImg from './CardImg';
+import CardBody from './CardBody';
+import CardFooter from './CardFooter';
 import CardHeader from './CardHeader';
+import CardImg from './CardImg';
+import CardImgOverlay from './CardImgOverlay';
+import CardLink from './CardLink';
+import CardSubtitle from './CardSubtitle';
+import CardText from './CardText';
+import CardTitle from './CardTitle';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 import { Color, Variant } from './types';
-
-const DivStyledAsH5 = divWithClassName('h5');
-const DivStyledAsH6 = divWithClassName('h6');
-const CardBody = createWithBsPrefix('card-body');
-const CardTitle = createWithBsPrefix('card-title', {
-  Component: DivStyledAsH5,
-});
-const CardSubtitle = createWithBsPrefix('card-subtitle', {
-  Component: DivStyledAsH6,
-});
-const CardLink = createWithBsPrefix('card-link', { Component: 'a' });
-const CardText = createWithBsPrefix('card-text', { Component: 'p' });
-const CardFooter = createWithBsPrefix('card-footer');
-const CardImgOverlay = createWithBsPrefix('card-img-overlay');
 
 export interface CardProps
   extends BsPrefixProps,

--- a/src/CardBody.tsx
+++ b/src/CardBody.tsx
@@ -3,14 +3,14 @@ import classNames from 'classnames';
 import { useBootstrapPrefix } from './ThemeProvider';
 import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface CardGroupProps
+export interface CardBodyProps
   extends BsPrefixProps,
     React.HTMLAttributes<HTMLElement> {}
 
-const CardGroup: BsPrefixRefForwardingComponent<'div', CardGroupProps> =
-  React.forwardRef<HTMLElement, CardGroupProps>(
+const CardBody: BsPrefixRefForwardingComponent<'div', CardBodyProps> =
+  React.forwardRef<HTMLElement, CardBodyProps>(
     ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
-      bsPrefix = useBootstrapPrefix(bsPrefix, 'card-group');
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'card-body');
       return (
         <Component
           ref={ref}
@@ -21,6 +21,6 @@ const CardGroup: BsPrefixRefForwardingComponent<'div', CardGroupProps> =
     },
   );
 
-CardGroup.displayName = 'CardGroup';
+CardBody.displayName = 'CardBody';
 
-export default CardGroup;
+export default CardBody;

--- a/src/CardFooter.tsx
+++ b/src/CardFooter.tsx
@@ -3,14 +3,14 @@ import classNames from 'classnames';
 import { useBootstrapPrefix } from './ThemeProvider';
 import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface CardGroupProps
+export interface CardFooterProps
   extends BsPrefixProps,
     React.HTMLAttributes<HTMLElement> {}
 
-const CardGroup: BsPrefixRefForwardingComponent<'div', CardGroupProps> =
-  React.forwardRef<HTMLElement, CardGroupProps>(
+const CardFooter: BsPrefixRefForwardingComponent<'div', CardFooterProps> =
+  React.forwardRef<HTMLElement, CardFooterProps>(
     ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
-      bsPrefix = useBootstrapPrefix(bsPrefix, 'card-group');
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'card-footer');
       return (
         <Component
           ref={ref}
@@ -21,6 +21,6 @@ const CardGroup: BsPrefixRefForwardingComponent<'div', CardGroupProps> =
     },
   );
 
-CardGroup.displayName = 'CardGroup';
+CardFooter.displayName = 'CardFooter';
 
-export default CardGroup;
+export default CardFooter;

--- a/src/CardImgOverlay.tsx
+++ b/src/CardImgOverlay.tsx
@@ -3,16 +3,16 @@ import classNames from 'classnames';
 import { useBootstrapPrefix } from './ThemeProvider';
 import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface FigureCaptionProps
+export interface CardImgOverlayProps
   extends BsPrefixProps,
     React.HTMLAttributes<HTMLElement> {}
 
-const FigureCaption: BsPrefixRefForwardingComponent<
-  'figcaption',
-  FigureCaptionProps
-> = React.forwardRef<HTMLElement, FigureCaptionProps>(
-  ({ className, bsPrefix, as: Component = 'figcaption', ...props }, ref) => {
-    bsPrefix = useBootstrapPrefix(bsPrefix, 'figure-caption');
+const CardImgOverlay: BsPrefixRefForwardingComponent<
+  'div',
+  CardImgOverlayProps
+> = React.forwardRef<HTMLElement, CardImgOverlayProps>(
+  ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'card-img-overlay');
     return (
       <Component
         ref={ref}
@@ -23,6 +23,6 @@ const FigureCaption: BsPrefixRefForwardingComponent<
   },
 );
 
-FigureCaption.displayName = 'FigureCaption';
+CardImgOverlay.displayName = 'CardImgOverlay';
 
-export default FigureCaption;
+export default CardImgOverlay;

--- a/src/CardLink.tsx
+++ b/src/CardLink.tsx
@@ -3,14 +3,14 @@ import classNames from 'classnames';
 import { useBootstrapPrefix } from './ThemeProvider';
 import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface CardGroupProps
+export interface CardLinkProps
   extends BsPrefixProps,
-    React.HTMLAttributes<HTMLElement> {}
+    React.AnchorHTMLAttributes<HTMLElement> {}
 
-const CardGroup: BsPrefixRefForwardingComponent<'div', CardGroupProps> =
-  React.forwardRef<HTMLElement, CardGroupProps>(
-    ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
-      bsPrefix = useBootstrapPrefix(bsPrefix, 'card-group');
+const CardLink: BsPrefixRefForwardingComponent<'a', CardLinkProps> =
+  React.forwardRef<HTMLElement, CardLinkProps>(
+    ({ className, bsPrefix, as: Component = 'a', ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'card-link');
       return (
         <Component
           ref={ref}
@@ -21,6 +21,6 @@ const CardGroup: BsPrefixRefForwardingComponent<'div', CardGroupProps> =
     },
   );
 
-CardGroup.displayName = 'CardGroup';
+CardLink.displayName = 'CardLink';
 
-export default CardGroup;
+export default CardLink;

--- a/src/CardSubtitle.tsx
+++ b/src/CardSubtitle.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
+import divWithClassName from './divWithClassName';
+
+const DivStyledAsH6 = divWithClassName('h6');
+
+export interface CardSubtitleProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const CardSubtitle: BsPrefixRefForwardingComponent<'div', CardSubtitleProps> =
+  React.forwardRef<HTMLElement, CardSubtitleProps>(
+    ({ className, bsPrefix, as: Component = DivStyledAsH6, ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'card-subtitle');
+      return (
+        <Component
+          ref={ref}
+          className={classNames(className, bsPrefix)}
+          {...props}
+        />
+      );
+    },
+  );
+
+CardSubtitle.displayName = 'CardSubtitle';
+
+export default CardSubtitle;

--- a/src/CardText.tsx
+++ b/src/CardText.tsx
@@ -3,14 +3,14 @@ import classNames from 'classnames';
 import { useBootstrapPrefix } from './ThemeProvider';
 import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface CardGroupProps
+export interface CardTextProps
   extends BsPrefixProps,
     React.HTMLAttributes<HTMLElement> {}
 
-const CardGroup: BsPrefixRefForwardingComponent<'div', CardGroupProps> =
-  React.forwardRef<HTMLElement, CardGroupProps>(
-    ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
-      bsPrefix = useBootstrapPrefix(bsPrefix, 'card-group');
+const CardText: BsPrefixRefForwardingComponent<'p', CardTextProps> =
+  React.forwardRef<HTMLElement, CardTextProps>(
+    ({ className, bsPrefix, as: Component = 'p', ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'card-text');
       return (
         <Component
           ref={ref}
@@ -21,6 +21,6 @@ const CardGroup: BsPrefixRefForwardingComponent<'div', CardGroupProps> =
     },
   );
 
-CardGroup.displayName = 'CardGroup';
+CardText.displayName = 'CardText';
 
-export default CardGroup;
+export default CardText;

--- a/src/CardTitle.tsx
+++ b/src/CardTitle.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
+import divWithClassName from './divWithClassName';
+
+const DivStyledAsH5 = divWithClassName('h5');
+
+export interface CardTitleProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const CardTitle: BsPrefixRefForwardingComponent<'div', CardTitleProps> =
+  React.forwardRef<HTMLElement, CardTitleProps>(
+    ({ className, bsPrefix, as: Component = DivStyledAsH5, ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'card-title');
+      return (
+        <Component
+          ref={ref}
+          className={classNames(className, bsPrefix)}
+          {...props}
+        />
+      );
+    },
+  );
+
+CardTitle.displayName = 'CardTitle';
+
+export default CardTitle;

--- a/src/CarouselCaption.tsx
+++ b/src/CarouselCaption.tsx
@@ -1,3 +1,28 @@
-import createWithBsPrefix from './createWithBsPrefix';
+import * as React from 'react';
+import classNames from 'classnames';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export default createWithBsPrefix('carousel-caption');
+export interface CarouselCaptionProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const CarouselCaption: BsPrefixRefForwardingComponent<
+  'div',
+  CarouselCaptionProps
+> = React.forwardRef<HTMLElement, CarouselCaptionProps>(
+  ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'carousel-caption');
+    return (
+      <Component
+        ref={ref}
+        className={classNames(className, bsPrefix)}
+        {...props}
+      />
+    );
+  },
+);
+
+CarouselCaption.displayName = 'CarouselCaption';
+
+export default CarouselCaption;

--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -9,25 +9,16 @@ import BaseDropdown, {
 import { useUncontrolled } from 'uncontrollable';
 import useEventCallback from '@restart/hooks/useEventCallback';
 import DropdownContext, { DropDirection } from './DropdownContext';
+import DropdownDivider from './DropdownDivider';
+import DropdownHeader from './DropdownHeader';
 import DropdownItem from './DropdownItem';
+import DropdownItemText from './DropdownItemText';
 import DropdownMenu, { getDropdownMenuPlacement } from './DropdownMenu';
 import DropdownToggle from './DropdownToggle';
 import InputGroupContext from './InputGroupContext';
 import { useBootstrapPrefix, useIsRTL } from './ThemeProvider';
-import createWithBsPrefix from './createWithBsPrefix';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 import { AlignType, alignPropType } from './types';
-
-const DropdownHeader = createWithBsPrefix('dropdown-header', {
-  defaultProps: { role: 'heading' },
-});
-const DropdownDivider = createWithBsPrefix('dropdown-divider', {
-  Component: 'hr',
-  defaultProps: { role: 'separator' },
-});
-const DropdownItemText = createWithBsPrefix('dropdown-item-text', {
-  Component: 'span',
-});
 
 export interface DropdownProps
   extends BaseDropdownProps,

--- a/src/DropdownDivider.tsx
+++ b/src/DropdownDivider.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
+
+export interface DropdownDividerProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const DropdownDivider: BsPrefixRefForwardingComponent<
+  'hr',
+  DropdownDividerProps
+> = React.forwardRef<HTMLElement, DropdownDividerProps>(
+  (
+    { className, bsPrefix, as: Component = 'hr', role = 'separator', ...props },
+    ref,
+  ) => {
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'dropdown-divider');
+    return (
+      <Component
+        ref={ref}
+        className={classNames(className, bsPrefix)}
+        role={role}
+        {...props}
+      />
+    );
+  },
+);
+
+DropdownDivider.displayName = 'DropdownDivider';
+
+export default DropdownDivider;

--- a/src/DropdownHeader.tsx
+++ b/src/DropdownHeader.tsx
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import classNames from 'classnames';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
+
+export interface DropdownHeaderProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const DropdownHeader: BsPrefixRefForwardingComponent<
+  'div',
+  DropdownHeaderProps
+> = React.forwardRef<HTMLElement, DropdownHeaderProps>(
+  (
+    { className, bsPrefix, as: Component = 'div', role = 'heading', ...props },
+    ref,
+  ) => {
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'dropdown-header');
+    return (
+      <Component
+        ref={ref}
+        className={classNames(className, bsPrefix)}
+        role={role}
+        {...props}
+      />
+    );
+  },
+);
+
+DropdownHeader.displayName = 'DropdownHeader';
+
+export default DropdownHeader;

--- a/src/DropdownItemText.tsx
+++ b/src/DropdownItemText.tsx
@@ -3,16 +3,16 @@ import classNames from 'classnames';
 import { useBootstrapPrefix } from './ThemeProvider';
 import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface FigureCaptionProps
+export interface DropdownItemTextProps
   extends BsPrefixProps,
     React.HTMLAttributes<HTMLElement> {}
 
-const FigureCaption: BsPrefixRefForwardingComponent<
-  'figcaption',
-  FigureCaptionProps
-> = React.forwardRef<HTMLElement, FigureCaptionProps>(
-  ({ className, bsPrefix, as: Component = 'figcaption', ...props }, ref) => {
-    bsPrefix = useBootstrapPrefix(bsPrefix, 'figure-caption');
+const DropdownItemText: BsPrefixRefForwardingComponent<
+  'span',
+  DropdownItemTextProps
+> = React.forwardRef<HTMLElement, DropdownItemTextProps>(
+  ({ className, bsPrefix, as: Component = 'span', ...props }, ref) => {
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'dropdown-item-text');
     return (
       <Component
         ref={ref}
@@ -23,6 +23,6 @@ const FigureCaption: BsPrefixRefForwardingComponent<
   },
 );
 
-FigureCaption.displayName = 'FigureCaption';
+DropdownItemText.displayName = 'DropdownItemText';
 
-export default FigureCaption;
+export default DropdownItemText;

--- a/src/Figure.tsx
+++ b/src/Figure.tsx
@@ -1,10 +1,29 @@
-import createWithBsPrefix from './createWithBsPrefix';
+import * as React from 'react';
+import classNames from 'classnames';
 import FigureImage from './FigureImage';
 import FigureCaption from './FigureCaption';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-const Figure = createWithBsPrefix('figure', {
-  Component: 'figure',
-});
+export interface FigureProps
+  extends BsPrefixProps,
+    React.AnchorHTMLAttributes<HTMLElement> {}
+
+const Figure: BsPrefixRefForwardingComponent<'figure', FigureProps> =
+  React.forwardRef<HTMLElement, FigureProps>(
+    ({ className, bsPrefix, as: Component = 'figure', ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'figure');
+      return (
+        <Component
+          ref={ref}
+          className={classNames(className, bsPrefix)}
+          {...props}
+        />
+      );
+    },
+  );
+
+Figure.displayName = 'Figure';
 
 export default Object.assign(Figure, {
   Image: FigureImage,

--- a/src/FormFloating.tsx
+++ b/src/FormFloating.tsx
@@ -1,3 +1,26 @@
-import createWithBsPrefix from './createWithBsPrefix';
+import * as React from 'react';
+import classNames from 'classnames';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export default createWithBsPrefix('form-floating');
+export interface FormFloatingProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const FormFloating: BsPrefixRefForwardingComponent<'div', FormFloatingProps> =
+  React.forwardRef<HTMLElement, FormFloatingProps>(
+    ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'form-floating');
+      return (
+        <Component
+          ref={ref}
+          className={classNames(className, bsPrefix)}
+          {...props}
+        />
+      );
+    },
+  );
+
+FormFloating.displayName = 'FormFloating';
+
+export default FormFloating;

--- a/src/InputGroup.tsx
+++ b/src/InputGroup.tsx
@@ -4,23 +4,19 @@ import PropTypes from 'prop-types';
 import * as React from 'react';
 import { useMemo } from 'react';
 
-import createWithBsPrefix from './createWithBsPrefix';
 import { useBootstrapPrefix } from './ThemeProvider';
-import FormCheckInput from './FormCheckInput';
+import FormCheckInput, { type FormCheckInputProps } from './FormCheckInput';
 import InputGroupContext from './InputGroupContext';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
+import InputGroupText from './InputGroupText';
 
-const InputGroupText = createWithBsPrefix('input-group-text', {
-  Component: 'span',
-});
-
-const InputGroupCheckbox = (props) => (
+const InputGroupCheckbox = (props: FormCheckInputProps) => (
   <InputGroupText>
     <FormCheckInput type="checkbox" {...props} />
   </InputGroupText>
 );
 
-const InputGroupRadio = (props) => (
+const InputGroupRadio = (props: FormCheckInputProps) => (
   <InputGroupText>
     <FormCheckInput type="radio" {...props} />
   </InputGroupText>

--- a/src/InputGroupText.tsx
+++ b/src/InputGroupText.tsx
@@ -3,16 +3,16 @@ import classNames from 'classnames';
 import { useBootstrapPrefix } from './ThemeProvider';
 import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface FigureCaptionProps
+export interface InputGroupTextProps
   extends BsPrefixProps,
     React.HTMLAttributes<HTMLElement> {}
 
-const FigureCaption: BsPrefixRefForwardingComponent<
-  'figcaption',
-  FigureCaptionProps
-> = React.forwardRef<HTMLElement, FigureCaptionProps>(
-  ({ className, bsPrefix, as: Component = 'figcaption', ...props }, ref) => {
-    bsPrefix = useBootstrapPrefix(bsPrefix, 'figure-caption');
+const InputGroupText: BsPrefixRefForwardingComponent<
+  'span',
+  InputGroupTextProps
+> = React.forwardRef<HTMLElement, InputGroupTextProps>(
+  ({ className, bsPrefix, as: Component = 'span', ...props }, ref) => {
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'input-group-text');
     return (
       <Component
         ref={ref}
@@ -23,6 +23,6 @@ const FigureCaption: BsPrefixRefForwardingComponent<
   },
 );
 
-FigureCaption.displayName = 'FigureCaption';
+InputGroupText.displayName = 'InputGroupText';
 
-export default FigureCaption;
+export default InputGroupText;

--- a/src/ModalBody.tsx
+++ b/src/ModalBody.tsx
@@ -1,3 +1,26 @@
-import createWithBsPrefix from './createWithBsPrefix';
+import * as React from 'react';
+import classNames from 'classnames';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export default createWithBsPrefix('modal-body');
+export interface ModalBodyProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const ModalBody: BsPrefixRefForwardingComponent<'div', ModalBodyProps> =
+  React.forwardRef<HTMLElement, ModalBodyProps>(
+    ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'modal-body');
+      return (
+        <Component
+          ref={ref}
+          className={classNames(className, bsPrefix)}
+          {...props}
+        />
+      );
+    },
+  );
+
+ModalBody.displayName = 'ModalBody';
+
+export default ModalBody;

--- a/src/ModalFooter.tsx
+++ b/src/ModalFooter.tsx
@@ -1,3 +1,26 @@
-import createWithBsPrefix from './createWithBsPrefix';
+import * as React from 'react';
+import classNames from 'classnames';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export default createWithBsPrefix('modal-footer');
+export interface ModalFooterProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const ModalFooter: BsPrefixRefForwardingComponent<'div', ModalFooterProps> =
+  React.forwardRef<HTMLElement, ModalFooterProps>(
+    ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'modal-footer');
+      return (
+        <Component
+          ref={ref}
+          className={classNames(className, bsPrefix)}
+          {...props}
+        />
+      );
+    },
+  );
+
+ModalFooter.displayName = 'ModalFooter';
+
+export default ModalFooter;

--- a/src/NavItem.tsx
+++ b/src/NavItem.tsx
@@ -1,3 +1,26 @@
-import createWithBsPrefix from './createWithBsPrefix';
+import * as React from 'react';
+import classNames from 'classnames';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export default createWithBsPrefix('nav-item');
+export interface NavItemProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const NavItem: BsPrefixRefForwardingComponent<'div', NavItemProps> =
+  React.forwardRef<HTMLElement, NavItemProps>(
+    ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'nav-item');
+      return (
+        <Component
+          ref={ref}
+          className={classNames(className, bsPrefix)}
+          {...props}
+        />
+      );
+    },
+  );
+
+NavItem.displayName = 'NavItem';
+
+export default NavItem;

--- a/src/Navbar.tsx
+++ b/src/Navbar.tsx
@@ -6,18 +6,14 @@ import SelectableContext from '@restart/ui/SelectableContext';
 import { SelectCallback } from '@restart/ui/types';
 import { useUncontrolled } from 'uncontrollable';
 
-import createWithBsPrefix from './createWithBsPrefix';
 import NavbarBrand from './NavbarBrand';
 import NavbarCollapse from './NavbarCollapse';
 import NavbarToggle from './NavbarToggle';
 import NavbarOffcanvas from './NavbarOffcanvas';
 import { useBootstrapPrefix } from './ThemeProvider';
 import NavbarContext, { NavbarContextType } from './NavbarContext';
+import NavbarText from './NavbarText';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
-
-const NavbarText = createWithBsPrefix('navbar-text', {
-  Component: 'span',
-});
 
 export interface NavbarProps
   extends BsPrefixProps,

--- a/src/NavbarText.tsx
+++ b/src/NavbarText.tsx
@@ -3,14 +3,14 @@ import classNames from 'classnames';
 import { useBootstrapPrefix } from './ThemeProvider';
 import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export interface CardGroupProps
+export interface NavbarTextProps
   extends BsPrefixProps,
     React.HTMLAttributes<HTMLElement> {}
 
-const CardGroup: BsPrefixRefForwardingComponent<'div', CardGroupProps> =
-  React.forwardRef<HTMLElement, CardGroupProps>(
-    ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
-      bsPrefix = useBootstrapPrefix(bsPrefix, 'card-group');
+const NavbarText: BsPrefixRefForwardingComponent<'span', NavbarTextProps> =
+  React.forwardRef<HTMLElement, NavbarTextProps>(
+    ({ className, bsPrefix, as: Component = 'span', ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'navbar-text');
       return (
         <Component
           ref={ref}
@@ -21,6 +21,6 @@ const CardGroup: BsPrefixRefForwardingComponent<'div', CardGroupProps> =
     },
   );
 
-CardGroup.displayName = 'CardGroup';
+NavbarText.displayName = 'NavbarText';
 
-export default CardGroup;
+export default NavbarText;

--- a/src/OffcanvasBody.tsx
+++ b/src/OffcanvasBody.tsx
@@ -1,3 +1,26 @@
-import createWithBsPrefix from './createWithBsPrefix';
+import * as React from 'react';
+import classNames from 'classnames';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export default createWithBsPrefix('offcanvas-body');
+export interface OffcanvasBodyProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const OffcanvasBody: BsPrefixRefForwardingComponent<'div', OffcanvasBodyProps> =
+  React.forwardRef<HTMLElement, OffcanvasBodyProps>(
+    ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'offcanvas-body');
+      return (
+        <Component
+          ref={ref}
+          className={classNames(className, bsPrefix)}
+          {...props}
+        />
+      );
+    },
+  );
+
+OffcanvasBody.displayName = 'OffcanvasBody';
+
+export default OffcanvasBody;

--- a/src/OffcanvasTitle.tsx
+++ b/src/OffcanvasTitle.tsx
@@ -1,8 +1,31 @@
-import createWithBsPrefix from './createWithBsPrefix';
+import * as React from 'react';
+import classNames from 'classnames';
 import divWithClassName from './divWithClassName';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
 const DivStyledAsH5 = divWithClassName('h5');
 
-export default createWithBsPrefix('offcanvas-title', {
-  Component: DivStyledAsH5,
-});
+export interface OffcanvasTitleProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const OffcanvasTitle: BsPrefixRefForwardingComponent<
+  'div',
+  OffcanvasTitleProps
+> = React.forwardRef<HTMLElement, OffcanvasTitleProps>(
+  ({ className, bsPrefix, as: Component = DivStyledAsH5, ...props }, ref) => {
+    bsPrefix = useBootstrapPrefix(bsPrefix, 'offcanvas-title');
+    return (
+      <Component
+        ref={ref}
+        className={classNames(className, bsPrefix)}
+        {...props}
+      />
+    );
+  },
+);
+
+OffcanvasTitle.displayName = 'OffcanvasTitle';
+
+export default OffcanvasTitle;

--- a/src/PopoverBody.tsx
+++ b/src/PopoverBody.tsx
@@ -1,3 +1,26 @@
-import createWithBsPrefix from './createWithBsPrefix';
+import * as React from 'react';
+import classNames from 'classnames';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export default createWithBsPrefix('popover-body');
+export interface PopoverBodyProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const PopoverBody: BsPrefixRefForwardingComponent<'div', PopoverBodyProps> =
+  React.forwardRef<HTMLElement, PopoverBodyProps>(
+    ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'popover-body');
+      return (
+        <Component
+          ref={ref}
+          className={classNames(className, bsPrefix)}
+          {...props}
+        />
+      );
+    },
+  );
+
+PopoverBody.displayName = 'PopoverBody';
+
+export default PopoverBody;

--- a/src/PopoverHeader.tsx
+++ b/src/PopoverHeader.tsx
@@ -1,3 +1,26 @@
-import createWithBsPrefix from './createWithBsPrefix';
+import * as React from 'react';
+import classNames from 'classnames';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export default createWithBsPrefix('popover-header');
+export interface PopoverHeaderProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const PopoverHeader: BsPrefixRefForwardingComponent<'div', PopoverHeaderProps> =
+  React.forwardRef<HTMLElement, PopoverHeaderProps>(
+    ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'popover-header');
+      return (
+        <Component
+          ref={ref}
+          className={classNames(className, bsPrefix)}
+          {...props}
+        />
+      );
+    },
+  );
+
+PopoverHeader.displayName = 'PopoverHeader';
+
+export default PopoverHeader;

--- a/src/TabContent.tsx
+++ b/src/TabContent.tsx
@@ -1,3 +1,26 @@
-import createWithBsPrefix from './createWithBsPrefix';
+import * as React from 'react';
+import classNames from 'classnames';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export default createWithBsPrefix('tab-content');
+export interface TabContentProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const TabContent: BsPrefixRefForwardingComponent<'div', TabContentProps> =
+  React.forwardRef<HTMLElement, TabContentProps>(
+    ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'tab-content');
+      return (
+        <Component
+          ref={ref}
+          className={classNames(className, bsPrefix)}
+          {...props}
+        />
+      );
+    },
+  );
+
+TabContent.displayName = 'TabContent';
+
+export default TabContent;

--- a/src/ToastBody.tsx
+++ b/src/ToastBody.tsx
@@ -1,3 +1,26 @@
-import createWithBsPrefix from './createWithBsPrefix';
+import * as React from 'react';
+import classNames from 'classnames';
+import { useBootstrapPrefix } from './ThemeProvider';
+import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 
-export default createWithBsPrefix('toast-body');
+export interface ToastBodyProps
+  extends BsPrefixProps,
+    React.HTMLAttributes<HTMLElement> {}
+
+const ToastBody: BsPrefixRefForwardingComponent<'div', ToastBodyProps> =
+  React.forwardRef<HTMLElement, ToastBodyProps>(
+    ({ className, bsPrefix, as: Component = 'div', ...props }, ref) => {
+      bsPrefix = useBootstrapPrefix(bsPrefix, 'toast-body');
+      return (
+        <Component
+          ref={ref}
+          className={classNames(className, bsPrefix)}
+          {...props}
+        />
+      );
+    },
+  );
+
+ToastBody.displayName = 'ToastBody';
+
+export default ToastBody;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,8 +11,20 @@ export {
 } from './AccordionButton';
 export type { AccordionButtonProps } from './AccordionButton';
 
+export { default as AccordionHeader } from './AccordionHeader';
+export type { AccordionHeaderProps } from './AccordionHeader';
+
+export { default as AccordionItem } from './AccordionItem';
+export type { AccordionItemProps } from './AccordionItem';
+
 export { default as Alert } from './Alert';
 export type { AlertProps } from './Alert';
+
+export { default as AlertHeading } from './AlertHeading';
+export type { AlertHeadingProps } from './AlertHeading';
+
+export { default as AlertLink } from './AlertLink';
+export type { AlertLinkProps } from './AlertLink';
 
 export { default as Anchor } from './Anchor';
 export type { AnchorProps } from './Anchor';
@@ -38,12 +50,41 @@ export type { ButtonToolbarProps } from './ButtonToolbar';
 export { default as Card } from './Card';
 export type { CardProps } from './Card';
 
+export { default as CardBody } from './CardBody';
+export type { CardBodyProps } from './CardBody';
+
+export { default as CardFooter } from './CardFooter';
+export type { CardFooterProps } from './CardFooter';
+
+export { default as CardGroup } from './CardGroup';
+export type { CardGroupProps } from './CardGroup';
+
+export { default as CardHeader } from './CardHeader';
+export type { CardHeaderProps } from './CardHeader';
+
 export { default as CardImg } from './CardImg';
 export type { CardImgProps } from './CardImg';
 
-export { default as CardGroup } from './CardGroup';
+export { default as CardImgOverlay } from './CardImgOverlay';
+export type { CardImgOverlayProps } from './CardImgOverlay';
+
+export { default as CardLink } from './CardLink';
+export type { CardLinkProps } from './CardLink';
+
+export { default as CardSubtitle } from './CardSubtitle';
+export type { CardSubtitleProps } from './CardSubtitle';
+
+export { default as CardText } from './CardText';
+export type { CardTextProps } from './CardText';
+
+export { default as CardTitle } from './CardTitle';
+export type { CardTitleProps } from './CardTitle';
+
 export { default as Carousel } from './Carousel';
 export type { CarouselProps } from './Carousel';
+
+export { default as CarouselCaption } from './CarouselCaption';
+export type { CarouselCaptionProps } from './CarouselCaption';
 
 export { default as CarouselItem } from './CarouselItem';
 export type { CarouselItemProps } from './CarouselItem';
@@ -57,14 +98,43 @@ export type { ColProps } from './Col';
 export { default as Collapse } from './Collapse';
 export type { CollapseProps } from './Collapse';
 
+export { default as Container } from './Container';
+export type { ContainerProps } from './Container';
+
 export { default as Dropdown } from './Dropdown';
 export type { DropdownProps } from './Dropdown';
 
 export { default as DropdownButton } from './DropdownButton';
 export type { DropdownButtonProps } from './DropdownButton';
 
+export { default as DropdownDivider } from './DropdownDivider';
+export type { DropdownDividerProps } from './DropdownDivider';
+
+export { default as DropdownHeader } from './DropdownHeader';
+export type { DropdownHeaderProps } from './DropdownHeader';
+
+export { default as DropdownItem } from './DropdownItem';
+export type { DropdownItemProps } from './DropdownItem';
+
+export { default as DropdownItemText } from './DropdownItemText';
+export type { DropdownItemTextProps } from './DropdownItemText';
+
+export { default as DropdownMenu } from './DropdownMenu';
+export type { DropdownMenuProps } from './DropdownMenu';
+
+export { default as DropdownToggle } from './DropdownToggle';
+export type { DropdownToggleProps } from './DropdownToggle';
+
 export { default as Fade } from './Fade';
 export type { FadeProps } from './Fade';
+
+export { default as Figure } from './Figure';
+export type { FigureProps } from './Figure';
+
+export { default as FigureCaption } from './FigureCaption';
+export type { FigureCaptionProps } from './FigureCaption';
+
+export { default as FigureImage } from './FigureImage';
 
 export { default as Form } from './Form';
 export type { FormProps } from './Form';
@@ -92,13 +162,9 @@ export type { FormTextProps } from './FormText';
 export { default as FormSelect } from './FormSelect';
 export type { FormSelectProps } from './FormSelect';
 
-export { default as Container } from './Container';
-export type { ContainerProps } from './Container';
-
 export { default as Image } from './Image';
 export type { ImageProps } from './Image';
 
-export { default as Figure } from './Figure';
 export { default as InputGroup } from './InputGroup';
 export type { InputGroupProps } from './InputGroup';
 
@@ -116,11 +182,15 @@ export { default as ModalBody } from './ModalBody';
 export { default as ModalDialog } from './ModalDialog';
 export type { ModalDialogProps } from './ModalDialog';
 
+export { default as ModalFooter } from './ModalFooter';
+export type { ModalFooterProps } from './ModalFooter';
+
 export { default as ModalHeader } from './ModalHeader';
 export type { ModalHeaderProps } from './ModalHeader';
 
-export { default as ModalFooter } from './ModalFooter';
 export { default as ModalTitle } from './ModalTitle';
+export type { ModalTitleProps } from './ModalTitle';
+
 export { default as Nav } from './Nav';
 export type { NavProps } from './Nav';
 
@@ -130,20 +200,41 @@ export type { NavbarProps } from './Navbar';
 export { default as NavbarBrand } from './NavbarBrand';
 export type { NavbarBrandProps } from './NavbarBrand';
 
+export { default as NavbarCollapse } from './NavbarCollapse';
+export type { NavbarCollapseProps } from './NavbarCollapse';
+
+export { default as NavbarOffcanvas } from './NavbarOffcanvas';
+export type { NavbarOffcanvasProps } from './NavbarOffcanvas';
+
+export { default as NavbarText } from './NavbarText';
+export type { NavbarTextProps } from './NavbarText';
+
+export { default as NavbarToggle } from './NavbarToggle';
+export type { NavbarToggleProps } from './NavbarToggle';
+
 export { default as NavDropdown } from './NavDropdown';
 export type { NavDropdownProps } from './NavDropdown';
 
 export { default as NavItem } from './NavItem';
+export type { NavItemProps } from './NavItem';
 
 export { default as NavLink } from './NavLink';
 export type { NavLinkProps } from './NavLink';
 
 export { default as Offcanvas } from './Offcanvas';
 export type { OffcanvasProps } from './Offcanvas';
+
+export { default as OffcanvasBody } from './OffcanvasBody';
+export type { OffcanvasBodyProps } from './OffcanvasBody';
+
 export { default as OffcanvasHeader } from './OffcanvasHeader';
 export type { OffcanvasHeaderProps } from './OffcanvasHeader';
+
 export { default as OffcanvasTitle } from './OffcanvasTitle';
-export { default as OffcanvasBody } from './OffcanvasBody';
+export type { OffcanvasTitleProps } from './OffcanvasTitle';
+
+export { default as OffcanvasToggling } from './OffcanvasToggling';
+export type { OffcanvasTogglingProps } from './OffcanvasToggling';
 
 export { default as Overlay } from './Overlay';
 export type { OverlayProps } from './Overlay';
@@ -159,14 +250,19 @@ export type { PaginationProps } from './Pagination';
 
 export { default as Placeholder } from './Placeholder';
 export type { PlaceholderProps } from './Placeholder';
+
 export { default as PlaceholderButton } from './PlaceholderButton';
 export type { PlaceholderButtonProps } from './PlaceholderButton';
 
 export { default as Popover } from './Popover';
 export type { PopoverProps } from './Popover';
 
-export { default as PopoverHeader } from './PopoverHeader';
 export { default as PopoverBody } from './PopoverBody';
+export type { PopoverBodyProps } from './PopoverBody';
+
+export { default as PopoverHeader } from './PopoverHeader';
+export type { PopoverHeaderProps } from './PopoverHeader';
+
 export { default as ProgressBar } from './ProgressBar';
 export type { ProgressBarProps } from './ProgressBar';
 
@@ -195,6 +291,8 @@ export { default as TabContainer } from './TabContainer';
 export type { TabContainerProps } from './TabContainer';
 
 export { default as TabContent } from './TabContent';
+export type { TabContentProps } from './TabContent';
+
 export { default as Table } from './Table';
 export type { TableProps } from './Table';
 
@@ -211,11 +309,13 @@ export { default as Toast } from './Toast';
 export type { ToastProps } from './Toast';
 
 export { default as ToastBody } from './ToastBody';
-export { default as ToastHeader } from './ToastHeader';
-export type { ToastHeaderProps } from './ToastHeader';
+export type { ToastBodyProps } from './ToastBody';
 
 export { default as ToastContainer } from './ToastContainer';
 export type { ToastContainerProps } from './ToastContainer';
+
+export { default as ToastHeader } from './ToastHeader';
+export type { ToastHeaderProps } from './ToastHeader';
 
 export { default as ToggleButton } from './ToggleButton';
 export type { ToggleButtonProps } from './ToggleButton';


### PR DESCRIPTION
Fixes this error mentioned in #6646

```
Error: Attempted to call the default export of createWithBsPrefix.js from the server but it's on the client. It's not possible to invoke a client function from the server, it can only be rendered as a Component or passed to props of a Client Component.
```

All components using `createWithBsPrefix` were cloned into their own files