### PR TITLE
fix: fix component type error

### DIFF
--- a/src/Accordion.tsx
+++ b/src/Accordion.tsx
@@ -91,7 +91,7 @@ const Accordion: BsPrefixRefForwardingComponent<'div', AccordionProps> =
         />
       </AccordionContext.Provider>
     );
-  });
+  }) as typeof Accordion;
 
 Accordion.displayName = 'Accordion';
 Accordion.propTypes = propTypes;

--- a/src/AccordionBody.tsx
+++ b/src/AccordionBody.tsx
@@ -85,7 +85,7 @@ const AccordionBody: BsPrefixRefForwardingComponent<'div', AccordionBodyProps> =
         </AccordionCollapse>
       );
     },
-  );
+  ) as typeof AccordionBody;
 
 AccordionBody.propTypes = propTypes;
 AccordionBody.displayName = 'AccordionBody';

--- a/src/AccordionButton.tsx
+++ b/src/AccordionButton.tsx
@@ -100,7 +100,7 @@ const AccordionButton: BsPrefixRefForwardingComponent<
       />
     );
   },
-);
+) as typeof AccordionButton;
 
 AccordionButton.propTypes = propTypes;
 AccordionButton.displayName = 'AccordionButton';

--- a/src/AccordionHeader.tsx
+++ b/src/AccordionHeader.tsx
@@ -48,7 +48,7 @@ const AccordionHeader: BsPrefixRefForwardingComponent<
       </Component>
     );
   },
-);
+) as typeof AccordionHeader;
 
 AccordionHeader.propTypes = propTypes;
 AccordionHeader.displayName = 'AccordionHeader';

--- a/src/AccordionItem.tsx
+++ b/src/AccordionItem.tsx
@@ -59,7 +59,7 @@ const AccordionItem: BsPrefixRefForwardingComponent<'div', AccordionItemProps> =
         </AccordionItemContext.Provider>
       );
     },
-  );
+  ) as typeof AccordionItem;
 
 AccordionItem.propTypes = propTypes;
 AccordionItem.displayName = 'AccordionItem';

--- a/src/AlertHeading.tsx
+++ b/src/AlertHeading.tsx
@@ -23,7 +23,7 @@ const AlertHeading: BsPrefixRefForwardingComponent<'div', AlertHeadingProps> =
         />
       );
     },
-  );
+  ) as typeof AlertHeading;
 
 AlertHeading.displayName = 'AlertHeading';
 

--- a/src/AlertLink.tsx
+++ b/src/AlertLink.tsx
@@ -20,7 +20,7 @@ const AlertLink: BsPrefixRefForwardingComponent<'a', AlertLinkProps> =
         />
       );
     },
-  );
+  ) as typeof AlertLink;
 
 AlertLink.displayName = 'AlertLink';
 

--- a/src/Badge.tsx
+++ b/src/Badge.tsx
@@ -71,7 +71,7 @@ const Badge: BsPrefixRefForwardingComponent<'span', BadgeProps> =
         />
       );
     },
-  );
+  ) as typeof Badge;
 
 Badge.displayName = 'Badge';
 Badge.propTypes = propTypes;

--- a/src/Breadcrumb.tsx
+++ b/src/Breadcrumb.tsx
@@ -66,7 +66,7 @@ const Breadcrumb: BsPrefixRefForwardingComponent<'nav', BreadcrumbProps> =
         </Component>
       );
     },
-  );
+  ) as typeof Breadcrumb;
 
 Breadcrumb.displayName = 'Breadcrumb';
 Breadcrumb.propTypes = propTypes;

--- a/src/BreadcrumbItem.tsx
+++ b/src/BreadcrumbItem.tsx
@@ -95,7 +95,7 @@ const BreadcrumbItem: BsPrefixRefForwardingComponent<
       </Component>
     );
   },
-);
+) as typeof BreadcrumbItem;
 
 BreadcrumbItem.displayName = 'BreadcrumbItem';
 BreadcrumbItem.propTypes = propTypes;

