### PR TITLE
docs: fix link in breadcrumb

### DIFF
--- a/www/docs/examples/Breadcrumb.js
+++ b/www/docs/examples/Breadcrumb.js
@@ -4,7 +4,7 @@ function BreadcrumbExample() {
   return (
     <Breadcrumb>
       <Breadcrumb.Item href="#">Home</Breadcrumb.Item>
-      <Breadcrumb.Item href="https://getbootstrap.com/docs/4.0/components/breadcrumb/">
+      <Breadcrumb.Item href="#">
         Library
       </Breadcrumb.Item>
       <Breadcrumb.Item active>Data</Breadcrumb.Item>


### PR DESCRIPTION
For this PR, I’ve updated the breadcrumb example link to `#` instead of linking directly to the Bootstrap documentation. 

This change was made to avoid redirecting users away from the React Bootstrap docs, which could disrupt their flow and cause confusion. 

By using `#` as a placeholder, the example now focuses purely on showing breadcrumb's structure without unexpected page navigation. This also aligns with the general practice of using non-functional links in component examples to maintain user focus on the example itself.