### PR TITLE
docs: fixed mistake with grid example

### DIFF
--- a/www/docs/examples/Grid/Ordering.js
+++ b/www/docs/examples/Grid/Ordering.js
@@ -7,8 +7,8 @@ function OrderingExample() {
     <Container>
       <Row>
         <Col xs>First, but unordered</Col>
-        <Col xs={{ order: 12 }}>Second, but last</Col>
-        <Col xs={{ order: 1 }}>Third, but second</Col>
+        <Col xs={{ order: 5 }}>Second, but last</Col>
+        <Col xs={{ order: 0 }}>Third, but second</Col>
       </Row>
     </Container>
   );


### PR DESCRIPTION
Error in the ["Grid"](https://react-bootstrap.netlify.app/docs/layout/grid/#responsive-grids) docs.

The example in the documentation for ordering suggest that the `order` property takes a value between `1` and `12` (inclusive). However, that is not working properly in the example.

The Bootstrap ["documentation"](https://getbootstrap.com/docs/5.3/utilities/flex/#order) says the range goes from `0` to `5` (inclusive). I changed the values in the example to those two.