### PR TITLE
Docs: Replace HTML button with react-bootstrap button in Accordion example

### DIFF
--- a/www/docs/examples/Accordion/ContextAwareToggle.js
+++ b/www/docs/examples/Accordion/ContextAwareToggle.js
@@ -3,9 +3,8 @@ import Accordion from 'react-bootstrap/Accordion';
 import AccordionContext from 'react-bootstrap/AccordionContext';
 import { useAccordionButton } from 'react-bootstrap/AccordionButton';
 import Card from 'react-bootstrap/Card';
+import Button from 'react-bootstrap/Button';
 
-const PINK = 'rgba(255, 192, 203, 0.6)';
-const BLUE = 'rgba(0, 0, 255, 0.6)';
 
 function ContextAwareToggle({ children, eventKey, callback }) {
   const { activeEventKey } = useContext(AccordionContext);
@@ -16,15 +15,12 @@ function ContextAwareToggle({ children, eventKey, callback }) {
   );
 
   const isCurrentEventKey = activeEventKey === eventKey;
+  const backgroundColor = isCurrentEventKey ? 'primary' : 'secondary';
 
   return (
-    <button
-      type="button"
-      style={{ backgroundColor: isCurrentEventKey ? PINK : BLUE }}
-      onClick={decoratedOnClick}
-    >
+    <Button variant={backgroundColor} onClick={decoratedOnClick}>
       {children}
-    </button>
+    </Button>
   );
 }
 

--- a/www/docs/examples/Accordion/CustomToggle.js
+++ b/www/docs/examples/Accordion/CustomToggle.js
@@ -1,6 +1,7 @@
 import Accordion from 'react-bootstrap/Accordion';
 import { useAccordionButton } from 'react-bootstrap/AccordionButton';
 import Card from 'react-bootstrap/Card';
+import Button from 'react-bootstrap/Button';
 
 function CustomToggle({ children, eventKey }) {
   const decoratedOnClick = useAccordionButton(eventKey, () =>
@@ -8,13 +9,9 @@ function CustomToggle({ children, eventKey }) {
   );
 
   return (
-    <button
-      type="button"
-      style={{ backgroundColor: 'pink' }}
-      onClick={decoratedOnClick}
-    >
+    <Button variant="primary" onClick={decoratedOnClick}>
       {children}
-    </button>
+    </Button>
   );
 }
 


### PR DESCRIPTION
Replaced the plain HTML `<button>` with the react-bootstrap `<Button>` component in Accordion example to maintain consistency across docs.