### PR TITLE
fix(button): typescript fix to allow as prop to accept react components

### DIFF
--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -9,9 +9,7 @@ import { useBootstrapPrefix } from './ThemeProvider';
 import { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 import { ButtonVariant } from './types';
 
-export interface ButtonProps
-  extends BaseButtonProps,
-    Omit<BsPrefixProps, 'as'> {
+export interface ButtonProps extends BsPrefixProps, BaseButtonProps {
   active?: boolean;
   variant?: ButtonVariant;
   size?: 'sm' | 'lg';


### PR DESCRIPTION
fixes typescript error when passing react component to the "as" prop.