### PR TITLE
fix(ToggleButtonGroup): add keyboard navigation for radio type + correct tabIndex (Fixes #6719)

### DIFF
--- a/src/ToggleButtonGroup.tsx
+++ b/src/ToggleButtonGroup.tsx
@@ -99,6 +99,7 @@ const ToggleButtonGroup: DynamicRefForwardingComponent<
     value,
     onChange,
     vertical = false,
+    onKeyDown,
     ...controlledProps
   } = useUncontrolled(props, {
     value: 'onChange',
@@ -128,6 +129,43 @@ const ToggleButtonGroup: DynamicRefForwardingComponent<
     }
   };
 
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (type === 'radio') {
+      const childValues = React.Children.map(
+        children,
+        (child: any) => child?.props?.value,
+      );
+      if (!childValues) {
+        onKeyDown?.(event);
+        return;
+      }
+
+      const currentIndex = childValues.indexOf(value);
+      let nextIndex = currentIndex;
+
+      switch (event.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          nextIndex = (currentIndex + 1) % childValues.length;
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          nextIndex =
+            (currentIndex - 1 + childValues.length) % childValues.length;
+          break;
+        default:
+          onKeyDown?.(event);
+          return;
+      }
+
+      event.preventDefault();
+      if (nextIndex !== currentIndex && childValues[nextIndex] !== undefined) {
+        onChange?.(childValues[nextIndex], event);
+      }
+    }
+    onKeyDown?.(event);
+  };
+
   invariant(
     type !== 'radio' || !!name,
     'A `name` is required to group the toggle buttons when the `type` ' +
@@ -135,17 +173,24 @@ const ToggleButtonGroup: DynamicRefForwardingComponent<
   );
 
   return (
-    <ButtonGroup {...controlledProps} ref={ref as any} vertical={vertical}>
+    <ButtonGroup
+      {...controlledProps}
+      ref={ref as any}
+      vertical={vertical}
+      onKeyDown={handleKeyDown}
+    >
       {map(children, (child) => {
         const values = getValues();
         const { value: childVal, onChange: childOnChange } = child.props;
         const handler = (e) => handleToggle(childVal, e);
+        const isChecked = values.indexOf(childVal) !== -1;
 
         return React.cloneElement(child, {
           type,
           name: (child as any).name || name,
-          checked: values.indexOf(childVal) !== -1,
+          checked: isChecked,
           onChange: chainFunction(childOnChange, handler),
+          tabIndex: type === 'radio' ? (isChecked ? 0 : -1) : undefined,
         });
       })}
     </ButtonGroup>


### PR DESCRIPTION
## Summary

Fixes keyboard interaction for `ToggleButtonGroup` with `type="radio"`.

### Problem

When `ToggleButtonGroup` is used as a radio group (`type="radio"`), each toggle button's label is focusable via tab, causing the user to tab through every option instead of navigating with arrow keys (as expected for a radio group). The selected value cannot be changed via keyboard.

### Fix

1. **Keyboard navigation** — Added `onKeyDown` handler on the `ButtonGroup` container that handles arrow keys (ArrowLeft/ArrowRight/ArrowUp/ArrowDown) to navigate between radio buttons and update the selection.

2. **Correct tabIndex** — For radio type, only the currently checked button gets `tabIndex={0}` (in the tab order), while unchecked buttons get `tabIndex={-1}` (skip in tab order). This follows the [WAI-ARIA radio group pattern](https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton/).

### Behavior

| Key | Action |
|:---|:---|
| Tab | Focuses the currently selected radio button's label |
| ArrowRight / ArrowDown | Selects the next radio button |
| ArrowLeft / ArrowUp | Selects the previous radio button |

### Checkbox behavior

The `type="checkbox"` mode is unchanged — all buttons remain individually tabbable.

### TypeScript

All type checks pass with `npx tsc --noEmit -p tsconfig.json`.

Closes #6719