--- a/src/Button.tsx
+++ b/src/Button.tsx
@@ -113,7 +113,7 @@ const Button: BsPrefixRefForwardingComponent<'button', ButtonProps> =
         />
       );
     },
-  );
+  ) as typeof Button;
 
 Button.displayName = 'Button';
 Button.propTypes = propTypes;

--- a/src/ButtonGroup.tsx
+++ b/src/ButtonGroup.tsx
@@ -71,7 +71,7 @@ const ButtonGroup: BsPrefixRefForwardingComponent<'div', ButtonGroupProps> =
         />
       );
     },
-  );
+  ) as typeof ButtonGroup;
 
 ButtonGroup.displayName = 'ButtonGroup';
 ButtonGroup.propTypes = propTypes;

--- a/src/Card.tsx
+++ b/src/Card.tsx
@@ -97,7 +97,7 @@ const Card: BsPrefixRefForwardingComponent<'div', CardProps> = React.forwardRef<
       </Component>
     );
   },
-);
+) as typeof Card;
 
 Card.displayName = 'Card';
 Card.propTypes = propTypes;

--- a/src/CardBody.tsx
+++ b/src/CardBody.tsx
@@ -19,7 +19,7 @@ const CardBody: BsPrefixRefForwardingComponent<'div', CardBodyProps> =
         />
       );
     },
-  );
+  ) as typeof CardBody;
 
 CardBody.displayName = 'CardBody';
 

--- a/src/CardFooter.tsx
+++ b/src/CardFooter.tsx
@@ -19,7 +19,7 @@ const CardFooter: BsPrefixRefForwardingComponent<'div', CardFooterProps> =
         />
       );
     },
-  );
+  ) as typeof CardFooter;
 
 CardFooter.displayName = 'CardFooter';
 

--- a/src/CardGroup.tsx
+++ b/src/CardGroup.tsx
@@ -19,7 +19,7 @@ const CardGroup: BsPrefixRefForwardingComponent<'div', CardGroupProps> =
         />
       );
     },
-  );
+  ) as typeof CardGroup;
 
 CardGroup.displayName = 'CardGroup';
 

--- a/src/CardHeader.tsx
+++ b/src/CardHeader.tsx
@@ -50,7 +50,7 @@ const CardHeader: BsPrefixRefForwardingComponent<'div', CardHeaderProps> =
         </CardHeaderContext.Provider>
       );
     },
-  );
+  ) as typeof CardHeader;
 
 CardHeader.displayName = 'CardHeader';
 CardHeader.propTypes = propTypes;

--- a/src/CardImg.tsx
+++ b/src/CardImg.tsx
@@ -54,7 +54,7 @@ const CardImg: BsPrefixRefForwardingComponent<'img', CardImgProps> =
         />
       );
     },
-  );
+  ) as typeof CardImg;
 CardImg.displayName = 'CardImg';
 CardImg.propTypes = propTypes;
 

--- a/src/CardImgOverlay.tsx
+++ b/src/CardImgOverlay.tsx
@@ -21,7 +21,7 @@ const CardImgOverlay: BsPrefixRefForwardingComponent<
       />
     );
   },
-);
+) as typeof CardImgOverlay;
 
 CardImgOverlay.displayName = 'CardImgOverlay';
 

--- a/src/CardLink.tsx
+++ b/src/CardLink.tsx
@@ -19,7 +19,7 @@ const CardLink: BsPrefixRefForwardingComponent<'a', CardLinkProps> =
         />
       );
     },
-  );
+  ) as typeof CardLink;
 
 CardLink.displayName = 'CardLink';
 

--- a/src/CardSubtitle.tsx
+++ b/src/CardSubtitle.tsx
@@ -22,7 +22,7 @@ const CardSubtitle: BsPrefixRefForwardingComponent<'div', CardSubtitleProps> =
         />
       );
     },
-  );
+  ) as typeof CardSubtitle;
 
 CardSubtitle.displayName = 'CardSubtitle';
 

