### PR TITLE
fix: handle React.Fragment overlay to fix React 19 compatibility

### DIFF
--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -151,6 +151,13 @@ const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
               hasDoneInitialMeasure,
             });
 
+          // React.Fragment cannot receive props like style, className, etc.
+          // In React 19, passing invalid props to Fragment throws an error.
+          // Return the Fragment as-is to avoid this issue.
+          if (overlay.type === React.Fragment) {
+            return overlay;
+          }
+
           return React.cloneElement(overlay, {
             ...overlayProps,
             placement: updatedPlacement,


### PR DESCRIPTION
### Summary
React 19 throws an error when DOM-related props (such as `style`, `className`, `placement`, etc.)
are passed to `React.Fragment`. Fragments can only receive `key` and `children`.

In `Overlay.tsx`, when the `overlay` prop is a Fragment, `React.cloneElement` was attempting to
pass these props to the Fragment, causing the React 19 runtime error:

> Invalid prop `style` supplied to React.Fragment.

### Fix
This PR adds a guard to detect if the overlay is a `React.Fragment` and returns it as-is,
avoiding cloning it with invalid props.

```ts
if (overlay.type === React.Fragment) {
  return overlay;
}
