### PR TITLE
fix(Navbar): remove default light variant to avoid forcing light mode (Closes #6822)

### DIFF
--- a/src/Navbar.tsx
+++ b/src/Navbar.tsx
@@ -142,7 +142,7 @@ const Navbar: DynamicRefForwardingComponent<'nav', NavbarProps> =
     const {
       bsPrefix: initialBsPrefix,
       expand = true,
-      variant = 'light',
+      variant,
       bg,
       fixed,
       sticky,

--- a/test/NavbarSpec.tsx
+++ b/test/NavbarSpec.tsx
@@ -10,7 +10,7 @@ describe('<Navbar>', () => {
 
     expect(navbarElem.classList).toContain('navbar');
     expect(navbarElem.classList).toContain('navbar-expand');
-    expect(navbarElem.classList).toContain('navbar-light');
+    expect(navbarElem.classList).not.toContain('navbar-light');
   });
 
   it('Should add "navigation" role when not using a `<nav>`', () => {


### PR DESCRIPTION
## Summary

The `<Navbar>` component force-adds the `navbar-light` class by default because its `variant` prop defaults to `'light'`:

```tsx
variant = 'light',
```

This forces a light color scheme on the navbar even when the parent page uses a dark theme (e.g. `data-bs-theme="dark"` set at the `<html>` level). Unlike other components such as `Pagination`, `Navbar` shouldn't force any default color mode.

### Fix

- Changed the default value of `variant` from `'light'` to `undefined` in `src/Navbar.tsx`
- Now the `navbar-light` class is **not** added unless the user explicitly sets `variant="light"`
- Users who want the old behavior can still pass `variant="light"` explicitly

### Test

Updated `test/NavbarSpec.tsx` to assert that the default `Navbar` render does **not** include `navbar-light`.

Closes #6822