### PR TITLE
fix(Overlay): avoid passing style to React.Fragment (Closes #6913)

### DIFF
--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -164,6 +164,11 @@ const Overlay = React.forwardRef<HTMLElement, OverlayProps>(
               hasDoneInitialMeasure,
             });
 
+          if (overlay.type === React.Fragment) {
+            // React.Fragment does not accept style, className, or custom props
+            return React.cloneElement(overlay, { key: overlay.key });
+          }
+
           return React.cloneElement(overlay, {
             ...overlayProps,
             placement: updatedPlacement,

--- a/test/OverlaySpec.tsx
+++ b/test/OverlaySpec.tsx
@@ -128,4 +128,15 @@ describe('<Overlay>', () => {
     expect(capturedPopper.state).toBeUndefined();
     expect(capturedPopper.scheduleUpdate).toBeUndefined();
   });
+
+  it('should not throw when overlay is a React Fragment', () => {
+    const ref = React.createRef<any>();
+    expect(() => {
+      render(
+        <Overlay show target={ref.current}>
+          <></>
+        </Overlay>,
+      );
+    }).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary

When the Overlay receives a React Fragment as its overlay, React.cloneElement was injecting style, className, placement, and other custom props that React.Fragment cannot accept. React 19 surfaces this as a runtime error:

> Invalid prop `style` supplied to `React.Fragment`.

## Changes

- **src/Overlay.tsx** — Check for `overlay.type === React.Fragment` before cloning. When the overlay is a Fragment, skip the non-standard props (style, className, placement, arrowProps, popper) since Fragment only accepts `key` and `children`.
- **test/OverlaySpec.tsx** — Add test to verify that passing a Fragment as overlay does not throw.

## Related issue

Closes #6913