### PR TITLE
Add package.json with type: module to esm directory

### DIFF
--- a/tools/build.js
+++ b/tools/build.js
@@ -79,14 +79,22 @@ const buildDist = step(
     }),
 );
 
-const buildDirectories = step('Linking directories', () =>
-  cherryPick({
+const buildDirectories = step('Linking directories', async () => {
+  await cherryPick({
     inputDir: '../src',
     cjsDir: 'cjs',
     esmDir: 'esm',
     cwd: libRoot,
-  }),
-);
+  });
+
+  await fse.writeJSON(
+    path.join(esRoot, 'package.json'),
+    {
+      type: 'module',
+    },
+    { spaces: 2 },
+  );
+});
 
 console.log(
   green(`Building targets: ${targets.length ? targets.join(', ') : 'all'}\n`),

--- a/tools/build.js
+++ b/tools/build.js
@@ -89,9 +89,7 @@ const buildDirectories = step('Linking directories', async () => {
 
   await fse.writeJSON(
     path.join(esRoot, 'package.json'),
-    {
-      type: 'module',
-    },
+    { type: 'module' },
     { spaces: 2 },
   );
 });


### PR DESCRIPTION
This is necessary for Node and similar environments to treat the contents of the `esm` directory as ES Modules. Otherwise both Node and TypeScript get quite confused.

This is a step in the right direction of resolving #6797. After this change, one should be able to write the following in a TypeScript file:


```tsx
import ModalDialog from `react-bootstrap/esm/ModalDialog.js`;

function MyComponent() {
  return <ModalDialog></ModalDialog>;
}
```

Importing e.g. `react-bootstrap/ModalDialog` doesn't yet work. And the above still doesn't work at runtime because the code in `esm/ModalDialog.js` isn't actually valid ESM, as it doesn't use extensions on its imports. I'd like to work towards resolving these issues in future PRs, as they're blocking the use of `react-bootstrap` in my application.