--- a/src/CardText.tsx
+++ b/src/CardText.tsx
@@ -19,7 +19,7 @@ const CardText: BsPrefixRefForwardingComponent<'p', CardTextProps> =
         />
       );
     },
-  );
+  ) as typeof CardText;
 
 CardText.displayName = 'CardText';
 

--- a/src/CardTitle.tsx
+++ b/src/CardTitle.tsx
@@ -22,7 +22,7 @@ const CardTitle: BsPrefixRefForwardingComponent<'div', CardTitleProps> =
         />
       );
     },
-  );
+  ) as typeof CardTitle;
 
 CardTitle.displayName = 'CardTitle';
 

--- a/src/CarouselCaption.tsx
+++ b/src/CarouselCaption.tsx
@@ -21,7 +21,7 @@ const CarouselCaption: BsPrefixRefForwardingComponent<
       />
     );
   },
-);
+) as typeof CarouselCaption;
 
 CarouselCaption.displayName = 'CarouselCaption';
 

--- a/src/CarouselItem.tsx
+++ b/src/CarouselItem.tsx
@@ -39,7 +39,7 @@ const CarouselItem: BsPrefixRefForwardingComponent<'div', CarouselItemProps> =
       );
       return <Component ref={ref} {...props} className={finalClassName} />;
     },
-  );
+  ) as typeof CarouselItem;
 
 CarouselItem.displayName = 'CarouselItem';
 CarouselItem.propTypes = propTypes;

--- a/src/Col.tsx
+++ b/src/Col.tsx
@@ -188,7 +188,7 @@ const Col: BsPrefixRefForwardingComponent<'div', ColProps> = React.forwardRef<
       />
     );
   },
-);
+) as typeof Col;
 
 Col.displayName = 'Col';
 Col.propTypes = propTypes;

--- a/src/Container.tsx
+++ b/src/Container.tsx
@@ -54,7 +54,7 @@ const Container: BsPrefixRefForwardingComponent<'div', ContainerProps> =
         />
       );
     },
-  );
+  ) as typeof Container;
 
 Container.displayName = 'Container';
 Container.propTypes = propTypes;

--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -216,7 +216,7 @@ const Dropdown: BsPrefixRefForwardingComponent<'div', DropdownProps> =
         </BaseDropdown>
       </DropdownContext.Provider>
     );
-  });
+  }) as typeof Dropdown;
 
 Dropdown.displayName = 'Dropdown';
 Dropdown.propTypes = propTypes;

--- a/src/DropdownButton.tsx
+++ b/src/DropdownButton.tsx
@@ -136,7 +136,7 @@ const DropdownButton: BsPrefixRefForwardingComponent<
       </DropdownMenu>
     </Dropdown>
   ),
-);
+) as typeof DropdownButton;
 
 DropdownButton.displayName = 'DropdownButton';
 DropdownButton.propTypes = propTypes;

--- a/src/DropdownDivider.tsx
+++ b/src/DropdownDivider.tsx
@@ -25,7 +25,7 @@ const DropdownDivider: BsPrefixRefForwardingComponent<
       />
     );
   },
-);
+) as typeof DropdownDivider;
 
 DropdownDivider.displayName = 'DropdownDivider';
 

--- a/src/DropdownHeader.tsx
+++ b/src/DropdownHeader.tsx
@@ -25,7 +25,7 @@ const DropdownHeader: BsPrefixRefForwardingComponent<
       />
     );
   },
-);
+) as typeof DropdownHeader;
 
 DropdownHeader.displayName = 'DropdownHeader';
 

--- a/src/DropdownItem.tsx
+++ b/src/DropdownItem.tsx
@@ -83,7 +83,7 @@ const DropdownItem: BsPrefixRefForwardingComponent<'a', DropdownItemProps> =
         />
       );
     },
-  );
+  ) as typeof DropdownItem;
 
 DropdownItem.displayName = 'DropdownItem';
 DropdownItem.propTypes = propTypes;

