### PR TITLE
fix: resolve no-promise-executor-return linting error

### DIFF
--- a/www/docs/examples/Button/Loading.js
+++ b/www/docs/examples/Button/Loading.js
@@ -6,7 +6,9 @@ function LoadingButton() {
 
   useEffect(() => {
     function simulateNetworkRequest() {
-      return new Promise((resolve) => setTimeout(resolve, 2000));
+      return new Promise(resolve => {
+        setTimeout(resolve, 2000);
+      });
     }
 
     if (isLoading) {


### PR DESCRIPTION
This PR fixes the `no-promise-executor-return` linting error in the `simulateNetworkRequest` function.

As arrow functions are shown as an example of incorrect code in the [rule docs](https://eslint.org/docs/rules/no-promise-executor-return), wrapping the code in curly braces makes the intent more clear and doesn't throw a linting error. 


