### PR TITLE
tabbed component file path created in navs.mdx

### DIFF
--- a/www/docs/components/navs.mdx
+++ b/www/docs/components/navs.mdx
@@ -70,7 +70,7 @@ others (e.g. `.flex-sm-column`).
 ### Tabs
 
 Visually represent nav items as "tabs". This style pairs nicely with
-tabbable regions created by our [Tab components](tabs).
+tabbable regions created by our [Tab components](./tabs.mdx).
 
 Note: creating a vertical nav (`.flex-column`) with tabs styling is unsupported by Bootstrap's
 default stylesheet.


### PR DESCRIPTION
Bug - Page Not Found for Tabs Doc Site #6748

The issue was the tab component link in navs and tabs page is resulting in page not found error.

![image](https://github.com/react-bootstrap/react-bootstrap/assets/90522898/6b626c46-8613-432e-a049-3185ee1ceb9d)

It can be clearly seen that the link here in href is not correct. It should be "https://react-bootstrap.netlify.app/docs/components/tabs" instead of "https://react-bootstrap.netlify.app/docs/components/navs/tabs". Hence, I pasted the link for the file directly in the navs.mdx. This is opening the link correctly without any page not found error. Moreover, I only solved half of the issue. The other issue was that navigation on active link in sample navs and tabs was resulting in page not found error. The issue was it has given "#home" link which results in page not found error as there is no home page. This might be there for a purpose that's why I did not try to make any changes. If home can be removed, i would like to pose a solution which is only inserting "#" instead of "#home". This same solution is opted by Bootstrap to avoid unnecessary navigation. 

Moreover, this is my first open source contribution. I might have done some mistakes here too. It will be a great help if a feedback is provided. This will help me to avoid the same mistakes in the future. 

Thanks 
Sahil Mahey