--- a/src/DropdownItemText.tsx
+++ b/src/DropdownItemText.tsx
@@ -21,7 +21,7 @@ const DropdownItemText: BsPrefixRefForwardingComponent<
       />
     );
   },
-);
+) as typeof DropdownItemText;
 
 DropdownItemText.displayName = 'DropdownItemText';
 

--- a/src/DropdownMenu.tsx
+++ b/src/DropdownMenu.tsx
@@ -223,7 +223,7 @@ const DropdownMenu: BsPrefixRefForwardingComponent<'div', DropdownMenuProps> =
         />
       );
     },
-  );
+  ) as typeof DropdownMenu;
 
 DropdownMenu.displayName = 'DropdownMenu';
 DropdownMenu.propTypes = propTypes;

--- a/src/DropdownToggle.tsx
+++ b/src/DropdownToggle.tsx
@@ -90,7 +90,7 @@ const DropdownToggle: DropdownToggleComponent = React.forwardRef(
       />
     );
   },
-);
+) as typeof DropdownToggle;
 
 DropdownToggle.displayName = 'DropdownToggle';
 DropdownToggle.propTypes = propTypes;

--- a/src/Feedback.tsx
+++ b/src/Feedback.tsx
@@ -51,7 +51,7 @@ const Feedback: BsPrefixRefForwardingComponent<'div', FeedbackProps> =
         )}
       />
     ),
-  );
+  ) as typeof Feedback;
 
 Feedback.displayName = 'Feedback';
 Feedback.propTypes = propTypes;

--- a/src/Figure.tsx
+++ b/src/Figure.tsx
@@ -21,7 +21,7 @@ const Figure: BsPrefixRefForwardingComponent<'figure', FigureProps> =
         />
       );
     },
-  );
+  ) as typeof Figure;
 
 Figure.displayName = 'Figure';
 

--- a/src/FigureCaption.tsx
+++ b/src/FigureCaption.tsx
@@ -21,7 +21,7 @@ const FigureCaption: BsPrefixRefForwardingComponent<
       />
     );
   },
-);
+) as typeof FigureCaption;
 
 FigureCaption.displayName = 'FigureCaption';
 

--- a/src/FloatingLabel.tsx
+++ b/src/FloatingLabel.tsx
@@ -42,7 +42,7 @@ const FloatingLabel: BsPrefixRefForwardingComponent<'div', FloatingLabelProps> =
         </FormGroup>
       );
     },
-  );
+  ) as typeof FloatingLabel;
 
 FloatingLabel.displayName = 'FloatingLabel';
 FloatingLabel.propTypes = propTypes;

--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -56,7 +56,7 @@ const Form: BsPrefixRefForwardingComponent<'form', FormProps> =
         className={classNames(className, validated && 'was-validated')}
       />
     ),
-  );
+  ) as typeof Form;
 
 Form.displayName = 'Form';
 Form.propTypes = propTypes as any;

--- a/src/FormCheck.tsx
+++ b/src/FormCheck.tsx
@@ -211,7 +211,7 @@ const FormCheck: BsPrefixRefForwardingComponent<'input', FormCheckProps> =
         </FormContext.Provider>
       );
     },
-  );
+  ) as typeof FormCheck;
 
 FormCheck.displayName = 'FormCheck';
 FormCheck.propTypes = propTypes;

--- a/src/FormCheckInput.tsx
+++ b/src/FormCheckInput.tsx
@@ -78,7 +78,7 @@ const FormCheckInput: BsPrefixRefForwardingComponent<
       />
     );
   },
-);
+) as typeof FormCheckInput;
 
 FormCheckInput.displayName = 'FormCheckInput';
 FormCheckInput.propTypes = propTypes;

--- a/src/FormControl.tsx
+++ b/src/FormControl.tsx
@@ -150,7 +150,7 @@ const FormControl: BsPrefixRefForwardingComponent<'input', FormControlProps> =
         />
       );
     },
