### PR TITLE
fix(Carousel): ensure nextActiveIndex is non-negative when no children are present (#6969)

### DIFF
--- a/src/Carousel.tsx
+++ b/src/Carousel.tsx
@@ -311,7 +311,7 @@ const Carousel: DynamicRefForwardingComponent<'div', CarouselProps> =
               return;
             }
 
-            nextActiveIndex = numChildren - 1;
+            nextActiveIndex = numChildren > 0 ? numChildren - 1 : 0;
           }
 
           nextDirectionRef.current = 'prev';


### PR DESCRIPTION
### **Description**

This PR fixes an issue where the `Carousel` component could break when clicking the previous button while there were no children present.
Previously, `nextActiveIndex` could become -1, causing the carousel to become unresponsive once items were added dynamically.

### **Fix**

Ensures that `nextActiveIndex` is always non-negative when no children are present, preventing invalid index states.

### **Related Issue**

Fixes [#6969](https://github.com/react-bootstrap/react-bootstrap/issues/6969)

### **Testing**

Created a carousel with dynamically loaded items.

Verified that clicking the previous button when no items exist no longer causes the carousel to break.

Confirmed that items display correctly once added.