### PR TITLE
feat(PageItem): use "as" property as an anchor element

### DIFF
--- a/src/PageItem.tsx
+++ b/src/PageItem.tsx
@@ -52,11 +52,12 @@ const PageItem: BsPrefixRefForwardingComponent<'li', PageItemProps> =
         children,
         linkStyle,
         linkClassName,
+        as = Anchor,
         ...props
       }: PageItemProps,
       ref,
     ) => {
-      const Component = active || disabled ? 'span' : Anchor;
+      const Component = active || disabled ? 'span' : as;
       return (
         <li
           ref={ref}

--- a/test/PageItemSpec.tsx
+++ b/test/PageItemSpec.tsx
@@ -67,5 +67,17 @@ describe('<PageItem>', () => {
 
       pageItemInnerElem.getAttribute('style')!.should.equal('color: red;');
     });
+
+    it('should support custom anchor element', () => {
+      const Component = ({ children, ...props }) => (
+        <a {...props} data-anchor="custom">
+          {children}
+        </a>
+      );
+      const { container } = render(<PageItem as={Component} />);
+      const pageItemElem = container.firstElementChild!;
+      const pageItemInnerElem = pageItemElem.firstElementChild!;
+      pageItemInnerElem.getAttribute('data-anchor')!.should.equal('custom');
+    });
   });
 });


### PR DESCRIPTION
This Pull Request addresses the issue of limited routing flexibility in the `PageItem` component (https://github.com/react-bootstrap/react-bootstrap/issues/6753). By introducing the `anchorAs` prop, it allows the specification of a custom component for rendering links, thereby enabling seamless integration with custom routing libraries like Next.js's `<Link>`.

Changes Made:
- Added a new prop `anchorAs` to `PageItemProps`.
- Updated the `PageItem` component to use `anchorAs` as the component type for rendering the link.
- Ensured backward compatibility by defaulting `anchorAs` to the existing `Anchor` component from `@restart/ui/Anchor`.

Benefits:
- Enhances the flexibility and usability of `PageItem` in applications with custom routing requirements.
- Allows integration with Next.js's `Link` component or any other custom component for link rendering.
- Maintains backward compatibility, ensuring that existing implementations are unaffected.

I believe this enhancement will significantly benefit developers working with custom routing solutions and look forward to feedback and suggestions.
