### PR TITLE
fix(DropdownToggle): prevent Ctrl/Cmd+click from opening the dropdown (Fixes #6834)

### DIFF
--- a/src/DropdownToggle.tsx
+++ b/src/DropdownToggle.tsx
@@ -1,4 +1,5 @@
 import useMergedRefs from '@restart/hooks/useMergedRefs';
+import useEventCallback from '@restart/hooks/useEventCallback';
 import DropdownContext from '@restart/ui/DropdownContext';
 import { useDropdownToggle } from '@restart/ui/DropdownToggle';
 import type { DynamicRefForwardingComponent } from '@restart/ui/types';
@@ -64,6 +65,21 @@ const DropdownToggle: DropdownToggleComponent = React.forwardRef(
     }
 
     const [toggleProps] = useDropdownToggle();
+
+    // Prevent a Ctrl/Cmd+click from opening the dropdown menu. Holding a
+    // modifier key (Ctrl on Windows/Linux, Cmd on macOS) signals an intent to
+    // open the target in a new tab/window rather than interact with the
+    // control itself, so it should not toggle the menu. Without this guard,
+    // Ctrl+clicking several toggles on the same page leaves every menu open
+    // simultaneously (https://github.com/react-bootstrap/react-bootstrap/issues/6834).
+    const originalOnClick = toggleProps.onClick;
+    const handleClick = useEventCallback(
+      (e: React.MouseEvent<Element, MouseEvent>) => {
+        if (e.ctrlKey || e.metaKey) return;
+        originalOnClick?.(e);
+      },
+    );
+    toggleProps.onClick = handleClick;
 
     toggleProps.ref = useMergedRefs(
       toggleProps.ref,

--- a/test/DropdownToggleSpec.tsx
+++ b/test/DropdownToggleSpec.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen } from '@testing-library/react';
 import DropdownToggle from '../src/DropdownToggle';
+import Dropdown from '../src/Dropdown';
 
 describe('<DropdownToggle>', () => {
   it('renders toggle button', () => {
@@ -55,5 +56,54 @@ describe('<DropdownToggle>', () => {
       'my-custom-bsPrefix',
     );
     expect(container.firstElementChild!.classList).toContain('btn');
+  });
+});
+
+describe('DropdownToggle Ctrl+click', () => {
+  it('does not open the dropdown on Ctrl+click', () => {
+    const { container } = render(
+      <Dropdown>
+        <Dropdown.Toggle id="test-id">Toggle</Dropdown.Toggle>
+        <Dropdown.Menu>
+          <Dropdown.Item>Item</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>,
+    );
+
+    const toggle = screen.getByText('Toggle');
+    expect(container.firstElementChild!.classList).not.toContain('show');
+
+    fireEvent.click(toggle, { ctrlKey: true });
+    expect(container.firstElementChild!.classList).not.toContain('show');
+  });
+
+  it('does not open the dropdown on Cmd+click (macOS)', () => {
+    const { container } = render(
+      <Dropdown>
+        <Dropdown.Toggle id="test-id">Toggle</Dropdown.Toggle>
+        <Dropdown.Menu>
+          <Dropdown.Item>Item</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>,
+    );
+
+    const toggle = screen.getByText('Toggle');
+    fireEvent.click(toggle, { metaKey: true });
+    expect(container.firstElementChild!.classList).not.toContain('show');
+  });
+
+  it('still opens the dropdown on a plain click', () => {
+    const { container } = render(
+      <Dropdown>
+        <Dropdown.Toggle id="test-id">Toggle</Dropdown.Toggle>
+        <Dropdown.Menu>
+          <Dropdown.Item>Item</Dropdown.Item>
+        </Dropdown.Menu>
+      </Dropdown>,
+    );
+
+    const toggle = screen.getByText('Toggle');
+    fireEvent.click(toggle);
+    expect(container.firstElementChild!.classList).toContain('show');
   });
 });


### PR DESCRIPTION
Fixes #6834

## What

Prevent a Ctrl/Cmd+click from opening the dropdown menu.

## Why

Holding a modifier key (Ctrl on Windows/Linux, Cmd on macOS) while clicking a dropdown toggle signals an intent to open the target in a new tab/window rather than interact with the control itself. Previously, `DropdownToggle` propagated the raw click to `@restart/ui`'s toggle handler, which opened the menu. As a result, Ctrl+clicking several toggles on the same page left every menu open simultaneously.

## How

Wrap the toggle's `onClick` in `DropdownToggle` to short-circuit when `e.ctrlKey` or `e.metaKey` is set, delegating normal clicks through to the original handler unchanged.

## Tests

Added three cases to `test/DropdownToggleSpec.tsx`:
- Ctrl+click does not open the dropdown.
- Cmd+click (macOS) does not open the dropdown.
- A plain click still opens the dropdown.