### PR TITLE
fix(Modal): prevent Tabs inside Modal from inheriting Navbar context (Fixes #6800)

### DIFF
--- a/src/Modal.tsx
+++ b/src/Modal.tsx
@@ -15,6 +15,7 @@ import Fade from './Fade.js';
 import ModalBody from './ModalBody.js';
 import ModalContext from './ModalContext.js';
 import ModalDialog from './ModalDialog.js';
+import NavbarContext from './NavbarContext.js';
 import ModalFooter from './ModalFooter.js';
 import ModalHeader from './ModalHeader.js';
 import ModalTitle from './ModalTitle.js';
@@ -320,14 +321,16 @@ const Modal = React.forwardRef<ModalHandle, ModalProps>(
         aria-labelledby={ariaLabelledby}
         aria-describedby={ariaDescribedby}
       >
-        <Dialog
-          {...props}
-          onMouseDown={handleDialogMouseDown}
-          className={dialogClassName}
-          contentClassName={contentClassName}
-        >
-          {children}
-        </Dialog>
+        <NavbarContext.Provider value={null}>
+          <Dialog
+            {...props}
+            onMouseDown={handleDialogMouseDown}
+            className={dialogClassName}
+            contentClassName={contentClassName}
+          >
+            {children}
+          </Dialog>
+        </NavbarContext.Provider>
       </div>
     );
 


### PR DESCRIPTION
## Summary

When a Modal is rendered inside a Navbar, the Modal's children (such as `Tabs` → `Nav`) inherit the `NavbarContext` through React context, causing them to use the `navbar-nav` class instead of `nav`. This breaks the Tabs component styling.

### Root Cause

The `Nav` component checks for `NavbarContext` via `useContext(NavbarContext)`. When a `Tab` (which renders a `Nav` internally) is inside a Modal that is a child of a Navbar in the React component tree, the `Nav` inherits the `NavbarContext` even though the Modal portal renders outside the Navbar DOM subtree.

### Fix

Wrap the Modal dialog content in a `NavbarContext.Provider value={null}` to break the context inheritance. This is the same pattern already used by `TabPane` (which wraps its content in `TabContext.Provider value={null}`).

### Changes

- `src/Modal.tsx`: Import `NavbarContext` and wrap dialog content in `NavbarContext.Provider value={null}`

Fixes #6800