### PR TITLE
feat!: extract hooks from component files

### DIFF
--- a/src/AccordionButton.tsx
+++ b/src/AccordionButton.tsx
@@ -2,15 +2,11 @@ import * as React from 'react';
 import { useContext } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import AccordionContext, {
-  isAccordionItemSelected,
-  type AccordionEventKey,
-} from './AccordionContext';
+import AccordionContext, { isAccordionItemSelected } from './AccordionContext';
 import AccordionItemContext from './AccordionItemContext';
 import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
 import { useBootstrapPrefix } from './ThemeProvider';
-
-type EventHandler = React.EventHandler<React.SyntheticEvent>;
+import useAccordionButton from './useAccordionButton';
 
 export interface AccordionButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
@@ -26,37 +22,6 @@ const propTypes = {
   /** A callback function for when this component is clicked */
   onClick: PropTypes.func,
 };
-
-export function useAccordionButton(
-  eventKey: string,
-  onClick?: EventHandler,
-): EventHandler {
-  const { activeEventKey, onSelect, alwaysOpen } = useContext(AccordionContext);
-
-  return (e) => {
-    /*
-      Compare the event key in context with the given event key.
-      If they are the same, then collapse the component.
-    */
-    let eventKeyPassed: AccordionEventKey =
-      eventKey === activeEventKey ? null : eventKey;
-    if (alwaysOpen) {
-      if (Array.isArray(activeEventKey)) {
-        if (activeEventKey.includes(eventKey)) {
-          eventKeyPassed = activeEventKey.filter((k) => k !== eventKey);
-        } else {
-          eventKeyPassed = [...activeEventKey, eventKey];
-        }
-      } else {
-        // activeEventKey is undefined.
-        eventKeyPassed = [eventKey];
-      }
-    }
-
-    onSelect?.(eventKeyPassed, e);
-    onClick?.(e);
-  };
-}
 
 const AccordionButton: BsPrefixRefForwardingComponent<
   'div',

--- a/src/Col.tsx
+++ b/src/Col.tsx
@@ -1,15 +1,10 @@
 import classNames from 'classnames';
 import * as React from 'react';
 import PropTypes from 'prop-types';
-
-import {
-  useBootstrapPrefix,
-  useBootstrapBreakpoints,
-  useBootstrapMinBreakpoint,
-} from './ThemeProvider';
 import type { BsPrefixProps, BsPrefixRefForwardingComponent } from './helpers';
+import useCol from './useCol';
 
-type NumberAttr =
+export type NumberAttr =
   | number
   | '1'
   | '2'
@@ -24,10 +19,10 @@ type NumberAttr =
   | '11'
   | '12';
 
-type ColOrderNumber = number | '1' | '2' | '3' | '4' | '5';
-type ColOrder = ColOrderNumber | 'first' | 'last';
-type ColSize = boolean | 'auto' | NumberAttr;
-type ColSpec =
+export type ColOrderNumber = number | '1' | '2' | '3' | '4' | '5';
+export type ColOrder = ColOrderNumber | 'first' | 'last';
+export type ColSize = boolean | 'auto' | NumberAttr;
+export type ColSpec =
   | ColSize
   | { span?: ColSize | null; offset?: NumberAttr; order?: ColOrder };
 
@@ -114,60 +109,6 @@ const propTypes = {
    */
   xxl: column,
 };
