### PR TITLE
fix: preventing redirects from live preview

### DIFF
--- a/www/src/theme/Playground/Preview.tsx
+++ b/www/src/theme/Playground/Preview.tsx
@@ -55,9 +55,17 @@ const Preview: React.FC<PreviewProps> = ({ className }) => {
     },
   );
 
+
+  const handleCustomRedirect = (e) => {
+    const target = e.target as HTMLElement;
+    if (target.closest('a[href]')) {
+      e.preventDefault(); 
+    }
+  };
+
   return (
-    <div ref={exampleRef}>
-      <LivePreview className={className} />
+    <div ref={exampleRef} >
+      <LivePreview className={className} onClick={handleCustomRedirect}/>
     </div>
   );
 };

--- a/www/src/theme/Playground/Preview.tsx
+++ b/www/src/theme/Playground/Preview.tsx
@@ -4,7 +4,7 @@ import { LiveContext, LivePreview } from 'react-live';
 import qsa from 'dom-helpers/querySelectorAll';
 import useIsomorphicEffect from '@restart/hooks/useIsomorphicEffect';
 import useMutationObserver from '@restart/hooks/useMutationObserver';
-import { useEventCallback } from '@restart/hooks';
+import useEventCallback from '@restart/hooks/useEventCallback';
 
 export interface PreviewProps {
   className?: string | undefined;

--- a/www/src/theme/Playground/Preview.tsx
+++ b/www/src/theme/Playground/Preview.tsx
@@ -4,6 +4,7 @@ import { LiveContext, LivePreview } from 'react-live';
 import qsa from 'dom-helpers/querySelectorAll';
 import useIsomorphicEffect from '@restart/hooks/useIsomorphicEffect';
 import useMutationObserver from '@restart/hooks/useMutationObserver';
+import { useEventCallback } from '@restart/hooks';
 
 export interface PreviewProps {
   className?: string | undefined;
@@ -55,13 +56,12 @@ const Preview: React.FC<PreviewProps> = ({ className }) => {
     },
   );
 
-
-  const handleCustomRedirect = (e) => {
-    const target = e.target as HTMLElement;
-    if (target.closest('a[href]')) {
-      e.preventDefault(); 
+  const handleCustomRedirect = useEventCallback((e: React.MouseEvent<HTMLElement>) => {
+    if (e.target.tagName === 'A') {
+      e.preventDefault();
     }
-  };
+  })
+
 
   return (
     <div ref={exampleRef}>

--- a/www/src/theme/Playground/Preview.tsx
+++ b/www/src/theme/Playground/Preview.tsx
@@ -62,7 +62,6 @@ const Preview: React.FC<PreviewProps> = ({ className }) => {
     }
   })
 
-
   return (
     <div ref={exampleRef}>
       <LivePreview className={className} onClick={handleCustomRedirect}/>

--- a/www/src/theme/Playground/Preview.tsx
+++ b/www/src/theme/Playground/Preview.tsx
@@ -64,7 +64,7 @@ const Preview: React.FC<PreviewProps> = ({ className }) => {
   };
 
   return (
-    <div ref={exampleRef} >
+    <div ref={exampleRef}>
       <LivePreview className={className} onClick={handleCustomRedirect}/>
     </div>
   );


### PR DESCRIPTION
fixes: #6843 

Hi! as discussed in PR #6852  `to prevent the action on all anchors within code examples within the playground component`, here is the revised solution.