### PR TITLE
Add CJS to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,16 @@
         "types": "./lib/*.d.ts",
         "default": "./lib/*.js"
       }
+    },
+    "./cjs/*": {
+      "require": {
+        "types": "./cjs/*.d.ts",
+        "default": "./cjs/*.js"
+      },
+      "import": {
+        "types": "./cjs/*.d.ts",
+        "default": "./cjs/*.js"
+      }
     }
   },
   "sideEffects": false,
@@ -58,8 +68,8 @@
   "scripts": {
     "bootstrap": "yarn --network-timeout 100000 && yarn --cwd www --network-timeout 100000",
     "build": "rimraf lib && yarn build:esm && yarn build:esm:types && yarn build:cjs && yarn build:cjs:types",
-    "build:esm": "babel src --out-dir lib --delete-dir-on-start --env-name esm --extensions .ts,.tsx --ignore '**/*.d.ts' && echo {\"type\": \"module\"} > lib/package.json",
-    "build:cjs": "babel src --out-dir cjs --env-name cjs --delete-dir-on-start --extensions .ts,.tsx --ignore '**/*.d.ts' && echo {\"type\": \"commonjs\"} > cjs/package.json",
+    "build:esm": "babel src --out-dir lib --delete-dir-on-start --env-name esm --extensions .ts,.tsx --ignore '**/*.d.ts' && echo '{\"type\": \"module\"}' > lib/package.json",
+    "build:cjs": "babel src --out-dir cjs --env-name cjs --delete-dir-on-start --extensions .ts,.tsx --ignore '**/*.d.ts' && echo '{\"type\": \"commonjs\"}' > cjs/package.json",
     "build:esm:types": "tsc --emitDeclarationOnly",
     "build:cjs:types": "tsc --emitDeclarationOnly --outDir cjs",
     "build-docs": "yarn --cwd www build",


### PR DESCRIPTION
It was called out in #6901 that the ESM build of this package is really only "faux" ESM; that is, `import` statements don't use fully-qualified paths with extensions, which is required for runtimes like Node. The addition of `"exports"` to `package.json` in #6901 poses a compatibility issue if this package continues shipping faux ESM: this package will be unusable in Node applications that are using native ESM. If one tries to import something like `react-bootstrap/Card` in such an application, one will see the following error:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/.../node_modules/react-bootstrap/lib/ThemeProvider' imported from /.../node_modules/react-bootstrap/lib/Card.js
```

A workaround would be to directly import the CJS files, e.g. `react-bootstrap/cjs/Card.js`, but trying to do that on current `master` fails with the following:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './cjs/Card.js' is not defined by "exports" in /.../node_modules/react-bootstrap/package.json imported from /.../index.js
```

This is expected, but leaves consumers of this package without any option to work around the faux ESM issue.

I'm opening this PR to give folks in this situation an escape hatch: they can explicitly use the CJS build with something like the following:

```ts
import Card from 'react-boostrap/cjs/Card'
```

If you plan on resolving the faux ESM issue before the release of `"exports"` in `package.json`, you can safely disregard this PR.