### PR TITLE
Add manual tab activation support

### DIFF
--- a/src/Nav.tsx
+++ b/src/Nav.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { useContext } from 'react';
 import { useUncontrolled } from 'uncontrollable';
 import BaseNav from '@restart/ui/Nav';
+import TabContext from '@restart/ui/TabContext';
 import { DynamicRefForwardingComponent, EventKey } from '@restart/ui/types';
 import { useBootstrapPrefix } from './ThemeProvider.js';
 import NavbarContext from './NavbarContext.js';
@@ -10,6 +11,38 @@ import CardHeaderContext from './CardHeaderContext.js';
 import NavItem from './NavItem.js';
 import NavLink from './NavLink.js';
 import type { BaseNavProps } from './types.js';
+
+const EVENT_KEY_ATTR = 'data-rr-ui-event-key';
+const SELECTABLE_TAB_SELECTOR = `[${EVENT_KEY_ATTR}]:not([aria-disabled=true])`;
+
+function getNextFocusedTab(
+  currentTarget: HTMLElement,
+  eventTarget: EventTarget | null,
+  offset: number,
+) {
+  if (!(eventTarget instanceof Element)) {
+    return null;
+  }
+
+  const currentTab = eventTarget.closest<HTMLElement>(SELECTABLE_TAB_SELECTOR);
+  if (!currentTab || !currentTarget.contains(currentTab)) {
+    return null;
+  }
+
+  const items = Array.from(
+    currentTarget.querySelectorAll<HTMLElement>(SELECTABLE_TAB_SELECTOR),
+  );
+  const index = items.indexOf(currentTab);
+  if (index === -1) {
+    return null;
+  }
+
+  let nextIndex = index + offset;
+  if (nextIndex >= items.length) nextIndex = 0;
+  if (nextIndex < 0) nextIndex = items.length - 1;
+
+  return items[nextIndex];
+}
 
 export interface NavProps extends BaseNavProps {
   /**
@@ -54,6 +87,13 @@ export interface NavProps extends BaseNavProps {
   navbarScroll?: boolean | undefined;
 
   /**
+   * Move focus with arrow keys without selecting the focused tab when the Nav
+   * has a tablist role. The focused tab can still be selected with Enter or
+   * Space.
+   */
+  manualActivation?: boolean | undefined;
+
+  /**
    * ARIA role for the Nav, in the context of a TabContainer, the default will
    * be set to "tablist", but can be overridden by the Nav when set explicitly.
    *
@@ -78,6 +118,10 @@ const Nav: DynamicRefForwardingComponent<'div', NavProps> = React.forwardRef<
     navbarScroll,
     className,
     activeKey,
+    role,
+    manualActivation = false,
+    onKeyDown,
+    onKeyDownCapture,
     ...props
   } = useUncontrolled(uncontrolledProps, { activeKey: 'onSelect' });
 
@@ -89,6 +133,7 @@ const Nav: DynamicRefForwardingComponent<'div', NavProps> = React.forwardRef<
 
   const navbarContext = useContext(NavbarContext);
   const cardHeaderContext = useContext(CardHeaderContext);
+  const tabContext = useContext(TabContext);
 
   if (navbarContext) {
     navbarBsPrefix = navbarContext.bsPrefix;
@@ -97,11 +142,55 @@ const Nav: DynamicRefForwardingComponent<'div', NavProps> = React.forwardRef<
     ({ cardHeaderBsPrefix } = cardHeaderContext);
   }
 
+  const handleKeyDownCapture: React.KeyboardEventHandler<HTMLElement> = (
+    event,
+  ) => {
+    onKeyDownCapture?.(event);
+
+    if (
+      !manualActivation ||
+      event.isPropagationStopped() ||
+      (role !== 'tablist' && !tabContext)
+    ) {
+      return;
+    }
+
+    let nextTab;
+    switch (event.key) {
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        nextTab = getNextFocusedTab(event.currentTarget, event.target, -1);
+        break;
+      case 'ArrowRight':
+      case 'ArrowDown':
+        nextTab = getNextFocusedTab(event.currentTarget, event.target, 1);
+        break;
+      default:
+        return;
+    }
+
+    if (!nextTab) {
+      return;
+    }
+
+    onKeyDown?.(event);
+    if (event.isPropagationStopped()) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    nextTab.focus();
+  };
+
   return (
     <BaseNav
       as={as}
       ref={ref}
       activeKey={activeKey}
+      role={role}
+      onKeyDown={onKeyDown}
+      onKeyDownCapture={handleKeyDownCapture}
       className={clsx(className, {
         [bsPrefix]: !isNavbar,
         [`${navbarBsPrefix}-nav`]: isNavbar,

--- a/test/TabsSpec.tsx
+++ b/test/TabsSpec.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import Tab from '../src/Tab';
 import Tabs from '../src/Tabs';
 
@@ -92,6 +93,47 @@ describe('<Tabs>', () => {
 
     fireEvent.click(screen.getByText('Tab 2'));
     expect(onSelectSpy).toHaveBeenCalledWith('2', expect.anything());
+  });
+
+  it('Should keep manual activation tabs inactive until selected from keyboard', async () => {
+    const user = userEvent.setup();
+    const onSelectSpy = vi.fn();
+
+    render(
+      <Tabs
+        id="test"
+        defaultActiveKey={1}
+        onSelect={onSelectSpy}
+        manualActivation
+      >
+        <Tab title="Tab 1" eventKey={1}>
+          Tab 1 content
+        </Tab>
+        <Tab title="Tab 2" eventKey={2}>
+          Tab 2 content
+        </Tab>
+      </Tabs>,
+    );
+
+    const firstTabButton = screen.getByRole('tab', { name: 'Tab 1' });
+    const secondTabButton = screen.getByRole('tab', { name: 'Tab 2' });
+    const firstTabContent = screen.getByText('Tab 1 content');
+
+    await user.tab();
+    expect(document.activeElement).toBe(firstTabButton);
+
+    await user.keyboard('{ArrowRight}');
+
+    expect(document.activeElement).toBe(secondTabButton);
+    expect(onSelectSpy).not.toHaveBeenCalled();
+    expect(firstTabButton.classList).toContain('active');
+    expect(firstTabContent.classList).toContain('active');
+    expect(secondTabButton.classList).not.toContain('active');
+
+    await user.keyboard('{Enter}');
+
+    expect(onSelectSpy).toHaveBeenCalledWith('2', expect.anything());
+    expect(secondTabButton.classList).toContain('active');
   });
 
   it('Should have children with the correct DOM properties', () => {

--- a/tests/simple-types-test.tsx
+++ b/tests/simple-types-test.tsx
@@ -932,6 +932,7 @@ const MegaComponent = () => (
       defaultActiveKey="profile"
       id="uncontrolled-tab-example"
       mountOnEnter
+      manualActivation
       onSelect={noop}
       transition={false}
       unmountOnExit


### PR DESCRIPTION
Closes #6878

## Summary
- Add a `manualActivation` option for tablist keyboard navigation.
- Keep arrow keys focused-only in manual mode while preserving Enter, Space, and click selection.
- Cover the behavior in the Tabs spec and type fixture.

## Testing
- `PLAYWRIGHT_BROWSERS_PATH=/tmp/react-bootstrap-6878-ms-playwright YARN_CACHE_FOLDER=/tmp/react-bootstrap-6878-yarn-cache corepack yarn test-browser --browser=chromium test/TabsSpec.tsx -t "manual activation"`
- `PLAYWRIGHT_BROWSERS_PATH=/tmp/react-bootstrap-6878-ms-playwright YARN_CACHE_FOLDER=/tmp/react-bootstrap-6878-yarn-cache corepack yarn test-browser --browser=chromium test/NavSpec.tsx test/TabsSpec.tsx`
- `YARN_CACHE_FOLDER=/tmp/react-bootstrap-6878-yarn-cache ./node_modules/.bin/eslint src/Nav.tsx test/TabsSpec.tsx tests/simple-types-test.tsx`
- `YARN_CACHE_FOLDER=/tmp/react-bootstrap-6878-yarn-cache corepack yarn check-types`
- `PLAYWRIGHT_BROWSERS_PATH=/tmp/react-bootstrap-6878-ms-playwright YARN_CACHE_FOLDER=/tmp/react-bootstrap-6878-yarn-cache corepack yarn test`
- `git diff --check`