### PR TITLE
fix: Prevent Dropdown Flickering on 'mousedown' rootCloseEvent

### DIFF
--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -147,6 +147,9 @@ const Dropdown: BsPrefixRefForwardingComponent<'div', DropdownProps> =
 
     const handleToggle = useEventCallback(
       (nextShow: boolean, meta: ToggleMetadata) => {
+        /** Checking if target of event is ToggleButton,
+         * if it is then nullify mousedown event
+         */
         const isToggleButton = (
           meta.originalEvent?.target as HTMLElement
         )?.classList.contains('dropdown-toggle');
@@ -154,6 +157,7 @@ const Dropdown: BsPrefixRefForwardingComponent<'div', DropdownProps> =
         if (isToggleButton && meta.source === 'mousedown') {
           return;
         }
+
         if (
           meta.originalEvent!.currentTarget === document &&
           (meta.source !== 'keydown' ||

--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -147,6 +147,13 @@ const Dropdown: BsPrefixRefForwardingComponent<'div', DropdownProps> =
 
     const handleToggle = useEventCallback(
       (nextShow: boolean, meta: ToggleMetadata) => {
+        const isToggleButton = (
+          meta.originalEvent?.target as HTMLElement
+        )?.classList.contains('dropdown-toggle');
+
+        if (isToggleButton && meta.source === 'mousedown') {
+          return;
+        }
         if (
           meta.originalEvent!.currentTarget === document &&
           (meta.source !== 'keydown' ||

--- a/test/DropdownMousedownSpec.tsx
+++ b/test/DropdownMousedownSpec.tsx
@@ -1,0 +1,25 @@
+import { render, fireEvent, screen } from '@testing-library/react';
+import Dropdown from '../src/Dropdown';
+
+describe('<Dropdown.Menu rootCloseEvent="mousedown">', () => {
+  it('does not flicker when rootCloseEvent is set to "mousedown" and toggle button is clicked', () => {
+    const { container } = render(
+      <Dropdown>
+        <Dropdown.Toggle id="dropdown-basic" data-testid="dropdown-toggle">
+          Dropdown Button
+        </Dropdown.Toggle>
+        <Dropdown.Menu rootCloseEvent="mousedown">
+          <Dropdown.Item href="#/action-1">Action</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>,
+    );
+    // Click the toggle button to open the menu
+    fireEvent.click(screen.getByTestId('dropdown-toggle'));
+    // The menu should now be in the DOM
+    container.firstElementChild!.classList.contains('show').should.be.true;
+    // Click the toggle button again to close the menu
+    fireEvent.click(screen.getByTestId('dropdown-toggle'));
+    // The menu should no longer be in the DOM
+    container.firstElementChild!.classList.contains('show').should.be.false;
+  });
+});


### PR DESCRIPTION
Issue
Closes #6712 and #3196 

### Description
This pull request addresses the issue reported in #6712. When a dropdown is open with rootCloseEvent set to 'mousedown,' it currently exhibits flickering behavior when the toggle button is clicked. This issue arises due to the combination of hiding and showing the dropdown within the same click event.

### Changes Made
To resolve this issue, I've made the following changes:
Modified the handleToggle function to skip execution when the dropdown is open, and rootCloseEvent is set to 'mousedown,' and the toggle button is clicked. This change prevents the flickering behavior by allowing the dropdown to remain open in this specific scenario.

### Result
https://github.com/react-bootstrap/react-bootstrap/assets/100420038/4e68d2d1-8e26-4164-bbbb-cffc3bcd9747

### Additional Information
This change is made in response to the issue reported by @Fyers. We believe this modification improves the behavior of the dropdown component when rootCloseEvent is set to 'mousedown.'

I kindly request a review from the maintainers and the community to consider including this fix in the React Bootstrap project.