### PR TITLE
Fix #6991: Clear cached popper references when overlays hide

### DIFF
--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -70,6 +70,11 @@ function wrapRefs(props, arrowProps) {
   arrowProps.ref = aRef.__wrapped || (aRef.__wrapped = (r) => aRef(r));
 }
 
+function clearPopperCache(popperRef: Partial<PopperRef>) {
+  popperRef.state = undefined;
+  popperRef.scheduleUpdate = undefined;
+}
+
 const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
   (
     {
@@ -108,8 +113,16 @@ const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
     useEffect(() => {
       if (!outerShow) {
         setFirstRenderedState(null);
+        clearPopperCache(popperRef.current);
       }
     }, [outerShow]);
+
+    useEffect(
+      () => () => {
+        clearPopperCache(popperRef.current);
+      },
+      [],
+    );
 
     return (
       <BaseOverlay

--- a/test/OverlaySpec.tsx
+++ b/test/OverlaySpec.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import Overlay from '../src/Overlay';
 import Popover from '../src/Popover';
 
@@ -40,5 +40,90 @@ describe('<Overlay>', () => {
     );
     const popoverElem = screen.getByTestId('test');
     expect(popoverElem.classList).not.toContain('fade');
+  });
+
+  it('should clear cached popper state when an overlay hides', async () => {
+    let capturedPopper: any;
+
+    function OverlayExample() {
+      const target = React.useRef<HTMLButtonElement>(null);
+      const [show, setShow] = React.useState(false);
+
+      return (
+        <>
+          <button
+            ref={target}
+            type="button"
+            data-testid="target"
+            onClick={() => setShow((value) => !value)}
+          >
+            toggle
+          </button>
+          <Overlay show={show} transition={false} target={target.current}>
+            {(props) => {
+              capturedPopper = props.popper;
+
+              return (
+                <Popover id="my-overlay" data-testid="test-overlay" {...props}>
+                  test
+                </Popover>
+              );
+            }}
+          </Overlay>
+        </>
+      );
+    }
+
+    render(<OverlayExample />);
+
+    fireEvent.click(screen.getByTestId('target'));
+
+    await screen.findByTestId('test-overlay');
+    await waitFor(() => expect(capturedPopper.state).toBeDefined());
+    expect(capturedPopper.scheduleUpdate).toBeDefined();
+
+    fireEvent.click(screen.getByTestId('target'));
+
+    await waitFor(() => expect(screen.queryByTestId('test-overlay')).toBeNull());
+    await waitFor(() => expect(capturedPopper.state).toBeUndefined());
+    expect(capturedPopper.scheduleUpdate).toBeUndefined();
+  });
+
+  it('should clear cached popper state when an overlay unmounts', async () => {
+    let capturedPopper: any;
+
+    function OverlayExample() {
+      const target = React.useRef<HTMLButtonElement>(null);
+
+      return (
+        <>
+          <button ref={target} type="button" data-testid="target">
+            toggle
+          </button>
+          <Overlay show transition={false} target={target.current}>
+            {(props) => {
+              capturedPopper = props.popper;
+
+              return (
+                <Popover id="my-overlay" data-testid="test-overlay" {...props}>
+                  test
+                </Popover>
+              );
+            }}
+          </Overlay>
+        </>
+      );
+    }
+
+    const { unmount } = render(<OverlayExample />);
+
+    await screen.findByTestId('test-overlay');
+    await waitFor(() => expect(capturedPopper.state).toBeDefined());
+    expect(capturedPopper.scheduleUpdate).toBeDefined();
+
+    unmount();
+
+    expect(capturedPopper.state).toBeUndefined();
+    expect(capturedPopper.scheduleUpdate).toBeUndefined();
   });
 });

--- a/test/OverlaySpec.tsx
+++ b/test/OverlaySpec.tsx
@@ -84,7 +84,9 @@ describe('<Overlay>', () => {
 
     fireEvent.click(screen.getByTestId('target'));
 
-    await waitFor(() => expect(screen.queryByTestId('test-overlay')).toBeNull());
+    await waitFor(() =>
+      expect(screen.queryByTestId('test-overlay')).toBeNull(),
+    );
     await waitFor(() => expect(capturedPopper.state).toBeUndefined());
     expect(capturedPopper.scheduleUpdate).toBeUndefined();
   });

--- a/test/OverlaySpec.tsx
+++ b/test/OverlaySpec.tsx
@@ -102,7 +102,7 @@ describe('<Overlay>', () => {
           <button ref={target} type="button" data-testid="target">
             toggle
           </button>
-          <Overlay show transition={false} target={target.current}>
+          <Overlay show transition={false} target={() => target.current}>
             {(props) => {
               capturedPopper = props.popper;
 


### PR DESCRIPTION
Fixes https://github.com/react-bootstrap/react-bootstrap/issues/6991

## Summary

- clear cached Popper state and update references when `Overlay` hides
- clear the same cached references again on unmount for safety
- add regression tests covering both hide and unmount cleanup paths

## Why

Issue #6991 reported detached tooltip nodes accumulating after `OverlayTrigger` renders and unmounts overlays. `Overlay` keeps a stable `popper` object for consumers, but it was still holding onto the last Popper `state` and `scheduleUpdate` references after the overlay was gone. Those references can retain DOM-backed data longer than necessary.

This change keeps the stable `popper` object behavior intact while scrubbing the cached Popper internals once the overlay is hidden or unmounted.

## Testing

- `npm run test-browser -- --browser=chromium test/OverlaySpec.tsx test/OverlayTriggerSpec.tsx`
