### PR TITLE
fix(ModalHeader): fix types

### DIFF
--- a/src/ModalHeader.tsx
+++ b/src/ModalHeader.tsx
@@ -10,7 +10,7 @@ import { BsPrefixAndClassNameOnlyProps } from './helpers';
 
 export interface ModalHeaderProps
   extends React.PropsWithChildren<BsPrefixAndClassNameOnlyProps>,
-    React.ComponentProps<'div'> {
+    React.HTMLAttributes<HTMLDivElement> {
   closeLabel?: string;
   closeButton?: boolean;
   onHide?: () => void;


### PR DESCRIPTION
Fixes #6733

Simplifies the built types by removing the `Pick` in the output.  This mirrors RB v2 which doesn't have this bug.