-
-export interface UseColMetadata {
-  as?: React.ElementType;
-  bsPrefix: string;
-  spans: string[];
-}
-
-export function useCol({
-  as,
-  bsPrefix,
-  className,
-  ...props
-}: ColProps): [any, UseColMetadata] {
-  bsPrefix = useBootstrapPrefix(bsPrefix, 'col');
-  const breakpoints = useBootstrapBreakpoints();
-  const minBreakpoint = useBootstrapMinBreakpoint();
-
-  const spans: string[] = [];
-  const classes: string[] = [];
-
-  breakpoints.forEach((brkPoint) => {
-    const propValue = props[brkPoint];
-    delete props[brkPoint];
-
-    let span: ColSize | undefined;
-    let offset: NumberAttr | undefined;
-    let order: ColOrder | undefined;
-
-    if (typeof propValue === 'object' && propValue != null) {
-      ({ span, offset, order } = propValue);
-    } else {
-      span = propValue;
-    }
-
-    const infix = brkPoint !== minBreakpoint ? `-${brkPoint}` : '';
-
-    if (span)
-      spans.push(
-        span === true ? `${bsPrefix}${infix}` : `${bsPrefix}${infix}-${span}`,
-      );
-
-    if (order != null) classes.push(`order${infix}-${order}`);
-    if (offset != null) classes.push(`offset${infix}-${offset}`);
-  });
-
-  return [
-    { ...props, className: classNames(className, ...spans, ...classes) },
-    {
-      as,
-      bsPrefix,
-      spans,
-    },
-  ];
-}
 
 const Col: BsPrefixRefForwardingComponent<'div', ColProps> = React.forwardRef<
   HTMLElement,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,10 +5,7 @@ export { default as AccordionContext } from './AccordionContext';
 export { default as AccordionCollapse } from './AccordionCollapse';
 export type { AccordionCollapseProps } from './AccordionCollapse';
 
-export {
-  default as AccordionButton,
-  useAccordionButton,
-} from './AccordionButton';
+export { default as AccordionButton } from './AccordionButton';
 export type { AccordionButtonProps } from './AccordionButton';
 
 export { default as AccordionBody } from './AccordionBody';
