### PR TITLE
fix: prevent scrollbar jitter on tooltip/popover render by using position:fixed as initial strategy (Closes #6563)

### DIFF
--- a/src/getInitialPopperStyles.ts
+++ b/src/getInitialPopperStyles.ts
@@ -1,5 +1,5 @@
 export default function getInitialPopperStyles(
-  position: React.CSSProperties['position'] = 'absolute',
+  position: React.CSSProperties['position'] = 'fixed',
 ): Partial<React.CSSProperties> {
   return {
     position,

--- a/test/getInitialPopperStylesSpec.ts
+++ b/test/getInitialPopperStylesSpec.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest';
 import getInitialPopperStyles from '../src/getInitialPopperStyles';
 
 describe('getInitialPopperStyles', () => {
-  it('defaults to absolute positioning when no strategy is provided', () => {
+  it('defaults to fixed positioning when no strategy is provided', () => {
     expect(getInitialPopperStyles()).toEqual({
-      position: 'absolute',
+      position: 'fixed',
       top: '0',
       left: '0',
       opacity: '0',


### PR DESCRIPTION
## Summary

Fixes #6563 — Scrollbar jitter on render of tooltips and popovers.

### Root cause

When a tooltip or popover is rendered, it is initially positioned at `top: 0; left: 0` with `position: absolute` (the default strategy in `getInitialPopperStyles`). This absolute positioning at (0,0) can cause the page content to shift, creating a scrollbar that appears and disappears in a loop — the scrollbar jitter.

The official Bootstrap 5 does not have this issue because it applies `translate3d(0,0,0)` only after the final position is calculated, preventing the initial layout shift.

### Fix

Changed the default `position` parameter in `getInitialPopperStyles()` from `'absolute'` to `'fixed'`.

By using `position: fixed` for the initial render, the tooltip/popover is positioned relative to the viewport instead of the document flow. This prevents the initial render from affecting the document height and eliminates the scrollbar jitter.

Note: This only affects the **initial** (brief) render before popper.js calculates the final position. The actual `strategy` passed in `popperConfig` still determines the final positioning strategy used by Popper.js.

### Changes

- `src/getInitialPopperStyles.ts`: Changed default position from `'absolute'` to `'fixed'`
- `test/getInitialPopperStylesSpec.ts`: Updated test to reflect new default

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)