### PR TITLE
fix(OverlayTrigger): prevent injecting ref to function components without forwardRef

### DIFF
--- a/src/OverlayTrigger.tsx
+++ b/src/OverlayTrigger.tsx
@@ -209,9 +209,16 @@ const OverlayTrigger: React.FC<OverlayTriggerProps> = ({
     [handleHide],
   );
 
+  const child =
+    typeof children !== 'function' ? React.Children.only(children) : null;
+  const isFunctionComponent =
+    child &&
+    typeof child.type === 'function' &&
+    !(child.type as any).prototype?.isReactComponent;
+
   const triggers: string[] = trigger == null ? [] : [].concat(trigger as any);
   const triggerProps: any = {
-    ref: mergedRef,
+    ...(!isFunctionComponent && { ref: mergedRef }),
   };
 
   if (triggers.indexOf('click') !== -1) {


### PR DESCRIPTION
**Problem:**
[OverlayTrigger](cci:1://file:///Users/harshgupta/projects/github%20contri/react-bootstrap/src/OverlayTrigger.tsx:113:0-259:2) uses `React.cloneElement` to automatically inject a `ref` into its child. If the child is a functional component that doesn't use `forwardRef`, this raises a React warning (or error) about invalid ref injection. 

**Solution:**
This PR detects when the child passes through as a standard Function Component (without `forwardRef`/`isReactComponent`) and safely conditionally omits injecting the `ref` prop into `triggerProps`, resolving the warning while keeping existing behaviors fully intact.