-  );
+  ) as typeof FormControl;
 
 FormControl.displayName = 'FormControl';
 FormControl.propTypes = propTypes;

--- a/src/FormFloating.tsx
+++ b/src/FormFloating.tsx
@@ -19,7 +19,7 @@ const FormFloating: BsPrefixRefForwardingComponent<'div', FormFloatingProps> =
         />
       );
     },
-  );
+  ) as typeof FormFloating;
 
 FormFloating.displayName = 'FormFloating';
 

--- a/src/FormGroup.tsx
+++ b/src/FormGroup.tsx
@@ -49,7 +49,7 @@ const FormGroup: BsPrefixRefForwardingComponent<'div', FormGroupProps> =
         </FormContext.Provider>
       );
     },
-  );
+  ) as typeof FormGroup;
 
 FormGroup.displayName = 'FormGroup';
 FormGroup.propTypes = propTypes;

--- a/src/FormLabel.tsx
+++ b/src/FormLabel.tsx
@@ -115,7 +115,7 @@ const FormLabel: BsPrefixRefForwardingComponent<'label', FormLabelProps> =
         <Component ref={ref} className={classes} htmlFor={htmlFor} {...props} />
       );
     },
-  );
+  ) as typeof FormLabel;
 
 FormLabel.displayName = 'FormLabel';
 FormLabel.propTypes = propTypes;

--- a/src/FormSelect.tsx
+++ b/src/FormSelect.tsx
@@ -92,7 +92,7 @@ const FormSelect: BsPrefixRefForwardingComponent<'select', FormSelectProps> =
         />
       );
     },
-  );
+  ) as typeof FormSelect;
 
 FormSelect.displayName = 'FormSelect';
 FormSelect.propTypes = propTypes;

--- a/src/FormText.tsx
+++ b/src/FormText.tsx
@@ -52,7 +52,7 @@ const FormText: BsPrefixRefForwardingComponent<'small', FormTextProps> =
         />
       );
     },
-  );
+  ) as typeof FormText;
 
 FormText.displayName = 'FormText';
 FormText.propTypes = propTypes;

--- a/src/InputGroup.tsx
+++ b/src/InputGroup.tsx
@@ -85,7 +85,7 @@ const InputGroup: BsPrefixRefForwardingComponent<'div', InputGroupProps> =
         </InputGroupContext.Provider>
       );
     },
-  );
+  ) as typeof InputGroup;
 
 InputGroup.propTypes = propTypes;
 InputGroup.displayName = 'InputGroup';

--- a/src/InputGroupText.tsx
+++ b/src/InputGroupText.tsx
@@ -21,7 +21,7 @@ const InputGroupText: BsPrefixRefForwardingComponent<
       />
     );
   },
-);
+) as typeof InputGroupText;
 
 InputGroupText.displayName = 'InputGroupText';
 

--- a/src/ListGroup.tsx
+++ b/src/ListGroup.tsx
@@ -91,7 +91,7 @@ const ListGroup: BsPrefixRefForwardingComponent<'div', ListGroupProps> =
         )}
       />
     );
-  });
+  }) as typeof ListGroup;
 
 ListGroup.propTypes = propTypes;
 ListGroup.displayName = 'ListGroup';

--- a/src/ListGroupItem.tsx
+++ b/src/ListGroupItem.tsx
@@ -126,7 +126,7 @@ const ListGroupItem: BsPrefixRefForwardingComponent<'a', ListGroupItemProps> =
         />
       );
     },
-  );
+  ) as typeof ListGroupItem;
 
 ListGroupItem.propTypes = propTypes;
 ListGroupItem.displayName = 'ListGroupItem';

--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -504,7 +504,7 @@ const Modal: BsPrefixRefForwardingComponent<'div', ModalProps> =
         </ModalContext.Provider>
       );
     },
-  );
+  ) as typeof Modal;
 
 Modal.displayName = 'Modal';
 Modal.propTypes = propTypes;

