### PR TITLE
fix: dropdown-button-spacing

### DIFF
--- a/www/docs/examples/Dropdown/AutoClose.js
+++ b/www/docs/examples/Dropdown/AutoClose.js
@@ -2,8 +2,8 @@ import Dropdown from 'react-bootstrap/Dropdown';
 
 function AutoCloseExample() {
   return (
-    <>
-      <Dropdown className="d-inline mx-2">
+    <div className="dropdown-btn-spacing">
+      <Dropdown className="d-inline">
         <Dropdown.Toggle id="dropdown-autoclose-true">
           Default Dropdown
         </Dropdown.Toggle>
@@ -15,7 +15,7 @@ function AutoCloseExample() {
         </Dropdown.Menu>
       </Dropdown>
 
-      <Dropdown className="d-inline mx-2" autoClose="inside">
+      <Dropdown className="d-inline" autoClose="inside">
         <Dropdown.Toggle id="dropdown-autoclose-inside">
           Clickable Outside
         </Dropdown.Toggle>
@@ -27,7 +27,7 @@ function AutoCloseExample() {
         </Dropdown.Menu>
       </Dropdown>
 
-      <Dropdown className="d-inline mx-2" autoClose="outside">
+      <Dropdown className="d-inline" autoClose="outside">
         <Dropdown.Toggle id="dropdown-autoclose-outside">
           Clickable Inside
         </Dropdown.Toggle>
@@ -39,7 +39,7 @@ function AutoCloseExample() {
         </Dropdown.Menu>
       </Dropdown>
 
-      <Dropdown className="d-inline mx-2" autoClose={false}>
+      <Dropdown className="d-inline" autoClose={false}>
         <Dropdown.Toggle id="dropdown-autoclose-false">
           Manual Close
         </Dropdown.Toggle>
@@ -50,7 +50,7 @@ function AutoCloseExample() {
           <Dropdown.Item href="#">Menu Item</Dropdown.Item>
         </Dropdown.Menu>
       </Dropdown>
-    </>
+    </div>
   );
 }
 

--- a/www/docs/examples/Dropdown/ButtonSizes.js
+++ b/www/docs/examples/Dropdown/ButtonSizes.js
@@ -6,7 +6,7 @@ import SplitButton from 'react-bootstrap/SplitButton';
 function ButtonSizesExample() {
   return (
     <>
-      <div className="mb-2">
+      <div className="mb-2 dropdown-btn-spacing">
         {[DropdownButton, SplitButton].map((DropdownType, idx) => (
           <DropdownType
             as={ButtonGroup}
@@ -23,7 +23,7 @@ function ButtonSizesExample() {
           </DropdownType>
         ))}
       </div>
-      <div>
+      <div className="dropdown-btn-spacing">
         {[DropdownButton, SplitButton].map((DropdownType, idx) => (
           <DropdownType
             as={ButtonGroup}

--- a/www/docs/examples/Dropdown/DropDirections.js
+++ b/www/docs/examples/Dropdown/DropDirections.js
@@ -5,7 +5,7 @@ import SplitButton from 'react-bootstrap/SplitButton';
 function DropDirectioExample() {
   return (
     <>
-      <div className="mb-2">
+      <div className="mb-2 dropdown-btn-spacing">
         {['up', 'up-centered', 'down', 'down-centered', 'start', 'end'].map(
           (direction) => (
             <DropdownButton
@@ -26,7 +26,7 @@ function DropDirectioExample() {
         )}
       </div>
 
-      <div>
+      <div className="dropdown-btn-spacing">
         {['up', 'up-centered', 'down', 'down-centered', 'start', 'end'].map(
           (direction) => (
             <SplitButton

--- a/www/docs/examples/Dropdown/SplitVariants.js
+++ b/www/docs/examples/Dropdown/SplitVariants.js
@@ -3,7 +3,7 @@ import SplitButton from 'react-bootstrap/SplitButton';
 
 function SplitVariantExample() {
   return (
-    <>
+    <div className="dropdown-btn-spacing">
       {['Primary', 'Secondary', 'Success', 'Info', 'Warning', 'Danger'].map(
         (variant) => (
           <SplitButton
@@ -22,7 +22,7 @@ function SplitVariantExample() {
           </SplitButton>
         ),
       )}
-    </>
+    </div>
   );
 }
 

--- a/www/docs/examples/Dropdown/Variants.js
+++ b/www/docs/examples/Dropdown/Variants.js
@@ -4,7 +4,7 @@ import DropdownButton from 'react-bootstrap/DropdownButton';
 
 function VariantsExample() {
   return (
-    <>
+    <div className="dropdown-btn-spacing">
       {['Primary', 'Secondary', 'Success', 'Info', 'Warning', 'Danger'].map(
         (variant) => (
           <DropdownButton
@@ -24,7 +24,7 @@ function VariantsExample() {
           </DropdownButton>
         ),
       )}
-    </>
+    </div>
   );
 }
 

--- a/www/src/css/examples.scss
+++ b/www/src/css/examples.scss
@@ -123,3 +123,9 @@
     font-size: 3.5rem;
   }
 }
+
+.dropdown-btn-spacing {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}


### PR DESCRIPTION
# In this PR, I fix the gapping issue in Dropdown buttons. The issue number is #6840.

## Previously 🔙

<div style="display: flex; flex-wrap: wrap; gap: 10px;">
  <img src="https://github.com/user-attachments/assets/6d763a59-1a0c-446d-8550-16bd2e6087ae" alt="Previous State 1" width="200" />
  <img src="https://github.com/user-attachments/assets/de67d2f8-4cc8-4120-85ef-a57449966f41" alt="Previous State 2" width="200" />
  <img src="https://github.com/user-attachments/assets/27c2df08-504c-4697-8cab-c9c1b7d63b6b" alt="Previous State 3" width="200" />
  <img src="https://github.com/user-attachments/assets/f0a5ee5f-d7e9-491c-ae6d-a856d6372af8" alt="Previous State 4" width="200" />
</div>

## Now ⌚

<div style="display: flex; flex-wrap: wrap; gap: 10px;">
  <img src="https://github.com/user-attachments/assets/1ce074a8-7b1d-4d35-879a-10a42996e579" alt="Current State 1" width="200" />
  <img src="https://github.com/user-attachments/assets/5a75a9ed-c7db-4613-a1db-0d9e259850c9" alt="Current State 2" width="200" />
  <img src="https://github.com/user-attachments/assets/4044007d-4e21-446b-a369-9274149ee29b" alt="Current State 3" width="200" />
  <img src="https://github.com/user-attachments/assets/a6092218-5000-4d0d-ab47-f87f5329fd01" alt="Current State 4" width="200" />
</div>

---

### Changes Overview 👀
1. **Change in example files** : add one styling class
2.  **Change in examples.scss** : write down styling for dropdown button spacing

---

#### This PR will help to fix the odd gapping issue in Dropdown component. 