### PR TITLE
Update Fade.tsx - element.ref is now a regular prop

### DIFF
--- a/src/Fade.tsx
+++ b/src/Fade.tsx
@@ -8,6 +8,7 @@ import Transition, {
   ENTERING,
 } from 'react-transition-group/Transition';
 import { TransitionCallbacks } from '@restart/ui/types';
+import { getReactVersion } from '@restart/ui/utils';
 import transitionEndListener from './transitionEndListener';
 import triggerBrowserReflow from './triggerBrowserReflow';
 import TransitionWrapper from './TransitionWrapper';
@@ -113,13 +114,16 @@ const Fade = React.forwardRef<Transition<any>, FadeProps>(
       [onEnter],
     );
 
+    const { major } = getReactVersion();
+    const childRef = major >= 19 ? (children as any).props.ref : (children as any).ref;
+
     return (
       <TransitionWrapper
         ref={ref}
         addEndListener={transitionEndListener}
         {...props}
         onEnter={handleEnter}
-        childRef={(children as any).ref}
+        childRef={childRef}
       >
         {(status: TransitionStatus, innerProps: Record<string, unknown>) =>
           React.cloneElement(children, {


### PR DESCRIPTION
In React >= 19, accessing element.ref is no longer supported and ref has become a regular prop. It will be removed from the JSX Element type in a future release.

Replaced .ref with .props.ref for React version 19+.