### PR TITLE
Fix Overlay target reference in Overlay.js

### DIFF
--- a/www/docs/examples/Overlays/Overlay.js
+++ b/www/docs/examples/Overlays/Overlay.js
@@ -11,7 +11,7 @@ function Example() {
       <Button variant="danger" ref={target} onClick={() => setShow(!show)}>
         Click me to see
       </Button>
-      <Overlay target={target} show={show} placement="right">
+      <Overlay target={() => target} show={show} placement="right">
         {({
           placement: _placement,
           arrowProps: _arrowProps,

--- a/www/docs/examples/Overlays/Overlay.js
+++ b/www/docs/examples/Overlays/Overlay.js
@@ -11,7 +11,7 @@ function Example() {
       <Button variant="danger" ref={target} onClick={() => setShow(!show)}>
         Click me to see
       </Button>
-      <Overlay target={target.current} show={show} placement="right">
+      <Overlay target={target} show={show} placement="right">
         {({
           placement: _placement,
           arrowProps: _arrowProps,


### PR DESCRIPTION
React does not allow access to content of refs during rendering, but to the ref itself.