### PR TITLE
feat(OverlayTrigger): add interactiveOverlay prop for hoverable overlay content

### DIFF
--- a/src/OverlayTrigger.tsx
+++ b/src/OverlayTrigger.tsx
@@ -82,6 +82,17 @@ export interface OverlayTriggerProps extends Omit<
    * The placement of the Overlay in relation to it's `target`.
    */
   placement?: Placement | undefined;
+
+  /**
+   * Keep the overlay visible when the cursor moves from the trigger onto the
+   * overlay content. Only applies when `trigger` includes `'hover'`.
+   *
+   * This is useful for interactive overlays where users need to click links
+   * or copy text inside a tooltip or popover.
+   *
+   * @default false
+   */
+  interactiveOverlay?: boolean | undefined;
 }
 
 function normalizeDelay(delay?: OverlayDelay) {
@@ -124,6 +135,7 @@ const OverlayTrigger: React.FC<OverlayTriggerProps> = ({
   delay: propsDelay,
   placement,
   flip = placement && placement.indexOf('auto') !== -1,
+  interactiveOverlay = false,
   ...props
 }: OverlayTriggerProps) => {
   const triggerNodeRef = useRef(null);
@@ -223,7 +235,9 @@ const OverlayTrigger: React.FC<OverlayTriggerProps> = ({
     triggerProps.onBlur = handleBlur;
   }
 
-  if (triggers.indexOf('hover') !== -1) {
+  const hasHoverTrigger = triggers.indexOf('hover') !== -1;
+
+  if (hasHoverTrigger) {
     warning(
       triggers.length > 1,
       '[react-bootstrap] Specifying only the `"hover"` trigger limits the visibility of the overlay to just mouse users. Consider also including the `"focus"` trigger so that touch and keyboard only users can see the overlay as well.',
@@ -231,6 +245,35 @@ const OverlayTrigger: React.FC<OverlayTriggerProps> = ({
     triggerProps.onMouseOver = handleMouseOver;
     triggerProps.onMouseOut = handleMouseOut;
   }
+
+  // Wrap overlay with mouse handlers to keep it visible when hovered
+  const wrappedOverlay = useCallback(
+    (injected: any) => {
+      const rendered =
+        typeof overlay === 'function'
+          ? overlay(injected)
+          : cloneElement(overlay, injected);
+
+      if (!interactiveOverlay || !hasHoverTrigger) return rendered;
+
+      return (
+        <div
+          onMouseOver={handleMouseOver}
+          onMouseOut={handleMouseOut}
+          style={{ display: 'contents' }}
+        >
+          {rendered}
+        </div>
+      );
+    },
+    [
+      overlay,
+      interactiveOverlay,
+      hasHoverTrigger,
+      handleMouseOver,
+      handleMouseOut,
+    ],
+  );
 
   return (
     <>
@@ -246,7 +289,7 @@ const OverlayTrigger: React.FC<OverlayTriggerProps> = ({
         popperConfig={popperConfig}
         target={triggerNodeRef.current}
       >
-        {overlay}
+        {wrappedOverlay}
       </Overlay>
     </>
   );

--- a/test/OverlayTriggerSpec.tsx
+++ b/test/OverlayTriggerSpec.tsx
@@ -340,6 +340,96 @@ describe('<OverlayTrigger>', () => {
     expect(overlay).toBeDefined();
   });
 
+  describe('interactiveOverlay', () => {
+    it('Should keep overlay visible when hovering over overlay content', async () => {
+      render(
+        <OverlayTrigger
+          trigger={['hover', 'focus']}
+          overlay={<TemplateDiv>interactive content</TemplateDiv>}
+          interactiveOverlay
+        >
+          <span data-testid="test-hover">hover me</span>
+        </OverlayTrigger>,
+      );
+
+      const hoverElem = screen.getByTestId('test-hover');
+
+      // Hover trigger to show overlay
+      fireEvent.mouseOver(hoverElem);
+      await waitFor(() =>
+        expect(screen.queryByTestId('test-overlay')).not.toBeNull(),
+      );
+
+      const overlayElem = screen.getByTestId('test-overlay');
+
+      // Move mouse to overlay content — should stay visible
+      fireEvent.mouseOut(hoverElem);
+      fireEvent.mouseOver(overlayElem);
+
+      // Overlay should still be visible
+      await waitFor(() =>
+        expect(screen.queryByTestId('test-overlay')).not.toBeNull(),
+      );
+    });
+
+    it('Should hide overlay when mouse leaves overlay content', async () => {
+      render(
+        <OverlayTrigger
+          trigger={['hover', 'focus']}
+          overlay={<TemplateDiv>interactive content</TemplateDiv>}
+          interactiveOverlay
+        >
+          <span data-testid="test-hover">hover me</span>
+        </OverlayTrigger>,
+      );
+
+      const hoverElem = screen.getByTestId('test-hover');
+
+      // Hover trigger to show overlay
+      fireEvent.mouseOver(hoverElem);
+      await waitFor(() =>
+        expect(screen.queryByTestId('test-overlay')).not.toBeNull(),
+      );
+
+      const overlayElem = screen.getByTestId('test-overlay');
+
+      // Move mouse to overlay, then leave overlay
+      fireEvent.mouseOut(hoverElem);
+      fireEvent.mouseOver(overlayElem);
+      fireEvent.mouseOut(overlayElem);
+
+      await waitFor(() =>
+        expect(screen.queryByTestId('test-overlay')).toBeNull(),
+      );
+    });
+
+    it('Should not add overlay hover handlers when interactiveOverlay is false', async () => {
+      render(
+        <OverlayTrigger
+          trigger={['hover', 'focus']}
+          overlay={<TemplateDiv>content</TemplateDiv>}
+        >
+          <span data-testid="test-hover">hover me</span>
+        </OverlayTrigger>,
+      );
+
+      const hoverElem = screen.getByTestId('test-hover');
+
+      // Hover trigger to show overlay
+      fireEvent.mouseOver(hoverElem);
+      await waitFor(() =>
+        expect(screen.queryByTestId('test-overlay')).not.toBeNull(),
+      );
+
+      // Mouse out should hide overlay (default behavior)
+      fireEvent.mouseOut(hoverElem);
+
+      await waitFor(() =>
+        expect(screen.queryByTestId('test-overlay')).toBeNull(),
+      );
+    });
+  });
+
   describe('rootClose', () => {
     [
       {


### PR DESCRIPTION
## Summary

Adds a new `interactiveOverlay` prop to `OverlayTrigger` that keeps the overlay visible when the cursor moves from the trigger element onto the overlay content. This enables users to interact with links, copy text, or click buttons inside tooltips and popovers.

### The problem

When `trigger` includes `'hover'`, moving the cursor from the trigger onto the overlay fires `mouseOut` on the trigger, which hides the overlay. This makes it impossible to interact with overlay content — a long-standing pain point:

- #1622 — "Popover that shows on OverlayTrigger on hover — how to keep it displayed while hovering over the popover?"

### The fix

The new `interactiveOverlay` prop (default `false`) wraps the overlay with `onMouseOver`/`onMouseOut` handlers that reuse the existing `handleShow`/`handleHide` logic:

- Mouse enters overlay → cancels hide timeout, keeps overlay visible
- Mouse leaves overlay → starts hide timeout (respects configured `delay`)
- Uses `display: contents` wrapper to avoid affecting overlay layout/positioning
- Only active when `trigger` includes `'hover'`
- Fully backwards compatible (opt-in, default `false`)

### Usage

```jsx
<OverlayTrigger
  interactiveOverlay
  overlay={
    <Tooltip>
      Click <a href="/docs">here</a> for details
    </Tooltip>
  }
>
  <button>Hover me</button>
</OverlayTrigger>
```

### Changes

- `src/OverlayTrigger.tsx` — new `interactiveOverlay` prop with JSDoc, overlay wrapping logic
- `test/OverlayTriggerSpec.tsx` — 3 new tests covering: overlay stays visible on hover, hides on leave, no effect when prop is false

## Test plan

- [x] TypeScript compiles cleanly
- [x] All 44 existing + new tests pass (`vitest run test/OverlayTriggerSpec.tsx`)
- [x] Lint passes (lint-staged ran on commit)
- [ ] Hover trigger → move cursor to overlay → overlay stays visible
- [ ] Move cursor away from overlay → overlay hides after delay
- [ ] Without `interactiveOverlay`, behavior is unchanged
- [ ] Works with both element overlays and render-prop overlays
- [ ] `display: contents` wrapper doesn't affect tooltip/popover positioning

Closes #1622