--- a/src/ModalBody.tsx
+++ b/src/ModalBody.tsx
@@ -19,7 +19,7 @@ const ModalBody: BsPrefixRefForwardingComponent<'div', ModalBodyProps> =
         />
       );
     },
-  );
+  ) as typeof ModalBody;
 
 ModalBody.displayName = 'ModalBody';
 

--- a/src/ModalFooter.tsx
+++ b/src/ModalFooter.tsx
@@ -19,7 +19,7 @@ const ModalFooter: BsPrefixRefForwardingComponent<'div', ModalFooterProps> =
         />
       );
     },
-  );
+  ) as typeof ModalFooter;
 
 ModalFooter.displayName = 'ModalFooter';
 

--- a/src/ModalTitle.tsx
+++ b/src/ModalTitle.tsx
@@ -22,7 +22,7 @@ const ModalTitle: BsPrefixRefForwardingComponent<'span', ModalTitleProps> =
         />
       );
     },
-  );
+  ) as typeof ModalTitle;
 
 ModalTitle.displayName = 'ModalTitle';
 

--- a/src/Nav.tsx
+++ b/src/Nav.tsx
@@ -156,7 +156,7 @@ const Nav: BsPrefixRefForwardingComponent<'div', NavProps> = React.forwardRef<
       {...props}
     />
   );
-});
+}) as typeof Nav;
 
 Nav.displayName = 'Nav';
 Nav.propTypes = propTypes;

--- a/src/NavDropdown.tsx
+++ b/src/NavDropdown.tsx
@@ -111,7 +111,7 @@ const NavDropdown: BsPrefixRefForwardingComponent<'div', NavDropdownProps> =
         </Dropdown>
       );
     },
-  );
+  ) as typeof NavDropdown;
 
 NavDropdown.displayName = 'NavDropdown';
 NavDropdown.propTypes = propTypes;

--- a/src/NavItem.tsx
+++ b/src/NavItem.tsx
@@ -19,7 +19,7 @@ const NavItem: BsPrefixRefForwardingComponent<'div', NavItemProps> =
         />
       );
     },
-  );
+  ) as typeof NavItem;
 
 NavItem.displayName = 'NavItem';
 

--- a/src/NavLink.tsx
+++ b/src/NavLink.tsx
@@ -37,7 +37,7 @@ const propTypes = {
    * */
   role: PropTypes.string,
 
-  /** 
+  /**
    * The HTML href attribute for the `NavLink`. Used as the unique identifier
    * for the `NavLink` if an `eventKey` is not provided.
    */
@@ -91,7 +91,7 @@ const NavLink: BsPrefixRefForwardingComponent<'a', NavLinkProps> =
         />
       );
     },
-  );
+  ) as typeof NavLink;
 
 NavLink.displayName = 'NavLink';
 NavLink.propTypes = propTypes;

--- a/src/Navbar.tsx
+++ b/src/Navbar.tsx
@@ -205,7 +205,7 @@ const Navbar: BsPrefixRefForwardingComponent<'nav', NavbarProps> =
         </SelectableContext.Provider>
       </NavbarContext.Provider>
     );
-  });
+  }) as typeof Navbar;
 
 Navbar.propTypes = propTypes;
 Navbar.displayName = 'Navbar';

--- a/src/NavbarBrand.tsx
+++ b/src/NavbarBrand.tsx
@@ -41,7 +41,7 @@ const NavbarBrand: BsPrefixRefForwardingComponent<'a', NavbarBrandProps> =
         />
       );
     },
-  );
+  ) as typeof NavbarBrand;
 
 NavbarBrand.displayName = 'NavbarBrand';
 NavbarBrand.propTypes = propTypes;

--- a/src/NavbarText.tsx
+++ b/src/NavbarText.tsx
@@ -19,7 +19,7 @@ const NavbarText: BsPrefixRefForwardingComponent<'span', NavbarTextProps> =
         />
       );
     },
-  );
+  ) as typeof NavbarText;
 
 NavbarText.displayName = 'NavbarText';
 

