### PR TITLE
fix(Tabs): missed id attribute of tabs

### DIFF
--- a/src/Tabs.tsx
+++ b/src/Tabs.tsx
@@ -152,7 +152,13 @@ const Tabs = (props: TabsProps) => {
       mountOnEnter={mountOnEnter}
       unmountOnExit={unmountOnExit}
     >
-      <Nav {...controlledProps} role="tablist" as="ul" variant={variant}>
+      <Nav
+        id={id}
+        {...controlledProps}
+        role="tablist"
+        as="ul"
+        variant={variant}
+      >
         {map(children, renderTab)}
       </Nav>
 


### PR DESCRIPTION
In the Tabs component, the Nav did not receive the ID properties. 

Issue: https://github.com/react-bootstrap/react-bootstrap/issues/676