### PR TITLE
fix(FormControl): ensures compatibility with @types/react@18.2.48

### DIFF
--- a/src/FormControl.tsx
+++ b/src/FormControl.tsx
@@ -12,7 +12,7 @@ type FormControlElement = HTMLInputElement | HTMLTextAreaElement;
 
 export interface FormControlProps
   extends BsPrefixProps,
-    React.HTMLAttributes<FormControlElement> {
+    Omit<React.InputHTMLAttributes<FormControlElement>, 'size'> {
   htmlSize?: number;
   size?: 'sm' | 'lg';
   plaintext?: boolean;


### PR DESCRIPTION
Looks like [`@types/react` removed the `placeholder` attribute from `HTMLAttributes`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/67170).
This may create inconsistencies when using `FormControl`.

The proposed fix replaces it with a more explicit `InputHTMLAttributes`.