--- a/src/NavbarToggle.tsx
+++ b/src/NavbarToggle.tsx
@@ -74,7 +74,7 @@ const NavbarToggle: BsPrefixRefForwardingComponent<
       </Component>
     );
   },
-);
+) as typeof NavbarToggle;
 
 NavbarToggle.displayName = 'NavbarToggle';
 NavbarToggle.propTypes = propTypes;

--- a/src/Offcanvas.tsx
+++ b/src/Offcanvas.tsx
@@ -354,7 +354,7 @@ const Offcanvas: BsPrefixRefForwardingComponent<'div', OffcanvasProps> =
         </>
       );
     },
-  );
+  ) as typeof Offcanvas;
 
 Offcanvas.displayName = 'Offcanvas';
 Offcanvas.propTypes = propTypes;

--- a/src/OffcanvasBody.tsx
+++ b/src/OffcanvasBody.tsx
@@ -19,7 +19,7 @@ const OffcanvasBody: BsPrefixRefForwardingComponent<'div', OffcanvasBodyProps> =
         />
       );
     },
-  );
+  ) as typeof OffcanvasBody;
 
 OffcanvasBody.displayName = 'OffcanvasBody';
 

--- a/src/OffcanvasTitle.tsx
+++ b/src/OffcanvasTitle.tsx
@@ -24,7 +24,7 @@ const OffcanvasTitle: BsPrefixRefForwardingComponent<
       />
     );
   },
-);
+) as typeof OffcanvasTitle;
 
 OffcanvasTitle.displayName = 'OffcanvasTitle';
 

--- a/src/PageItem.tsx
+++ b/src/PageItem.tsx
@@ -77,7 +77,7 @@ const PageItem: BsPrefixRefForwardingComponent<'li', PageItemProps> =
         </li>
       );
     },
-  );
+  ) as typeof PageItem;
 
 PageItem.propTypes = propTypes;
 PageItem.displayName = 'PageItem';

--- a/src/Placeholder.tsx
+++ b/src/Placeholder.tsx
@@ -41,7 +41,7 @@ const Placeholder: BsPrefixRefForwardingComponent<'span', PlaceholderProps> =
 
       return <Component {...placeholderProps} ref={ref} />;
     },
-  );
+  ) as typeof Placeholder;
 
 Placeholder.displayName = 'Placeholder';
 Placeholder.propTypes = propTypes;

--- a/src/PlaceholderButton.tsx
+++ b/src/PlaceholderButton.tsx
@@ -37,7 +37,7 @@ const PlaceholderButton: BsPrefixRefForwardingComponent<
 
     return <Button {...placeholderProps} ref={ref} disabled tabIndex={-1} />;
   },
-);
+) as typeof PlaceholderButton;
 
 PlaceholderButton.displayName = 'PlaceholderButton';
 PlaceholderButton.propTypes = propTypes;

--- a/src/PopoverBody.tsx
+++ b/src/PopoverBody.tsx
@@ -19,7 +19,7 @@ const PopoverBody: BsPrefixRefForwardingComponent<'div', PopoverBodyProps> =
         />
       );
     },
-  );
+  ) as typeof PopoverBody;
 
 PopoverBody.displayName = 'PopoverBody';
 

--- a/src/PopoverHeader.tsx
+++ b/src/PopoverHeader.tsx
@@ -19,7 +19,7 @@ const PopoverHeader: BsPrefixRefForwardingComponent<'div', PopoverHeaderProps> =
         />
       );
     },
-  );
+  ) as typeof PopoverHeader;
 
 PopoverHeader.displayName = 'PopoverHeader';
 

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -150,7 +150,7 @@ const Row: BsPrefixRefForwardingComponent<'div', RowProps> = React.forwardRef<
       />
     );
   },
-);
+) as typeof Row;
 
 Row.displayName = 'Row';
 Row.propTypes = propTypes;

