### PR TITLE
fix(DropdownMenu): use Popper for navbar dropdown positioning when navbar is expanded

### DIFF
--- a/src/DropdownMenu.tsx
+++ b/src/DropdownMenu.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx';
 import * as React from 'react';
-import { useContext } from 'react';
+import { useContext, useState, useCallback } from 'react';
 import {
   useDropdownMenu,
   UseDropdownMenuOptions,
@@ -125,6 +125,9 @@ const DropdownMenu: DynamicRefForwardingComponent<'div', DropdownMenuProps> =
     ) => {
       let alignEnd = false;
       const isNavbar = useContext(NavbarContext);
+      const [isNavbarExpanded, setIsNavbarExpanded] = useState(
+        isNavbar ? (isNavbar.expand === true || !('matchMedia' in window)) : false,
+      );
       const prefix = useBootstrapPrefix(bsPrefix, 'dropdown-menu');
       const { align: contextAlign, drop, isRTL } = useContext(DropdownContext);
       align = align || contextAlign;
@@ -156,11 +159,13 @@ const DropdownMenu: DynamicRefForwardingComponent<'div', DropdownMenuProps> =
 
       const placement = getDropdownMenuPlacement(alignEnd, drop, isRTL);
 
+      const isNavbarElementExpanded = isNavbarExpanded;
+
       const [menuProps, { hasShown, popper, show, toggle }] = useDropdownMenu({
         flip,
         rootCloseEvent,
         show: showProps,
-        usePopper: !isNavbar && alignClasses.length === 0,
+        usePopper: (!isNavbar || isNavbarElementExpanded) && alignClasses.length === 0,
         offset: [0, 2],
         popperConfig,
         placement,
@@ -176,6 +181,29 @@ const DropdownMenu: DynamicRefForwardingComponent<'div', DropdownMenuProps> =
         // renderOnMount=true. Need to call update() to correct it.
         if (show) popper?.update();
       }, [show]);
+
+      useIsomorphicEffect(() => {
+        if (!isNavbar) return;
+        const { expand } = isNavbar;
+        if (expand === true) {
+          setIsNavbarExpanded(true);
+          return;
+        }
+        const breakpointMap: Record<string, string> = {
+          sm: '576px',
+          md: '768px',
+          lg: '992px',
+          xl: '1200px',
+          xxl: '1400px',
+        };
+        const bp = typeof expand === 'string' ? breakpointMap[expand] : undefined;
+        if (!bp) return;
+        const mql = window.matchMedia(`(min-width: ${bp})`);
+        const handler = () => setIsNavbarExpanded(mql.matches);
+        handler();
+        mql.addEventListener('change', handler);
+        return () => mql.removeEventListener('change', handler);
+      }, [isNavbar]);
 
       if (!hasShown && !renderOnMount && !isInputGroup) return null;
 
@@ -200,7 +228,7 @@ const DropdownMenu: DynamicRefForwardingComponent<'div', DropdownMenuProps> =
           {...menuProps}
           style={style}
           // Bootstrap css requires this data attrib to style responsive menus.
-          {...((alignClasses.length || isNavbar) && {
+          {...((alignClasses.length || (isNavbar && !isNavbarElementExpanded)) && {
             'data-bs-popper': 'static',
           })}
           className={clsx(


### PR DESCRIPTION
## Fix: Use Popper for navbar dropdown positioning when navbar is expanded

### Problem
When a Dropdown component is placed inside a Navbar, the dropdown menu always uses static CSS positioning (`data-bs-popper="static"`) and never uses Popper.js, regardless of whether the navbar is expanded or collapsed. This causes the dropdown menu to appear in the wrong position (e.g., at the bottom of the screen) when the navbar is expanded on larger viewports.

### Root Cause
In `DropdownMenu.tsx`, the `usePopper` option is set to `!isNavbar` — which disables Popper for ALL dropdowns inside a Navbar, even when the navbar is expanded and there's enough space for proper Popper positioning.

### Fix
- When inside a Navbar, use `window.matchMedia()` to check if the viewport is above the navbar's expand breakpoint
- If the navbar is expanded (above breakpoint): use Popper for positioning (correct positioning)
- If the navbar is collapsed (below breakpoint): use static CSS positioning (current behavior, works well in collapsed mobile menus)

### Changes
- `src/DropdownMenu.tsx`: Added `useState` and a media query listener via `useIsomorphicEffect` to detect the navbar expand state
- Modified `usePopper` condition to allow Popper when the navbar is expanded
- Only add `data-bs-popper="static"` when the navbar is collapsed (not expanded)

### Testing
- Dropdown inside an expanded Navbar on large screens → should use Popper and position correctly
- Dropdown inside a collapsed Navbar on small screens → should use static positioning (unchanged behavior)
- Dropdown outside a Navbar → unchanged behavior

Closes #6985