@@ -329,3 +326,5 @@ export type {
 
 export { default as Tooltip } from './Tooltip';
 export type { TooltipProps } from './Tooltip';
+
+export { default as useAccordionButton } from './useAccordionButton';

--- a/src/useAccordionButton.ts
+++ b/src/useAccordionButton.ts
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { useContext } from 'react';
+import AccordionContext, { type AccordionEventKey } from './AccordionContext';
+
+type EventHandler = React.EventHandler<React.SyntheticEvent>;
+
+export default function useAccordionButton(
+  eventKey: string,
+  onClick?: EventHandler,
+): EventHandler {
+  const { activeEventKey, onSelect, alwaysOpen } = useContext(AccordionContext);
+
+  return (e) => {
+    /*
+      Compare the event key in context with the given event key.
+      If they are the same, then collapse the component.
+    */
+    let eventKeyPassed: AccordionEventKey =
+      eventKey === activeEventKey ? null : eventKey;
+    if (alwaysOpen) {
+      if (Array.isArray(activeEventKey)) {
+        if (activeEventKey.includes(eventKey)) {
+          eventKeyPassed = activeEventKey.filter((k) => k !== eventKey);
+        } else {
+          eventKeyPassed = [...activeEventKey, eventKey];
+        }
+      } else {
+        // activeEventKey is undefined.
+        eventKeyPassed = [eventKey];
+      }
+    }
+
+    onSelect?.(eventKeyPassed, e);
+    onClick?.(e);
+  };
+}

--- a/src/useCol.ts
+++ b/src/useCol.ts
@@ -1,0 +1,61 @@
+import classNames from 'classnames';
+import {
+  useBootstrapPrefix,
+  useBootstrapBreakpoints,
+  useBootstrapMinBreakpoint,
+} from './ThemeProvider';
+import type { ColProps, ColOrder, ColSize, NumberAttr } from './Col';
+
+export interface UseColMetadata {
+  as?: React.ElementType;
+  bsPrefix: string;
+  spans: string[];
+}
+
+export default function useCol({
+  as,
+  bsPrefix,
+  className,
+  ...props
+}: ColProps): [any, UseColMetadata] {
+  bsPrefix = useBootstrapPrefix(bsPrefix, 'col');
+  const breakpoints = useBootstrapBreakpoints();
+  const minBreakpoint = useBootstrapMinBreakpoint();
+
+  const spans: string[] = [];
+  const classes: string[] = [];
+
+  breakpoints.forEach((brkPoint) => {
+    const propValue = props[brkPoint];
+    delete props[brkPoint];
+
+    let span: ColSize | undefined;
+    let offset: NumberAttr | undefined;
+    let order: ColOrder | undefined;
+
+    if (typeof propValue === 'object' && propValue != null) {
+      ({ span, offset, order } = propValue);
+    } else {
+      span = propValue;
+    }
+
+    const infix = brkPoint !== minBreakpoint ? `-${brkPoint}` : '';
+
+    if (span)
+      spans.push(
+        span === true ? `${bsPrefix}${infix}` : `${bsPrefix}${infix}-${span}`,
+      );
+
+    if (order != null) classes.push(`order${infix}-${order}`);
+    if (offset != null) classes.push(`offset${infix}-${offset}`);
+  });
+
+  return [
+    { ...props, className: classNames(className, ...spans, ...classes) },
+    {
+      as,
+      bsPrefix,
+      spans,
+    },
+  ];
+}

--- a/src/usePlaceholder.ts
+++ b/src/usePlaceholder.ts
@@ -1,6 +1,7 @@
 import classNames from 'classnames';
 import { useBootstrapPrefix } from './ThemeProvider';
-import { useCol, type ColProps } from './Col';
+import type { ColProps } from './Col';
+import useCol from './useCol';
 import type { Variant } from './types';
 
 export type PlaceholderAnimation = 'glow' | 'wave';

--- a/www/docs/components/accordion.mdx
+++ b/www/docs/components/accordion.mdx
@@ -95,7 +95,7 @@ this can be achieved with a custom toggle that is context aware and also takes a
 ### useAccordionButton
 
 ```jsx
-import { useAccordionButton } from 'react-bootstrap/AccordionButton';
+import useAccordionButton from 'react-bootstrap/useAccordionButton';
 
 const decoratedOnClick = useAccordionButton(eventKey, onClick);
 ```

--- a/www/docs/examples/Accordion/ContextAwareToggle.js
+++ b/www/docs/examples/Accordion/ContextAwareToggle.js
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 import Accordion from 'react-bootstrap/Accordion';
 import AccordionContext from 'react-bootstrap/AccordionContext';
-import { useAccordionButton } from 'react-bootstrap/AccordionButton';
+import useAccordionButton from 'react-bootstrap/useAccordionButton';
 import Card from 'react-bootstrap/Card';
 
 const PINK = 'rgba(255, 192, 203, 0.6)';

--- a/www/docs/examples/Accordion/CustomToggle.js
+++ b/www/docs/examples/Accordion/CustomToggle.js
@@ -1,5 +1,5 @@
 import Accordion from 'react-bootstrap/Accordion';
-import { useAccordionButton } from 'react-bootstrap/AccordionButton';
+import useAccordionButton from 'react-bootstrap/useAccordionButton';
 import Card from 'react-bootstrap/Card';
 
 function CustomToggle({ children, eventKey }) {

--- a/www/docs/migrating/migrating_v2.mdx
+++ b/www/docs/migrating/migrating_v2.mdx
@@ -35,6 +35,10 @@ Below is a _rough_ account of the breaking API changes as well as the minimal ch
 
 - React >= 18.3.1 is now required
 
+### AccordionButton
+
+- `useAccordionButton` is now exported from its own file. You can now import via `import useAccordionButton from 'react-bootstrap/useAccordionButton'`.
+
 ### Collapse
 
 - collapse now requires a child component that forwards the ref to the underlying HTML element.


### PR DESCRIPTION
BREAKING CHANGE: Extracts the `useCol` and `useAccordionButton` from `Col.tsx` and `AccordionButton.tsx` so the CJS default export is consistent with other components (ie. no `export.default = ***`).

Fixes #6539