--- a/src/Spinner.tsx
+++ b/src/Spinner.tsx
@@ -88,7 +88,7 @@ const Spinner: BsPrefixRefForwardingComponent<'div', SpinnerProps> =
         />
       );
     },
-  );
+  ) as typeof Spinner;
 
 Spinner.propTypes = propTypes as any;
 Spinner.displayName = 'Spinner';

--- a/src/Stack.tsx
+++ b/src/Stack.tsx
@@ -71,7 +71,7 @@ const Stack: BsPrefixRefForwardingComponent<'span', StackProps> =
         />
       );
     },
-  );
+  ) as typeof Stack;
 
 Stack.displayName = 'Stack';
 Stack.propTypes = propTypes;

--- a/src/Switch.tsx
+++ b/src/Switch.tsx
@@ -7,7 +7,7 @@ type SwitchProps = Omit<FormCheckProps, 'type'>;
 const Switch: BsPrefixRefForwardingComponent<typeof FormCheck, SwitchProps> =
   React.forwardRef<typeof FormCheck, SwitchProps>((props, ref) => (
     <FormCheck {...props} ref={ref} type="switch" />
-  ));
+  )) as typeof Switch;
 
 Switch.displayName = 'Switch';
 

--- a/src/TabContent.tsx
+++ b/src/TabContent.tsx
@@ -19,7 +19,7 @@ const TabContent: BsPrefixRefForwardingComponent<'div', TabContentProps> =
         />
       );
     },
-  );
+  ) as typeof TabContent;
 
 TabContent.displayName = 'TabContent';
 

--- a/src/TabPane.tsx
+++ b/src/TabPane.tsx
@@ -153,7 +153,7 @@ const TabPane: BsPrefixRefForwardingComponent<'div', TabPaneProps> =
         </TabContext.Provider>
       );
     },
-  );
+  ) as typeof TabPane;
 
 TabPane.displayName = 'TabPane';
 TabPane.propTypes = propTypes;

--- a/src/Toast.tsx
+++ b/src/Toast.tsx
@@ -196,7 +196,7 @@ const Toast: BsPrefixRefForwardingComponent<'div', ToastProps> =
         </ToastContext.Provider>
       );
     },
-  );
+  ) as typeof Toast;
 
 Toast.propTypes = propTypes;
 Toast.displayName = 'Toast';

--- a/src/ToastBody.tsx
+++ b/src/ToastBody.tsx
@@ -19,7 +19,7 @@ const ToastBody: BsPrefixRefForwardingComponent<'div', ToastBodyProps> =
         />
       );
     },
-  );
+  ) as typeof ToastBody;
 
 ToastBody.displayName = 'ToastBody';
 

--- a/src/ToastContainer.tsx
+++ b/src/ToastContainer.tsx
@@ -92,7 +92,7 @@ const ToastContainer: BsPrefixRefForwardingComponent<
       />
     );
   },
-);
+) as typeof ToastContainer;
 
 ToastContainer.displayName = 'ToastContainer';
 ToastContainer.propTypes = propTypes;

--- a/src/ToggleButtonGroup.tsx
+++ b/src/ToggleButtonGroup.tsx
@@ -137,7 +137,7 @@ const ToggleButtonGroup: BsPrefixRefForwardingComponent<
       })}
     </ButtonGroup>
   );
-});
+}) as typeof ToggleButtonGroup;
 
 ToggleButtonGroup.propTypes = propTypes;
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -28,7 +28,7 @@ export interface BsPrefixRefForwardingComponent<
   <As extends React.ElementType = TInitial>(
     props: React.PropsWithChildren<ReplaceProps<As, BsPrefixProps<As> & P>>,
     context?: any,
-  ): React.ReactNode;
+  ): React.ReactElement | null;
   propTypes?: any;
   contextTypes?: any;
   defaultProps?: Partial<P>;


### PR DESCRIPTION
Fixes #6819 

Accidentally broke types when making them compatible with R18 types.  This fix restores the original type but also adds a hack for any component that explicitly declares `BsPrefixRefForwardingComponent` as a return type so the build would work.