### PR TITLE
docs: Add notes about NavLink key behavior

### DIFF
--- a/src/NavLink.tsx
+++ b/src/NavLink.tsx
@@ -37,12 +37,16 @@ const propTypes = {
    * */
   role: PropTypes.string,
 
-  /** The HTML href attribute for the `NavLink` */
+  /** 
+   * The HTML href attribute for the `NavLink`. Used as the unique identifier
+   * for the `NavLink` if an `eventKey` is not provided.
+   */
   href: PropTypes.string,
 
   /**
    * Uniquely identifies the `NavItem` amongst its siblings,
    * used to determine and control the active state of the parent `Nav`
+   * as well as onSelect behavior of a parent `Navbar`.
    */
   eventKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 

--- a/src/Navbar.tsx
+++ b/src/Navbar.tsx
@@ -109,8 +109,8 @@ const propTypes = {
    * Toggles `expanded` to `false` after the onSelect event of a descendant of a
    * child `<Nav>` fires. Does nothing if no `<Nav>` or `<Nav>` descendants exist.
    *
-   * `<Nav.Link>` descentants of `<Nav>` will not trigger the onSelect event unless
-   * the `eventKey` or `href` props are defined.
+   * `<NavLink>` descentants of `<Nav>` will not trigger the onSelect event unless
+   * an `eventKey` or `href` prop is defined.
    *
    * Manually controlling `expanded` via the onSelect callback is recommended instead,
    * for more complex operations that need to be executed after

--- a/src/Navbar.tsx
+++ b/src/Navbar.tsx
@@ -109,7 +109,7 @@ const propTypes = {
    * Toggles `expanded` to `false` after the onSelect event of a descendant of a
    * child `<Nav>` fires. Does nothing if no `<Nav>` or `<Nav>` descendants exist.
    *
-   * `<NavLink>` descentants of `<Nav>` will not trigger the onSelect event unless
+   * `<NavLink>` descendants of `<Nav>` will not trigger the `onSelect` event unless
    * an `eventKey` or `href` prop is defined.
    *
    * Manually controlling `expanded` via the onSelect callback is recommended instead,

--- a/src/Navbar.tsx
+++ b/src/Navbar.tsx
@@ -109,6 +109,9 @@ const propTypes = {
    * Toggles `expanded` to `false` after the onSelect event of a descendant of a
    * child `<Nav>` fires. Does nothing if no `<Nav>` or `<Nav>` descendants exist.
    *
+   * `<Nav.Link>` descentants of `<Nav>` will not trigger the onSelect event unless
+   * the `eventKey` or `href` props are defined.
+   *
    * Manually controlling `expanded` via the onSelect callback is recommended instead,
    * for more complex operations that need to be executed after
    * the `select` event of `<Nav>` descendants.


### PR DESCRIPTION
Just ran into the issue outlined in PR #6654 and wanted to add an explicit note about it to the API docs to both `Navbar` and `NavLink`