### PR TITLE
fix(Nav): remove prop-types-extra import from build

### DIFF
--- a/src/Nav.tsx
+++ b/src/Nav.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 
-import all from 'prop-types-extra/lib/all';
+import { all } from 'prop-types-extra';
 import * as React from 'react';
 import { useContext } from 'react';
 import { useUncontrolled } from 'uncontrollable';


### PR DESCRIPTION
Fixes #6830

The import wasn't removed due to how we declared `additionalLibraries` for `babel-plugin-transform-react-remove-prop-types`.  It was looking for an exact import path.

https://github.com/react-bootstrap/configs/blob/99ab44dd872eee57d495f188dadee98608a03d23/packages/babel-preset/index.js#L48