### PR TITLE
fix(OverlayTrigger) ensure the overlay closes, when it contains a scrollbar

### DIFF
--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -202,6 +202,7 @@ const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
         }}
         transition={actualTransition}
         rootClose={rootClose}
+        rootCloseEvent="mouseup"
         placement={placement}
         show={outerShow}
       >


### PR DESCRIPTION
# Done
- fix(OverlayTrigger) ensure the overlay closes, when it contains a scrollbarollbar and the user interacted with it right before clicking outside. fixes #6836