### PR TITLE
fix: warn once for hover-only overlay triggers

### DIFF
--- a/src/OverlayTrigger.tsx
+++ b/src/OverlayTrigger.tsx
@@ -93,6 +93,8 @@ function normalizeDelay(delay?: OverlayDelay) {
       };
 }
 
+let hasWarnedAboutHoverOnly = false;
+
 // Simple implementation of mouseEnter and mouseLeave.
 // React's built version is broken: https://github.com/facebook/react/issues/4251
 // for cases when the trigger is disabled and mouseOut/Over can cause flicker
@@ -224,10 +226,14 @@ const OverlayTrigger: React.FC<OverlayTriggerProps> = ({
   }
 
   if (triggers.indexOf('hover') !== -1) {
-    warning(
-      triggers.length > 1,
-      '[react-bootstrap] Specifying only the `"hover"` trigger limits the visibility of the overlay to just mouse users. Consider also including the `"focus"` trigger so that touch and keyboard only users can see the overlay as well.',
-    );
+    if (triggers.length === 1 && !hasWarnedAboutHoverOnly) {
+      hasWarnedAboutHoverOnly = true;
+      warning(
+        false,
+        '[react-bootstrap] Specifying only the `"hover"` trigger limits the visibility of the overlay to just mouse users. Consider also including the `"focus"` trigger so that touch and keyboard only users can see the overlay as well.',
+      );
+    }
+
     triggerProps.onMouseOver = handleMouseOver;
     triggerProps.onMouseOut = handleMouseOut;
   }

--- a/test/OverlayTriggerSpec.tsx
+++ b/test/OverlayTriggerSpec.tsx
@@ -185,6 +185,30 @@ describe('<OverlayTrigger>', () => {
     );
   });
 
+  it('Should warn only once for hover-only triggers', () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    render(
+      <>
+        <OverlayTrigger trigger="hover" overlay={<TemplateDiv />}>
+          <span>hover one</span>
+        </OverlayTrigger>
+        <OverlayTrigger trigger="hover" overlay={<TemplateDiv />}>
+          <span>hover two</span>
+        </OverlayTrigger>
+      </>,
+    );
+
+    expect(consoleErrorSpy).toHaveBeenCalledOnce();
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Specifying only the `"hover"` trigger'),
+    );
+
+    consoleErrorSpy.mockRestore();
+  });
+
   it('Should not set aria-describedby if the state is not show', () => {
     render(
       <OverlayTrigger trigger="click" overlay={<TemplateDiv />}>


### PR DESCRIPTION
### Summary
- warn only once when OverlayTrigger is configured with only the hover trigger
- keep the accessibility warning in place without flooding the console for repeated overlay instances
- add regression coverage for multiple hover-only triggers

Closes #6989.

### Tests
- yarn tdd test/OverlayTriggerSpec.tsx --run
- yarn lint