### PR TITLE
docs: Navbar example spelling error in NavDropdown's ID 

### DIFF
--- a/www/docs/examples/Navbar/Collapsible.js
+++ b/www/docs/examples/Navbar/Collapsible.js
@@ -13,7 +13,7 @@ function CollapsibleExample() {
           <Nav className="me-auto">
             <Nav.Link href="#features">Features</Nav.Link>
             <Nav.Link href="#pricing">Pricing</Nav.Link>
-            <NavDropdown title="Dropdown" id="collasible-nav-dropdown">
+            <NavDropdown title="Dropdown" id="collapsible-nav-dropdown">
               <NavDropdown.Item href="#action/3.1">Action</NavDropdown.Item>
               <NavDropdown.Item href="#action/3.2">
                 Another action


### PR DESCRIPTION
Minor spelling error for the example component "CollapsibleExample" under Navbars, Responsive behaviors.
www > docs > examples > Navbar > Collapsible.js - Line 16 was missing the "p" in "collapsible" for the NavDropdown's id.

Not trying to be pedantic, just noticed it and figured I'd correct it :)